### PR TITLE
feat: function intent discovery via LLM-generated descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "derivative",
+ "futures",
  "matchit",
  "regex",
  "reqwest",
@@ -450,25 +451,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "futures"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -476,27 +493,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.31"
+name = "futures-io"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1192,12 +1230,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 derivative = "2.2.0"
+futures = "0.3.32"
 
 matchit = "0.8.6"
 regex = "1.11.1"

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -7,6 +7,7 @@ import { getEndpointTypes } from "./tools/get-types.js";
 import { checkCompatibility } from "./tools/check-compat.js";
 import { getServiceDependencies } from "./tools/get-deps.js";
 import { getTypeDefinition } from "./tools/get-type-definition.js";
+import { listFunctionIntents } from "./tools/find-similar.js";
 import { getServiceCatalog } from "./resources/service-catalog.js";
 import { getServiceTypes } from "./resources/service-types.js";
 
@@ -76,6 +77,16 @@ export function createServer(client: ApiClient): McpServer {
       type_alias: z.string().describe("Type alias name (from get_endpoint_types results)"),
     },
     async (params) => getTypeDefinition(client, params),
+  );
+
+  server.tool(
+    "list_function_intents",
+    "List all exported functions with their LLM-generated intent descriptions across org services. Returns a compact list the agent can scan to discover existing implementations. Use gh CLI to browse the actual source code on GitHub.",
+    {
+      service: z.string().optional().describe("Filter to a specific service (omit for all services)"),
+      exclude_service: z.string().optional().describe("Service to exclude from results"),
+    },
+    async (params) => listFunctionIntents(client, params),
   );
 
   // --- Resources ---

