### PR TITLE
feat: monorepo workspace support

### DIFF
--- a/docs/monorepo-support.md
+++ b/docs/monorepo-support.md
@@ -1,0 +1,110 @@
+# Monorepo Support
+
+## Requirements
+
+For Carrick to detect and analyze a monorepo, the repository must meet these requirements:
+
+### 1. Root `package.json` with a `workspaces` field
+
+The root `package.json` must declare workspaces using one of the standard formats:
+
+**Array format** (Yarn / npm):
+```json
+{
+  "name": "my-monorepo",
+  "workspaces": ["apps/*", "libs/*"]
+}
+```
+
+**Object format** (Yarn classic):
+```json
+{
+  "name": "my-monorepo",
+  "workspaces": {
+    "packages": ["apps/*", "libs/*"]
+  }
+}
+```
+
+### 2. Simple glob patterns only
+
+Workspace patterns must be simple `<directory>/*` or `<directory>/**` globs. Carrick expands these by listing immediate child directories of the base path. It does **not** support:
+
+- Multi-level globs like `packages/group-*/app-*`
+- Literal paths like `packages/specific-app` (treated as a directory to list children of)
+- Negation patterns like `!packages/ignored`
+
+### 3. Each package must have its own `package.json`
+
+Each workspace package directory must contain a `package.json`. Directories without one are silently skipped.
+
+The `name` field is used as the package identifier. If absent, the directory name is used as a fallback.
+
+```
+my-monorepo/
+  package.json          <- root, declares workspaces
+  apps/
+    service-a/
+      package.json      <- {"name": "service-a", ...}
+      src/
+        index.ts
+    service-b/
+      package.json      <- {"name": "service-b", ...}
+      src/
+        app.ts
+```
+
+### 4. No special tooling required
+
+Carrick does not depend on NX, Lerna, Turborepo, or any specific monorepo tool. It reads the `workspaces` field directly from `package.json`. Any monorepo that uses Yarn workspaces, npm workspaces, or pnpm workspaces (with a compatible `package.json`) will work.
+
+pnpm workspaces declared only in `pnpm-workspace.yaml` (without a `workspaces` field in `package.json`) are **not** currently detected.
+
+## How it works
+
+1. Carrick reads the root `package.json` and checks for a `workspaces` field
+2. If found, it expands each pattern into concrete package directories
+3. Each package is analyzed independently — its own framework detection, file discovery, mount graph, and `CloudRepoData`
+4. Results are stored with a composite key: `<repo-name>::<package-name>`
+5. Cross-repo comparison works automatically — packages within the same monorepo participate alongside packages from other repos
+6. If no `workspaces` field is found, Carrick falls back to single-repo mode with no behavior change
+
+## Limitations and known gaps
+
+These are known issues that may be addressed in future work.
+
+### Parallel package analysis
+
+Packages are currently analyzed sequentially. For a monorepo with many packages, this means wall-clock time scales linearly with the number of packages. Each package triggers independent LLM calls (framework detection, per-file analysis) that could run concurrently.
+
+### Monorepo / single-repo code duplication
+
+The monorepo and single-repo orchestration paths in `engine/mod.rs` share similar logic (lookup previous data, analyze, upload, cross-repo assembly). These could be unified into a single loop with one entry for single-repo mode.
+
+### `build_cross_repo_analyzer` signature
+
+The function takes a distinguished `current_repo_data` parameter, but internally just pushes it into the list with all other repos. In monorepo mode, the "current" package is arbitrarily chosen (first alphabetically). If this function is ever changed to treat `current_repo_data` specially, the monorepo path would need updating.
+
+### Linear scan for previous data
+
+Previous analysis data is looked up by scanning the full list of downloaded repos per package. Converting to a `HashMap<String, CloudRepoData>` keyed by `repo_name` would be more efficient and would also avoid deep-cloning each match.
+
+### Multiple partial `PackageJson` models
+
+The codebase has several structs that partially model `package.json`:
+
+| Struct | File | Fields |
+|--------|------|--------|
+| `PackageJson` | `packages.rs` | `name`, `version`, `dependencies`, `devDependencies`, `peerDependencies` |
+| `RootPackageJson` | `workspace.rs` | `workspaces` |
+| `PackageJsonSummary` | `framework_detector.rs` | `dependencies`, `dev_dependencies` |
+
+These could be consolidated into a single canonical struct with `#[serde(default)]` on all fields.
+
+### pnpm workspace detection
+
+Monorepos using pnpm that declare workspaces only in `pnpm-workspace.yaml` (not in `package.json`) are not detected. Adding support would require parsing the YAML file as a secondary detection path.
+
+### Complex glob patterns
+
+Workspace patterns like `packages/group-*/app-*` or negation patterns are not supported. Only simple `dir/*` and `dir/**` patterns are expanded. Using a proper glob crate would handle these correctly.

