### PR TITLE
feat: add --no-cache flag to skip incremental analysis

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -88,7 +88,7 @@ pub async fn run_analysis_engine<T: CloudStorage>(
     storage: T,
     repo_path: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    run_analysis_engine_with_sidecar(storage, repo_path, None).await
+    run_analysis_engine_with_sidecar(storage, repo_path, None, false).await
 }
 
 /// Run analysis engine with optional sidecar for type extraction
@@ -96,6 +96,7 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
     storage: T,
     repo_path: &str,
     sidecar: Option<&TypeSidecar>,
+    no_cache: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let carrick_org = env::var("CARRICK_ORG").map_err(|_| "CARRICK_ORG must be set in CI mode")?;
 
@@ -119,14 +120,19 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
 
     // 3. Extract previous data for current repo (if any)
     let repo_name = get_repository_name(repo_path);
-    let previous_data = all_repo_data
-        .iter()
-        .find(|r| r.repo_name == repo_name)
-        .cloned();
-
-    if previous_data.is_some() {
-        debug!("Found previous analysis data for {}", repo_name);
-    }
+    let previous_data = if no_cache {
+        debug!("--no-cache: skipping incremental cache");
+        None
+    } else {
+        let data = all_repo_data
+            .iter()
+            .find(|r| r.repo_name == repo_name)
+            .cloned();
+        if data.is_some() {
+            debug!("Found previous analysis data for {}", repo_name);
+        }
+        data
+    };
     logging::finish_spinner(
         &sp,
         &format!("Downloaded data from {} repos", all_repo_data.len()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,13 +40,20 @@ struct CliArgs {
     repo_path: String,
     /// Enable verbose (debug-level) terminal output
     verbose: bool,
+    /// Skip incremental cache and run a full analysis
+    no_cache: bool,
 }
 
 impl CliArgs {
     fn parse() -> Self {
         let args: Vec<String> = env::args().skip(1).collect();
+        Self::parse_from(&args)
+    }
+
+    fn parse_from(args: &[String]) -> Self {
         let mut repo_path = ".".to_string();
         let mut verbose = false;
+        let mut no_cache = false;
 
         let mut i = 0;
         while i < args.len() {
@@ -57,6 +64,9 @@ impl CliArgs {
                 }
                 "--verbose" | "-v" => {
                     verbose = true;
+                }
+                "--no-cache" => {
+                    no_cache = true;
                 }
                 arg if !arg.starts_with('-') => {
                     repo_path = arg.to_string();
@@ -70,7 +80,11 @@ impl CliArgs {
             i += 1;
         }
 
-        Self { repo_path, verbose }
+        Self {
+            repo_path,
+            verbose,
+            no_cache,
+        }
     }
 
     fn print_help() {
@@ -86,6 +100,7 @@ ARGUMENTS:
 OPTIONS:
     -h, --help     Print this help message
     -v, --verbose  Enable verbose (debug-level) terminal output
+    --no-cache     Skip incremental cache and run a full analysis
 
 ENVIRONMENT VARIABLES:
     CARRICK_API_KEY         API key for the LLM service (required)
@@ -178,10 +193,10 @@ async fn run_analysis(args: CliArgs) -> Result<(), Box<dyn std::error::Error>> {
     if use_mock {
         info!("Using MockStorage");
         let storage = MockStorage::new();
-        run_analysis_engine_with_sidecar(storage, &args.repo_path, sidecar_ref).await
+        run_analysis_engine_with_sidecar(storage, &args.repo_path, sidecar_ref, args.no_cache).await
     } else {
         let storage = AwsStorage::new()?;
-        run_analysis_engine_with_sidecar(storage, &args.repo_path, sidecar_ref).await
+        run_analysis_engine_with_sidecar(storage, &args.repo_path, sidecar_ref, args.no_cache).await
     }
 
     // Sidecar will be automatically shut down when it goes out of scope (Drop impl)
@@ -272,4 +287,61 @@ fn spawn_sidecar(
     sidecar.start_init(&absolute_repo_path, None);
 
     Ok(sidecar)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(input: &[&str]) -> Vec<String> {
+        input.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_defaults() {
+        let cli = CliArgs::parse_from(&args(&[]));
+        assert_eq!(cli.repo_path, ".");
+        assert!(!cli.verbose);
+        assert!(!cli.no_cache);
+    }
+
+    #[test]
+    fn test_repo_path() {
+        let cli = CliArgs::parse_from(&args(&["/some/path"]));
+        assert_eq!(cli.repo_path, "/some/path");
+    }
+
+    #[test]
+    fn test_verbose_short() {
+        let cli = CliArgs::parse_from(&args(&["-v"]));
+        assert!(cli.verbose);
+    }
+
+    #[test]
+    fn test_verbose_long() {
+        let cli = CliArgs::parse_from(&args(&["--verbose"]));
+        assert!(cli.verbose);
+    }
+
+    #[test]
+    fn test_no_cache() {
+        let cli = CliArgs::parse_from(&args(&["--no-cache"]));
+        assert!(cli.no_cache);
+        assert!(!cli.verbose);
+    }
+
+    #[test]
+    fn test_no_cache_with_repo_path() {
+        let cli = CliArgs::parse_from(&args(&["--no-cache", "/my/repo"]));
+        assert!(cli.no_cache);
+        assert_eq!(cli.repo_path, "/my/repo");
+    }
+
+    #[test]
+    fn test_all_flags() {
+        let cli = CliArgs::parse_from(&args(&["-v", "--no-cache", "/my/repo"]));
+        assert!(cli.verbose);
+        assert!(cli.no_cache);
+        assert_eq!(cli.repo_path, "/my/repo");
+    }
 }


### PR DESCRIPTION
## Summary

- Add `--no-cache` CLI flag that forces a full re-analysis, ignoring previously cached file results
- Useful for overwriting stale metadata or debugging incremental cache issues
- Refactor `CliArgs::parse` into `parse_from` for testability
- Add 7 unit tests for CLI argument parsing

## Usage

```bash
carrick --no-cache /path/to/repo
```

## Test plan

- [x] `cargo build` — clean, zero warnings
- [x] `cargo test` — 182 Rust tests + 60 TS tests pass
- [x] New CLI parsing tests cover `--no-cache` flag in isolation and combination with other flags