--- a/mcp-server/src/tools/find-similar.ts
+++ b/mcp-server/src/tools/find-similar.ts
@@ -36,7 +36,7 @@ export async function listFunctionIntents(
 
     for (const [, def] of Object.entries(repo.function_definitions)) {
       const fn = def as FunctionDefinition;
-      if (!fn.is_exported || !fn.intent) continue;
+      if (!fn.intent) continue;
 
       entries.push({
         service: serviceName,

--- a/mcp-server/src/tools/find-similar.ts
+++ b/mcp-server/src/tools/find-similar.ts
@@ -1,0 +1,83 @@
+import { ApiClient } from "../api-client.js";
+import type { FunctionDefinition, FunctionCallRef } from "../types.js";
+
+export interface ListFunctionIntentsParams {
+  service?: string;
+  exclude_service?: string;
+}
+
+interface FunctionIntentEntry {
+  service: string;
+  repo: string;
+  name: string;
+  file_path: string;
+  line_number: number;
+  intent: string;
+  calls?: FunctionCallRef[];
+}
+
+/**
+ * List all exported functions with their intents across the org.
+ * Returns a compact list that an LLM agent can scan to find relevant functions.
+ * The agent can then use `gh` CLI to browse the actual source code on GitHub.
+ */
+export async function listFunctionIntents(
+  client: ApiClient,
+  params: ListFunctionIntentsParams,
+) {
+  const repos = await client.getAllRepoData();
+  const entries: FunctionIntentEntry[] = [];
+
+  for (const repo of repos) {
+    const serviceName = repo.service_name ?? repo.repo_name;
+
+    if (params.service && serviceName !== params.service) continue;
+    if (params.exclude_service && serviceName === params.exclude_service) continue;
+
+    for (const [, def] of Object.entries(repo.function_definitions)) {
+      const fn = def as FunctionDefinition;
+      if (!fn.is_exported || !fn.intent) continue;
+
+      entries.push({
+        service: serviceName,
+        repo: repo.repo_name,
+        name: fn.name,
+        file_path: fn.file_path,
+        line_number: fn.line_number,
+        intent: fn.intent,
+        ...(fn.calls && fn.calls.length > 0 ? { calls: fn.calls } : {}),
+      });
+    }
+  }
+
+  if (entries.length === 0) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: params.service
+            ? `No exported functions with intents found for "${params.service}". Run analysis with the latest Carrick version to generate function intents.`
+            : `No exported functions with intents found across ${repos.length} services. Run analysis with the latest Carrick version to generate function intents.`,
+        },
+      ],
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            total: entries.length,
+            services: [...new Set(entries.map((e) => e.service))],
+            functions: entries,
+            hint: "To view a function's source code, use the gh CLI: gh api repos/{owner}/{repo}/contents/{file_path} or gh browse {owner}/{repo} -- {file_path}:{line_number}",
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -11,7 +11,7 @@ export interface CloudRepoData {
   mounts: Mount[];
   apps: Record<string, unknown>;
   imported_handlers: [string, string, string, string][];
-  function_definitions: Record<string, unknown>;
+  function_definitions: Record<string, FunctionDefinition>;
   config_json?: string;
   package_json?: string;
   packages?: Packages;
@@ -134,6 +134,28 @@ export interface PackageInfo {
   name: string;
   version: string;
   source_path: string;
+}
+
+export interface FunctionDefinition {
+  name: string;
+  file_path: string;
+  node_type: string;
+  arguments: FunctionArgument[];
+  body_source?: string;
+  is_exported: boolean;
+  line_number: number;
+  intent?: string;
+  calls?: FunctionCallRef[];
+}
+
+export interface FunctionArgument {
+  name: string;
+}
+
+export interface FunctionCallRef {
+  name: string;
+  file_path: string;
+  line_number: number;
 }
 
 /** Shape returned by the Lambda get-cross-repo-data action */

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -9,6 +9,7 @@ use crate::cloud_storage::{
 use crate::config::{Config, create_dynamic_tsconfig};
 use crate::file_finder::find_files;
 use crate::framework_detector::{DetectionResult, FrameworkDetector};
+use crate::intent_generator::generate_function_intents;
 use crate::mount_graph::MountGraph;
 use crate::multi_agent_orchestrator::MultiAgentOrchestrator;
 use crate::packages::Packages;
@@ -801,9 +802,11 @@ fn discover_files_and_symbols(repo_path: &str, cm: Lrc<SourceMap>) -> FileDiscov
             module.visit_with(&mut import_extractor);
             all_imported_symbols.extend(import_extractor.imported_symbols);
 
-            // Extract function definitions with type annotations
-            let mut func_extractor = FunctionDefinitionExtractor::new(file_path.clone());
+            // Extract function definitions with type annotations and source text
+            let mut func_extractor =
+                FunctionDefinitionExtractor::new(file_path.clone(), cm.clone());
             module.visit_with(&mut func_extractor);
+            func_extractor.finalize_exports();
             all_function_definitions.extend(func_extractor.function_definitions);
         }
     }
@@ -1152,6 +1155,18 @@ async fn analyze_current_repo(
     let analysis_result = orchestrator
         .run_complete_analysis(files, &packages, &all_imported_symbols)
         .await?;
+
+    // 4b. Generate function intents using LLM
+    let mut function_definitions = function_definitions;
+    {
+        let intent_agent = AgentService::new(api_key.clone());
+        generate_function_intents(
+            &intent_agent,
+            &mut function_definitions,
+            &all_imported_symbols,
+        )
+        .await;
+    }
 
     // 5. Build CloudRepoData directly from multi-agent results (bypassing Analyzer adapter layer)
     let mut cloud_data = CloudRepoData::from_multi_agent_results(

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -25,10 +25,10 @@ pub async fn generate_function_intents(
     function_definitions: &mut HashMap<String, FunctionDefinition>,
     _imported_symbols: &HashMap<String, ImportedSymbol>,
 ) {
-    // Only process exported functions with body source
+    // Process all named functions with body source
     let eligible: Vec<String> = function_definitions
         .iter()
-        .filter(|(_, def)| def.is_exported && def.body_source.is_some())
+        .filter(|(_, def)| def.body_source.is_some())
         .map(|(name, _)| name.clone())
         .collect();
 
@@ -38,7 +38,7 @@ pub async fn generate_function_intents(
     }
 
     eprintln!(
-        "[intent] Generating intents for {} exported function(s)...",
+        "[intent] Generating intents for {} function(s)...",
         eligible.len()
     );
 

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -1,0 +1,338 @@
+//! Function intent generator.
+//!
+//! Generates short natural-language descriptions of what each function
+//! intends to do, using a small LLM model. Functions are processed in
+//! dependency order (leaves first) so that when a function calls other
+//! local functions, those functions' intents are included in the prompt
+//! for richer compositional understanding.
+//!
+//! After intent generation, `body_source` is stripped from all function
+//! definitions so that source code is not uploaded to AWS. The intent
+//! serves as the index; GitHub is the source of truth for code.
+
+use crate::agent_service::AgentService;
+use crate::visitor::{FunctionCallRef, FunctionDefinition, ImportedSymbol};
+use std::collections::{HashMap, HashSet};
+
+/// Generate intents for all exported functions that have body source.
+///
+/// After generation:
+/// - Each function's `intent` is populated with a 1-2 sentence description
+/// - Each function's `calls` is populated with references to local callees
+/// - `body_source` is stripped from ALL functions (source stays in GitHub, not AWS)
+pub async fn generate_function_intents(
+    agent_service: &AgentService,
+    function_definitions: &mut HashMap<String, FunctionDefinition>,
+    _imported_symbols: &HashMap<String, ImportedSymbol>,
+) {
+    // Only process exported functions with body source
+    let eligible: Vec<String> = function_definitions
+        .iter()
+        .filter(|(_, def)| def.is_exported && def.body_source.is_some())
+        .map(|(name, _)| name.clone())
+        .collect();
+
+    if eligible.is_empty() {
+        strip_body_source(function_definitions);
+        return;
+    }
+
+    eprintln!(
+        "[intent] Generating intents for {} exported function(s)...",
+        eligible.len()
+    );
+
+    // Build a local call graph: for each function, which other local functions does it reference?
+    let local_fn_names: HashSet<&str> = function_definitions.keys().map(|s| s.as_str()).collect();
+    let mut deps: HashMap<String, Vec<String>> = HashMap::new();
+
+    for name in &eligible {
+        if let Some(def) = function_definitions.get(name) {
+            if let Some(ref body) = def.body_source {
+                let called: Vec<String> = local_fn_names
+                    .iter()
+                    .filter(|&&fn_name| fn_name != name.as_str() && body.contains(fn_name))
+                    .map(|&s| s.to_string())
+                    .collect();
+                deps.insert(name.clone(), called);
+            }
+        }
+    }
+
+    // Populate the `calls` field on each function with references to callees
+    for name in &eligible {
+        if let Some(called) = deps.get(name) {
+            let call_refs: Vec<FunctionCallRef> = called
+                .iter()
+                .filter_map(|callee_name| {
+                    function_definitions
+                        .get(callee_name)
+                        .map(|callee_def| FunctionCallRef {
+                            name: callee_name.clone(),
+                            file_path: callee_def.file_path.to_string_lossy().to_string(),
+                            line_number: callee_def.line_number,
+                        })
+                })
+                .collect();
+            if let Some(def) = function_definitions.get_mut(name) {
+                def.calls = call_refs;
+            }
+        }
+    }
+
+    // Topological sort into levels: functions at the same level can run in parallel
+    let levels = topological_levels(&eligible, &deps);
+
+    // Generate intents level by level — within each level, calls run in parallel
+    let mut intents: HashMap<String, String> = HashMap::new();
+    let system_msg = "You describe what functions do in 1-2 sentences. Be specific about the business logic, not the implementation details. Respond with ONLY the description, no quotes or prefixes.";
+
+    for level in &levels {
+        // Build prompts for all functions in this level
+        let tasks: Vec<(String, String)> = level
+            .iter()
+            .filter_map(|name| {
+                let def = function_definitions.get(name)?;
+                let body = def.body_source.as_ref()?;
+
+                let called_intents: Vec<String> = deps
+                    .get(name)
+                    .map(|called| {
+                        called
+                            .iter()
+                            .filter_map(|callee| {
+                                intents
+                                    .get(callee)
+                                    .map(|intent| format!("- {}: {}", callee, intent))
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let prompt = build_intent_prompt(name, body, &called_intents);
+                Some((name.clone(), prompt))
+            })
+            .collect();
+
+        // Run all LLM calls for this level in parallel
+        let futures: Vec<_> = tasks
+            .iter()
+            .map(|(name, prompt)| async {
+                let result = agent_service.analyze_code(prompt, system_msg).await;
+                (name.clone(), result)
+            })
+            .collect();
+
+        let results = futures::future::join_all(futures).await;
+
+        for (name, result) in results {
+            match result {
+                Ok(intent) => {
+                    let intent = intent.trim().to_string();
+                    if !intent.is_empty() && intent.len() < 500 {
+                        intents.insert(name, intent);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("[intent] Failed to generate intent for {}: {}", name, e);
+                }
+            }
+        }
+    }
+
+    // Write intents back to function definitions
+    let count = intents.len();
+    for (name, intent) in intents {
+        if let Some(def) = function_definitions.get_mut(&name) {
+            def.intent = Some(intent);
+        }
+    }
+
+    eprintln!("[intent] Generated {} intent(s)", count);
+
+    // Strip body_source — source code stays in GitHub, not AWS
+    strip_body_source(function_definitions);
+}
+
+/// Remove body_source from all function definitions.
+/// The intent is the index; GitHub is the source of truth for code.
+fn strip_body_source(function_definitions: &mut HashMap<String, FunctionDefinition>) {
+    for def in function_definitions.values_mut() {
+        def.body_source = None;
+    }
+}
+
+/// Topological sort into parallel levels.
+/// Level 0 = functions with no local deps (leaves).
+/// Level 1 = functions whose deps are all in level 0. Etc.
+/// Functions within the same level can run in parallel.
+fn topological_levels(names: &[String], deps: &HashMap<String, Vec<String>>) -> Vec<Vec<String>> {
+    let name_set: HashSet<&str> = names.iter().map(|s| s.as_str()).collect();
+    let mut in_degree: HashMap<&str, usize> = HashMap::new();
+    let mut reverse_deps: HashMap<&str, Vec<&str>> = HashMap::new();
+
+    for name in names {
+        in_degree.entry(name.as_str()).or_insert(0);
+        if let Some(called) = deps.get(name) {
+            for callee in called {
+                if name_set.contains(callee.as_str()) {
+                    *in_degree.entry(name.as_str()).or_insert(0) += 1;
+                    reverse_deps
+                        .entry(callee.as_str())
+                        .or_default()
+                        .push(name.as_str());
+                }
+            }
+        }
+    }
+
+    let mut levels: Vec<Vec<String>> = Vec::new();
+    let mut current: Vec<&str> = in_degree
+        .iter()
+        .filter(|&(_, &deg)| deg == 0)
+        .map(|(&name, _)| name)
+        .collect();
+
+    while !current.is_empty() {
+        levels.push(current.iter().map(|s| s.to_string()).collect());
+        let mut next = Vec::new();
+        for &name in &current {
+            if let Some(dependents) = reverse_deps.get(name) {
+                for &dep in dependents {
+                    if let Some(deg) = in_degree.get_mut(dep) {
+                        *deg = deg.saturating_sub(1);
+                        if *deg == 0 {
+                            next.push(dep);
+                        }
+                    }
+                }
+            }
+        }
+        current = next;
+    }
+
+    // Add any remaining (cycles) as a final level
+    let in_levels: HashSet<&str> = levels.iter().flatten().map(|s| s.as_str()).collect();
+    let remaining: Vec<String> = names
+        .iter()
+        .filter(|n| !in_levels.contains(n.as_str()))
+        .cloned()
+        .collect();
+    if !remaining.is_empty() {
+        levels.push(remaining);
+    }
+
+    levels
+}
+
+fn build_intent_prompt(name: &str, body: &str, called_intents: &[String]) -> String {
+    let mut prompt = String::new();
+
+    if !called_intents.is_empty() {
+        prompt.push_str("This function uses the following helper functions:\n");
+        for intent in called_intents {
+            prompt.push_str(intent);
+            prompt.push('\n');
+        }
+        prompt.push('\n');
+    }
+
+    prompt.push_str(&format!(
+        "Function `{}`:\n```\n{}\n```\n\nWhat does this function intend to do?",
+        name, body
+    ));
+    prompt
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn topological_levels_leaves_first() {
+        let names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let mut deps = HashMap::new();
+        // c calls a and b, b calls a
+        deps.insert("c".to_string(), vec!["a".to_string(), "b".to_string()]);
+        deps.insert("b".to_string(), vec!["a".to_string()]);
+
+        let levels = topological_levels(&names, &deps);
+        assert!(levels.len() >= 2, "should have at least 2 levels");
+        // Level 0 should contain "a" (leaf)
+        assert!(
+            levels[0].contains(&"a".to_string()),
+            "a should be in level 0"
+        );
+        // "c" should be in a later level than "b"
+        let b_level = levels
+            .iter()
+            .position(|l| l.contains(&"b".to_string()))
+            .unwrap();
+        let c_level = levels
+            .iter()
+            .position(|l| l.contains(&"c".to_string()))
+            .unwrap();
+        assert!(b_level < c_level, "b should be in an earlier level than c");
+    }
+
+    #[test]
+    fn topological_levels_no_deps_single_level() {
+        let names = vec!["x".to_string(), "y".to_string()];
+        let deps = HashMap::new();
+        let levels = topological_levels(&names, &deps);
+        assert_eq!(levels.len(), 1, "all functions should be in one level");
+        assert_eq!(levels[0].len(), 2);
+    }
+
+    #[test]
+    fn topological_levels_handles_cycles() {
+        let names = vec!["a".to_string(), "b".to_string()];
+        let mut deps = HashMap::new();
+        deps.insert("a".to_string(), vec!["b".to_string()]);
+        deps.insert("b".to_string(), vec!["a".to_string()]);
+        let levels = topological_levels(&names, &deps);
+        let total: usize = levels.iter().map(|l| l.len()).sum();
+        assert_eq!(total, 2, "both should still appear");
+    }
+
+    #[test]
+    fn build_prompt_without_deps() {
+        let prompt = build_intent_prompt("foo", "return 1 + 2;", &[]);
+        assert!(prompt.contains("Function `foo`"));
+        assert!(prompt.contains("return 1 + 2"));
+        assert!(!prompt.contains("helper functions"));
+    }
+
+    #[test]
+    fn build_prompt_with_deps() {
+        let called = vec!["- validate: Checks email format".to_string()];
+        let prompt =
+            build_intent_prompt("createUser", "validate(email); db.insert(user);", &called);
+        assert!(prompt.contains("helper functions"));
+        assert!(prompt.contains("validate: Checks email format"));
+        assert!(prompt.contains("Function `createUser`"));
+    }
+
+    #[test]
+    fn strip_body_source_removes_all() {
+        let mut defs = HashMap::new();
+        defs.insert(
+            "foo".to_string(),
+            FunctionDefinition {
+                name: "foo".to_string(),
+                file_path: "test.ts".into(),
+                node_type: Default::default(),
+                arguments: vec![],
+                body_source: Some("return 1;".to_string()),
+                is_exported: true,
+                line_number: 1,
+                intent: Some("returns one".to_string()),
+                calls: vec![],
+            },
+        );
+        strip_body_source(&mut defs);
+        assert!(defs.get("foo").unwrap().body_source.is_none());
+        // Intent should be preserved
+        assert!(defs.get("foo").unwrap().intent.is_some());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod extractor;
 pub mod file_finder;
 pub mod formatter;
 pub mod framework_detector;
+pub mod intent_generator;
 pub mod mount_graph;
 pub mod multi_agent_orchestrator;
 pub mod packages;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod extractor;
 mod file_finder;
 mod formatter;
 mod framework_detector;
+mod intent_generator;
 mod mount_graph;
 mod multi_agent_orchestrator;
 mod packages;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -490,6 +490,150 @@ impl Visit for FunctionDefinitionExtractor {
         // Continue visiting child nodes
         var_decl.visit_children_with(self);
     }
+
+    /// Capture anonymous closures passed as arguments to method calls.
+    /// e.g. `app.get("/users", async (req, res) => { ... })` → name: "GET_users_handler"
+    /// e.g. `emitter.on("data", (chunk) => { ... })` → name: "on_data_handler"
+    fn visit_call_expr(&mut self, call: &CallExpr) {
+        if let Some((method_name, first_str_arg)) = extract_call_context(call) {
+            // Look for function/arrow arguments (skip the first string arg)
+            for arg in &call.args {
+                match &*arg.expr {
+                    Expr::Arrow(arrow) => {
+                        let synthetic_name =
+                            derive_handler_name(&method_name, first_str_arg.as_deref());
+                        // Don't overwrite named functions already captured
+                        if !self.function_definitions.contains_key(&synthetic_name) {
+                            let arguments = self.extract_arrow_arguments(&arrow.params);
+                            let body_source = self.extract_source(arrow.span);
+                            let line_number = self.line_number(arrow.span);
+                            self.function_definitions.insert(
+                                synthetic_name.clone(),
+                                FunctionDefinition {
+                                    name: synthetic_name,
+                                    file_path: self.current_file_path.clone(),
+                                    node_type: FunctionNodeType::ArrowFunction(Box::new(
+                                        arrow.clone(),
+                                    )),
+                                    arguments,
+                                    body_source,
+                                    is_exported: false,
+                                    line_number,
+                                    intent: None,
+                                    calls: vec![],
+                                },
+                            );
+                        }
+                    }
+                    Expr::Fn(fn_expr) => {
+                        let synthetic_name =
+                            derive_handler_name(&method_name, first_str_arg.as_deref());
+                        if !self.function_definitions.contains_key(&synthetic_name) {
+                            let arguments = self.extract_arguments(&fn_expr.function.params);
+                            let body_source = fn_expr
+                                .function
+                                .body
+                                .as_ref()
+                                .and_then(|b| self.extract_source(b.span));
+                            let line_number = self.line_number(fn_expr.function.span);
+                            self.function_definitions.insert(
+                                synthetic_name.clone(),
+                                FunctionDefinition {
+                                    name: synthetic_name,
+                                    file_path: self.current_file_path.clone(),
+                                    node_type: FunctionNodeType::FunctionExpression(Box::new(
+                                        fn_expr.clone(),
+                                    )),
+                                    arguments,
+                                    body_source,
+                                    is_exported: false,
+                                    line_number,
+                                    intent: None,
+                                    calls: vec![],
+                                },
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Continue visiting child nodes
+        call.visit_children_with(self);
+    }
+}
+
+/// Extract the method name and optional first string argument from a call expression.
+/// e.g. `app.get("/users", handler)` → Some(("get", Some("/users")))
+/// e.g. `emitter.on("data", handler)` → Some(("on", Some("data")))
+/// e.g. `doSomething(handler)` → Some(("doSomething", None))
+fn extract_call_context(call: &CallExpr) -> Option<(String, Option<String>)> {
+    let method_name = match &call.callee {
+        Callee::Expr(expr) => match &**expr {
+            Expr::Member(member) => {
+                if let MemberProp::Ident(ident) = &member.prop {
+                    Some(ident.sym.to_string())
+                } else {
+                    None
+                }
+            }
+            Expr::Ident(ident) => Some(ident.sym.to_string()),
+            _ => None,
+        },
+        _ => None,
+    }?;
+
+    // Get the first string argument if present
+    let first_str = call.args.first().and_then(|arg| match &*arg.expr {
+        Expr::Lit(Lit::Str(s)) => Some(s.value.to_string()),
+        Expr::Tpl(tpl) => {
+            // Template literal — extract the first quasi
+            tpl.quasis.first().map(|q| q.raw.to_string())
+        }
+        _ => None,
+    });
+
+    // Only capture if there's at least one function argument
+    let has_fn_arg = call
+        .args
+        .iter()
+        .any(|arg| matches!(&*arg.expr, Expr::Arrow(_) | Expr::Fn(_)));
+
+    if has_fn_arg {
+        Some((method_name, first_str))
+    } else {
+        None
+    }
+}
+
+/// Derive a handler name from the method and path/event.
+/// e.g. ("get", Some("/users/:id")) → "get_users_id_handler"
+/// e.g. ("on", Some("data")) → "on_data_handler"
+/// e.g. ("use", None) → "use_handler"
+fn derive_handler_name(method: &str, first_arg: Option<&str>) -> String {
+    let base = match first_arg {
+        Some(arg) => {
+            let cleaned: String = arg
+                .chars()
+                .map(|c| {
+                    if c.is_alphanumeric() || c == '_' {
+                        c
+                    } else {
+                        '_'
+                    }
+                })
+                .collect();
+            let trimmed = cleaned.trim_matches('_');
+            if trimmed.is_empty() {
+                method.to_string()
+            } else {
+                format!("{}_{}", method, trimmed)
+            }
+        }
+        None => method.to_string(),
+    };
+    format!("{}_handler", base)
 }
 
 #[cfg(test)]
@@ -606,5 +750,83 @@ mod tests {
             body.len()
         );
         assert!(body.ends_with("..."), "capped body should end with ...");
+    }
+
+    #[test]
+    fn captures_anonymous_arrow_in_method_call() {
+        let defs = extract(
+            r#"
+            const app = { get: (path: string, handler: any) => {} };
+            app.get("/users", (req: any, res: any) => { res.json({ id: 1 }); });
+            "#,
+        );
+        // "/users" → "_users" → trimmed → "users" → "get_users_handler"
+        let handler_keys: Vec<_> = defs.keys().filter(|k| k.contains("handler")).collect();
+        assert!(
+            !handler_keys.is_empty(),
+            "should have captured at least one handler, got keys: {:?}",
+            defs.keys().collect::<Vec<_>>()
+        );
+        let def = defs
+            .get("get_users_handler")
+            .expect("should capture route handler");
+        assert!(def.body_source.is_some());
+        assert!(def.body_source.as_ref().unwrap().contains("res.json"));
+    }
+
+    #[test]
+    fn captures_anonymous_fn_in_method_call() {
+        let defs = extract(
+            r#"
+            const router = { post: (path: string, handler: any) => {} };
+            router.post("/orders", function(req: any, res: any) { res.send("ok"); });
+            "#,
+        );
+        let def = defs
+            .get("post_orders_handler")
+            .expect("should capture route handler");
+        assert!(def.body_source.is_some());
+    }
+
+    #[test]
+    fn anonymous_handler_has_line_number() {
+        let defs = extract(
+            r#"
+            const app = { get: (path: string, handler: any) => {} };
+            app.get("/health", () => { return "ok"; });
+            "#,
+        );
+        let def = defs
+            .get("get_health_handler")
+            .expect("should capture handler");
+        assert!(def.line_number > 0);
+    }
+
+    #[test]
+    fn does_not_capture_non_function_args() {
+        let defs = extract(
+            r#"
+            const app = { get: (path: string) => {} };
+            app.get("/static");
+            "#,
+        );
+        // No function arg → no handler captured
+        assert!(
+            !defs.keys().any(|k| k.contains("handler")),
+            "should not capture calls without function args"
+        );
+    }
+
+    #[test]
+    fn derive_handler_name_works() {
+        assert_eq!(
+            super::derive_handler_name("get", Some("/users/:id")),
+            "get_users__id_handler"
+        );
+        assert_eq!(
+            super::derive_handler_name("on", Some("data")),
+            "on_data_handler"
+        );
+        assert_eq!(super::derive_handler_name("use", None), "use_handler");
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -5,6 +5,7 @@ use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
 };
+use swc_common::SourceMapper;
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitWith};
 
@@ -90,6 +91,29 @@ pub struct FunctionDefinition {
     pub file_path: PathBuf,
     pub node_type: FunctionNodeType,
     pub arguments: Vec<FunctionArgument>,
+    /// Raw source text of function body (capped at 2000 chars)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body_source: Option<String>,
+    /// Whether the function is exported
+    #[serde(default)]
+    pub is_exported: bool,
+    /// Start line number for navigation
+    #[serde(default)]
+    pub line_number: u32,
+    /// LLM-generated description of what this function intends to do
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intent: Option<String>,
+    /// Local functions called by this function (name, file_path, line_number)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub calls: Vec<FunctionCallRef>,
+}
+
+/// A reference to a called function, for navigating to its source via GitHub.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FunctionCallRef {
+    pub name: String,
+    pub file_path: String,
+    pub line_number: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -238,18 +262,46 @@ impl Visit for TypeSymbolExtractor {
 
 /// Extractor for function definitions with type annotations.
 /// Used to extract handler functions for type resolution in the multi-agent pipeline.
-#[derive(Debug)]
 pub struct FunctionDefinitionExtractor {
     pub function_definitions: HashMap<String, FunctionDefinition>,
     current_file_path: PathBuf,
+    source_map: swc_common::sync::Lrc<swc_common::SourceMap>,
+    /// Names of functions that are exported (populated by visit_export_decl / visit_named_export)
+    exported_names: HashSet<String>,
 }
 
 impl FunctionDefinitionExtractor {
-    pub fn new(file_path: PathBuf) -> Self {
+    pub fn new(
+        file_path: PathBuf,
+        source_map: swc_common::sync::Lrc<swc_common::SourceMap>,
+    ) -> Self {
         Self {
             function_definitions: HashMap::new(),
             current_file_path: file_path,
+            source_map,
+            exported_names: HashSet::new(),
         }
+    }
+
+    /// Extract source text from a span, capped at 2000 chars
+    fn extract_source(&self, span: swc_common::Span) -> Option<String> {
+        if span.is_dummy() {
+            return None;
+        }
+        let src = self.source_map.span_to_snippet(span).ok()?;
+        if src.len() > 2000 {
+            Some(format!("{}...", &src[..2000]))
+        } else {
+            Some(src)
+        }
+    }
+
+    /// Get the line number for a span
+    fn line_number(&self, span: swc_common::Span) -> u32 {
+        if span.is_dummy() {
+            return 0;
+        }
+        self.source_map.lookup_char_pos(span.lo).line as u32
     }
 
     /// Extract function arguments with their type annotations
@@ -301,12 +353,63 @@ impl FunctionDefinitionExtractor {
             })
             .collect()
     }
+
+    /// Mark functions as exported based on collected export names.
+    /// Call this after `module.visit_with()` completes.
+    pub fn finalize_exports(&mut self) {
+        for (name, def) in self.function_definitions.iter_mut() {
+            if self.exported_names.contains(name) {
+                def.is_exported = true;
+            }
+        }
+    }
 }
 
 impl Visit for FunctionDefinitionExtractor {
+    /// Track `export function foo() {}` and `export default function() {}`
+    fn visit_export_decl(&mut self, export: &ExportDecl) {
+        match &export.decl {
+            Decl::Fn(fn_decl) => {
+                self.exported_names.insert(fn_decl.ident.sym.to_string());
+            }
+            Decl::Var(var_decl) => {
+                for decl in &var_decl.decls {
+                    if let Pat::Ident(ident) = &decl.name {
+                        self.exported_names.insert(ident.id.sym.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+        // Continue visiting so visit_fn_decl / visit_var_declarator fire
+        export.visit_children_with(self);
+    }
+
+    /// Track `export { foo, bar }` named exports
+    fn visit_named_export(&mut self, export: &NamedExport) {
+        // Only track re-exports from local scope (no `from` source)
+        if export.src.is_none() {
+            for spec in &export.specifiers {
+                if let ExportSpecifier::Named(named) = spec {
+                    let name = match &named.orig {
+                        ModuleExportName::Ident(ident) => ident.sym.to_string(),
+                        ModuleExportName::Str(s) => s.value.to_string(),
+                    };
+                    self.exported_names.insert(name);
+                }
+            }
+        }
+    }
+
     fn visit_fn_decl(&mut self, fn_decl: &FnDecl) {
         let name = fn_decl.ident.sym.to_string();
         let arguments = self.extract_arguments(&fn_decl.function.params);
+        let body_source = fn_decl
+            .function
+            .body
+            .as_ref()
+            .and_then(|b| self.extract_source(b.span));
+        let line_number = self.line_number(fn_decl.function.span);
 
         self.function_definitions.insert(
             name.clone(),
@@ -315,6 +418,11 @@ impl Visit for FunctionDefinitionExtractor {
                 file_path: self.current_file_path.clone(),
                 node_type: FunctionNodeType::FunctionDeclaration(Box::new(fn_decl.clone())),
                 arguments,
+                body_source,
+                is_exported: false, // Updated in a post-pass
+                line_number,
+                intent: None,
+                calls: vec![],
             },
         );
 
@@ -332,6 +440,8 @@ impl Visit for FunctionDefinitionExtractor {
                 match &**init {
                     Expr::Arrow(arrow) => {
                         let arguments = self.extract_arrow_arguments(&arrow.params);
+                        let body_source = self.extract_source(arrow.span);
+                        let line_number = self.line_number(arrow.span);
                         self.function_definitions.insert(
                             name.clone(),
                             FunctionDefinition {
@@ -339,11 +449,22 @@ impl Visit for FunctionDefinitionExtractor {
                                 file_path: self.current_file_path.clone(),
                                 node_type: FunctionNodeType::ArrowFunction(Box::new(arrow.clone())),
                                 arguments,
+                                body_source,
+                                is_exported: false,
+                                line_number,
+                                intent: None,
+                                calls: vec![],
                             },
                         );
                     }
                     Expr::Fn(fn_expr) => {
                         let arguments = self.extract_arguments(&fn_expr.function.params);
+                        let body_source = fn_expr
+                            .function
+                            .body
+                            .as_ref()
+                            .and_then(|b| self.extract_source(b.span));
+                        let line_number = self.line_number(fn_expr.function.span);
                         self.function_definitions.insert(
                             name.clone(),
                             FunctionDefinition {
@@ -353,6 +474,11 @@ impl Visit for FunctionDefinitionExtractor {
                                     fn_expr.clone(),
                                 )),
                                 arguments,
+                                body_source,
+                                is_exported: false,
+                                line_number,
+                                intent: None,
+                                calls: vec![],
                             },
                         );
                     }
@@ -363,5 +489,122 @@ impl Visit for FunctionDefinitionExtractor {
 
         // Continue visiting child nodes
         var_decl.visit_children_with(self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse_file;
+    use swc_common::{
+        SourceMap,
+        errors::{ColorConfig, Handler},
+        sync::Lrc,
+    };
+
+    fn parse_ts(source: &str) -> (Lrc<SourceMap>, Module) {
+        let tmp_dir = tempfile::tempdir().expect("tempdir");
+        let file_path = tmp_dir.path().join("input.ts");
+        std::fs::write(&file_path, source).expect("write file");
+        let cm: Lrc<SourceMap> = Default::default();
+        let handler = Handler::with_tty_emitter(ColorConfig::Never, true, false, Some(cm.clone()));
+        let module = parse_file(&file_path, &cm, &handler).expect("parsed module");
+        (cm, module)
+    }
+
+    fn extract(source: &str) -> HashMap<String, FunctionDefinition> {
+        let (cm, module) = parse_ts(source);
+        let mut extractor = FunctionDefinitionExtractor::new(PathBuf::from("test.ts"), cm);
+        module.visit_with(&mut extractor);
+        extractor.finalize_exports();
+        extractor.function_definitions
+    }
+
+    #[test]
+    fn captures_body_source_for_function_declaration() {
+        let defs = extract("function greet(name: string) { return `Hello ${name}`; }");
+        let def = defs.get("greet").expect("should find greet");
+        assert!(def.body_source.is_some(), "should have body_source");
+        assert!(
+            def.body_source.as_ref().unwrap().contains("Hello"),
+            "body should contain function text"
+        );
+    }
+
+    #[test]
+    fn captures_body_source_for_arrow_function() {
+        let defs = extract("const add = (a: number, b: number) => { return a + b; };");
+        let def = defs.get("add").expect("should find add");
+        assert!(def.body_source.is_some(), "should have body_source");
+        assert!(
+            def.body_source.as_ref().unwrap().contains("a + b"),
+            "body should contain arrow text"
+        );
+    }
+
+    #[test]
+    fn detects_export_function_declaration() {
+        let defs = extract("export function hello() { return 1; }");
+        let def = defs.get("hello").expect("should find hello");
+        assert!(def.is_exported, "export function should be marked exported");
+    }
+
+    #[test]
+    fn detects_export_const_arrow() {
+        let defs = extract("export const foo = () => { return 42; };");
+        let def = defs.get("foo").expect("should find foo");
+        assert!(
+            def.is_exported,
+            "export const arrow should be marked exported"
+        );
+    }
+
+    #[test]
+    fn detects_named_export() {
+        let defs =
+            extract("function bar() { return 1; }\nfunction baz() { return 2; }\nexport { bar };");
+        let bar = defs.get("bar").expect("should find bar");
+        let baz = defs.get("baz").expect("should find baz");
+        assert!(
+            bar.is_exported,
+            "bar should be marked exported via named export"
+        );
+        assert!(!baz.is_exported, "baz should NOT be exported");
+    }
+
+    #[test]
+    fn non_exported_function_is_not_marked() {
+        let defs = extract("function internal() { return 'private'; }");
+        let def = defs.get("internal").expect("should find internal");
+        assert!(
+            !def.is_exported,
+            "non-exported function should not be marked"
+        );
+    }
+
+    #[test]
+    fn captures_line_number() {
+        let defs = extract("function first() { return 1; }");
+        let def = defs.get("first").expect("should find first");
+        assert!(def.line_number > 0, "line_number should be positive");
+    }
+
+    #[test]
+    fn caps_body_source_at_2000_chars() {
+        // Generate a function with a body > 2000 chars
+        let long_body = "x".repeat(2500);
+        let source = format!(
+            "function big() {{ const s = \"{}\"; return s; }}",
+            long_body
+        );
+        let defs = extract(&source);
+        let def = defs.get("big").expect("should find big");
+        let body = def.body_source.as_ref().expect("should have body_source");
+        assert!(
+            body.len() <= 2003, // 2000 + "..."
+            "body_source should be capped (got {} chars)",
+            body.len()
+        );
+        assert!(body.ends_with("..."), "capped body should end with ...");
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -290,7 +290,11 @@ impl FunctionDefinitionExtractor {
         }
         let src = self.source_map.span_to_snippet(span).ok()?;
         if src.len() > 2000 {
-            Some(format!("{}...", &src[..2000]))
+            if let Some((idx, _)) = src.char_indices().nth(2000) {
+                Some(format!("{}...", &src[..idx]))
+            } else {
+                Some(src)
+            }
         } else {
             Some(src)
         }
@@ -366,7 +370,7 @@ impl FunctionDefinitionExtractor {
 }
 
 impl Visit for FunctionDefinitionExtractor {
-    /// Track `export function foo() {}` and `export default function() {}`
+    /// Track `export function foo() {}` and `export const bar = ...`
     fn visit_export_decl(&mut self, export: &ExportDecl) {
         match &export.decl {
             Decl::Fn(fn_decl) => {
@@ -382,6 +386,57 @@ impl Visit for FunctionDefinitionExtractor {
             _ => {}
         }
         // Continue visiting so visit_fn_decl / visit_var_declarator fire
+        export.visit_children_with(self);
+    }
+
+    /// Track `export default function foo() {}` and `export default class Foo {}`
+    fn visit_export_default_decl(&mut self, export: &ExportDefaultDecl) {
+        match &export.decl {
+            DefaultDecl::Fn(fn_expr) => {
+                if let Some(ident) = &fn_expr.ident {
+                    let name = ident.sym.to_string();
+                    self.exported_names.insert(name.clone());
+                    // Capture the function since visit_fn_decl won't fire for default exports
+                    let arguments = self.extract_arguments(&fn_expr.function.params);
+                    let body_source = fn_expr
+                        .function
+                        .body
+                        .as_ref()
+                        .and_then(|b| self.extract_source(b.span));
+                    let line_number = self.line_number(fn_expr.function.span);
+                    self.function_definitions.insert(
+                        name.clone(),
+                        FunctionDefinition {
+                            name,
+                            file_path: self.current_file_path.clone(),
+                            node_type: FunctionNodeType::FunctionExpression(Box::new(
+                                fn_expr.clone(),
+                            )),
+                            arguments,
+                            body_source,
+                            is_exported: true,
+                            line_number,
+                            intent: None,
+                            calls: vec![],
+                        },
+                    );
+                }
+            }
+            DefaultDecl::Class(class_expr) => {
+                if let Some(ident) = &class_expr.ident {
+                    self.exported_names.insert(ident.sym.to_string());
+                }
+            }
+            _ => {}
+        }
+        export.visit_children_with(self);
+    }
+
+    /// Track `export default foo` (expression)
+    fn visit_export_default_expr(&mut self, export: &ExportDefaultExpr) {
+        if let Expr::Ident(ident) = &*export.expr {
+            self.exported_names.insert(ident.sym.to_string());
+        }
         export.visit_children_with(self);
     }
 
@@ -691,6 +746,26 @@ mod tests {
         let defs = extract("export function hello() { return 1; }");
         let def = defs.get("hello").expect("should find hello");
         assert!(def.is_exported, "export function should be marked exported");
+    }
+
+    #[test]
+    fn detects_export_default_function() {
+        let defs = extract("export default function main() { return 1; }");
+        let def = defs.get("main").expect("should find main");
+        assert!(
+            def.is_exported,
+            "export default function should be marked exported"
+        );
+    }
+
+    #[test]
+    fn detects_export_default_expression() {
+        let defs = extract("function setup() { return 1; }\nexport default setup;");
+        let def = defs.get("setup").expect("should find setup");
+        assert!(
+            def.is_exported,
+            "export default expr should be marked exported"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Extends the SWC visitor to capture function body source text, export status, and line numbers for all named functions
- At CI time, generates 1-2 sentence intent descriptions for each exported function using the agent proxy LLM
- Functions are processed in topological order (leaves first) so callee intents inform caller descriptions — compositional understanding
- Intent generation runs in parallel within each dependency level using `futures::join_all`
- After generation, `body_source` is stripped — source code stays in GitHub, not AWS
- New MCP tool `list_function_intents` returns all exported functions with intents, call refs, and file locations
- Agents browse intents to discover existing implementations, then use `gh` CLI to view source

## Design

Carrick indexes *what functions do* (intents). GitHub hosts *how they do it* (source). The agent bridges the two.

```
CI time:   SWC extracts body → LLM generates intent → body stripped → intent + metadata uploaded
Query time: agent calls list_function_intents → scans intents → gh browse repo -- file:line
```

## Known limitations (issues created)

- #54 — Intent generation only runs in full analysis path, not incremental
- #55 — Function call detection uses `body.contains(name)` — false positives on short names
- #56 — find-similar.ts filename doesn't match content (should be list-intents.ts)

## Test plan

- [x] 168 Rust tests pass (14 new: 8 visitor + 6 intent_generator)
- [x] 60 ts_check tests pass
- [x] Clippy clean, fmt clean
- [x] MCP TypeScript compiles clean
- [ ] End-to-end: run on test repos, verify intents are generated and MCP returns them