### PR TITLE
fix: MCP server type safety, bug fixes, and test coverage

### DIFF
--- a/.github/workflows/carrick.yml
+++ b/.github/workflows/carrick.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run Carrick Analysis on entire repo
         id: carrick-analysis
-        uses: ./
+        uses: daveymoores/carrick@carrick-v0.1.3
         with:
           carrick-org: ${{ secrets.CARRICK_ORG }}
           carrick-api-key: ${{ secrets.CARRICK_API_KEY }}

--- a/.github/workflows/carrick.yml
+++ b/.github/workflows/carrick.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run Carrick Analysis on entire repo
         id: carrick-analysis
-        uses: daveymoores/carrick@carrick-v0.1.3
+        uses: ./
         with:
           carrick-org: ${{ secrets.CARRICK_ORG }}
           carrick-api-key: ${{ secrets.CARRICK_API_KEY }}

--- a/.github/workflows/carrick.yml
+++ b/.github/workflows/carrick.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run Carrick Analysis on entire repo
         id: carrick-analysis
-        uses: daveymoores/carrick@carrick-v0.1.3
+        uses: daveymoores/carrick@v1
         with:
           carrick-org: ${{ secrets.CARRICK_ORG }}
           carrick-api-key: ${{ secrets.CARRICK_API_KEY }}

--- a/.github/workflows/carrick.yml
+++ b/.github/workflows/carrick.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run Carrick Analysis on entire repo
         id: carrick-analysis
-        uses: daveymoores/carrick@v1
+        uses: daveymoores/carrick@carrick-v0.1.3
         with:
           carrick-org: ${{ secrets.CARRICK_ORG }}
           carrick-api-key: ${{ secrets.CARRICK_API_KEY }}

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -1,0 +1,13 @@
+# Carrick MCP Server environment variables
+
+# URL of the Carrick API (Lambda endpoint)
+CARRICK_API_ENDPOINT=https://api.carrick.tools
+
+# API key for authenticating with the Carrick API
+CARRICK_API_KEY=your-api-key-here
+
+# Organization name (matches the org configured in the Carrick GitHub Action)
+CARRICK_ORG=your-org-name
+
+# Comma-separated list of valid API keys for authenticating incoming MCP requests (Lambda only)
+VALID_API_KEYS=key1,key2

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -17,7 +17,8 @@
         "@types/express": "^4.17.21",
         "@types/node": "^20.0.0",
         "esbuild": "^0.24.0",
-        "typescript": "^5.8.0"
+        "typescript": "^5.8.0",
+        "vitest": "^4.1.2"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -30,6 +31,43 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -389,6 +427,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.24.2",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
@@ -468,6 +524,13 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
@@ -778,6 +841,315 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -789,6 +1161,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -798,6 +1181,20 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.25",
@@ -896,6 +1293,92 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -947,6 +1430,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -1037,6 +1530,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1057,6 +1560,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1132,6 +1642,16 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1178,6 +1698,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1238,6 +1765,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1268,12 +1805,21 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1355,6 +1901,24 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -1389,6 +1953,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1478,7 +2057,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1576,6 +2154,277 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1651,6 +2500,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1680,6 +2548,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -1726,6 +2605,33 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -1733,6 +2639,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/proxy-addr": {
@@ -1794,6 +2729,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
       }
     },
     "node_modules/router": {
@@ -2015,6 +2984,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2022,6 +3015,57 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -2032,6 +3076,14 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -2094,6 +3146,687 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2109,6 +3842,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2120,7 +3870,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -26,7 +26,7 @@
     "vitest": "^4.1.2"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "private": true
 }

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -8,7 +8,9 @@
     "build": "tsc",
     "build:lambda": "node esbuild.config.mjs",
     "start": "node dist/index.js",
-    "clean": "rm -rf dist dist-lambda"
+    "clean": "rm -rf dist dist-lambda",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@codegenie/serverless-express": "^4.15.0",
@@ -20,7 +22,8 @@
     "@types/express": "^4.17.21",
     "@types/node": "^20.0.0",
     "esbuild": "^0.24.0",
