### PR TITLE
feat: structured logging with tracing, spinners, and S3 log upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,9 @@ dependencies = [
  "async-trait",
  "chrono",
  "derivative",
+ "dirs",
  "futures",
+ "indicatif",
  "matchit",
  "regex",
  "reqwest",
@@ -228,6 +230,9 @@ dependencies = [
  "swc_ecma_visit",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "walkdir",
 ]
 
@@ -284,6 +289,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +325,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -335,6 +368,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +398,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +434,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -903,6 +972,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,10 +1019,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "libredox"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -969,6 +1066,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -1032,6 +1138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1156,12 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -1069,6 +1190,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -1128,6 +1255,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "outref"
@@ -1238,6 +1371,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1463,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1647,6 +1803,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,7 +1962,7 @@ dependencies = [
  "swc_visit",
  "termcolor",
  "tracing",
- "unicode-width",
+ "unicode-width 0.1.14",
  "url",
 ]
 
@@ -2108,6 +2273,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,6 +2442,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,6 +2471,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2269,6 +2556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,6 +2595,12 @@ name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2431,6 +2730,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2024"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 derivative = "2.2.0"
+dirs = "5.0"
 futures = "0.3.32"
+indicatif = "0.17"
 
 matchit = "0.8.6"
 regex = "1.11.1"
@@ -23,6 +25,9 @@ swc_ecma_parser = "15.0.0"
 swc_ecma_transforms_base = "16.0.0"
 swc_ecma_visit = "12.0.0"
 tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/lambdas/check-or-upload/index.js
+++ b/lambdas/check-or-upload/index.js
@@ -485,7 +485,11 @@ async function handleUploadLogs(payload) {
   try {
     const uploadUrl = await getSignedUrl(
       s3Client,
-      new PutObjectCommand({ Bucket: BUCKET_NAME, Key: s3Key }),
+      new PutObjectCommand({
+        Bucket: BUCKET_NAME,
+        Key: s3Key,
+        Tagging: "log=true",
+      }),
       { expiresIn: 60 * 5 },
     );
 

--- a/lambdas/check-or-upload/index.js
+++ b/lambdas/check-or-upload/index.js
@@ -58,6 +58,8 @@ exports.handler = async (event) => {
       return await handleGetCrossRepoData(payload, apiKey);
     case "download-file":
       return await handleDownloadFile(payload, apiKey);
+    case "upload-logs":
+      return await handleUploadLogs(payload);
     default:
       // Default behavior - backward compatibility
       return await handleCheckOrUpload(body);
@@ -466,6 +468,34 @@ async function handleDownloadFile(payload, apiKey) {
       return response(404, { error: "File not found" });
     }
     return response(500, { error: "Failed to download file" });
+  }
+}
+
+async function handleUploadLogs(payload) {
+  const { org, repo, timestamp } = payload;
+
+  if (!org || !repo || !timestamp) {
+    return response(400, {
+      error: "Missing required fields: org, repo, timestamp",
+    });
+  }
+
+  const s3Key = `${org}/${repo}/logs/${timestamp}.log`;
+
+  try {
+    const uploadUrl = await getSignedUrl(
+      s3Client,
+      new PutObjectCommand({ Bucket: BUCKET_NAME, Key: s3Key }),
+      { expiresIn: 60 * 5 },
+    );
+
+    return response(200, {
+      uploadUrl,
+      s3Key,
+    });
+  } catch (err) {
+    console.error("Failed to generate log upload URL:", err);
+    return response(500, { error: "Failed to generate upload URL" });
   }
 }
 

--- a/src/agent_service.rs
+++ b/src/agent_service.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use tokio::time::{Duration, sleep};
+use tracing::{debug, warn};
 
 /// Reusable service for making Agent API calls
 #[derive(Debug, Clone)]
@@ -126,7 +127,7 @@ impl AgentService {
                         // Retry on 429 Too Many Requests with exponential backoff
                         if status == 429 && attempt < max_retries {
                             let wait_time = Duration::from_secs(2u64.pow(attempt as u32));
-                            eprintln!(
+                            warn!(
                                 "Agent API 429 Too Many Requests. Retrying in {:?} (attempt {}/{})",
                                 wait_time, attempt, max_retries
                             );
@@ -138,7 +139,7 @@ impl AgentService {
                         // This handles API Gateway timeout issues
                         if status == 503 && attempt < max_retries {
                             let wait_time = Duration::from_secs(2u64.pow(attempt as u32));
-                            eprintln!(
+                            warn!(
                                 "Agent API returned 503, retrying in {:?} (attempt {}/{})",
                                 wait_time, attempt, max_retries
                             );
@@ -158,7 +159,7 @@ impl AgentService {
                     // Retry network errors with exponential backoff
                     if attempt < max_retries {
                         let wait_time = Duration::from_secs(2u64.pow(attempt as u32));
-                        eprintln!(
+                        warn!(
                             "Agent proxy call failed: {}, retrying in {:?} (attempt {}/{})",
                             e, wait_time, attempt, max_retries
                         );
@@ -270,7 +271,7 @@ pub async fn extract_calls_from_async_expressions(
 
     // Emergency disable option for Agent API
     if env::var("DISABLE_AGENT").is_ok() {
-        println!("Agent API disabled via DISABLE_AGENT environment variable");
+        debug!("Agent API disabled via DISABLE_AGENT environment variable");
         return Ok(vec![]);
     }
 
@@ -286,14 +287,14 @@ pub async fn extract_calls_from_async_expressions(
 
     const MAX_REASONABLE_SIZE: usize = 200_000; // 200KB - warn above this
     if total_size > MAX_REASONABLE_SIZE {
-        eprintln!(
+        warn!(
             "Warning: Large amount of source code to analyze ({:.1}KB total). This may result in high token usage.",
             total_size as f64 / 1024.0
         );
     }
 
-    println!(
-        "Found {} async expressions, sending to Agent Service with framework context...",
+    debug!(
+        "Found {} async expressions, sending to Agent Service with framework context",
         async_calls.len()
     );
 
@@ -469,7 +470,7 @@ fn parse_agent_response(response: &str, contexts: &[AsyncCallContext]) -> Vec<Ca
         }
     }
 
-    eprintln!("All JSON parsing attempts failed. Response: {}", json_str);
+    warn!("All JSON parsing attempts failed. Response: {}", json_str);
     vec![]
 }
 
@@ -917,7 +918,7 @@ fn generate_mock_file_analysis_response(prompt: &str) -> String {
     }
 
     // Log mock generation for debugging
-    eprintln!(
+    debug!(
         "Mock file analysis for {}: {} mounts, {} endpoints, {} data_calls",
         file_path,
         mounts.len(),

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use tracing::{debug, warn};
 
 /// Result of analyzing a single mount relationship
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -184,14 +185,14 @@ impl FileAnalyzerAgent {
             import_map,
         );
 
-        println!("=== FILE ANALYZER AGENT (AST-GATED) ===");
-        println!("Analyzing file: {}", file_path);
-        println!(
+        debug!("=== FILE ANALYZER AGENT (AST-GATED) ===");
+        debug!("Analyzing file: {}", file_path);
+        debug!(
             "File size: {} chars, {} lines",
             file_content.len(),
             file_content.lines().count()
         );
-        println!("Candidate targets: {}", candidate_hints.len());
+        debug!("Candidate targets: {}", candidate_hints.len());
 
         let schema = AgentSchemas::file_analysis_schema();
         let response = self
@@ -199,9 +200,9 @@ impl FileAnalyzerAgent {
             .analyze_code_with_schema(&user_message, &system_message, Some(schema.clone()))
             .await?;
 
-        println!("=== RAW FILE ANALYSIS RESPONSE ===");
-        println!("{}", response);
-        println!("=== END RAW RESPONSE ===");
+        debug!("=== RAW FILE ANALYSIS RESPONSE ===");
+        debug!("{}", response);
+        debug!("=== END RAW RESPONSE ===");
 
         let mut result: FileAnalysisResult = serde_json::from_str(&response).map_err(|e| {
             format!(
@@ -214,15 +215,15 @@ impl FileAnalyzerAgent {
         let needs_retry = Self::sanitize_result(&mut result);
         let initial_result = result.clone();
         if needs_retry {
-            println!("[FileAnalyzerAgent] Suspicious fields detected in LLM output; retrying once");
+            warn!("[FileAnalyzerAgent] Suspicious fields detected in LLM output; retrying once");
             let response = self
                 .agent_service
                 .analyze_code_with_schema(&user_message, &system_message, Some(schema))
                 .await?;
 
-            println!("=== RAW FILE ANALYSIS RESPONSE ===");
-            println!("{}", response);
-            println!("=== END RAW RESPONSE ===");
+            debug!("=== RAW FILE ANALYSIS RESPONSE ===");
+            debug!("{}", response);
+            debug!("=== END RAW RESPONSE ===");
 
             let mut retry_result: FileAnalysisResult =
                 serde_json::from_str(&response).map_err(|e| {
@@ -235,7 +236,7 @@ impl FileAnalyzerAgent {
             Self::sanitize_result(&mut retry_result);
             let chosen = Self::choose_best_result(initial_result, retry_result);
 
-            println!(
+            debug!(
                 "File analysis complete: {} mounts, {} endpoints, {} data_calls",
                 chosen.mounts.len(),
                 chosen.endpoints.len(),
@@ -245,7 +246,7 @@ impl FileAnalyzerAgent {
             return Ok(chosen);
         }
 
-        println!(
+        debug!(
             "File analysis complete: {} mounts, {} endpoints, {} data_calls",
             result.mounts.len(),
             result.endpoints.len(),
@@ -269,7 +270,7 @@ impl FileAnalyzerAgent {
         if retry_score >= initial_score {
             retry
         } else {
-            println!("[FileAnalyzerAgent] Retry produced fewer findings; keeping original result");
+            warn!("[FileAnalyzerAgent] Retry produced fewer findings; keeping original result");
             initial
         }
     }

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -48,6 +48,7 @@ use swc_common::{
     sync::Lrc,
 };
 use swc_ecma_visit::VisitWith;
+use tracing::{debug, warn};
 
 /// Complete result of file-centric analysis
 #[derive(Debug)]
@@ -137,8 +138,8 @@ impl FileOrchestrator {
         guidance: &FrameworkGuidance,
         framework_detection: &DetectionResult,
     ) -> Result<FileCentricAnalysisResult, Box<dyn std::error::Error>> {
-        println!("=== AST-GATED FILE-CENTRIC ORCHESTRATOR ===");
-        println!("Processing {} files with SWC gatekeeper", files.len());
+        debug!("=== AST-GATED FILE-CENTRIC ORCHESTRATOR ===");
+        debug!("Processing {} files with SWC gatekeeper", files.len());
 
         let mut file_results: HashMap<String, FileAnalysisResult> = HashMap::new();
         let mut stats = ProcessingStats::default();
@@ -163,7 +164,7 @@ impl FileOrchestrator {
 
             // Skip empty files
             if content.trim().is_empty() {
-                println!("Skipping empty file: {}", path_str);
+                debug!("Skipping empty file: {}", path_str);
                 stats.files_skipped += 1;
                 continue;
             }
@@ -173,7 +174,7 @@ impl FileOrchestrator {
 
             // STEP 2: Check Relevance - if no candidates, SKIP (zero LLM cost)
             if !scan_result.should_analyze {
-                println!("Skipped (no API patterns): {} [0 candidates]", path_str);
+                debug!("Skipped (no API patterns): {} [0 candidates]", path_str);
                 stats.files_skipped += 1;
                 stats.files_skipped_no_candidates += 1;
                 // Store empty result so incremental cache knows this file was processed
@@ -181,7 +182,7 @@ impl FileOrchestrator {
                 continue;
             }
 
-            println!(
+            debug!(
                 "Analyzing: {} [{} candidates detected by SWC]",
                 path_str,
                 scan_result.candidates.len()
@@ -244,16 +245,16 @@ impl FileOrchestrator {
             }
         }
 
-        println!("\n=== FILE PROCESSING COMPLETE ===");
-        println!("  - Files processed (LLM calls): {}", stats.files_processed);
-        println!("  - Files skipped (total): {}", stats.files_skipped);
-        println!(
+        debug!("\n=== FILE PROCESSING COMPLETE ===");
+        debug!("  - Files processed (LLM calls): {}", stats.files_processed);
+        debug!("  - Files skipped (total): {}", stats.files_skipped);
+        debug!(
             "  - Zero-cost skips (no API patterns): {}",
             stats.files_skipped_no_candidates
         );
-        println!("  - Total mounts: {}", stats.total_mounts);
-        println!("  - Total endpoints: {}", stats.total_endpoints);
-        println!("  - Total data calls: {}", stats.total_data_calls);
+        debug!("  - Total mounts: {}", stats.total_mounts);
+        debug!("  - Total endpoints: {}", stats.total_endpoints);
+        debug!("  - Total data calls: {}", stats.total_data_calls);
 
         // STEP 5: Build aggregated mount graph from all file results
         let mount_graph = self.build_mount_graph(&file_results);
@@ -491,7 +492,7 @@ impl FileOrchestrator {
                 } else if endpoint.type_import_source.is_some()
                     && endpoint.primary_type_symbol.is_none()
                 {
-                    eprintln!(
+                    warn!(
                         "[FileOrchestrator] Endpoint at {}:{} has import source {:?} but no symbol; relying on inference",
                         file_path, line_number, endpoint.type_import_source
                     );
@@ -631,7 +632,7 @@ impl FileOrchestrator {
                 } else if data_call.type_import_source.is_some()
                     && data_call.primary_type_symbol.is_none()
                 {
-                    eprintln!(
+                    warn!(
                         "[FileOrchestrator] Data call at {}:{} has import source {:?} but no symbol; relying on inference",
                         file_path, line_number, data_call.type_import_source
                     );
@@ -677,7 +678,7 @@ impl FileOrchestrator {
             }
         }
 
-        eprintln!(
+        debug!(
             "[FileOrchestrator] Collected {} explicit type requests, {} inference requests, {} inline aliases",
             explicit_requests.len(),
             infer_requests.len(),
@@ -830,7 +831,7 @@ impl FileOrchestrator {
             .collect();
 
         if dropped_count > 0 {
-            eprintln!(
+            warn!(
                 "[FileOrchestrator] {} data call(s) had no matching SWC candidate (spans unavailable)",
                 dropped_count
             );
@@ -861,7 +862,7 @@ impl FileOrchestrator {
         let (explicit, infer, inline_aliases) =
             self.collect_type_requests(file_results, repo_path, mount_graph, config);
 
-        eprintln!(
+        debug!(
             "[FileOrchestrator] Resolving types: {} explicit, {} inferred",
             explicit.len(),
             infer.len()
@@ -876,7 +877,7 @@ impl FileOrchestrator {
         let result = self.append_inline_aliases(result, inline_aliases);
 
         // Log results
-        eprintln!(
+        debug!(
             "[FileOrchestrator] Type resolution complete: {} manifest entries, {} inferred types, {} failures",
             result.explicit_manifest.len(),
             result.inferred_types.len(),
@@ -884,7 +885,7 @@ impl FileOrchestrator {
         );
 
         if !result.errors.is_empty() {
-            eprintln!(
+            warn!(
                 "[FileOrchestrator] Type resolution warnings: {:?}",
                 result.errors
             );

--- a/src/agents/framework_guidance_agent.rs
+++ b/src/agents/framework_guidance_agent.rs
@@ -2,6 +2,7 @@ use crate::{
     agent_service::AgentService, agents::schemas::AgentSchemas, framework_detector::DetectionResult,
 };
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 /// A single pattern example for a specific framework
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -89,18 +90,18 @@ impl FrameworkGuidanceAgent {
         &self,
         framework_detection: &DetectionResult,
     ) -> Result<FrameworkGuidance, Box<dyn std::error::Error>> {
-        println!("=== FRAMEWORK GUIDANCE AGENT DEBUG ===");
-        println!(
+        debug!("=== FRAMEWORK GUIDANCE AGENT DEBUG ===");
+        debug!(
             "Generating guidance for frameworks: {:?}",
             framework_detection.frameworks
         );
-        println!("Data fetchers: {:?}", framework_detection.data_fetchers);
+        debug!("Data fetchers: {:?}", framework_detection.data_fetchers);
 
         let system_message = self.build_system_message();
         let prompt_context = self.build_context_string(framework_detection);
 
         // Execute calls in parallel for speed (flattened schema makes this fast enough)
-        println!("  Fetching all patterns in parallel...");
+        debug!("  Fetching all patterns in parallel...");
         let mount_task = self.fetch_patterns("mount", &prompt_context, &system_message);
         let endpoint_task = self.fetch_patterns("endpoint", &prompt_context, &system_message);
         let middleware_task = self.fetch_patterns("middleware", &prompt_context, &system_message);
@@ -131,14 +132,14 @@ impl FrameworkGuidanceAgent {
             parsing_notes: general_guidance.parsing_notes,
         };
 
-        println!("Generated guidance with:");
-        println!("  - {} mount patterns", guidance.mount_patterns.len());
-        println!("  - {} endpoint patterns", guidance.endpoint_patterns.len());
-        println!(
+        debug!("Generated guidance with:");
+        debug!("  - {} mount patterns", guidance.mount_patterns.len());
+        debug!("  - {} endpoint patterns", guidance.endpoint_patterns.len());
+        debug!(
             "  - {} middleware patterns",
             guidance.middleware_patterns.len()
         );
-        println!(
+        debug!(
             "  - {} data fetching patterns",
             guidance.data_fetching_patterns.len()
         );

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -18,6 +18,7 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
 };
+use tracing::{debug, warn};
 
 // Type aliases to reduce complexity
 type RouteFieldMap = HashMap<(String, String), Json>;
@@ -237,7 +238,7 @@ impl Analyzer {
 
         // Skip Gemini call if no async expressions found (safety check)
         if all_async_contexts.is_empty() {
-            println!("No async expressions found, skipping Gemini analysis");
+            debug!("No async expressions found, skipping Gemini analysis");
             return;
         }
 
@@ -251,12 +252,12 @@ impl Analyzer {
         {
             Ok(calls) => calls,
             Err(e) => {
-                eprintln!("Failed to extract calls from async expressions: {}", e);
+                warn!("Failed to extract calls from async expressions: {}", e);
                 vec![]
             }
         };
 
-        println!("Gemini extracted {} HTTP calls", gemini_calls.len());
+        debug!("Gemini extracted {} HTTP calls", gemini_calls.len());
 
         // Process calls as before
         let processed_calls = self.process_fetch_calls(gemini_calls);
@@ -622,8 +623,8 @@ impl Analyzer {
         let loc = cm.lookup_char_pos(type_ref_span.lo);
         let file_start_bytepos = loc.file.start_pos;
         if type_ref_span.lo < file_start_bytepos {
-            eprintln!(
-                "Warning: Span `lo` ({:?}) is before its supposed file's start_pos ({:?}) for file {:?}. This indicates a SourceMap or span issue.",
+            warn!(
+                "Span `lo` ({:?}) is before its supposed file's start_pos ({:?}) for file {:?}. This indicates a SourceMap or span issue.",
                 type_ref_span.lo, file_start_bytepos, loc.file.name
             );
             return None; // Or handle as an error appropriately
@@ -633,7 +634,7 @@ impl Analyzer {
         let actual_span_file_path = match &*loc.file.name {
             FileName::Real(pathbuf) => pathbuf.clone(), // Clone to own PathBuf
             other => {
-                eprintln!(
+                warn!(
                     "Span found in a non-real file: {:?}. Cannot process.",
                     other
                 );
@@ -644,7 +645,7 @@ impl Analyzer {
         let file_content = match std::fs::read_to_string(&actual_span_file_path) {
             Ok(content) => content,
             Err(e) => {
-                eprintln!(
+                warn!(
                     "Failed to read file {:?} for offset calculation: {}. Skipping.",
                     actual_span_file_path, e
                 );
@@ -1052,12 +1053,12 @@ impl Analyzer {
                 .push((endpoint.route.clone(), endpoint.method.clone()));
         }
 
-        println!("Unique endpoint paths: {}", path_to_endpoints.len());
+        debug!("Unique endpoint paths: {}", path_to_endpoints.len());
 
         // Now insert each unique path once, with a collection of route-method pairs
         for (path, route_methods) in path_to_endpoints {
             if let Err(e) = router.insert(&path, route_methods) {
-                println!("Warning: Could not add route to router: {}", e);
+                warn!("Could not add route to router: {}", e);
             }
         }
 
@@ -1182,18 +1183,16 @@ impl Analyzer {
             .collect();
 
         if type_files.is_empty() {
-            println!(
-                "⚠️  No bundled .d.ts files found in ts_check/output/ - skipping type checking"
-            );
-            println!("   This may happen if:");
-            println!("   - Source code lacks explicit TypeScript type annotations");
-            println!("   - Type extraction agents couldn't identify response/request types");
-            println!("   - This is the first run and no cross-repo data exists yet");
-            println!("   Type checking will work when type annotations are present in the source.");
+            debug!("No bundled .d.ts files found in ts_check/output/ - skipping type checking");
+            debug!("   This may happen if:");
+            debug!("   - Source code lacks explicit TypeScript type annotations");
+            debug!("   - Type extraction agents couldn't identify response/request types");
+            debug!("   - This is the first run and no cross-repo data exists yet");
+            debug!("   Type checking will work when type annotations are present in the source.");
             return Ok(());
         }
 
-        println!(
+        debug!(
             "Found {} type file(s) to check: {:?}",
             type_files.len(),
             type_files.iter().map(|f| f.file_name()).collect::<Vec<_>>()
@@ -1234,12 +1233,16 @@ impl Analyzer {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
 
-        // Print the output from the type checking script
+        // Log type checking output at debug level
         if !stdout.trim().is_empty() {
-            print!("{}", stdout);
+            for line in stdout.lines() {
+                debug!("{}", line);
+            }
         }
         if !stderr.trim().is_empty() && !output.status.success() {
-            print!("{}", stderr);
+            for line in stderr.lines() {
+                debug!("{}", line);
+            }
         }
 
         if !output.status.success() {

--- a/src/call_site_classifier.rs
+++ b/src/call_site_classifier.rs
@@ -2,6 +2,7 @@ use crate::{
     agent_service::AgentService, call_site_extractor::CallSite, framework_detector::DetectionResult,
 };
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 /// Classification result for a call site with detailed extraction
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -55,39 +56,39 @@ impl CallSiteClassifier {
         call_sites: &[CallSite],
         framework_detection: &DetectionResult,
     ) -> Result<Vec<ClassifiedCallSite>, Box<dyn std::error::Error>> {
-        println!("=== CALL SITE CLASSIFICATION DEBUG ===");
-        println!("Number of call sites to classify: {}", call_sites.len());
-        println!("Framework detection: {:?}", framework_detection);
+        debug!("=== CALL SITE CLASSIFICATION DEBUG ===");
+        debug!("Number of call sites to classify: {}", call_sites.len());
+        debug!("Framework detection: {:?}", framework_detection);
 
         // Print each call site for debugging
         for (i, call_site) in call_sites.iter().enumerate() {
-            println!(
+            debug!(
                 "Call site {}: {}.{}()",
                 i + 1,
                 call_site.callee_object,
                 call_site.callee_property
             );
-            println!("  Location: {}", call_site.location);
-            println!("  Args: {} arguments", call_site.args.len());
+            debug!("  Location: {}", call_site.location);
+            debug!("  Args: {} arguments", call_site.args.len());
         }
 
         let prompt = self.build_classification_prompt(call_sites, framework_detection);
         let system_message = self.build_system_message();
 
-        println!("=== PROMPT BEING SENT TO AGENT ===");
-        println!("System message length: {} chars", system_message.len());
-        println!("Prompt length: {} chars", prompt.len());
-        println!("Full prompt:\n{}", prompt);
-        println!("=== END OF PROMPT ===");
+        debug!("=== PROMPT BEING SENT TO AGENT ===");
+        debug!("System message length: {} chars", system_message.len());
+        debug!("Prompt length: {} chars", prompt.len());
+        debug!("Full prompt:\n{}", prompt);
+        debug!("=== END OF PROMPT ===");
 
         let response = self
             .agent_service
             .analyze_code(&prompt, &system_message)
             .await?;
 
-        println!("=== AGENT RESPONSE ===");
-        println!("{}", response);
-        println!("=== END OF RESPONSE ===");
+        debug!("=== AGENT RESPONSE ===");
+        debug!("{}", response);
+        debug!("=== END OF RESPONSE ===");
 
         let classified_sites: Vec<ClassifiedCallSite> = serde_json::from_str(&response)
             .map_err(|e| format!("Failed to parse LLM classification response: {}", e))?;

--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
+use tracing::{debug, warn};
 
 pub struct AwsStorage {
     lambda_url: String,
@@ -216,7 +217,7 @@ impl AwsStorage {
         };
 
         let _response: StoreMetadataResponse = self.call_lambda(&request).await?;
-        println!("Successfully stored metadata for {}", data.repo_name);
+        debug!("Successfully stored metadata for {}", data.repo_name);
 
         Ok(())
     }
@@ -243,7 +244,7 @@ impl CloudStorage for AwsStorage {
         // Step 2: Upload type file if needed
         if let Some(upload_url) = lambda_response.upload_url {
             if let Some(bundled_types) = data.bundled_types.as_ref() {
-                println!("Uploading bundled types to S3...");
+                debug!("Uploading bundled types to S3...");
                 self.upload_to_s3(&upload_url, bundled_types).await?;
 
                 // Step 3: Complete the upload by storing metadata
@@ -259,9 +260,9 @@ impl CloudStorage for AwsStorage {
 
                 let _complete_response: serde_json::Value =
                     self.call_lambda(&complete_request).await?;
-                println!("Successfully completed upload and stored metadata");
+                debug!("Successfully completed upload and stored metadata");
             } else {
-                println!(
+                debug!(
                     "No bundled types available for {}; storing metadata only",
                     repo
                 );
@@ -269,7 +270,7 @@ impl CloudStorage for AwsStorage {
                     .await?;
             }
         } else {
-            println!("Type file already exists, just updating metadata");
+            debug!("Type file already exists, just updating metadata");
             self.store_repo_metadata(data, &lambda_response.s3_url, org)
                 .await?;
         }
@@ -321,11 +322,11 @@ impl CloudStorage for AwsStorage {
 
         for adjacent in response.repos {
             if let Some(metadata) = adjacent.metadata {
-                println!("Processing repo: {} with full metadata", adjacent.repo);
+                debug!("Processing repo: {} with full metadata", adjacent.repo);
                 repo_s3_urls.insert(metadata.repo_name.clone(), adjacent.s3_url);
                 all_repo_data.push(metadata);
             } else {
-                println!("Warning: No metadata found for repo: {}", adjacent.repo);
+                warn!("No metadata found for repo: {}", adjacent.repo);
                 let repo_data = CloudRepoData {
                     repo_name: adjacent.repo.clone(),
                     service_name: None,
@@ -355,6 +356,41 @@ impl CloudStorage for AwsStorage {
         }
 
         Ok((all_repo_data, repo_s3_urls))
+    }
+
+    async fn upload_logs(
+        &self,
+        org: &str,
+        repo: &str,
+        log_content: &str,
+    ) -> Result<(), StorageError> {
+        let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H-%M-%S").to_string();
+
+        #[derive(Serialize)]
+        struct UploadLogsRequest {
+            action: String,
+            org: String,
+            repo: String,
+            timestamp: String,
+        }
+
+        #[derive(Deserialize)]
+        struct UploadLogsResponse {
+            #[serde(rename = "uploadUrl")]
+            upload_url: String,
+        }
+
+        let request = UploadLogsRequest {
+            action: "upload-logs".to_string(),
+            org: org.to_string(),
+            repo: repo.to_string(),
+            timestamp,
+        };
+
+        let resp: UploadLogsResponse = self.call_lambda_generic(&request).await?;
+        self.upload_to_s3(&resp.upload_url, log_content).await?;
+
+        Ok(())
     }
 
     async fn health_check(&self) -> Result<(), StorageError> {

--- a/src/cloud_storage/mock_storage.rs
+++ b/src/cloud_storage/mock_storage.rs
@@ -5,6 +5,7 @@ use chrono::Utc;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
+use tracing::debug;
 
 pub struct MockStorage {
     // Group data by org, then store repos
@@ -30,7 +31,7 @@ impl MockStorage {
 #[async_trait]
 impl CloudStorage for MockStorage {
     async fn upload_repo_data(&self, org: &str, data: &CloudRepoData) -> Result<(), StorageError> {
-        println!(
+        debug!(
             "MOCK: Uploading repo data for org: {}, repo: {}",
             org, data.repo_name
         );
@@ -48,7 +49,7 @@ impl CloudStorage for MockStorage {
         file_name: &str,
         content: &str,
     ) -> Result<(), StorageError> {
-        println!(
+        debug!(
             "MOCK: Uploading type file for repo: {}, file: {}",
             repo_name, file_name
         );
@@ -62,7 +63,7 @@ impl CloudStorage for MockStorage {
         &self,
         org: &str,
     ) -> Result<(Vec<CloudRepoData>, HashMap<String, String>), StorageError> {
-        println!("MOCK: Downloading all repo data for org: {}", org);
+        debug!("MOCK: Downloading all repo data for org: {}", org);
         let storage = self.data.lock().unwrap();
         let mut result = storage.get(org).cloned().unwrap_or_default();
 
@@ -133,12 +134,22 @@ impl CloudStorage for MockStorage {
             );
         }
 
-        println!("MOCK: Found {} repos for org {}", result.len(), org);
+        debug!("MOCK: Found {} repos for org {}", result.len(), org);
         Ok((result, mock_s3_urls))
     }
 
     async fn health_check(&self) -> Result<(), StorageError> {
-        println!("MOCK: Health check passed");
+        debug!("MOCK: Health check passed");
+        Ok(())
+    }
+
+    async fn upload_logs(
+        &self,
+        org: &str,
+        repo: &str,
+        _log_content: &str,
+    ) -> Result<(), StorageError> {
+        debug!("MOCK: Skipping log upload for {}/{}", org, repo);
         Ok(())
     }
 }

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::PathBuf;
+use tracing::debug;
 
 mod mock_storage;
 pub use mock_storage::MockStorage;
@@ -209,11 +210,13 @@ impl CloudRepoData {
             })
             .collect();
 
-        println!("Created CloudRepoData directly from multi-agent results:");
-        println!("  - {} endpoints", endpoints.len());
-        println!("  - {} calls", calls.len());
-        println!("  - {} mounts", mounts.len());
-        println!("  - {} function definitions", function_definitions.len());
+        debug!(
+            endpoints = endpoints.len(),
+            calls = calls.len(),
+            mounts = mounts.len(),
+            function_definitions = function_definitions.len(),
+            "Created CloudRepoData directly from multi-agent results"
+        );
 
         Self {
             repo_name,
@@ -279,6 +282,12 @@ pub trait CloudStorage {
         content: &str,
     ) -> Result<(), StorageError>;
     async fn health_check(&self) -> Result<(), StorageError>;
+    async fn upload_logs(
+        &self,
+        org: &str,
+        repo: &str,
+        log_content: &str,
+    ) -> Result<(), StorageError>;
 }
 
 pub fn get_current_commit_hash(repo_path: &str) -> String {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -186,15 +186,30 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
     let results = analyzer.get_results();
     print_results(results);
 
-    // 7. Best-effort log upload
-    if let Some(log_path) = logging::get_log_file_path() {
-        if let Ok(log_content) = std::fs::read_to_string(&log_path) {
-            let repo_name = get_repository_name(repo_path);
-            if let Err(e) = storage
-                .upload_logs(&carrick_org, &repo_name, &log_content)
-                .await
-            {
-                debug!("Failed to upload logs: {:?}", e);
+    // 7. Best-effort log upload (only on main/master, same policy as data upload)
+    if should_upload {
+        if let Some(log_path) = logging::get_log_file_path() {
+            const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024;
+
+            if let Ok(mut file) = std::fs::File::open(&log_path) {
+                use std::io::{Read, Seek};
+                if let Ok(metadata) = file.metadata() {
+                    let file_len = metadata.len();
+                    let start = file_len.saturating_sub(MAX_LOG_BYTES);
+                    if file.seek(std::io::SeekFrom::Start(start)).is_ok() {
+                        let mut buf = Vec::with_capacity((file_len - start) as usize);
+                        if file.read_to_end(&mut buf).is_ok() {
+                            let log_content = String::from_utf8_lossy(&buf);
+                            let repo_name = get_repository_name(repo_path);
+                            if let Err(e) = storage
+                                .upload_logs(&carrick_org, &repo_name, &log_content)
+                                .await
+                            {
+                                debug!("Failed to upload logs: {:?}", e);
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -10,6 +10,7 @@ use crate::config::{Config, create_dynamic_tsconfig};
 use crate::file_finder::find_files;
 use crate::framework_detector::{DetectionResult, FrameworkDetector};
 use crate::intent_generator::generate_function_intents;
+use crate::logging;
 use crate::mount_graph::MountGraph;
 use crate::multi_agent_orchestrator::MultiAgentOrchestrator;
 use crate::packages::Packages;
@@ -30,6 +31,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+use tracing::{debug, warn};
 
 use serde::Serialize;
 use swc_common::{
@@ -98,19 +100,18 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
     let carrick_org = env::var("CARRICK_ORG").map_err(|_| "CARRICK_ORG must be set in CI mode")?;
 
     let should_upload = should_upload_data();
-    println!(
-        "Running Carrick in CI mode with org: {} (upload: {})",
-        &carrick_org, should_upload
-    );
+    debug!(org = %carrick_org, upload = should_upload, "Running Carrick in CI mode");
 
     // 1. Health check
+    let sp = logging::spinner("Connecting to AWS...");
     storage
         .health_check()
         .await
         .map_err(|e| format!("Failed to connect to AWS services: {}", e))?;
-    println!("AWS connectivity verified");
+    logging::finish_spinner(&sp, "AWS connectivity verified");
 
     // 2. Download all repos (moved earlier for incremental cache lookup)
+    let sp = logging::spinner("Downloading cross-repo data...");
     let (mut all_repo_data, _repo_s3_urls) = storage
         .download_all_repo_data(&carrick_org)
         .await
@@ -124,20 +125,22 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
         .cloned();
 
     if previous_data.is_some() {
-        println!(
-            "[incremental] Found previous analysis data for {}",
-            repo_name
-        );
+        debug!("Found previous analysis data for {}", repo_name);
     }
+    logging::finish_spinner(
+        &sp,
+        &format!("Downloaded data from {} repos", all_repo_data.len()),
+    );
 
     // 4. Analyze (incremental if possible)
+    let sp = logging::spinner("Analyzing repository...");
     let current_repo_data =
         analyze_current_repo_incremental(repo_path, sidecar, previous_data.as_ref()).await?;
-    println!("Analyzed current repo: {}", current_repo_data.repo_name);
+    logging::finish_spinner(&sp, &format!("Analyzed {}", current_repo_data.repo_name));
 
     // Log sidecar type resolution results if available
     if current_repo_data.bundled_types.is_some() {
-        println!(
+        debug!(
             "Type resolution: {} bundled types, {} manifest entries",
             current_repo_data
                 .bundled_types
@@ -154,14 +157,15 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
 
     // 5. Conditionally upload current repo data to cloud storage
     if should_upload {
+        let sp = logging::spinner("Uploading results...");
         let cloud_data_serialized = strip_ast_nodes(current_repo_data.clone());
         storage
             .upload_repo_data(&carrick_org, &cloud_data_serialized)
             .await
             .map_err(|e| format!("Failed to upload repo data: {}", e))?;
-        println!("Uploaded current repo data to cloud storage");
+        logging::finish_spinner(&sp, "Uploaded results to cloud storage");
     } else {
-        println!("Skipping upload (PR/branch mode - analyzing only)");
+        debug!("Skipping upload (PR/branch mode)");
     }
 
     // 6. Cross-repo analysis (reuse already-downloaded data)
@@ -169,17 +173,31 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
     let current_repo_name = &current_repo_data.repo_name;
     all_repo_data.retain(|repo| &repo.repo_name != current_repo_name);
 
-    println!(
-        "Downloaded data from {} repos (excluding current repo: {})",
+    debug!(
+        "Cross-repo analysis with {} repos (excluding {})",
         all_repo_data.len(),
         current_repo_name
     );
 
+    let sp = logging::spinner("Running cross-repo analysis...");
     let analyzer = build_cross_repo_analyzer(all_repo_data, current_repo_data).await?;
-    println!("Reconstructed analyzer with cross-repo data");
+    logging::finish_spinner(&sp, "Cross-repo analysis complete");
 
     let results = analyzer.get_results();
     print_results(results);
+
+    // 7. Best-effort log upload
+    if let Some(log_path) = logging::get_log_file_path() {
+        if let Ok(log_content) = std::fs::read_to_string(&log_path) {
+            let repo_name = get_repository_name(repo_path);
+            if let Err(e) = storage
+                .upload_logs(&carrick_org, &repo_name, &log_content)
+                .await
+            {
+                debug!("Failed to upload logs: {:?}", e);
+            }
+        }
+    }
 
     Ok(())
 }
@@ -256,8 +274,8 @@ fn strip_ast_nodes(mut data: CloudRepoData) -> CloudRepoData {
     const MAX_PAYLOAD_BYTES: usize = 5 * 1024 * 1024; // 5MB safety margin
     if let Ok(serialized) = serde_json::to_string(&data) {
         if serialized.len() > MAX_PAYLOAD_BYTES {
-            println!(
-                "[incremental] WARNING: Payload size {}KB exceeds {}KB limit, dropping file_results cache for this upload",
+            warn!(
+                "Payload size {}KB exceeds {}KB limit, dropping file_results cache for this upload",
                 serialized.len() / 1024,
                 MAX_PAYLOAD_BYTES / 1024
             );
@@ -281,11 +299,8 @@ fn get_changed_files(repo_path: &str, base_commit: &str) -> Option<Vec<String>> 
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        println!(
-            "[incremental] git diff failed (shallow clone?): {}",
-            stderr.trim()
-        );
-        println!("[incremental] Set fetch-depth: 0 in your workflow for incremental mode.");
+        debug!("git diff failed (shallow clone?): {}", stderr.trim());
+        debug!("Set fetch-depth: 0 in your workflow for incremental mode.");
         return None;
     }
 
@@ -385,32 +400,30 @@ async fn analyze_current_repo_incremental(
     let (config, packages) = load_config_and_packages(repo_path)?;
 
     // 3. Check if we can use incremental mode
-    let can_use_incremental = previous_data
-        .and_then(|prev| {
-            // Must have file_results and matching cache_version
-            let has_cache = prev.file_results.is_some();
-            let version_matches = prev.cache_version == Some(CACHE_VERSION);
-            if has_cache && version_matches {
-                Some(prev)
-            } else {
-                if !has_cache {
-                    println!("[incremental] No cached file_results found, running full analysis");
-                }
-                if !version_matches {
-                    println!(
-                        "[incremental] Cache version mismatch (expected {}, got {:?}), running full analysis",
-                        CACHE_VERSION,
-                        prev.cache_version
-                    );
-                }
-                None
+    let can_use_incremental = previous_data.and_then(|prev| {
+        // Must have file_results and matching cache_version
+        let has_cache = prev.file_results.is_some();
+        let version_matches = prev.cache_version == Some(CACHE_VERSION);
+        if has_cache && version_matches {
+            Some(prev)
+        } else {
+            if !has_cache {
+                debug!("No cached file_results found, running full analysis");
             }
-        });
+            if !version_matches {
+                debug!(
+                    "Cache version mismatch (expected {}, got {:?}), running full analysis",
+                    CACHE_VERSION, prev.cache_version
+                );
+            }
+            None
+        }
+    });
 
     if let Some(prev) = can_use_incremental {
         let prev_commit = &prev.commit_hash;
-        println!(
-            "[incremental] Found previous analysis (commit {})",
+        debug!(
+            "Found previous analysis (commit {})",
             &prev_commit[..std::cmp::min(7, prev_commit.len())]
         );
 
@@ -451,13 +464,9 @@ async fn analyze_current_repo_incremental(
             let changed_count = files_to_analyze.len();
             let reused_count = total_files - changed_count;
 
-            println!(
-                "[incremental] Detected {} changed file(s) out of {}",
-                changed_count, total_files
-            );
-            println!(
-                "[incremental] Reusing cached results for {} files",
-                reused_count
+            debug!(
+                "Detected {} changed file(s) out of {}, reusing {} cached",
+                changed_count, total_files, reused_count
             );
 
             // Check if package.json changed → need fresh framework detection/guidance
@@ -475,24 +484,21 @@ async fn analyze_current_repo_incremental(
             // Get framework detection and guidance (cached or fresh)
             let (detection, guidance) = if !pkg_changed {
                 if let (Some(det), Some(guid)) = (&prev.cached_detection, &prev.cached_guidance) {
-                    println!("[incremental] Reusing cached framework detection and guidance");
+                    debug!("Reusing cached framework detection and guidance");
                     (det.clone(), guid.clone())
                 } else {
                     run_framework_detection_and_guidance(&api_key, &packages, &all_imported_symbols)
                         .await?
                 }
             } else {
-                println!("[incremental] package.json changed, re-running framework detection");
+                debug!("package.json changed, re-running framework detection");
                 run_framework_detection_and_guidance(&api_key, &packages, &all_imported_symbols)
                     .await?
             };
 
             // Run Gemini file analysis ONLY on changed files
             if changed_count > 0 {
-                println!(
-                    "[incremental] Running LLM analysis on {} changed file(s)...",
-                    changed_count
-                );
+                debug!("Running LLM analysis on {} changed file(s)", changed_count);
             }
 
             let agent_service = AgentService::new(api_key.clone());
@@ -532,8 +538,8 @@ async fn analyze_current_repo_incremental(
             let mount_graph = graph_orchestrator.build_mount_graph(&merged_results);
 
             let elapsed = start.elapsed();
-            println!(
-                "[incremental] Analysis complete in {:.1}s",
+            debug!(
+                "Incremental analysis complete in {:.1}s",
                 elapsed.as_secs_f64()
             );
 
@@ -587,19 +593,16 @@ async fn analyze_current_repo_incremental(
 
             return Ok(cloud_data);
         } else {
-            println!("[incremental] git diff failed, falling back to full analysis");
+            debug!("git diff failed, falling back to full analysis");
         }
     }
 
     // Fallback: full analysis (analyze_current_repo now populates cache fields)
-    println!("[incremental] Running full analysis...");
+    debug!("Running full analysis...");
     let cloud_data = analyze_current_repo(repo_path, sidecar).await?;
 
     let elapsed = start.elapsed();
-    println!(
-        "[incremental] Full analysis complete in {:.1}s",
-        elapsed.as_secs_f64()
-    );
+    debug!("Full analysis complete in {:.1}s", elapsed.as_secs_f64());
 
     Ok(cloud_data)
 }
@@ -686,10 +689,12 @@ fn build_cloud_data_from_mount_graph(
         })
         .collect();
 
-    println!("Created CloudRepoData from incremental analysis:");
-    println!("  - {} endpoints", endpoints.len());
-    println!("  - {} calls", calls.len());
-    println!("  - {} mounts", mounts.len());
+    debug!(
+        "CloudRepoData from incremental: {} endpoints, {} calls, {} mounts",
+        endpoints.len(),
+        calls.len(),
+        mounts.len()
+    );
 
     CloudRepoData {
         repo_name: repo_name.to_string(),
@@ -730,7 +735,7 @@ fn resolve_types_if_available(
 ) {
     let Some(sidecar) = sidecar else { return };
 
-    println!("\n=== Sidecar Type Resolution ===");
+    debug!("Starting sidecar type resolution");
     match sidecar.wait_ready(Duration::from_secs(10)) {
         Ok(()) => {
             match file_orchestrator.resolve_types_with_sidecar(
@@ -742,8 +747,8 @@ fn resolve_types_if_available(
                 config,
             ) {
                 Ok(type_resolution) => {
-                    println!(
-                        "Type resolution successful: {} explicit, {} inferred, {} failures",
+                    debug!(
+                        "Type resolution: {} explicit, {} inferred, {} failures",
                         type_resolution.explicit_manifest.len(),
                         type_resolution.inferred_types.len(),
                         type_resolution.symbol_failures.len()
@@ -757,21 +762,21 @@ fn resolve_types_if_available(
                         );
                     }
                     for failure in &type_resolution.symbol_failures {
-                        eprintln!(
-                            "[Sidecar] Failed to resolve symbol '{}' from '{}': {}",
+                        debug!(
+                            "Failed to resolve symbol '{}' from '{}': {}",
                             failure.symbol_name, failure.source_file, failure.reason
                         );
                     }
                 }
                 Err(e) => {
-                    eprintln!("[Sidecar] Type resolution failed: {}", e);
-                    eprintln!("[Sidecar] Continuing without bundled types");
+                    warn!("Type resolution failed: {}", e);
+                    debug!("Continuing without bundled types");
                 }
             }
         }
         Err(e) => {
-            eprintln!("[Sidecar] Sidecar not ready: {}", e);
-            eprintln!("[Sidecar] Skipping type resolution");
+            warn!("Sidecar not ready: {}", e);
+            debug!("Skipping type resolution");
         }
     }
 }
@@ -785,11 +790,7 @@ fn discover_files_and_symbols(repo_path: &str, cm: Lrc<SourceMap>) -> FileDiscov
     let ignore_patterns = ["node_modules", "dist", "build", ".next", "ts_check"];
     let (files, _, _) = find_files(repo_path, &ignore_patterns);
 
-    println!(
-        "Found {} files to analyze in directory {}",
-        files.len(),
-        repo_path
-    );
+    debug!("Found {} files to analyze in {}", files.len(), repo_path);
 
     // Extract imported symbols and function definitions by parsing files
     let mut all_imported_symbols = HashMap::new();
@@ -811,7 +812,7 @@ fn discover_files_and_symbols(repo_path: &str, cm: Lrc<SourceMap>) -> FileDiscov
         }
     }
 
-    println!(
+    debug!(
         "Extracted {} imported symbols and {} function definitions from {} files",
         all_imported_symbols.len(),
         all_function_definitions.len(),
@@ -834,9 +835,9 @@ fn load_config_and_packages(
     let (_, config_file_path, package_json_path) = find_files(repo_path, &ignore_patterns);
 
     let config = if let Some(config_path) = config_file_path {
-        println!("Found carrick.json file: {}", config_path.display());
+        debug!("Found carrick.json: {}", config_path.display());
         Config::new(vec![config_path]).unwrap_or_else(|e| {
-            eprintln!("Warning: Error parsing config file: {}", e);
+            warn!("Error parsing config file: {}", e);
             Config::default()
         })
     } else {
@@ -844,9 +845,9 @@ fn load_config_and_packages(
     };
 
     let packages = if let Some(package_path) = package_json_path {
-        println!("Found package.json: {}", package_path.display());
+        debug!("Found package.json: {}", package_path.display());
         Packages::new(vec![package_path]).unwrap_or_else(|e| {
-            eprintln!("Warning: Error parsing package.json: {}", e);
+            warn!("Error parsing package.json: {}", e);
             Packages::default()
         })
     } else {
@@ -880,8 +881,8 @@ fn resolve_per_endpoint_definitions(sidecar: &TypeSidecar, cloud_data: &mut Clou
         return;
     }
 
-    eprintln!(
-        "[Sidecar] Resolving {} type definition(s) via compiler...",
+    debug!(
+        "Resolving {} type definition(s) via compiler",
         aliases.len()
     );
 
@@ -897,13 +898,11 @@ fn resolve_per_endpoint_definitions(sidecar: &TypeSidecar, cloud_data: &mut Clou
                     entry.expanded_definition = Some(r.expanded.clone());
                 }
             }
-            eprintln!("[Sidecar] Resolved {} type definition(s)", lookup.len());
+            debug!("Resolved {} type definition(s)", lookup.len());
         }
         Err(e) => {
-            eprintln!("[Sidecar] Per-endpoint definition resolution failed: {}", e);
-            eprintln!(
-                "[Sidecar] Continuing without resolved definitions (MCP will use regex fallback)"
-            );
+            warn!("Per-endpoint definition resolution failed: {}", e);
+            debug!("Continuing without resolved definitions (MCP will use regex fallback)");
         }
     }
 }
@@ -1104,8 +1103,8 @@ fn enrich_manifest_with_type_resolution(
         .iter()
         .filter(|e| e.type_state == ManifestTypeState::Unknown)
         .count();
-    eprintln!(
-        "[Manifest Enrichment] {} explicit, {} implicit, {} unknown",
+    debug!(
+        "Manifest enrichment: {} explicit, {} implicit, {} unknown",
         explicit_count, implicit_count, unknown_count
     );
 }
@@ -1127,17 +1126,14 @@ async fn analyze_current_repo(
         .unwrap_or_else(|_| repo_path.to_string());
     let repo_path = canonical.as_str();
 
-    println!(
-        "---> Running multi-agent framework-agnostic analysis on: {}",
-        repo_path
-    );
+    debug!("Running multi-agent analysis on: {}", repo_path);
 
     // 1. Create shared SourceMap and discover files and symbols
     let cm: Lrc<SourceMap> = Default::default();
     let (files, all_imported_symbols, function_definitions, repo_name) =
         discover_files_and_symbols(repo_path, cm.clone())?;
-    println!(
-        "Extracted repository name: '{}' from {} files ({} function definitions)",
+    debug!(
+        "Repository '{}': {} files, {} function definitions",
         repo_name,
         files.len(),
         function_definitions.len()
@@ -1258,7 +1254,7 @@ async fn build_cross_repo_analyzer(
 
     // 6. Run final type checking
     if let Err(e) = analyzer.run_final_type_checking() {
-        println!("⚠️  Warning: Type checking failed: {}", e);
+        warn!("Type checking failed: {}", e);
     }
 
     Ok(analyzer)
@@ -1270,16 +1266,16 @@ fn recreate_type_files_and_check(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let output_dir = std::path::Path::new("ts_check/output");
     if output_dir.exists() {
-        println!("Cleaning output directory: ts_check/output");
+        debug!("Cleaning output directory: ts_check/output");
         if let Err(e) = std::fs::remove_dir_all(output_dir) {
-            println!("Warning: Failed to clean output directory: {}", e);
+            warn!("Failed to clean output directory: {}", e);
         }
     }
 
     if let Err(e) = std::fs::create_dir_all(output_dir) {
-        println!("Warning: Failed to create output directory: {}", e);
+        warn!("Failed to create output directory: {}", e);
     } else {
-        println!("Created clean output directory: ts_check/output");
+        debug!("Created clean output directory: ts_check/output");
     }
 
     for repo_data in all_repo_data {
@@ -1291,12 +1287,12 @@ fn recreate_type_files_and_check(
                 append_missing_aliases(bundled_types.clone(), repo_data.type_manifest.as_ref());
 
             if let Err(e) = std::fs::write(&file_path, content) {
-                println!("Warning: Failed to write type file {}: {}", file_name, e);
+                warn!("Failed to write type file {}: {}", file_name, e);
             } else {
-                println!("Created bundled type file: {}", file_path.display());
+                debug!("Created bundled type file: {}", file_path.display());
             }
         } else {
-            println!(
+            debug!(
                 "No bundled types available for repo: {}",
                 repo_data.repo_name
             );
@@ -1352,11 +1348,9 @@ fn write_manifest_files(
         serde_json::to_string_pretty(&consumer_manifest)?,
     )?;
 
-    println!(
-        "Wrote manifest files: {} ({} entries), {} ({} entries)",
-        producer_path.display(),
+    debug!(
+        "Wrote manifest files: {} producers, {} consumers",
         producer_manifest.entries.len(),
-        consumer_path.display(),
         consumer_manifest.entries.len()
     );
 
@@ -1444,31 +1438,31 @@ fn recreate_package_and_tsconfig(
         &package_json_path,
         serde_json::to_string_pretty(&package_json_content)?,
     )?;
-    println!("Recreated package.json at {}", package_json_path.display());
+    debug!("Recreated package.json at {}", package_json_path.display());
 
     let skip_npm_install = std::env::var("CARRICK_SKIP_NPM_INSTALL").is_ok()
         || std::env::var("CARRICK_MOCK_ALL").is_ok();
 
     if skip_npm_install {
-        println!("Skipping npm install (mock mode or CARRICK_SKIP_NPM_INSTALL set)");
+        debug!("Skipping npm install (mock mode or CARRICK_SKIP_NPM_INSTALL set)");
     } else {
         // Clean any existing node_modules and package-lock.json to avoid conflicts
         let node_modules_path = output_dir.join("node_modules");
         let package_lock_path = output_dir.join("package-lock.json");
 
         if node_modules_path.exists() {
-            println!("Removing existing node_modules directory...");
+            debug!("Removing existing node_modules directory");
             std::fs::remove_dir_all(&node_modules_path).ok();
         }
 
         if package_lock_path.exists() {
-            println!("Removing existing package-lock.json...");
+            debug!("Removing existing package-lock.json");
             std::fs::remove_file(&package_lock_path).ok();
         }
 
         // Install dependencies
         use std::process::Command;
-        println!("Installing dependencies...");
+        debug!("Installing dependencies...");
 
         let install_output = Command::new("npm")
             .arg("install")
@@ -1478,9 +1472,9 @@ fn recreate_package_and_tsconfig(
 
         if !install_output.status.success() {
             let stderr = String::from_utf8_lossy(&install_output.stderr);
-            eprintln!("Warning: npm install failed: {}", stderr);
+            warn!("npm install failed: {}", stderr);
         } else {
-            println!("Dependencies installed successfully");
+            debug!("Dependencies installed successfully");
         }
     }
 
@@ -1492,7 +1486,7 @@ fn recreate_package_and_tsconfig(
         &tsconfig_path,
         serde_json::to_string_pretty(&tsconfig_content)?,
     )?;
-    println!("Recreated tsconfig.json at {}", tsconfig_path.display());
+    debug!("Recreated tsconfig.json at {}", tsconfig_path.display());
 
     Ok(())
 }

--- a/src/framework_detector.rs
+++ b/src/framework_detector.rs
@@ -1,6 +1,7 @@
 use crate::{agent_service::AgentService, packages::Packages, visitor::ImportedSymbol};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use tracing::debug;
 
 /// Result of framework and library detection
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -158,10 +159,10 @@ impl FrameworkDetector {
             "You are analyzing a Node.js/TypeScript project to detect HTTP frameworks and data-fetching libraries."
         ).await?;
 
-        // Debug: Print the actual LLM response
-        println!("Framework Detection LLM Response:");
-        println!("{}", response);
-        println!("--- End of Response ---");
+        // Debug: log the actual LLM response
+        debug!("Framework Detection LLM Response:");
+        debug!("{}", response);
+        debug!("--- End of Response ---");
 
         // Extract JSON from response using robust method
         let json_str = self.extract_json_from_response(&response)?;

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -13,6 +13,7 @@
 use crate::agent_service::AgentService;
 use crate::visitor::{FunctionCallRef, FunctionDefinition, ImportedSymbol};
 use std::collections::{HashMap, HashSet};
+use tracing::{debug, warn};
 
 /// Generate intents for all exported functions that have body source.
 ///
@@ -37,10 +38,7 @@ pub async fn generate_function_intents(
         return;
     }
 
-    eprintln!(
-        "[intent] Generating intents for {} function(s)...",
-        eligible.len()
-    );
+    debug!("Generating intents for {} function(s)", eligible.len());
 
     // Build a local call graph: for each function, which other local functions does it reference?
     let local_fn_names: HashSet<&str> = function_definitions.keys().map(|s| s.as_str()).collect();
@@ -134,7 +132,7 @@ pub async fn generate_function_intents(
                     }
                 }
                 Err(e) => {
-                    eprintln!("[intent] Failed to generate intent for {}: {}", name, e);
+                    warn!("Failed to generate intent for {}: {}", name, e);
                 }
             }
         }
@@ -148,7 +146,7 @@ pub async fn generate_function_intents(
         }
     }
 
-    eprintln!("[intent] Generated {} intent(s)", count);
+    debug!("Generated {} intent(s)", count);
 
     // Strip body_source — source code stays in GitHub, not AWS
     strip_body_source(function_definitions);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod file_finder;
 pub mod formatter;
 pub mod framework_detector;
 pub mod intent_generator;
+pub mod logging;
 pub mod mount_graph;
 pub mod multi_agent_orchestrator;
 pub mod packages;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,91 @@
+use indicatif::{ProgressBar, ProgressStyle};
+use std::time::Duration;
+use tracing_appender::rolling;
+use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Initialize the global tracing subscriber with two layers:
+///
+/// 1. **Terminal layer** (stderr): Shows `INFO` by default, `DEBUG` with `--verbose`.
+///    Uses a minimal format without timestamps or targets for a clean look.
+///
+/// 2. **File layer**: Always writes `DEBUG`-level logs with timestamps to
+///    `~/.carrick/logs/carrick.log` (daily rotation).
+///
+/// The file layer is best-effort — if the log directory can't be created, only
+/// the terminal layer is active.
+pub fn init(verbose: bool) {
+    let terminal_filter = if verbose {
+        EnvFilter::new("debug")
+    } else {
+        EnvFilter::new("info")
+    };
+
+    let terminal_layer = fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_target(false)
+        .with_level(false)
+        .without_time()
+        .with_filter(terminal_filter);
+
+    // Try to set up file logging to ~/.carrick/logs/
+    let log_dir = dirs::home_dir().map(|h| h.join(".carrick").join("logs"));
+
+    if let Some(ref dir) = log_dir {
+        if std::fs::create_dir_all(dir).is_ok() {
+            let file_appender = rolling::daily(dir, "carrick.log");
+            let file_layer = fmt::layer()
+                .with_writer(file_appender)
+                .with_ansi(false)
+                .with_target(true)
+                .with_filter(EnvFilter::new("debug"));
+
+            tracing_subscriber::registry()
+                .with(terminal_layer)
+                .with(file_layer)
+                .init();
+            return;
+        }
+    }
+
+    // Fallback: terminal only
+    tracing_subscriber::registry().with(terminal_layer).init();
+}
+
+/// Return the path to today's log file, if it exists.
+///
+/// The rolling appender creates files named `carrick.log.YYYY-MM-DD`.
+pub fn get_log_file_path() -> Option<std::path::PathBuf> {
+    let log_dir = dirs::home_dir()?.join(".carrick").join("logs");
+    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+    let log_file = log_dir.join(format!("carrick.log.{}", today));
+    if log_file.exists() {
+        Some(log_file)
+    } else {
+        None
+    }
+}
+
+/// Create a spinner with a message. Call `finish_with_message` when done.
+pub fn spinner(msg: &str) -> ProgressBar {
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .unwrap()
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+    );
+    pb.set_message(msg.to_string());
+    pb.enable_steady_tick(Duration::from_millis(80));
+    pb
+}
+
+/// Finish a spinner with a success checkmark.
+pub fn finish_spinner(pb: &ProgressBar, msg: &str) {
+    pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
+    pb.finish_with_message(format!("\x1b[32m✓\x1b[0m {}", msg));
+}
+
+/// Finish a spinner with a warning marker.
+pub fn finish_spinner_warn(pb: &ProgressBar, msg: &str) {
+    pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
+    pb.finish_with_message(format!("\x1b[33m⚠\x1b[0m {}", msg));
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -39,16 +39,18 @@ pub fn init(verbose: bool) {
                 .with_target(true)
                 .with_filter(EnvFilter::new("debug"));
 
-            tracing_subscriber::registry()
+            let _ = tracing_subscriber::registry()
                 .with(terminal_layer)
                 .with(file_layer)
-                .init();
+                .try_init();
             return;
         }
     }
 
     // Fallback: terminal only
-    tracing_subscriber::registry().with(terminal_layer).init();
+    let _ = tracing_subscriber::registry()
+        .with(terminal_layer)
+        .try_init();
 }
 
 /// Return the path to today's log file, if it exists.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod file_finder;
 mod formatter;
 mod framework_detector;
 mod intent_generator;
+mod logging;
 mod mount_graph;
 mod multi_agent_orchestrator;
 mod packages;
@@ -31,17 +32,21 @@ use engine::run_analysis_engine_with_sidecar;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use tracing::{debug, info, warn};
 
 /// CLI arguments for the carrick analyzer
 struct CliArgs {
     /// Path to the repository to analyze
     repo_path: String,
+    /// Enable verbose (debug-level) terminal output
+    verbose: bool,
 }
 
 impl CliArgs {
     fn parse() -> Self {
         let args: Vec<String> = env::args().skip(1).collect();
         let mut repo_path = ".".to_string();
+        let mut verbose = false;
 
         let mut i = 0;
         while i < args.len() {
@@ -49,6 +54,9 @@ impl CliArgs {
                 "--help" | "-h" => {
                     Self::print_help();
                     std::process::exit(0);
+                }
+                "--verbose" | "-v" => {
+                    verbose = true;
                 }
                 arg if !arg.starts_with('-') => {
                     repo_path = arg.to_string();
@@ -62,7 +70,7 @@ impl CliArgs {
             i += 1;
         }
 
-        Self { repo_path }
+        Self { repo_path, verbose }
     }
 
     fn print_help() {
@@ -77,6 +85,7 @@ ARGUMENTS:
 
 OPTIONS:
     -h, --help     Print this help message
+    -v, --verbose  Enable verbose (debug-level) terminal output
 
 ENVIRONMENT VARIABLES:
     CARRICK_API_KEY         API key for the LLM service (required)
@@ -90,37 +99,37 @@ ENVIRONMENT VARIABLES:
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = run_analysis().await {
+    let args = CliArgs::parse();
+    logging::init(args.verbose);
+
+    if let Err(e) = run_analysis(args).await {
         eprintln!("Analysis failed: {}", e);
         std::process::exit(1);
     }
 }
 
-async fn run_analysis() -> Result<(), Box<dyn std::error::Error>> {
-    let args = CliArgs::parse();
-
+async fn run_analysis(args: CliArgs) -> Result<(), Box<dyn std::error::Error>> {
     // =======================================================================
     // STEP 1: Discover and spawn sidecar (non-blocking)
     // The sidecar is bundled with the tool - auto-discover its location
     // =======================================================================
+    let sp = logging::spinner("Initializing sidecar...");
     let sidecar = match discover_sidecar_path() {
         Some(sidecar_path) => {
-            eprintln!("[main] Found sidecar at: {}", sidecar_path.display());
+            debug!("Found sidecar at: {}", sidecar_path.display());
             match spawn_sidecar(&sidecar_path, &args.repo_path) {
                 Ok(sidecar) => {
-                    eprintln!("[main] Sidecar spawned, initializing in background...");
+                    debug!("Sidecar spawned, initializing in background...");
                     Some(sidecar)
                 }
                 Err(e) => {
-                    eprintln!("[main] Warning: Failed to spawn sidecar: {}", e);
-                    eprintln!("[main] Continuing without sidecar type extraction");
+                    warn!("Failed to spawn sidecar: {}", e);
                     None
                 }
             }
         }
         None => {
-            eprintln!("[main] Sidecar not found, continuing without type extraction");
-            eprintln!("[main] (Run 'npm run build' in src/sidecar to enable type extraction)");
+            debug!("Sidecar not found, continuing without type extraction");
             None
         }
     };
@@ -130,19 +139,20 @@ async fn run_analysis() -> Result<(), Box<dyn std::error::Error>> {
     // The sidecar initializes in parallel, so it should be ready by now
     // =======================================================================
     let sidecar_ready = if let Some(ref sidecar) = sidecar {
-        eprintln!("[main] Waiting for sidecar to be ready...");
+        debug!("Waiting for sidecar to be ready...");
         match sidecar.wait_ready(Duration::from_secs(30)) {
             Ok(()) => {
-                eprintln!("[main] Sidecar is ready for type extraction");
+                logging::finish_spinner(&sp, "Sidecar ready");
                 true
             }
             Err(e) => {
-                eprintln!("[main] Warning: Sidecar failed to initialize: {}", e);
-                eprintln!("[main] Continuing without sidecar type extraction");
+                warn!("Sidecar failed to initialize: {}", e);
+                logging::finish_spinner_warn(&sp, "Sidecar unavailable");
                 false
             }
         }
     } else {
+        logging::finish_spinner_warn(&sp, "Sidecar not found");
         false
     };
 
@@ -161,7 +171,7 @@ async fn run_analysis() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     if use_mock {
-        println!("Using MockStorage (CARRICK_MOCK_ALL environment variable detected)");
+        info!("Using MockStorage");
         let storage = MockStorage::new();
         run_analysis_engine_with_sidecar(storage, &args.repo_path, sidecar_ref).await
     } else {
@@ -201,7 +211,7 @@ fn discover_sidecar_path() -> Option<PathBuf> {
     for candidate in candidates {
         let full_path = candidate.join(sidecar_entry);
         if full_path.exists() {
-            eprintln!("[main] Checking sidecar candidate: {:?}", full_path);
+            debug!("Checking sidecar candidate: {:?}", full_path);
             return Some(full_path);
         }
     }
@@ -230,18 +240,14 @@ fn spawn_sidecar(
     let absolute_repo_path = if repo_path.is_absolute() {
         repo_path.to_path_buf()
     } else {
-        // Get current working directory and join with relative path
         let cwd = env::current_dir()
             .map_err(|e| format!("Failed to get current working directory: {}", e))?;
-        eprintln!("[main] Current working directory: {:?}", cwd);
-        eprintln!("[main] Repo path (relative): {:?}", repo_path);
+        debug!("Current working directory: {:?}", cwd);
+        debug!("Repo path (relative): {:?}", repo_path);
         cwd.join(repo_path)
     };
 
-    eprintln!(
-        "[main] Repo path (before canonicalize): {:?}",
-        absolute_repo_path
-    );
+    debug!("Repo path (before canonicalize): {:?}", absolute_repo_path);
 
     // Canonicalize to resolve any .. or . segments in the path
     let absolute_repo_path = absolute_repo_path.canonicalize().map_err(|e| {
@@ -253,7 +259,7 @@ fn spawn_sidecar(
         )
     })?;
 
-    eprintln!("[main] Repo path (canonicalized): {:?}", absolute_repo_path);
+    debug!("Repo path (canonicalized): {:?}", absolute_repo_path);
 
     // Spawn the sidecar process
     let sidecar = TypeSidecar::spawn(sidecar_path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use engine::run_analysis_engine_with_sidecar;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// CLI arguments for the carrick analyzer
 struct CliArgs {
@@ -103,7 +103,7 @@ async fn main() {
     logging::init(args.verbose);
 
     if let Err(e) = run_analysis(args).await {
-        eprintln!("Analysis failed: {}", e);
+        error!("Analysis failed: {}", e);
         std::process::exit(1);
     }
 }
@@ -114,8 +114,10 @@ async fn run_analysis(args: CliArgs) -> Result<(), Box<dyn std::error::Error>> {
     // The sidecar is bundled with the tool - auto-discover its location
     // =======================================================================
     let sp = logging::spinner("Initializing sidecar...");
+    let mut sidecar_found = false;
     let sidecar = match discover_sidecar_path() {
         Some(sidecar_path) => {
+            sidecar_found = true;
             debug!("Found sidecar at: {}", sidecar_path.display());
             match spawn_sidecar(&sidecar_path, &args.repo_path) {
                 Ok(sidecar) => {
@@ -151,6 +153,9 @@ async fn run_analysis(args: CliArgs) -> Result<(), Box<dyn std::error::Error>> {
                 false
             }
         }
+    } else if sidecar_found {
+        logging::finish_spinner_warn(&sp, "Sidecar failed to start");
+        false
     } else {
         logging::finish_spinner_warn(&sp, "Sidecar not found");
         false

--- a/src/multi_agent_orchestrator.rs
+++ b/src/multi_agent_orchestrator.rs
@@ -26,6 +26,7 @@ use crate::{
 };
 use std::collections::HashMap;
 use swc_common::{SourceMap, sync::Lrc};
+use tracing::debug;
 
 /// Complete analysis result from the multi-agent workflow
 #[derive(Debug)]
@@ -80,29 +81,29 @@ impl MultiAgentOrchestrator {
         packages: &Packages,
         imported_symbols: &HashMap<String, ImportedSymbol>,
     ) -> Result<MultiAgentAnalysisResult, Box<dyn std::error::Error>> {
-        println!("Starting AST-Gated File-Centric analysis...");
+        debug!("Starting AST-Gated File-Centric analysis...");
 
         // Stage 0: Framework Detection
-        println!("\n=== Stage 0: Framework Detection ===");
+        debug!("=== Stage 0: Framework Detection ===");
         let framework_detector = FrameworkDetector::new(self.agent_service.clone());
         let framework_detection = framework_detector
             .detect_frameworks_and_libraries(packages, imported_symbols)
             .await?;
 
-        println!("Detected frameworks: {:?}", framework_detection.frameworks);
-        println!(
+        debug!("Detected frameworks: {:?}", framework_detection.frameworks);
+        debug!(
             "Detected data fetchers: {:?}",
             framework_detection.data_fetchers
         );
 
         // Stage 1: Framework Guidance Generation
-        println!("\n=== Stage 1: Framework Guidance Generation ===");
+        debug!("=== Stage 1: Framework Guidance Generation ===");
         let framework_guidance_agent = FrameworkGuidanceAgent::new(self.agent_service.clone());
         let framework_guidance = framework_guidance_agent
             .generate_guidance(&framework_detection)
             .await?;
 
-        println!(
+        debug!(
             "Generated guidance with {} mount patterns, {} endpoint patterns, {} data fetching patterns",
             framework_guidance.mount_patterns.len(),
             framework_guidance.endpoint_patterns.len(),
@@ -110,7 +111,7 @@ impl MultiAgentOrchestrator {
         );
 
         // Stage 2: AST-Gated File-Centric Analysis
-        println!("\n=== Stage 2: AST-Gated File-Centric Analysis ===");
+        debug!("=== Stage 2: AST-Gated File-Centric Analysis ===");
         let file_orchestrator = FileOrchestrator::new(self.agent_service.clone());
         let file_centric_result = file_orchestrator
             .analyze_files(&files, &framework_guidance, &framework_detection)
@@ -119,16 +120,16 @@ impl MultiAgentOrchestrator {
         self.print_analysis_summary(&file_centric_result);
 
         // Stage 3: Mount Graph is already built by FileOrchestrator
-        println!("\n=== Stage 3: Mount Graph Summary ===");
+        debug!("=== Stage 3: Mount Graph Summary ===");
         let mount_graph = &file_centric_result.mount_graph;
-        println!("Built mount graph:");
-        println!("  - {} nodes", mount_graph.get_nodes().len());
-        println!("  - {} mounts", mount_graph.get_mounts().len());
-        println!(
+        debug!("Built mount graph:");
+        debug!("  - {} nodes", mount_graph.get_nodes().len());
+        debug!("  - {} mounts", mount_graph.get_mounts().len());
+        debug!(
             "  - {} endpoints",
             mount_graph.get_resolved_endpoints().len()
         );
-        println!("  - {} data calls", mount_graph.get_data_calls().len());
+        debug!("  - {} data calls", mount_graph.get_data_calls().len());
 
         Ok(MultiAgentAnalysisResult {
             framework_detection,
@@ -140,27 +141,27 @@ impl MultiAgentOrchestrator {
     }
 
     fn print_analysis_summary(&self, result: &FileCentricAnalysisResult) {
-        println!("\n=== ANALYSIS SUMMARY ===");
-        println!("File Processing:");
-        println!(
+        debug!("=== ANALYSIS SUMMARY ===");
+        debug!("File Processing:");
+        debug!(
             "  - Files processed (LLM calls): {}",
             result.stats.files_processed
         );
-        println!("  - Files skipped (total): {}", result.stats.files_skipped);
-        println!(
+        debug!("  - Files skipped (total): {}", result.stats.files_skipped);
+        debug!(
             "  - Zero-cost skips (no API patterns): {}",
             result.stats.files_skipped_no_candidates
         );
 
-        println!("Extracted Items:");
-        println!("  - Total mounts: {}", result.stats.total_mounts);
-        println!("  - Total endpoints: {}", result.stats.total_endpoints);
-        println!("  - Total data calls: {}", result.stats.total_data_calls);
+        debug!("Extracted Items:");
+        debug!("  - Total mounts: {}", result.stats.total_mounts);
+        debug!("  - Total endpoints: {}", result.stats.total_endpoints);
+        debug!("  - Total data calls: {}", result.stats.total_data_calls);
 
         if !result.stats.errors.is_empty() {
-            println!("Errors ({}):", result.stats.errors.len());
+            debug!("Errors ({}):", result.stats.errors.len());
             for error in &result.stats.errors {
-                println!("  - {}", error);
+                debug!("  - {}", error);
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,6 +5,7 @@ use swc_ecma_ast::Module;
 use swc_ecma_parser::{Parser, StringInput, Syntax, lexer::Lexer};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_visit::VisitMutWith;
+use tracing::warn;
 
 /// Parse a JavaScript or TypeScript file into an AST
 pub fn parse_file(
@@ -26,7 +27,7 @@ pub fn parse_file(
     let file_content = match fs::read_to_string(file_path) {
         Ok(content) => content,
         Err(e) => {
-            eprintln!("Error reading file {}: {}", file_path.display(), e);
+            warn!("Error reading file {}: {}", file_path.display(), e);
             return None;
         }
     };

--- a/src/services/type_sidecar.rs
+++ b/src/services/type_sidecar.rs
@@ -20,6 +20,7 @@ use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
+use tracing::debug;
 
 // ============================================================================
 // Sidecar State
@@ -342,14 +343,14 @@ impl TypeSidecar {
     pub fn spawn(sidecar_path: &Path) -> Result<Self, SidecarError> {
         let spawn_time = Instant::now();
 
-        eprintln!("[type_sidecar] Spawning sidecar from: {:?}", sidecar_path);
+        debug!("[type_sidecar] Spawning sidecar from: {:?}", sidecar_path);
 
         // Spawn the Node.js process
         let mut child = Command::new("node")
             .arg(sidecar_path)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit()) // Let sidecar logs go to stderr
+            .stderr(Stdio::piped()) // Capture stderr, pipe through tracing
             .spawn()
             .map_err(|e| SidecarError::SpawnFailed(e.to_string()))?;
 
@@ -363,7 +364,19 @@ impl TypeSidecar {
             .take()
             .ok_or_else(|| SidecarError::SpawnFailed("Failed to get stdout".to_string()))?;
 
-        eprintln!(
+        // Pipe sidecar stderr through tracing on a background thread
+        if let Some(stderr) = child.stderr.take() {
+            thread::spawn(move || {
+                let reader = BufReader::new(stderr);
+                for line in reader.lines().map_while(Result::ok) {
+                    if !line.trim().is_empty() {
+                        debug!("{}", line);
+                    }
+                }
+            });
+        }
+
+        debug!(
             "[type_sidecar] Sidecar spawned in {:?}",
             spawn_time.elapsed()
         );
@@ -397,7 +410,7 @@ impl TypeSidecar {
             *state = SidecarState::Initializing;
         }
 
-        eprintln!("[type_sidecar] Starting init for repo: {}", repo_root_str);
+        debug!("[type_sidecar] Starting init for repo: {}", repo_root_str);
 
         // Send init request
         let request = SidecarRequest::Init {
@@ -450,7 +463,7 @@ impl TypeSidecar {
                         let mut state = self.state.lock().unwrap();
                         if response.status == "ready" {
                             *state = SidecarState::Ready;
-                            eprintln!(
+                            debug!(
                                 "[type_sidecar] Sidecar ready (init_time: {:?}ms, total: {:?})",
                                 response.init_time_ms,
                                 self.spawn_time.elapsed()
@@ -876,7 +889,7 @@ impl TypeSidecar {
 
 impl Drop for TypeSidecar {
     fn drop(&mut self) {
-        eprintln!("[type_sidecar] Shutting down sidecar");
+        debug!("[type_sidecar] Shutting down sidecar");
 
         // Try graceful shutdown first
         let _ = self.shutdown();

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -3,6 +3,23 @@ resource "aws_s3_bucket" "carrick_types" {
   force_destroy = true
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "log_expiry" {
+  bucket = aws_s3_bucket.carrick_types.id
+
+  rule {
+    id     = "expire-logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "*/logs/"
+    }
+
+    expiration {
+      days = 60
+    }
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "carrick_types" {
   bucket = aws_s3_bucket.carrick_types.id
   block_public_acls   = true

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -11,7 +11,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_expiry" {
     status = "Enabled"
 
     filter {
-      prefix = "*/logs/"
+      tag {
+        key   = "log"
+        value = "true"
+      }
     }
 
     expiration {


### PR DESCRIPTION
## Summary

- Replace all ad-hoc `println!`/`eprintln!` with structured `tracing` macros across the entire codebase (22 files)
- Add `indicatif` spinners for key analysis phases — default terminal output is now minimal and clean
- Add `--verbose`/`-v` CLI flag to show debug output on the terminal
- Write detailed debug logs to `~/.carrick/logs/` with daily rotation (always on)
- Upload logs to S3 (`{org}/{repo}/logs/{timestamp}.log`) after each analysis run for remote debugging
- Add 60-day S3 lifecycle rule to auto-expire old logs

## Default terminal output

```
✓ Sidecar ready
✓ AWS connectivity verified
✓ Downloaded data from 3 repos
✓ Analyzed repo-a
✓ Uploaded results to cloud storage
✓ Cross-repo analysis complete
<!-- report -->
```

## Test plan

- [x] `cargo build` — clean, zero warnings
- [x] `cargo test` — 175 Rust tests + 60 TS tests pass
- [x] Manual test against `express-demo-1` repo — clean output confirmed
- [ ] Deploy Lambda (`lambdas/build.sh && terraform apply`) and verify logs appear in S3
- [x] Verify `--verbose` flag shows debug output
- [ ] Verify `~/.carrick/logs/` contains daily log files