--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -329,6 +329,7 @@ impl CloudStorage for AwsStorage {
                 let repo_data = CloudRepoData {
                     repo_name: adjacent.repo.clone(),
                     service_name: None,
+                    package_name: None,
                     endpoints: Vec::new(),
                     calls: Vec::new(),
                     mounts: Vec::new(),

--- a/src/cloud_storage/mock_storage.rs
+++ b/src/cloud_storage/mock_storage.rs
@@ -77,6 +77,7 @@ impl CloudStorage for MockStorage {
                 CloudRepoData {
                     repo_name: "repo-a".to_string(),
                     service_name: None,
+                    package_name: None,
                     endpoints: vec![],
                     calls: vec![],
                     mounts: vec![],
@@ -100,6 +101,7 @@ impl CloudStorage for MockStorage {
                 CloudRepoData {
                     repo_name: "repo-b".to_string(),
                     service_name: None,
+                    package_name: None,
                     endpoints: vec![],
                     calls: vec![],
                     mounts: vec![],

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -94,6 +94,8 @@ pub struct CloudRepoData {
     pub repo_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_name: Option<String>, // Service name from carrick.json for cross-repo resolution
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package_name: Option<String>, // Workspace package name for monorepo support
     pub endpoints: Vec<ApiEndpointDetails>,
     pub calls: Vec<ApiEndpointDetails>,
     pub mounts: Vec<Mount>,
@@ -210,6 +212,7 @@ impl CloudRepoData {
         Self {
             repo_name,
             service_name,
+            package_name: None,
             endpoints,
             calls,
             mounts,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -24,6 +24,7 @@ use crate::type_manifest::{
 use crate::url_normalizer::UrlNormalizer;
 use crate::utils::get_repository_name;
 use crate::visitor::{FunctionDefinition, FunctionDefinitionExtractor, ImportSymbolExtractor};
+use crate::workspace::detect_workspace;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -115,70 +116,158 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
         .await
         .map_err(|e| format!("Failed to download cross-repo data: {}", e))?;
 
-    // 3. Extract previous data for current repo (if any)
+    // 3. Detect monorepo workspace
     let repo_name = get_repository_name(repo_path);
-    let previous_data = all_repo_data
-        .iter()
-        .find(|r| r.repo_name == repo_name)
-        .cloned();
+    let workspace = detect_workspace(repo_path);
 
-    if previous_data.is_some() {
+    if workspace.is_monorepo {
+        // === Monorepo mode: analyze each package independently ===
+        let mut all_package_data: Vec<CloudRepoData> = Vec::new();
+
+        for package in &workspace.packages {
+            let composite_name = format!("{}::{}", repo_name, package.name);
+            println!(
+                "\n=== Analyzing package: {} ({}) ===",
+                package.name,
+                package.path.display()
+            );
+
+            let previous_data = all_repo_data
+                .iter()
+                .find(|r| r.repo_name == composite_name)
+                .cloned();
+
+            if previous_data.is_some() {
+                println!(
+                    "[incremental] Found previous analysis data for {}",
+                    composite_name
+                );
+            }
+
+            let package_path = package.path.to_string_lossy().to_string();
+            let mut package_data = analyze_current_repo_incremental(
+                &package_path,
+                sidecar,
+                previous_data.as_ref(),
+                Some(repo_path),
+            )
+            .await?;
+
+            // Set composite repo_name and package_name
+            package_data.repo_name = composite_name.clone();
+            package_data.package_name = Some(package.name.clone());
+
+            println!(
+                "Analyzed package {}: {} endpoints, {} calls",
+                package.name,
+                package_data.endpoints.len(),
+                package_data.calls.len()
+            );
+
+            if should_upload {
+                let cloud_data_serialized = strip_ast_nodes(package_data.clone());
+                storage
+                    .upload_repo_data(&carrick_org, &cloud_data_serialized)
+                    .await
+                    .map_err(|e| {
+                        format!("Failed to upload data for package {}: {}", package.name, e)
+                    })?;
+                println!("Uploaded data for package {}", package.name);
+            }
+
+            all_package_data.push(package_data);
+        }
+
+        if !should_upload {
+            println!("Skipping upload (PR/branch mode - analyzing only)");
+        }
+
+        // Cross-repo analysis: remove all current monorepo package entries
+        let composite_prefix = format!("{}::", repo_name);
+        all_repo_data.retain(|repo| {
+            !repo.repo_name.starts_with(&composite_prefix) && repo.repo_name != repo_name
+        });
+
         println!(
-            "[incremental] Found previous analysis data for {}",
-            repo_name
+            "\nDownloaded data from {} external repos",
+            all_repo_data.len()
         );
-    }
 
-    // 4. Analyze (incremental if possible)
-    let current_repo_data =
-        analyze_current_repo_incremental(repo_path, sidecar, previous_data.as_ref()).await?;
-    println!("Analyzed current repo: {}", current_repo_data.repo_name);
+        // Build cross-repo analyzer with all package data + external repos
+        if !all_package_data.is_empty() {
+            // Split: first package is "current", rest go into the pool
+            let first_package = all_package_data.remove(0);
+            all_repo_data.extend(all_package_data);
 
-    // Log sidecar type resolution results if available
-    if current_repo_data.bundled_types.is_some() {
-        println!(
-            "Type resolution: {} bundled types, {} manifest entries",
-            current_repo_data
-                .bundled_types
-                .as_ref()
-                .map(|s| s.lines().count())
-                .unwrap_or(0),
-            current_repo_data
-                .type_manifest
-                .as_ref()
-                .map(|v| v.len())
-                .unwrap_or(0)
-        );
-    }
+            let analyzer = build_cross_repo_analyzer(all_repo_data, first_package).await?;
+            println!("Reconstructed analyzer with cross-repo data");
 
-    // 5. Conditionally upload current repo data to cloud storage
-    if should_upload {
-        let cloud_data_serialized = strip_ast_nodes(current_repo_data.clone());
-        storage
-            .upload_repo_data(&carrick_org, &cloud_data_serialized)
-            .await
-            .map_err(|e| format!("Failed to upload repo data: {}", e))?;
-        println!("Uploaded current repo data to cloud storage");
+            let results = analyzer.get_results();
+            print_results(results);
+        } else {
+            println!("No packages to analyze in monorepo");
+        }
     } else {
-        println!("Skipping upload (PR/branch mode - analyzing only)");
+        // === Single-repo mode: existing behavior unchanged ===
+        let previous_data = all_repo_data
+            .iter()
+            .find(|r| r.repo_name == repo_name)
+            .cloned();
+
+        if previous_data.is_some() {
+            println!(
+                "[incremental] Found previous analysis data for {}",
+                repo_name
+            );
+        }
+
+        let current_repo_data =
+            analyze_current_repo_incremental(repo_path, sidecar, previous_data.as_ref(), None)
+                .await?;
+        println!("Analyzed current repo: {}", current_repo_data.repo_name);
+
+        if current_repo_data.bundled_types.is_some() {
+            println!(
+                "Type resolution: {} bundled types, {} manifest entries",
+                current_repo_data
+                    .bundled_types
+                    .as_ref()
+                    .map(|s| s.lines().count())
+                    .unwrap_or(0),
+                current_repo_data
+                    .type_manifest
+                    .as_ref()
+                    .map(|v| v.len())
+                    .unwrap_or(0)
+            );
+        }
+
+        if should_upload {
+            let cloud_data_serialized = strip_ast_nodes(current_repo_data.clone());
+            storage
+                .upload_repo_data(&carrick_org, &cloud_data_serialized)
+                .await
+                .map_err(|e| format!("Failed to upload repo data: {}", e))?;
+            println!("Uploaded current repo data to cloud storage");
+        } else {
+            println!("Skipping upload (PR/branch mode - analyzing only)");
+        }
+
+        let current_repo_name = &current_repo_data.repo_name;
+        all_repo_data.retain(|repo| &repo.repo_name != current_repo_name);
+
+        println!(
+            "Downloaded data from {} repos (excluding current repo: {})",
+            all_repo_data.len(),
+            current_repo_name
+        );
+
+        let analyzer = build_cross_repo_analyzer(all_repo_data, current_repo_data).await?;
+        println!("Reconstructed analyzer with cross-repo data");
+
+        let results = analyzer.get_results();
+        print_results(results);
     }
-
-    // 6. Cross-repo analysis (reuse already-downloaded data)
-    // Remove current repo from cross-repo data to prevent duplicate processing
-    let current_repo_name = &current_repo_data.repo_name;
-    all_repo_data.retain(|repo| &repo.repo_name != current_repo_name);
-
-    println!(
-        "Downloaded data from {} repos (excluding current repo: {})",
-        all_repo_data.len(),
-        current_repo_name
-    );
-
-    let analyzer = build_cross_repo_analyzer(all_repo_data, current_repo_data).await?;
-    println!("Reconstructed analyzer with cross-repo data");
-
-    let results = analyzer.get_results();
-    print_results(results);
 
     Ok(())
 }
@@ -362,10 +451,13 @@ fn strip_diagnostic_fields(
 }
 
 /// Incremental analysis: reuse cached per-file LLM results for unchanged files.
+/// `repo_root` is the git root directory (used for monorepo packages where repo_path
+/// is a subdirectory). When None, repo_path is assumed to be the git root.
 async fn analyze_current_repo_incremental(
     repo_path: &str,
     sidecar: Option<&TypeSidecar>,
     previous_data: Option<&CloudRepoData>,
+    repo_root: Option<&str>,
 ) -> Result<CloudRepoData, Box<dyn std::error::Error>> {
     let start = Instant::now();
 
@@ -414,7 +506,9 @@ async fn analyze_current_repo_incremental(
         );
 
         // Get changed files via git diff
-        if let Some(changed_files) = get_changed_files(repo_path, prev_commit) {
+        // For monorepo packages, run git from the repo root and filter by package prefix
+        let git_dir = repo_root.unwrap_or(repo_path);
+        if let Some(changed_files) = get_changed_files(git_dir, prev_commit) {
             let prev_file_results = prev.file_results.as_ref().unwrap();
             let repo_prefix = format!("{}/", repo_path);
 
@@ -433,8 +527,32 @@ async fn analyze_current_repo_incremental(
             // Build set of currently discovered file paths (normalized to relative)
             let current_file_set: HashSet<String> = files.iter().map(&normalize_path).collect();
 
-            // Normalize changed files relative to repo root
-            let changed_set: HashSet<String> = changed_files.into_iter().collect();
+            // For monorepo packages, git diff returns paths relative to repo root
+            // (e.g., "apps/event-api/src/app.ts"), but our file normalization yields
+            // paths relative to the package dir (e.g., "src/app.ts").
+            // Compute the package prefix to filter and strip changed files.
+            let changed_set: HashSet<String> = if let Some(root) = repo_root {
+                let canon_root = std::fs::canonicalize(root)
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|_| root.to_string());
+                let package_prefix = repo_path
+                    .strip_prefix(&format!("{}/", canon_root))
+                    .or_else(|| repo_path.strip_prefix(&canon_root))
+                    .unwrap_or("");
+
+                let prefix_with_slash = if package_prefix.is_empty() {
+                    String::new()
+                } else {
+                    format!("{}/", package_prefix)
+                };
+
+                changed_files
+                    .into_iter()
+                    .filter_map(|f| f.strip_prefix(&prefix_with_slash).map(|s| s.to_string()))
+                    .collect()
+            } else {
+                changed_files.into_iter().collect()
+            };
 
             // Partition: which files need fresh analysis?
             let files_to_analyze: Vec<PathBuf> = files
@@ -688,6 +806,7 @@ fn build_cloud_data_from_mount_graph(
     CloudRepoData {
         repo_name: repo_name.to_string(),
         service_name,
+        package_name: None,
         endpoints,
         calls,
         mounts,
@@ -1461,6 +1580,7 @@ mod tests {
         let test_data = CloudRepoData {
             repo_name: "test-repo".to_string(),
             service_name: None,
+            package_name: None,
             endpoints: vec![endpoint.clone()],
             calls: vec![endpoint.clone()],
             mounts: vec![],
@@ -1499,6 +1619,7 @@ mod tests {
         let test_data = vec![CloudRepoData {
             repo_name: "test-repo".to_string(),
             service_name: None,
+            package_name: None,
             endpoints: vec![],
             calls: vec![],
             mounts: vec![],
@@ -1572,6 +1693,7 @@ mod tests {
         let test_data = vec![CloudRepoData {
             repo_name: "test-repo".to_string(),
             service_name: None,
+            package_name: None,
             endpoints: vec![endpoint.clone()],
             calls: vec![endpoint.clone()],
             mounts: vec![],
@@ -1921,6 +2043,7 @@ mod tests {
         let data = CloudRepoData {
             repo_name: "test-repo".to_string(),
             service_name: None,
+            package_name: None,
             endpoints: vec![],
             calls: vec![],
             mounts: vec![],
@@ -1962,6 +2085,7 @@ mod tests {
         let data = CloudRepoData {
             repo_name: "test-repo".to_string(),
             service_name: None,
+            package_name: None,
             endpoints: vec![],
             calls: vec![],
             mounts: vec![],
@@ -2090,6 +2214,7 @@ mod tests {
         let data = CloudRepoData {
             repo_name: "test-repo".to_string(),
             service_name: None,
+            package_name: None,
             endpoints: vec![],
             calls: vec![],
             mounts: vec![],

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -49,6 +49,8 @@ type FileDiscoveryResult = Result<
         HashMap<String, crate::visitor::ImportedSymbol>,
         HashMap<String, FunctionDefinition>,
         String,
+        Option<PathBuf>, // config file path
+        Option<PathBuf>, // package.json path
     ),
     Box<dyn std::error::Error>,
 >;
@@ -116,12 +118,18 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
         .await
         .map_err(|e| format!("Failed to download cross-repo data: {}", e))?;
 
-    // 3. Detect monorepo workspace
     let repo_name = get_repository_name(repo_path);
     let workspace = detect_workspace(repo_path);
 
     if workspace.is_monorepo {
-        // === Monorepo mode: analyze each package independently ===
+        println!(
+            "[workspace] Detected monorepo with {} packages:",
+            workspace.packages.len()
+        );
+        for pkg in &workspace.packages {
+            println!("  - {} ({})", pkg.name, pkg.path.display());
+        }
+
         let mut all_package_data: Vec<CloudRepoData> = Vec::new();
 
         for package in &workspace.packages {
@@ -153,8 +161,7 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
             )
             .await?;
 
-            // Set composite repo_name and package_name
-            package_data.repo_name = composite_name.clone();
+            package_data.repo_name = composite_name;
             package_data.package_name = Some(package.name.clone());
 
             println!(
@@ -182,7 +189,6 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
             println!("Skipping upload (PR/branch mode - analyzing only)");
         }
 
-        // Cross-repo analysis: remove all current monorepo package entries
         let composite_prefix = format!("{}::", repo_name);
         all_repo_data.retain(|repo| {
             !repo.repo_name.starts_with(&composite_prefix) && repo.repo_name != repo_name
@@ -193,9 +199,7 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
             all_repo_data.len()
         );
 
-        // Build cross-repo analyzer with all package data + external repos
         if !all_package_data.is_empty() {
-            // Split: first package is "current", rest go into the pool
             let first_package = all_package_data.remove(0);
             all_repo_data.extend(all_package_data);
 
@@ -208,7 +212,6 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
             println!("No packages to analyze in monorepo");
         }
     } else {
-        // === Single-repo mode: existing behavior unchanged ===
         let previous_data = all_repo_data
             .iter()
             .find(|r| r.repo_name == repo_name)
@@ -394,6 +397,45 @@ fn get_changed_files(repo_path: &str, base_commit: &str) -> Option<Vec<String>> 
     Some(changed)
 }
 
+/// Filter git diff paths for a monorepo package.
+/// Git diff returns paths relative to the repo root (e.g., "apps/event-api/src/app.ts"),
+/// but file discovery normalizes to package-relative paths (e.g., "src/app.ts").
+/// This function strips the package prefix so the paths match.
+fn filter_changed_files_for_package(
+    changed_files: Vec<String>,
+    repo_path: &str,
+    repo_root: Option<&str>,
+) -> HashSet<String> {
+    let Some(root) = repo_root else {
+        return changed_files.into_iter().collect();
+    };
+
+    let canon_root = std::fs::canonicalize(root)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| root.to_string());
+
+    let package_prefix = repo_path
+        .strip_prefix(&format!("{}/", canon_root))
+        .or_else(|| repo_path.strip_prefix(&canon_root))
+        .unwrap_or("");
+
+    if package_prefix.is_empty() {
+        eprintln!(
+            "[incremental] WARNING: Could not compute package prefix (repo_path={}, root={}), \
+             falling back to full diff",
+            repo_path, canon_root
+        );
+        return changed_files.into_iter().collect();
+    }
+
+    let prefix_with_slash = format!("{}/", package_prefix);
+
+    changed_files
+        .into_iter()
+        .filter_map(|f| f.strip_prefix(&prefix_with_slash).map(|s| s.to_string()))
+        .collect()
+}
+
 /// Hash file content for cache invalidation (package.json).
 fn hash_file_content(content: &str) -> String {
     let mut hasher = Sha256::new();
@@ -467,13 +509,11 @@ async fn analyze_current_repo_incremental(
         .unwrap_or_else(|_| repo_path.to_string());
     let repo_path = canonical.as_str();
 
-    // 1. Discover files and symbols (fast SWC pass, always full)
     let cm: Lrc<SourceMap> = Default::default();
-    let (files, all_imported_symbols, function_definitions, repo_name) =
+    let (files, all_imported_symbols, function_definitions, repo_name, config_file, package_json) =
         discover_files_and_symbols(repo_path, cm.clone())?;
 
-    // 2. Load config and packages
-    let (config, packages) = load_config_and_packages(repo_path)?;
+    let (config, packages) = load_config_and_packages(config_file, package_json)?;
 
     // 3. Check if we can use incremental mode
     let can_use_incremental = previous_data
@@ -505,14 +545,11 @@ async fn analyze_current_repo_incremental(
             &prev_commit[..std::cmp::min(7, prev_commit.len())]
         );
 
-        // Get changed files via git diff
-        // For monorepo packages, run git from the repo root and filter by package prefix
         let git_dir = repo_root.unwrap_or(repo_path);
         if let Some(changed_files) = get_changed_files(git_dir, prev_commit) {
             let prev_file_results = prev.file_results.as_ref().unwrap();
             let repo_prefix = format!("{}/", repo_path);
 
-            // Helper to normalize a file path to repo-relative
             let normalize_path = |f: &PathBuf| -> String {
                 let s = f.to_string_lossy();
                 if let Some(stripped) = s.strip_prefix(&repo_prefix) {
@@ -524,35 +561,10 @@ async fn analyze_current_repo_incremental(
                 }
             };
 
-            // Build set of currently discovered file paths (normalized to relative)
             let current_file_set: HashSet<String> = files.iter().map(&normalize_path).collect();
 
-            // For monorepo packages, git diff returns paths relative to repo root
-            // (e.g., "apps/event-api/src/app.ts"), but our file normalization yields
-            // paths relative to the package dir (e.g., "src/app.ts").
-            // Compute the package prefix to filter and strip changed files.
-            let changed_set: HashSet<String> = if let Some(root) = repo_root {
-                let canon_root = std::fs::canonicalize(root)
-                    .map(|p| p.to_string_lossy().to_string())
-                    .unwrap_or_else(|_| root.to_string());
-                let package_prefix = repo_path
-                    .strip_prefix(&format!("{}/", canon_root))
-                    .or_else(|| repo_path.strip_prefix(&canon_root))
-                    .unwrap_or("");
-
-                let prefix_with_slash = if package_prefix.is_empty() {
-                    String::new()
-                } else {
-                    format!("{}/", package_prefix)
-                };
-
-                changed_files
-                    .into_iter()
-                    .filter_map(|f| f.strip_prefix(&prefix_with_slash).map(|s| s.to_string()))
-                    .collect()
-            } else {
-                changed_files.into_iter().collect()
-            };
+            let changed_set: HashSet<String> =
+                filter_changed_files_for_package(changed_files, repo_path, repo_root);
 
             // Partition: which files need fresh analysis?
             let files_to_analyze: Vec<PathBuf> = files
@@ -889,14 +901,15 @@ fn resolve_types_if_available(
     }
 }
 
-/// Discover files and extract symbols for MultiAgentOrchestrator
+/// Discover files and extract symbols for MultiAgentOrchestrator.
+/// Returns source files, symbols, function defs, repo name, and config/package.json paths
+/// from a single directory traversal.
 fn discover_files_and_symbols(repo_path: &str, cm: Lrc<SourceMap>) -> FileDiscoveryResult {
     let handler = Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(cm.clone()));
     let repo_name = get_repository_name(repo_path);
 
-    // Find files in current repo only
     let ignore_patterns = ["node_modules", "dist", "build", ".next", "ts_check"];
-    let (files, _, _) = find_files(repo_path, &ignore_patterns);
+    let (files, config_file, package_json) = find_files(repo_path, &ignore_patterns);
 
     println!(
         "Found {} files to analyze in directory {}",
@@ -904,18 +917,15 @@ fn discover_files_and_symbols(repo_path: &str, cm: Lrc<SourceMap>) -> FileDiscov
         repo_path
     );
 
-    // Extract imported symbols and function definitions by parsing files
     let mut all_imported_symbols = HashMap::new();
     let mut all_function_definitions = HashMap::new();
 
     for file_path in &files {
         if let Some(module) = parse_file(file_path, &cm, &handler) {
-            // Extract import symbols
             let mut import_extractor = ImportSymbolExtractor::new();
             module.visit_with(&mut import_extractor);
             all_imported_symbols.extend(import_extractor.imported_symbols);
 
-            // Extract function definitions with type annotations
             let mut func_extractor = FunctionDefinitionExtractor::new(file_path.clone());
             module.visit_with(&mut func_extractor);
             all_function_definitions.extend(func_extractor.function_definitions);
@@ -934,16 +944,16 @@ fn discover_files_and_symbols(repo_path: &str, cm: Lrc<SourceMap>) -> FileDiscov
         all_imported_symbols,
         all_function_definitions,
         repo_name,
+        config_file,
+        package_json,
     ))
 }
 
-/// Extract config and package loading logic
+/// Load config and packages from pre-discovered file paths (avoids redundant directory traversal).
 fn load_config_and_packages(
-    repo_path: &str,
+    config_file_path: Option<PathBuf>,
+    package_json_path: Option<PathBuf>,
 ) -> Result<(Config, Packages), Box<dyn std::error::Error>> {
-    let ignore_patterns = ["node_modules", "dist", "build", ".next", "ts_check"];
-    let (_, config_file_path, package_json_path) = find_files(repo_path, &ignore_patterns);
-
     let config = if let Some(config_path) = config_file_path {
         println!("Found carrick.json file: {}", config_path.display());
         Config::new(vec![config_path]).unwrap_or_else(|e| {
@@ -1189,9 +1199,8 @@ async fn analyze_current_repo(
         repo_path
     );
 
-    // 1. Create shared SourceMap and discover files and symbols
     let cm: Lrc<SourceMap> = Default::default();
-    let (files, all_imported_symbols, function_definitions, repo_name) =
+    let (files, all_imported_symbols, function_definitions, repo_name, config_file, package_json) =
         discover_files_and_symbols(repo_path, cm.clone())?;
     println!(
         "Extracted repository name: '{}' from {} files ({} function definitions)",
@@ -1200,8 +1209,7 @@ async fn analyze_current_repo(
         function_definitions.len()
     );
 
-    // 2. Load config and packages using existing logic
-    let (config, packages) = load_config_and_packages(repo_path)?;
+    let (config, packages) = load_config_and_packages(config_file, package_json)?;
 
     // 3. Get API key and create MultiAgentOrchestrator
     let api_key = env::var("CARRICK_API_KEY")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,4 +22,5 @@ pub mod type_manifest;
 pub mod url_normalizer;
 pub mod utils;
 pub mod visitor;
+pub mod workspace;
 pub mod wrapper_registry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod type_manifest;
 mod url_normalizer;
 mod utils;
 mod visitor;
+mod workspace;
 mod wrapper_registry;
 
 use crate::cloud_storage::{AwsStorage, MockStorage};

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,11 +1,10 @@
+use crate::packages::PackageJson;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
 pub struct WorkspacePackage {
-    /// Package name from package.json "name" field
     pub name: String,
-    /// Absolute path to the package directory
     pub path: PathBuf,
 }
 
@@ -21,7 +20,7 @@ struct RootPackageJson {
     workspaces: WorkspacesField,
 }
 
-/// package.json "workspaces" can be an array of globs or an object with a "packages" array
+/// package.json "workspaces" can be an array of globs or an object with a "packages" array.
 #[derive(Deserialize, Default)]
 #[serde(untagged)]
 enum WorkspacesField {
@@ -42,11 +41,6 @@ impl WorkspacesField {
             WorkspacesField::None => &[],
         }
     }
-}
-
-#[derive(Deserialize)]
-struct PackageJsonName {
-    name: Option<String>,
 }
 
 /// Detect whether the given repo path is a monorepo with workspace packages.
@@ -114,13 +108,12 @@ pub fn detect_workspace(repo_path: &str) -> WorkspaceInfo {
                 continue;
             }
 
-            // Read the package name
             let pkg_content = match std::fs::read_to_string(&pkg_json_path) {
                 Ok(c) => c,
                 Err(_) => continue,
             };
 
-            let pkg: PackageJsonName = match serde_json::from_str(&pkg_content) {
+            let pkg: PackageJson = match serde_json::from_str(&pkg_content) {
                 Ok(p) => p,
                 Err(_) => continue,
             };
@@ -140,22 +133,10 @@ pub fn detect_workspace(repo_path: &str) -> WorkspaceInfo {
         }
     }
 
-    // Sort by name for deterministic ordering
     packages.sort_by(|a, b| a.name.cmp(&b.name));
 
-    let is_monorepo = !packages.is_empty();
-    if is_monorepo {
-        println!(
-            "[workspace] Detected monorepo with {} packages:",
-            packages.len()
-        );
-        for pkg in &packages {
-            println!("  - {} ({})", pkg.name, pkg.path.display());
-        }
-    }
-
     WorkspaceInfo {
-        is_monorepo,
+        is_monorepo: !packages.is_empty(),
         packages,
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,278 @@
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct WorkspacePackage {
+    /// Package name from package.json "name" field
+    pub name: String,
+    /// Absolute path to the package directory
+    pub path: PathBuf,
+}
+
+#[derive(Debug)]
+pub struct WorkspaceInfo {
+    pub is_monorepo: bool,
+    pub packages: Vec<WorkspacePackage>,
+}
+
+#[derive(Deserialize)]
+struct RootPackageJson {
+    #[serde(default)]
+    workspaces: WorkspacesField,
+}
+
+/// package.json "workspaces" can be an array of globs or an object with a "packages" array
+#[derive(Deserialize, Default)]
+#[serde(untagged)]
+enum WorkspacesField {
+    Array(Vec<String>),
+    Object {
+        #[serde(default)]
+        packages: Vec<String>,
+    },
+    #[default]
+    None,
+}
+
+impl WorkspacesField {
+    fn patterns(&self) -> &[String] {
+        match self {
+            WorkspacesField::Array(v) => v,
+            WorkspacesField::Object { packages } => packages,
+            WorkspacesField::None => &[],
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct PackageJsonName {
+    name: Option<String>,
+}
+
+/// Detect whether the given repo path is a monorepo with workspace packages.
+/// Reads the root package.json for a "workspaces" field and expands the glob patterns.
+pub fn detect_workspace(repo_path: &str) -> WorkspaceInfo {
+    let root = Path::new(repo_path);
+    let pkg_path = root.join("package.json");
+
+    let content = match std::fs::read_to_string(&pkg_path) {
+        Ok(c) => c,
+        Err(_) => {
+            return WorkspaceInfo {
+                is_monorepo: false,
+                packages: vec![],
+            };
+        }
+    };
+
+    let root_pkg: RootPackageJson = match serde_json::from_str(&content) {
+        Ok(p) => p,
+        Err(_) => {
+            return WorkspaceInfo {
+                is_monorepo: false,
+                packages: vec![],
+            };
+        }
+    };
+
+    let patterns = root_pkg.workspaces.patterns();
+    if patterns.is_empty() {
+        return WorkspaceInfo {
+            is_monorepo: false,
+            packages: vec![],
+        };
+    }
+
+    let mut packages = Vec::new();
+
+    for pattern in patterns {
+        // Handle simple glob patterns like "apps/*" or "packages/*"
+        // Strip trailing /* or /** to get the base directory
+        let base_dir = pattern
+            .trim_end_matches("/**")
+            .trim_end_matches("/*")
+            .trim_end_matches('/');
+
+        let search_dir = root.join(base_dir);
+        if !search_dir.is_dir() {
+            continue;
+        }
+
+        let entries = match std::fs::read_dir(&search_dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for entry in entries.flatten() {
+            let entry_path = entry.path();
+            if !entry_path.is_dir() {
+                continue;
+            }
+
+            let pkg_json_path = entry_path.join("package.json");
+            if !pkg_json_path.exists() {
+                continue;
+            }
+
+            // Read the package name
+            let pkg_content = match std::fs::read_to_string(&pkg_json_path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            let pkg: PackageJsonName = match serde_json::from_str(&pkg_content) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+
+            let name = pkg.name.unwrap_or_else(|| {
+                entry_path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            });
+
+            packages.push(WorkspacePackage {
+                name,
+                path: entry_path,
+            });
+        }
+    }
+
+    // Sort by name for deterministic ordering
+    packages.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let is_monorepo = !packages.is_empty();
+    if is_monorepo {
+        println!(
+            "[workspace] Detected monorepo with {} packages:",
+            packages.len()
+        );
+        for pkg in &packages {
+            println!("  - {} ({})", pkg.name, pkg.path.display());
+        }
+    }
+
+    WorkspaceInfo {
+        is_monorepo,
+        packages,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn detect_workspace_with_array_workspaces() {
+        let tmp = tempdir().expect("temp dir");
+        let root = tmp.path();
+
+        // Create root package.json with workspaces
+        fs::write(
+            root.join("package.json"),
+            r#"{"name": "monorepo", "workspaces": ["apps/*"]}"#,
+        )
+        .unwrap();
+
+        // Create two app packages
+        let app_a = root.join("apps").join("app-a");
+        fs::create_dir_all(&app_a).unwrap();
+        fs::write(app_a.join("package.json"), r#"{"name": "app-a"}"#).unwrap();
+
+        let app_b = root.join("apps").join("app-b");
+        fs::create_dir_all(&app_b).unwrap();
+        fs::write(app_b.join("package.json"), r#"{"name": "app-b"}"#).unwrap();
+
+        let info = detect_workspace(root.to_str().unwrap());
+
+        assert!(info.is_monorepo);
+        assert_eq!(info.packages.len(), 2);
+        assert_eq!(info.packages[0].name, "app-a");
+        assert_eq!(info.packages[1].name, "app-b");
+    }
+
+    #[test]
+    fn detect_workspace_not_monorepo() {
+        let tmp = tempdir().expect("temp dir");
+        let root = tmp.path();
+
+        fs::write(
+            root.join("package.json"),
+            r#"{"name": "single-repo", "version": "1.0.0"}"#,
+        )
+        .unwrap();
+
+        let info = detect_workspace(root.to_str().unwrap());
+
+        assert!(!info.is_monorepo);
+        assert!(info.packages.is_empty());
+    }
+
+    #[test]
+    fn detect_workspace_no_package_json() {
+        let tmp = tempdir().expect("temp dir");
+        let info = detect_workspace(tmp.path().to_str().unwrap());
+
+        assert!(!info.is_monorepo);
+        assert!(info.packages.is_empty());
+    }
+
+    #[test]
+    fn detect_workspace_with_multiple_patterns() {
+        let tmp = tempdir().expect("temp dir");
+        let root = tmp.path();
+
+        fs::write(
+            root.join("package.json"),
+            r#"{"name": "monorepo", "workspaces": ["apps/*", "libs/*"]}"#,
+        )
+        .unwrap();
+
+        let app = root.join("apps").join("my-app");
+        fs::create_dir_all(&app).unwrap();
+        fs::write(app.join("package.json"), r#"{"name": "my-app"}"#).unwrap();
+
+        let lib = root.join("libs").join("my-lib");
+        fs::create_dir_all(&lib).unwrap();
+        fs::write(lib.join("package.json"), r#"{"name": "@scope/my-lib"}"#).unwrap();
+
+        let info = detect_workspace(root.to_str().unwrap());
+
+        assert!(info.is_monorepo);
+        assert_eq!(info.packages.len(), 2);
+        // Sorted by name: "@scope/my-lib" comes before "my-app"
+        assert_eq!(info.packages[0].name, "@scope/my-lib");
+        assert_eq!(info.packages[1].name, "my-app");
+    }
+
+    #[test]
+    fn detect_workspace_skips_dirs_without_package_json() {
+        let tmp = tempdir().expect("temp dir");
+        let root = tmp.path();
+
+        fs::write(
+            root.join("package.json"),
+            r#"{"name": "monorepo", "workspaces": ["apps/*"]}"#,
+        )
+        .unwrap();
+
+        // One app with package.json
+        let app = root.join("apps").join("real-app");
+        fs::create_dir_all(&app).unwrap();
+        fs::write(app.join("package.json"), r#"{"name": "real-app"}"#).unwrap();
+
+        // One dir without package.json
+        let no_pkg = root.join("apps").join("not-a-package");
+        fs::create_dir_all(&no_pkg).unwrap();
+
+        let info = detect_workspace(root.to_str().unwrap());
+
+        assert!(info.is_monorepo);
+        assert_eq!(info.packages.len(), 1);
+        assert_eq!(info.packages[0].name, "real-app");
+    }
+}

--- a/tests/mock_storage_test.rs
+++ b/tests/mock_storage_test.rs
@@ -25,6 +25,7 @@ fn create_test_repo_data(repo_name: &str, commit_hash: &str) -> CloudRepoData {
     CloudRepoData {
         repo_name: repo_name.to_string(),
         service_name: None,
+        package_name: None,
         endpoints: vec![],
         calls: vec![],
         mounts: vec![],


### PR DESCRIPTION
## Summary

- Auto-detect monorepo workspaces by reading the root `package.json` `workspaces` field (Yarn/npm workspaces)
- When detected, analyze each workspace package independently with its own framework detection, mount graph, and `CloudRepoData`
- Use composite storage keys (`repo::package`) so cross-repo comparison works automatically between packages and external repos
- Single-repo behavior is completely unchanged

## Changes

- **New:** `src/workspace.rs` — workspace detection with `WorkspaceInfo`/`WorkspacePackage` structs and 5 unit tests
- **Modified:** `src/engine/mod.rs` — monorepo loop in `run_analysis_engine_with_sidecar`, git diff path normalization for package subdirectories
- **Modified:** `src/cloud_storage/mod.rs` — `package_name` field on `CloudRepoData`
- **Minor:** module registration in `lib.rs`/`main.rs`, `package_name: None` in all existing constructors

## Test plan

- [x] `cargo build` compiles clean
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — all 371 tests pass (including 5 new workspace detection tests)
- [ ] Run against optaxe-ts-monorepo with `CARRICK_MOCK_ALL=true` to verify package detection and per-package analysis
- [ ] Run against a single-repo to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)