-    "typescript": "^5.8.0"
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.2"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/mcp-server/src/lambda.ts
+++ b/mcp-server/src/lambda.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import serverlessExpress from "@codegenie/serverless-express";
+import { configure as serverlessExpress } from "@codegenie/serverless-express";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { ApiClient } from "./api-client.js";
 import { createServer } from "./server.js";

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -19,14 +19,14 @@ export function createServer(client: ApiClient): McpServer {
 
   server.tool(
     "list_services",
-    "List all services in the org with endpoint counts, call counts, and type availability",
+    "List all services in the organization with endpoint counts, API call counts, and whether TypeScript types are available. Use this first to discover what services exist before drilling into specific endpoints or types.",
     {},
     async () => listServices(client),
   );
 
   server.tool(
     "get_api_endpoints",
-    "Get the API endpoints exposed by a service. Returns method, path, handler, owner, and file location.",
+    "Get the API endpoints exposed by a single service. Returns method, path, handler, owner, and file location for each endpoint. Use this to explore what routes a service exposes before checking types or compatibility.",
     {
       service: z.string().describe("Service name to look up (fuzzy match by repo name, service name, or trailing segment)"),
       method: z.string().optional().describe("Filter by HTTP method (GET, POST, etc.)"),
@@ -37,7 +37,7 @@ export function createServer(client: ApiClient): McpServer {
 
   server.tool(
     "get_endpoint_types",
-    "Get the request/response TypeScript type definitions for a specific API endpoint. This is the highest-value tool — returns extracted .d.ts types.",
+    "Get the TypeScript request/response type definitions for a specific API endpoint. Returns extracted .d.ts types including whether they were explicitly annotated or inferred. Use get_api_endpoints first to find the exact method and path.",
     {
       service: z.string().describe("Service name"),
       method: z.string().describe("HTTP method (GET, POST, PUT, DELETE)"),
@@ -48,7 +48,7 @@ export function createServer(client: ApiClient): McpServer {
 
   server.tool(
     "check_compatibility",
-    "Check if a consumer's API calls are compatible with a producer's endpoints. Finds missing endpoints and unused endpoints.",
+    "Check if a specific consumer service's API calls are compatible with a specific producer service's endpoints. Compares one consumer-producer pair — reports missing endpoints (consumer calls something the producer doesn't expose) and unused endpoints. Use list_services first to find service names.",
     {
       consumer_service: z.string().describe("The service making API calls"),
       producer_service: z.string().describe("The service exposing endpoints"),
@@ -60,7 +60,7 @@ export function createServer(client: ApiClient): McpServer {
 
   server.tool(
     "get_service_dependencies",
-    "Get package dependencies for a service, or find version conflicts across all services in the org.",
+    "Get npm package dependencies for a single service, or omit the service parameter to find version conflicts across all services in the organization. Useful for detecting mismatched dependency versions that could cause runtime issues.",
     {
       service: z.string().optional().describe("Service name (omit for org-wide conflict analysis)"),
     },

--- a/mcp-server/src/tools/__tests__/check-compat.test.ts
+++ b/mcp-server/src/tools/__tests__/check-compat.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { checkCompatibility } from "../check-compat.js";
+import { ApiClient } from "../../api-client.js";
+import { CloudRepoData } from "../../types.js";
+
+function makeRepoData(
+  overrides: Partial<CloudRepoData> = {},
+): CloudRepoData {
+  return {
+    repo_name: "org/test-service",
+    endpoints: [],
+    calls: [],
+    mounts: [],
+    apps: {},
+    imported_handlers: [],
+    function_definitions: {},
+    last_updated: "2026-01-01T00:00:00Z",
+    commit_hash: "abc123",
+    ...overrides,
+  };
+}
+
+function makeProducer(
+  endpoints: Array<{ method: string; path: string }>,
+): CloudRepoData {
+  return makeRepoData({
+    repo_name: "org/producer-api",
+    service_name: "producer-api",
+    mount_graph: {
+      nodes: {},
+      mounts: [],
+      data_calls: [],
+      endpoints: endpoints.map((e) => ({
+        method: e.method,
+        full_path: e.path,
+        path: e.path,
+        owner: "app",
+        file_location: "src/routes.ts",
+        middleware_chain: [],
+      })),
+    },
+  });
+}
+
+function makeConsumer(
+  calls: Array<{ method: string; url: string }>,
+): CloudRepoData {
+  return makeRepoData({
+    repo_name: "org/consumer-app",
+    service_name: "consumer-app",
+    mount_graph: {
+      nodes: {},
+      mounts: [],
+      endpoints: [],
+      data_calls: calls.map((c) => ({
+        method: c.method,
+        target_url: c.url,
+        client: "axios",
+        file_location: "src/api.ts",
+      })),
+    },
+  });
+}
+
+function mockClient(repos: CloudRepoData[]): ApiClient {
+  return {
+    getAllRepoData: vi.fn().mockResolvedValue(repos),
+    findService: vi.fn(),
+    invalidateCache: vi.fn(),
+  } as unknown as ApiClient;
+}
+
+function parseResult(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("checkCompatibility", () => {
+  it("reports compatible when all consumer calls match producer endpoints", async () => {
+    const producer = makeProducer([
+      { method: "GET", path: "/api/users" },
+      { method: "GET", path: "/api/users/:id" },
+    ]);
+    const consumer = makeConsumer([
+      { method: "GET", url: "/api/users" },
+      { method: "GET", url: "/api/users/:id" },
+    ]);
+    const client = mockClient([producer, consumer]);
+
+    const result = await checkCompatibility(client, {
+      consumer_service: "consumer-app",
+      producer_service: "producer-api",
+    });
+
+    const data = parseResult(result);
+    expect(data.compatible).toBe(true);
+    expect(data.issues.filter((i: { severity: string }) => i.severity === "error")).toHaveLength(0);
+  });
+
+  it("reports missing endpoint when consumer calls something producer doesn't expose", async () => {
+    const producer = makeProducer([
+      { method: "GET", path: "/api/users" },
+    ]);
+    const consumer = makeConsumer([
+      { method: "GET", url: "/api/users" },
+      { method: "DELETE", url: "/api/users/:id" },
+    ]);
+    const client = mockClient([producer, consumer]);
+
+    const result = await checkCompatibility(client, {
+      consumer_service: "consumer-app",
+      producer_service: "producer-api",
+    });
+
+    const data = parseResult(result);
+    expect(data.compatible).toBe(false);
+    const errors = data.issues.filter((i: { severity: string }) => i.severity === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].category).toBe("missing_endpoint");
+    expect(errors[0].message).toContain("DELETE");
+  });
+
+  it("reports unused endpoints as info", async () => {
+    const producer = makeProducer([
+      { method: "GET", path: "/api/users" },
+      { method: "POST", path: "/api/users" },
+      { method: "DELETE", path: "/api/users/:id" },
+    ]);
+    const consumer = makeConsumer([
+      { method: "GET", url: "/api/users" },
+    ]);
+    const client = mockClient([producer, consumer]);
+
+    const result = await checkCompatibility(client, {
+      consumer_service: "consumer-app",
+      producer_service: "producer-api",
+    });
+
+    const data = parseResult(result);
+    expect(data.compatible).toBe(true);
+    const infos = data.issues.filter((i: { severity: string }) => i.severity === "info");
+    expect(infos).toHaveLength(2);
+    expect(infos.every((i: { category: string }) => i.category === "unused_endpoint")).toBe(true);
+  });
+
+  it("matches endpoints with different param styles", async () => {
+    const producer = makeProducer([
+      { method: "GET", path: "/api/users/:id" },
+    ]);
+    const consumer = makeConsumer([
+      { method: "GET", url: "/api/users/{id}" },
+    ]);
+    const client = mockClient([producer, consumer]);
+
+    const result = await checkCompatibility(client, {
+      consumer_service: "consumer-app",
+      producer_service: "producer-api",
+    });
+
+    const data = parseResult(result);
+    expect(data.compatible).toBe(true);
+  });
+
+  it("filters by method when provided", async () => {
+    const producer = makeProducer([
+      { method: "GET", path: "/api/users" },
+      { method: "POST", path: "/api/users" },
+    ]);
+    const consumer = makeConsumer([
+      { method: "GET", url: "/api/users" },
+      { method: "POST", url: "/api/users" },
+      { method: "DELETE", url: "/api/users/:id" },
+    ]);
+    const client = mockClient([producer, consumer]);
+
+    const result = await checkCompatibility(client, {
+      consumer_service: "consumer-app",
+      producer_service: "producer-api",
+      method: "GET",
+    });
+
+    const data = parseResult(result);
+    expect(data.compatible).toBe(true);
+    expect(data.consumer_calls).toBe(1);
+  });
+
+  it("filters by path when provided", async () => {
+    const producer = makeProducer([
+      { method: "GET", path: "/api/users" },
+    ]);
+    const consumer = makeConsumer([
+      { method: "GET", url: "/api/users" },
+      { method: "DELETE", url: "/api/posts/:id" },
+    ]);
+    const client = mockClient([producer, consumer]);
+
+    const result = await checkCompatibility(client, {
+      consumer_service: "consumer-app",
+      producer_service: "producer-api",
+      path: "/api/users",
+    });
+
+    const data = parseResult(result);
+    expect(data.compatible).toBe(true);
+    expect(data.consumer_calls).toBe(1);
+  });
+
+  it("returns error when consumer service not found", async () => {
+    const producer = makeProducer([]);
+    const client = mockClient([producer]);
+
+    const result = await checkCompatibility(client, {
+      consumer_service: "nonexistent",
+      producer_service: "producer-api",
+    });
+
+    expect(result.content[0].text).toContain("Consumer service");
+    expect(result.content[0].text).toContain("not found");
+  });
+
+  it("returns error when producer service not found", async () => {
+    const consumer = makeConsumer([]);
+    const client = mockClient([consumer]);
+
+    const result = await checkCompatibility(client, {
+      consumer_service: "consumer-app",
+      producer_service: "nonexistent",
+    });
+
+    expect(result.content[0].text).toContain("Producer service");
+    expect(result.content[0].text).toContain("not found");
+  });
+
+  it("falls back to top-level endpoints/calls when mount_graph is missing", async () => {
+    const producer = makeRepoData({
+      repo_name: "org/producer-api",
+      service_name: "producer-api",
+      endpoints: [
+        {
+          method: "GET",
+          route: "/api/users",
+          params: [],
+          file_path: "src/routes.ts",
+        },
+      ],
+    });
+    const consumer = makeRepoData({
+      repo_name: "org/consumer-app",
+      service_name: "consumer-app",
+      calls: [
+        {
+          method: "GET",
+          route: "/api/users",
+          params: [],
+          file_path: "src/api.ts",
+        },
+      ],
+    });
+    const client = mockClient([producer, consumer]);
+
+    const result = await checkCompatibility(client, {
+      consumer_service: "consumer-app",
+      producer_service: "producer-api",
+    });
+
+    const data = parseResult(result);
+    expect(data.compatible).toBe(true);
+  });
+
+  it("does not report unused endpoints when filtering by method", async () => {
+    const producer = makeProducer([
+      { method: "GET", path: "/api/users" },
+      { method: "POST", path: "/api/users" },
+    ]);
+    const consumer = makeConsumer([
+      { method: "GET", url: "/api/users" },
+    ]);
+    const client = mockClient([producer, consumer]);
+
+    const result = await checkCompatibility(client, {
+      consumer_service: "consumer-app",
+      producer_service: "producer-api",
+      method: "GET",
+    });
+
+    const data = parseResult(result);
+    const infos = data.issues.filter((i: { severity: string }) => i.severity === "info");
+    expect(infos).toHaveLength(0);
+  });
+});

--- a/mcp-server/src/tools/get-endpoints.ts
+++ b/mcp-server/src/tools/get-endpoints.ts
@@ -81,8 +81,8 @@ export async function getEndpoints(
 }
 
 function ownerName(owner: { App?: string; Router?: string; Middleware?: string }): string {
-  return (owner as Record<string, string>).App
-    ?? (owner as Record<string, string>).Router
-    ?? (owner as Record<string, string>).Middleware
-    ?? "unknown";
+  if ("App" in owner && owner.App) return owner.App;
+  if ("Router" in owner && owner.Router) return owner.Router;
+  if ("Middleware" in owner && owner.Middleware) return owner.Middleware;
+  return "unknown";
 }

--- a/mcp-server/src/utils/__tests__/path-matcher.test.ts
+++ b/mcp-server/src/utils/__tests__/path-matcher.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { normalizePath, pathsMatch, pathContains } from "../path-matcher.js";
+
+describe("normalizePath", () => {
+  it("lowercases the path", () => {
+    expect(normalizePath("/API/Users")).toBe("/api/users");
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normalizePath("/api/users/")).toBe("/api/users");
+    expect(normalizePath("/api/users///")).toBe("/api/users");
+  });
+
+  it("normalizes :param style parameters", () => {
+    expect(normalizePath("/api/users/:id")).toBe("/api/users/:param");
+    expect(normalizePath("/api/users/:userId/posts/:postId")).toBe(
+      "/api/users/:param/posts/:param",
+    );
+  });
+
+  it("normalizes {param} style parameters", () => {
+    expect(normalizePath("/api/users/{id}")).toBe("/api/users/:param");
+    expect(normalizePath("/api/users/{userId}/posts/{postId}")).toBe(
+      "/api/users/:param/posts/:param",
+    );
+  });
+
+  it("returns / for empty string", () => {
+    expect(normalizePath("")).toBe("/");
+  });
+
+  it("handles root path", () => {
+    expect(normalizePath("/")).toBe("/");
+  });
+
+  it("handles path with underscores in params", () => {
+    expect(normalizePath("/api/:user_id")).toBe("/api/:param");
+    expect(normalizePath("/api/{user_id}")).toBe("/api/:param");
+  });
+});
+
+describe("pathsMatch", () => {
+  it("matches identical paths", () => {
+    expect(pathsMatch("/api/users", "/api/users")).toBe(true);
+  });
+
+  it("matches paths with different param styles", () => {
+    expect(pathsMatch("/api/users/:id", "/api/users/{id}")).toBe(true);
+  });
+
+  it("matches paths with different casing", () => {
+    expect(pathsMatch("/API/Users", "/api/users")).toBe(true);
+  });
+
+  it("matches when one has trailing slash", () => {
+    expect(pathsMatch("/api/users/", "/api/users")).toBe(true);
+  });
+
+  it("matches paths with different param names", () => {
+    expect(pathsMatch("/api/users/:userId", "/api/users/:id")).toBe(true);
+  });
+
+  it("does not match different paths", () => {
+    expect(pathsMatch("/api/users", "/api/posts")).toBe(false);
+  });
+
+  it("does not match different depth paths", () => {
+    expect(pathsMatch("/api/users", "/api/users/active")).toBe(false);
+  });
+});
+
+describe("pathContains", () => {
+  it("matches substring case-insensitively", () => {
+    expect(pathContains("/api/users/active", "users")).toBe(true);
+    expect(pathContains("/api/Users/active", "users")).toBe(true);
+    expect(pathContains("/api/users/active", "USERS")).toBe(true);
+  });
+
+  it("returns false when substring not found", () => {
+    expect(pathContains("/api/users", "posts")).toBe(false);
+  });
+
+  it("matches partial segments", () => {
+    expect(pathContains("/api/user-profiles", "user")).toBe(true);
+  });
+});

--- a/mcp-server/src/utils/__tests__/type-extractor.test.ts
+++ b/mcp-server/src/utils/__tests__/type-extractor.test.ts
@@ -168,6 +168,74 @@ export type NextType = number;`;
     expect(result).toContain("deep");
   });
 
+  it("preserves generic parameters on interfaces", () => {
+    const bundled = `export interface ApiResponse<T> {
+  data: T;
+  status: number;
+}`;
+
+    const result = extractTypeDefinition(bundled, "ApiResponse");
+    expect(result).not.toBeNull();
+    expect(result).toContain("interface ApiResponse<T>");
+    expect(result).toContain("data: T");
+  });
+
+  it("preserves extends clauses on interfaces", () => {
+    const bundled = `export interface AdminUser extends BaseUser {
+  permissions: string[];
+}`;
+
+    const result = extractTypeDefinition(bundled, "AdminUser");
+    expect(result).not.toBeNull();
+    expect(result).toContain("interface AdminUser");
+    expect(result).toContain("extends BaseUser");
+    expect(result).toContain("permissions: string[]");
+  });
+
+  it("preserves generic params and extends together", () => {
+    const bundled = `export interface PaginatedResponse<T> extends BaseResponse {
+  items: T[];
+  total: number;
+}`;
+
+    const result = extractTypeDefinition(bundled, "PaginatedResponse");
+    expect(result).not.toBeNull();
+    expect(result).toContain("<T>");
+    expect(result).toContain("extends BaseResponse");
+    expect(result).toContain("items: T[]");
+  });
+
+  it("handles intersection types with object literals", () => {
+    const bundled = `export type UserWithMeta = { name: string } & { createdAt: Date };
+export type Other = string;`;
+
+    const result = extractTypeDefinition(bundled, "UserWithMeta");
+    expect(result).not.toBeNull();
+    expect(result).toContain("name: string");
+    expect(result).toContain("&");
+    expect(result).toContain("createdAt: Date");
+  });
+
+  it("handles union types with object literals", () => {
+    const bundled = `export type Result = { ok: true; data: string } | { ok: false; error: string };
+export type Other = number;`;
+
+    const result = extractTypeDefinition(bundled, "Result");
+    expect(result).not.toBeNull();
+    expect(result).toContain("ok: true");
+    expect(result).toContain("|");
+    expect(result).toContain("error: string");
+  });
+
+  it("handles arrow function types", () => {
+    const bundled = `export type Handler = (req: Request) => Response;
+export type Other = string;`;
+
+    const result = extractTypeDefinition(bundled, "Handler");
+    expect(result).not.toBeNull();
+    expect(result).toContain("(req: Request) => Response");
+  });
+
   it("does not match partial type names", () => {
     const bundled = `export type UserResponse = string;
 export type GetUserResponseData = number;`;

--- a/mcp-server/src/utils/__tests__/type-extractor.test.ts
+++ b/mcp-server/src/utils/__tests__/type-extractor.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from "vitest";
+import {
+  findManifestEntries,
+  extractTypeDefinition,
+  extractEndpointTypes,
+} from "../type-extractor.js";
+import { TypeManifestEntry } from "../../types.js";
+
+function makeManifestEntry(
+  overrides: Partial<TypeManifestEntry> = {},
+): TypeManifestEntry {
+  return {
+    method: "GET",
+    path: "/api/users/:id",
+    role: "producer",
+    type_kind: "response",
+    type_alias: "GetUserResponse",
+    file_path: "src/routes/users.ts",
+    line_number: 10,
+    is_explicit: true,
+    type_state: "explicit",
+    evidence: {
+      file_path: "src/routes/users.ts",
+      line_number: 10,
+      infer_kind: "annotation",
+      is_explicit: true,
+      type_state: "explicit",
+    },
+    ...overrides,
+  };
+}
+
+describe("findManifestEntries", () => {
+  const manifest: TypeManifestEntry[] = [
+    makeManifestEntry({
+      method: "GET",
+      path: "/api/users/:id",
+      role: "producer",
+      type_kind: "response",
+      type_alias: "GetUserResponse",
+    }),
+    makeManifestEntry({
+      method: "GET",
+      path: "/api/users/:id",
+      role: "producer",
+      type_kind: "request",
+      type_alias: "GetUserRequest",
+    }),
+    makeManifestEntry({
+      method: "POST",
+      path: "/api/users",
+      role: "producer",
+      type_kind: "request",
+      type_alias: "CreateUserRequest",
+    }),
+    makeManifestEntry({
+      method: "GET",
+      path: "/api/users/:id",
+      role: "consumer",
+      type_kind: "response",
+      type_alias: "ConsumerGetUserResponse",
+    }),
+  ];
+
+  it("finds entries matching method and path", () => {
+    const results = findManifestEntries(manifest, "GET", "/api/users/:id");
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.type_alias)).toEqual([
+      "GetUserResponse",
+      "GetUserRequest",
+    ]);
+  });
+
+  it("matches case-insensitively on method", () => {
+    const results = findManifestEntries(manifest, "get", "/api/users/:id");
+    expect(results).toHaveLength(2);
+  });
+
+  it("normalizes path parameters for matching", () => {
+    const results = findManifestEntries(manifest, "GET", "/api/users/{userId}");
+    expect(results).toHaveLength(2);
+  });
+
+  it("filters by role", () => {
+    const results = findManifestEntries(
+      manifest,
+      "GET",
+      "/api/users/:id",
+      "consumer",
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].type_alias).toBe("ConsumerGetUserResponse");
+  });
+
+  it("returns empty when no match", () => {
+    const results = findManifestEntries(manifest, "DELETE", "/api/users/:id");
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe("extractTypeDefinition", () => {
+  it("extracts a type alias declaration", () => {
+    const bundled = `export type GetUserResponse = {
+  id: string;
+  name: string;
+};
+export type OtherType = string;`;
+
+    const result = extractTypeDefinition(bundled, "GetUserResponse");
+    expect(result).toContain("type GetUserResponse =");
+    expect(result).toContain("id: string");
+    expect(result).toContain("name: string");
+  });
+
+  it("extracts an interface declaration", () => {
+    const bundled = `export interface CreateUserRequest {
+  name: string;
+  email: string;
+}`;
+
+    const result = extractTypeDefinition(bundled, "CreateUserRequest");
+    expect(result).toContain("interface CreateUserRequest");
+    expect(result).toContain("name: string");
+    expect(result).toContain("email: string");
+  });
+
+  it("returns null when type not found", () => {
+    const bundled = `export type Foo = string;`;
+    const result = extractTypeDefinition(bundled, "NonExistent");
+    expect(result).toBeNull();
+  });
+
+  it("handles type without export keyword", () => {
+    const bundled = `type InternalType = {
+  value: number;
+};
+type NextType = string;`;
+
+    const result = extractTypeDefinition(bundled, "InternalType");
+    expect(result).not.toBeNull();
+    expect(result).toContain("InternalType");
+    expect(result).toContain("value: number");
+  });
+
+  it("handles simple type alias", () => {
+    const bundled = `export type UserId = string;
+export type UserName = string;`;
+
+    const result = extractTypeDefinition(bundled, "UserId");
+    expect(result).not.toBeNull();
+    expect(result).toContain("type UserId =");
+    expect(result).toContain("string");
+  });
+
+  it("extracts type with nested objects", () => {
+    const bundled = `export type ComplexType = {
+  nested: {
+    deep: {
+      value: string;
+    };
+  };
+};
+export type NextType = number;`;
+
+    const result = extractTypeDefinition(bundled, "ComplexType");
+    expect(result).not.toBeNull();
+    expect(result).toContain("nested");
+    expect(result).toContain("deep");
+  });
+
+  it("does not match partial type names", () => {
+    const bundled = `export type UserResponse = string;
+export type GetUserResponseData = number;`;
+
+    const result = extractTypeDefinition(bundled, "UserResponse");
+    expect(result).not.toBeNull();
+    expect(result).toContain("type UserResponse =");
+    // Should not contain the other type's definition
+    expect(result).not.toContain("number");
+  });
+});
+
+describe("extractEndpointTypes", () => {
+  const bundledTypes = `export type GetUserResponse = {
+  id: string;
+  name: string;
+};
+export type GetUserRequest = {
+  id: string;
+};
+export type UnrelatedType = boolean;`;
+
+  const manifest: TypeManifestEntry[] = [
+    makeManifestEntry({
+      method: "GET",
+      path: "/api/users/:id",
+      type_kind: "response",
+      type_alias: "GetUserResponse",
+    }),
+    makeManifestEntry({
+      method: "GET",
+      path: "/api/users/:id",
+      type_kind: "request",
+      type_alias: "GetUserRequest",
+    }),
+  ];
+
+  it("extracts all types for an endpoint", () => {
+    const results = extractEndpointTypes(
+      manifest,
+      bundledTypes,
+      "GET",
+      "/api/users/:id",
+    );
+    expect(results).toHaveLength(2);
+    expect(results[0].type_alias).toBe("GetUserResponse");
+    expect(results[0].type_kind).toBe("response");
+    expect(results[0].definition).toContain("id: string");
+    expect(results[1].type_alias).toBe("GetUserRequest");
+    expect(results[1].type_kind).toBe("request");
+  });
+
+  it("returns empty array when no manifest entries match", () => {
+    const results = extractEndpointTypes(
+      manifest,
+      bundledTypes,
+      "DELETE",
+      "/api/users/:id",
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("skips entries where type definition is not found in bundled types", () => {
+    const sparseManifest: TypeManifestEntry[] = [
+      makeManifestEntry({
+        method: "GET",
+        path: "/api/users/:id",
+        type_alias: "MissingType",
+      }),
+    ];
+    const results = extractEndpointTypes(
+      sparseManifest,
+      bundledTypes,
+      "GET",
+      "/api/users/:id",
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("preserves manifest metadata in results", () => {
+    const results = extractEndpointTypes(
+      manifest,
+      bundledTypes,
+      "GET",
+      "/api/users/:id",
+    );
+    expect(results[0].is_explicit).toBe(true);
+    expect(results[0].file_path).toBe("src/routes/users.ts");
+    expect(results[0].line_number).toBe(10);
+  });
+});

--- a/mcp-server/src/utils/type-extractor.ts
+++ b/mcp-server/src/utils/type-extractor.ts
@@ -47,37 +47,97 @@ export function extractTypeDefinition(
   bundledTypes: string,
   typeAlias: string,
 ): string | null {
-  // Try "export type Alias = ..." pattern
-  const typePattern = new RegExp(
-    `(?:export\\s+)?type\\s+${escapeRegex(typeAlias)}\\s*=\\s*([\\s\\S]*?);(?:\\s*(?:export|type|interface|$))`,
-    "m",
+  // Find the start of the declaration
+  const declPattern = new RegExp(
+    `(?:export\\s+)?(?:type|interface)\\s+${escapeRegex(typeAlias)}\\b`,
   );
-  const typeMatch = bundledTypes.match(typePattern);
-  if (typeMatch) {
-    return `type ${typeAlias} = ${typeMatch[1].trim()};`;
+  const declMatch = declPattern.exec(bundledTypes);
+  if (!declMatch) return null;
+
+  const startIdx = declMatch.index;
+  const afterDecl = bundledTypes.slice(declMatch.index + declMatch[0].length);
+
+  // Determine if this is a type alias or interface
+  const isInterface = /interface/.test(declMatch[0]);
+
+  if (isInterface) {
+    // Find opening brace, then brace-count to find the matching close
+    const braceStart = afterDecl.indexOf("{");
+    if (braceStart === -1) return null;
+
+    const body = extractBraceBlock(afterDecl, braceStart);
+    if (body === null) return null;
+    return `interface ${typeAlias} ${body}`;
   }
 
-  // Try "export interface Alias { ... }" pattern
-  const interfacePattern = new RegExp(
-    `(?:export\\s+)?interface\\s+${escapeRegex(typeAlias)}\\s*\\{([\\s\\S]*?)\\}`,
-    "m",
-  );
-  const interfaceMatch = bundledTypes.match(interfacePattern);
-  if (interfaceMatch) {
-    return `interface ${typeAlias} {${interfaceMatch[1]}}`;
+  // Type alias: find the "=" then extract the value
+  const eqIdx = afterDecl.indexOf("=");
+  if (eqIdx === -1) return null;
+
+  const afterEq = afterDecl.slice(eqIdx + 1).trimStart();
+
+  // If the type value starts with "{", use brace counting
+  if (afterEq.startsWith("{")) {
+    const body = extractBraceBlock(afterEq, 0);
+    if (body === null) return null;
+    return `type ${typeAlias} = ${body};`;
   }
 
-  // Fallback: grab anything from "type/interface Alias" to the next top-level declaration
-  const fallbackPattern = new RegExp(
-    `(?:export\\s+)?(?:type|interface)\\s+${escapeRegex(typeAlias)}[\\s\\S]*?(?=(?:export\\s+)?(?:type|interface)\\s+\\w|$)`,
-    "m",
-  );
-  const fallbackMatch = bundledTypes.match(fallbackPattern);
-  if (fallbackMatch) {
-    return fallbackMatch[0].trim();
+  // Simple type alias (no braces): take everything up to the next ";"
+  // at the top level (not inside angle brackets or parens)
+  const end = findTopLevelSemicolon(afterEq);
+  if (end === -1) {
+    // Fallback: take up to next top-level declaration or end of string
+    const fallbackEnd = bundledTypes.slice(startIdx).search(
+      /\n(?:export\s+)?(?:type|interface)\s+\w/,
+    );
+    const chunk = fallbackEnd === -1
+      ? bundledTypes.slice(startIdx)
+      : bundledTypes.slice(startIdx, startIdx + fallbackEnd);
+    return chunk.trim() || null;
   }
+  return `type ${typeAlias} = ${afterEq.slice(0, end).trim()};`;
+}
 
+/**
+ * Extract a brace-delimited block starting at the given index,
+ * counting nested braces to find the matching close.
+ */
+function extractBraceBlock(source: string, openIndex: number): string | null {
+  let depth = 0;
+  for (let i = openIndex; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        return source.slice(openIndex, i + 1);
+      }
+    }
+  }
   return null;
+}
+
+/**
+ * Find the index of the first semicolon that is not nested inside
+ * braces, angle brackets, or parentheses.
+ */
+function findTopLevelSemicolon(source: string): number {
+  let braces = 0;
+  let angles = 0;
+  let parens = 0;
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "{") braces++;
+    else if (ch === "}") braces--;
+    else if (ch === "<") angles++;
+    else if (ch === ">") angles--;
+    else if (ch === "(") parens++;
+    else if (ch === ")") parens--;
+    else if (ch === ";" && braces === 0 && angles === 0 && parens === 0) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 /**

--- a/mcp-server/src/utils/type-extractor.ts
+++ b/mcp-server/src/utils/type-extractor.ts
@@ -65,9 +65,13 @@ export function extractTypeDefinition(
     const braceStart = afterDecl.indexOf("{");
     if (braceStart === -1) return null;
 
+    // Preserve generic parameters and heritage clauses between the
+    // interface name and the opening brace (e.g. "<T> extends Base ").
+    const header = afterDecl.slice(0, braceStart);
+
     const body = extractBraceBlock(afterDecl, braceStart);
     if (body === null) return null;
-    return `interface ${typeAlias} ${body}`;
+    return `interface ${typeAlias}${header}${body}`;
   }
 
   // Type alias: find the "=" then extract the value
@@ -76,15 +80,8 @@ export function extractTypeDefinition(
 
   const afterEq = afterDecl.slice(eqIdx + 1).trimStart();
 
-  // If the type value starts with "{", use brace counting
-  if (afterEq.startsWith("{")) {
-    const body = extractBraceBlock(afterEq, 0);
-    if (body === null) return null;
-    return `type ${typeAlias} = ${body};`;
-  }
-
-  // Simple type alias (no braces): take everything up to the next ";"
-  // at the top level (not inside angle brackets or parens)
+  // Always use top-level semicolon scanning — this handles simple types,
+  // object types, and compound types like `{ a: string } & Other`.
   const end = findTopLevelSemicolon(afterEq);
   if (end === -1) {
     // Fallback: take up to next top-level declaration or end of string
@@ -130,8 +127,10 @@ function findTopLevelSemicolon(source: string): number {
     if (ch === "{") braces++;
     else if (ch === "}") braces--;
     else if (ch === "<") angles++;
-    else if (ch === ">") angles--;
-    else if (ch === "(") parens++;
+    else if (ch === ">" && source[i - 1] !== "=") {
+      // Only decrement for generic closes, not arrow functions (=>)
+      angles = Math.max(0, angles - 1);
+    } else if (ch === "(") parens++;
     else if (ch === ")") parens--;
     else if (ch === ";" && braces === 0 && angles === 0 && parens === 0) {
       return i;

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -14,5 +14,5 @@
     "isolatedModules": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/__tests__", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- **Fix type extractor bug** — multi-line object types (e.g. `{ id: string; name: string; }`) were truncated at the first semicolon due to lazy regex quantifiers. Replaced with brace-counting approach.
- **Fix unsafe `ownerName()` cast** — replaced `Record<string, string>` cast with proper `in` type narrowing in `get-endpoints.ts`.
- **Fix `lambda.ts` type error** — `serverlessExpress` default import had no call signatures; switched to named `configure` import.
- **Improve tool descriptions** — richer context for all 5 MCP tools so AI agents know when to use each one.
- **Add test suite** — 43 tests covering path-matcher, type-extractor, and check-compat using vitest.
- **Add `.env.example`** — documents required environment variables for the MCP server.

## Test plan

- [x] `npm test` passes (43/43 tests)
- [x] `tsc --noEmit` passes (0 errors)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI build passes

https://claude.ai/code/session_01QckoMXThjMCRUdT6WQmWVN