### PR TITLE
feat: add get_function_source MCP endpoint

### DIFF
--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -8,6 +8,7 @@ import { checkCompatibility } from "./tools/check-compat.js";
 import { getServiceDependencies } from "./tools/get-deps.js";
 import { getTypeDefinition } from "./tools/get-type-definition.js";
 import { listFunctionIntents } from "./tools/find-similar.js";
+import { getFunctionSource } from "./tools/get-function-source.js";
 import { getServiceCatalog } from "./resources/service-catalog.js";
 import { getServiceTypes } from "./resources/service-types.js";
 
@@ -87,6 +88,20 @@ export function createServer(client: ApiClient): McpServer {
       exclude_service: z.string().optional().describe("Service to exclude from results"),
     },
     async (params) => listFunctionIntents(client, params),
+  );
+
+  server.tool(
+    "get_function_source",
+    "Get structured metadata and GitHub fetch coordinates for a specific function. Returns route, resolved request/response types, external API calls, internal calls, and intent. Use detail='signature' for metadata only, or detail='full' (default) to also get line-precise GitHub coordinates for fetching just the function source. Use list_function_intents first to find function names.",
+    {
+      service: z.string().describe("Service name (fuzzy match)"),
+      function_name: z.string().describe("Function name from list_function_intents"),
+      detail: z
+        .enum(["signature", "full"])
+        .default("full")
+        .describe("'signature' for metadata only, 'full' adds GitHub source coordinates"),
+    },
+    async (params) => getFunctionSource(client, params),
   );
 
   // --- Resources ---

--- a/mcp-server/src/tools/__tests__/get-function-source.test.ts
+++ b/mcp-server/src/tools/__tests__/get-function-source.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect, vi } from "vitest";
+import { getFunctionSource } from "../get-function-source.js";
+import { ApiClient } from "../../api-client.js";
+import { CloudRepoData } from "../../types.js";
+
+function makeRepoData(
+  overrides: Partial<CloudRepoData> = {},
+): CloudRepoData {
+  return {
+    repo_name: "org/test-service",
+    endpoints: [],
+    calls: [],
+    mounts: [],
+    apps: {},
+    imported_handlers: [],
+    function_definitions: {},
+    last_updated: "2026-01-01T00:00:00Z",
+    commit_hash: "abc123def456",
+    ...overrides,
+  };
+}
+
+function makeServiceRepo(): CloudRepoData {
+  return makeRepoData({
+    repo_name: "org/user-service",
+    service_name: "user-service",
+    function_definitions: {
+      get_users__id_profile_handler: {
+        name: "get_users__id_profile_handler",
+        file_path: "src/routes/users.ts",
+        node_type: "ArrowFunction",
+        arguments: [{ name: "req" }, { name: "res" }],
+        is_exported: true,
+        line_number: 46,
+        end_line_number: 90,
+        intent:
+          "Builds a user profile by fetching and validating their orders and comments.",
+        calls: [
+          { name: "isOrderArray", file_path: "src/utils.ts", line_number: 10 },
+          {
+            name: "isCommentArray",
+            file_path: "src/utils.ts",
+            line_number: 20,
+          },
+        ],
+      },
+      isOrderArray: {
+        name: "isOrderArray",
+        file_path: "src/utils.ts",
+        node_type: "ArrowFunction",
+        arguments: [{ name: "arr" }],
+        is_exported: true,
+        line_number: 10,
+        end_line_number: 15,
+        intent: "Type guard for Order arrays.",
+      },
+    },
+    mount_graph: {
+      nodes: {},
+      mounts: [],
+      endpoints: [
+        {
+          method: "GET",
+          path: "/users/:id/profile",
+          full_path: "/users/:id/profile",
+          handler: "get_users__id_profile_handler",
+          owner: "app",
+          file_location: "src/routes/users.ts",
+          middleware_chain: [],
+        },
+      ],
+      data_calls: [
+        {
+          method: "GET",
+          target_url: "/orders?userId=",
+          client: "axios",
+          file_location: "src/routes/users.ts",
+        },
+        {
+          method: "GET",
+          target_url: "/api/comments?userId=",
+          client: "axios",
+          file_location: "src/routes/users.ts",
+        },
+        {
+          method: "POST",
+          target_url: "/audit/log",
+          client: "axios",
+          file_location: "src/middleware/audit.ts",
+        },
+      ],
+    },
+    type_manifest: [
+      {
+        method: "GET",
+        path: "/users/:id/profile",
+        role: "producer",
+        type_kind: "response",
+        type_alias: "UserProfile",
+        file_path: "src/routes/users.ts",
+        line_number: 48,
+        is_explicit: true,
+        type_state: "explicit",
+        evidence: {
+          file_path: "src/routes/users.ts",
+          line_number: 48,
+          infer_kind: "response_body",
+          is_explicit: true,
+          type_state: "explicit",
+        },
+        resolved_definition:
+          "interface UserProfile { userId: number; name: string; orders: Order[]; }",
+        expanded_definition:
+          "{ userId: number; name: string; orders: { id: number; total: number; }[]; }",
+      },
+    ],
+    bundled_types:
+      "export interface UserProfile { userId: number; name: string; orders: Order[]; }",
+  });
+}
+
+function makeOrderServiceRepo(): CloudRepoData {
+  return makeRepoData({
+    repo_name: "org/order-service",
+    service_name: "order-service",
+    mount_graph: {
+      nodes: {},
+      mounts: [],
+      data_calls: [],
+      endpoints: [
+        {
+          method: "GET",
+          path: "/orders",
+          full_path: "/orders",
+          handler: "getOrders",
+          owner: "app",
+          file_location: "src/routes.ts",
+          middleware_chain: [],
+        },
+      ],
+    },
+  });
+}
+
+function mockClient(repos: CloudRepoData[]): ApiClient {
+  return {
+    getAllRepoData: vi.fn().mockResolvedValue(repos),
+    findService: vi.fn((name: string) => {
+      const lower = name.toLowerCase();
+      return Promise.resolve(
+        repos.find(
+          (r) =>
+            r.service_name?.toLowerCase() === lower ||
+            r.repo_name.toLowerCase().includes(lower),
+        ),
+      );
+    }),
+    invalidateCache: vi.fn(),
+  } as unknown as ApiClient;
+}
+
+function parseResult(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("getFunctionSource", () => {
+  describe("service/function lookup", () => {
+    it("returns error when service is not found", async () => {
+      const client = mockClient([]);
+      const result = await getFunctionSource(client, {
+        service: "nonexistent",
+        function_name: "foo",
+      });
+      expect(result.content[0].text).toContain("not found");
+      expect(result.content[0].text).toContain("nonexistent");
+    });
+
+    it("returns error when function is not found in service", async () => {
+      const client = mockClient([makeServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "nonexistent_handler",
+      });
+      expect(result.content[0].text).toContain("not found");
+      expect(result.content[0].text).toContain("nonexistent_handler");
+    });
+  });
+
+  describe("signature detail", () => {
+    it("returns metadata without source coordinates", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+
+      expect(data.function_name).toBe("get_users__id_profile_handler");
+      expect(data.service).toBe("user-service");
+      expect(data.route).toBe("GET /users/:id/profile");
+      expect(data.intent).toContain("user profile");
+      expect(data).not.toHaveProperty("source");
+    });
+
+    it("includes resolved route params", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+      expect(data.params).toEqual({ id: "string" });
+    });
+
+    it("includes internal calls", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+      expect(data.internal_calls).toEqual(["isOrderArray", "isCommentArray"]);
+    });
+
+    it("includes intent", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+      expect(data.intent).toBe(
+        "Builds a user profile by fetching and validating their orders and comments.",
+      );
+    });
+  });
+
+  describe("type resolution", () => {
+    it("resolves response type with alias and expanded definition", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+
+      expect(data.response_type).toBeTruthy();
+      expect(data.response_type.alias).toBe("UserProfile");
+      expect(data.response_type.definition).toContain("userId");
+      expect(data.response_type.is_explicit).toBe(true);
+    });
+
+    it("returns null for request_body when none exists", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+      expect(data.request_body).toBeNull();
+    });
+
+    it("returns null types for functions with no endpoint", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "isOrderArray",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+
+      expect(data.route).toBeNull();
+      expect(data.params).toBeNull();
+      expect(data.response_type).toBeNull();
+      expect(data.request_body).toBeNull();
+    });
+  });
+
+  describe("external calls", () => {
+    it("includes data calls from the function's file", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+
+      expect(data.external_calls).toHaveLength(2);
+      expect(data.external_calls[0].method).toBe("GET");
+      expect(data.external_calls[0].path).toBe("/orders");
+    });
+
+    it("excludes data calls from other files", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+
+      // The POST /audit/log call is in middleware/audit.ts, not routes/users.ts
+      const auditCall = data.external_calls.find(
+        (c: { path: string }) => c.path === "/audit/log",
+      );
+      expect(auditCall).toBeUndefined();
+    });
+
+    it("resolves call targets to known service names", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+
+      const orderCall = data.external_calls.find(
+        (c: { path: string }) => c.path === "/orders",
+      );
+      expect(orderCall.service).toBe("order-service");
+    });
+
+    it("returns empty external_calls for utility functions", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "isOrderArray",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+      expect(data.external_calls).toEqual([]);
+    });
+  });
+
+  describe("full detail (source coordinates)", () => {
+    it("includes source coordinates by default", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+      });
+      const data = parseResult(result);
+
+      expect(data.source).toBeDefined();
+      expect(data.source.repo).toBe("org/user-service");
+      expect(data.source.path).toBe("src/routes/users.ts");
+      expect(data.source.ref).toBe("abc123def456");
+      expect(data.source.start_line).toBe(46);
+      expect(data.source.end_line).toBe(90);
+    });
+
+    it("defaults to full detail when detail param is omitted", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+      });
+      const data = parseResult(result);
+      expect(data.source).toBeDefined();
+    });
+
+    it("omits source when detail is signature", async () => {
+      const client = mockClient([makeServiceRepo(), makeOrderServiceRepo()]);
+      const result = await getFunctionSource(client, {
+        service: "user-service",
+        function_name: "get_users__id_profile_handler",
+        detail: "signature",
+      });
+      const data = parseResult(result);
+      expect(data).not.toHaveProperty("source");
+    });
+  });
+});

--- a/mcp-server/src/tools/get-function-source.ts
+++ b/mcp-server/src/tools/get-function-source.ts
@@ -1,0 +1,244 @@
+import { ApiClient } from "../api-client.js";
+import { extractEndpointTypes } from "../utils/type-extractor.js";
+import { extractPathParams, pathsMatch } from "../utils/path-matcher.js";
+import type {
+  CloudRepoData,
+  FunctionDefinition,
+  ResolvedEndpoint,
+} from "../types.js";
+
+export interface GetFunctionSourceParams {
+  service: string;
+  function_name: string;
+  detail?: "signature" | "full";
+}
+
+interface ResolvedType {
+  alias: string;
+  /** Compiler-expanded definition string, or null if unresolvable. */
+  definition: string | null;
+  is_explicit?: boolean;
+  reason?: string;
+}
+
+interface ExternalCall {
+  service: string;
+  method: string;
+  path: string;
+}
+
+interface SourceCoordinates {
+  repo: string;
+  path: string;
+  ref: string;
+  start_line: number;
+  end_line: number;
+}
+
+interface GetFunctionSourceResult {
+  function_name: string;
+  service: string;
+  route: string | null;
+  params: Record<string, string> | null;
+  request_body: ResolvedType | null;
+  response_type: ResolvedType | null;
+  external_calls: ExternalCall[];
+  internal_calls: string[];
+  intent: string | null;
+  source?: SourceCoordinates;
+}
+
+export async function getFunctionSource(
+  client: ApiClient,
+  params: GetFunctionSourceParams,
+) {
+  const repo = await client.findService(params.service);
+  if (!repo) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Service "${params.service}" not found. Use list_services to see available services.`,
+        },
+      ],
+    };
+  }
+
+  const fn = repo.function_definitions[params.function_name] as
+    | FunctionDefinition
+    | undefined;
+  if (!fn) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Function "${params.function_name}" not found in "${params.service}". Use list_function_intents to see available functions.`,
+        },
+      ],
+    };
+  }
+
+  const endpoint = repo.mount_graph?.endpoints?.find(
+    (e) => e.handler === fn.name,
+  );
+
+  const allRepos = await client.getAllRepoData();
+
+  const result: GetFunctionSourceResult = {
+    function_name: fn.name,
+    service: repo.service_name ?? repo.repo_name,
+    route: endpoint
+      ? `${endpoint.method.toUpperCase()} ${endpoint.full_path}`
+      : null,
+    params: endpoint ? nullIfEmpty(extractPathParams(endpoint.full_path)) : null,
+    request_body: resolveEndpointType(repo, endpoint, "request"),
+    response_type: resolveEndpointType(repo, endpoint, "response"),
+    external_calls: resolveExternalCalls(repo, fn, allRepos),
+    internal_calls: (fn.calls ?? []).map((c) => c.name),
+    intent: fn.intent ?? null,
+  };
+
+  if ((params.detail ?? "full") === "full") {
+    const source = buildSourceCoordinates(repo, fn);
+    if (source) result.source = source;
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}
+
+function nullIfEmpty<T extends object>(obj: T): T | null {
+  return Object.keys(obj).length === 0 ? null : obj;
+}
+
+/**
+ * Resolve a request or response type for an endpoint via the existing
+ * type-extractor utility, returning a structured `ResolvedType` for the agent.
+ */
+function resolveEndpointType(
+  repo: CloudRepoData,
+  endpoint: ResolvedEndpoint | undefined,
+  kind: "request" | "response",
+): ResolvedType | null {
+  if (!endpoint || !repo.type_manifest) return null;
+
+  const extracted = extractEndpointTypes(
+    repo.type_manifest,
+    repo.bundled_types ?? "",
+    endpoint.method,
+    endpoint.full_path,
+  ).find((t) => t.type_kind === kind);
+
+  if (!extracted) return null;
+
+  // Prefer the compiler-expanded form (fully inlined) when available, since
+  // the agent gets a self-contained type without needing follow-up lookups.
+  const definition = extracted.expanded ?? extracted.definition ?? null;
+
+  return {
+    alias: extracted.type_alias,
+    definition,
+    is_explicit: extracted.is_explicit,
+    ...(definition === null ? { reason: "unresolved" } : {}),
+  };
+}
+
+/**
+ * Resolve external API calls made from the function's file. Each call is
+ * mapped to its target service by matching the call's URL path against
+ * known endpoints across the org.
+ *
+ * Note: this returns calls scoped to the function's file, not the function
+ * itself — `DataFetchingCall` doesn't currently carry line numbers, so we
+ * can't filter to the function's body. Agents should use the source
+ * coordinates to verify which calls actually belong to this function.
+ */
+function resolveExternalCalls(
+  repo: CloudRepoData,
+  fn: FunctionDefinition,
+  allRepos: CloudRepoData[],
+): ExternalCall[] {
+  const dataCalls = repo.mount_graph?.data_calls ?? [];
+  const funcFile = normalizeFilePath(fn.file_path);
+
+  return dataCalls
+    .filter((call) => normalizeFilePath(call.file_location) === funcFile)
+    .map((call) => {
+      const path = extractPathFromUrl(call.target_url);
+      return {
+        service: resolveCallService(call.method, path, allRepos) ?? path,
+        method: call.method.toUpperCase(),
+        path,
+      };
+    });
+}
+
+function normalizeFilePath(p: string): string {
+  return p.replace(/^\.\//, "");
+}
+
+/**
+ * Pull a request path out of a call URL. Strips scheme/host/env-var prefixes
+ * and query strings so the result can be matched against a service's routes.
+ */
+function extractPathFromUrl(url: string): string {
+  let cleaned = url
+    .replace(/\$\{[^}]+\}/g, "")
+    .replace(/\$[A-Z_][A-Z0-9_]*/g, "");
+
+  try {
+    if (/^https?:\/\//.test(cleaned)) {
+      cleaned = new URL(cleaned).pathname;
+    }
+  } catch {
+    // fall through with the cleaned string
+  }
+
+  // Drop query string and trailing whitespace, ensure leading slash
+  cleaned = cleaned.split("?")[0].trim();
+  if (!cleaned.startsWith("/")) cleaned = "/" + cleaned;
+  return cleaned;
+}
+
+/**
+ * Find which service in the org owns an endpoint matching the given
+ * method+path. Returns the service name, or undefined if no match.
+ */
+function resolveCallService(
+  method: string,
+  path: string,
+  allRepos: CloudRepoData[],
+): string | undefined {
+  const m = method.toUpperCase();
+  for (const r of allRepos) {
+    const endpoints = r.mount_graph?.endpoints ?? [];
+    if (
+      endpoints.some(
+        (e) => e.method.toUpperCase() === m && pathsMatch(e.full_path, path),
+      )
+    ) {
+      return r.service_name ?? r.repo_name;
+    }
+  }
+  return undefined;
+}
+
+function buildSourceCoordinates(
+  repo: CloudRepoData,
+  fn: FunctionDefinition,
+): SourceCoordinates | null {
+  if (!fn.line_number || !fn.end_line_number) return null;
+  return {
+    repo: repo.repo_name,
+    path: fn.file_path,
+    ref: repo.commit_hash,
+    start_line: fn.line_number,
+    end_line: fn.end_line_number,
+  };
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -144,6 +144,7 @@ export interface FunctionDefinition {
   body_source?: string;
   is_exported: boolean;
   line_number: number;
+  end_line_number: number;
   intent?: string;
   calls?: FunctionCallRef[];
 }

--- a/mcp-server/src/utils/path-matcher.ts
+++ b/mcp-server/src/utils/path-matcher.ts
@@ -34,3 +34,18 @@ export function pathsMatch(a: string, b: string): boolean {
 export function pathContains(path: string, substring: string): boolean {
   return path.toLowerCase().includes(substring.toLowerCase());
 }
+
+/**
+ * Extract named parameters from a path. Handles both `:id` and `{id}` styles.
+ * Returns a record mapping parameter names to "string" (their inferred type).
+ */
+export function extractPathParams(path: string): Record<string, string> {
+  const params: Record<string, string> = {};
+  for (const match of path.matchAll(/:([a-zA-Z_][a-zA-Z0-9_]*)/g)) {
+    params[match[1]] = "string";
+  }
+  for (const match of path.matchAll(/\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g)) {
+    params[match[1]] = "string";
+  }
+  return params;
+}

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -324,6 +324,7 @@ mod tests {
                 body_source: Some("return 1;".to_string()),
                 is_exported: true,
                 line_number: 1,
+                end_line_number: 1,
                 intent: Some("returns one".to_string()),
                 calls: vec![],
             },

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -100,6 +100,9 @@ pub struct FunctionDefinition {
     /// Start line number for navigation
     #[serde(default)]
     pub line_number: u32,
+    /// End line number for source extraction
+    #[serde(default)]
+    pub end_line_number: u32,
     /// LLM-generated description of what this function intends to do
     #[serde(skip_serializing_if = "Option::is_none")]
     pub intent: Option<String>,
@@ -300,12 +303,20 @@ impl FunctionDefinitionExtractor {
         }
     }
 
-    /// Get the line number for a span
+    /// Get the start line number for a span
     fn line_number(&self, span: swc_common::Span) -> u32 {
         if span.is_dummy() {
             return 0;
         }
         self.source_map.lookup_char_pos(span.lo).line as u32
+    }
+
+    /// Get the end line number for a span
+    fn end_line_number(&self, span: swc_common::Span) -> u32 {
+        if span.is_dummy() {
+            return 0;
+        }
+        self.source_map.lookup_char_pos(span.hi).line as u32
     }
 
     /// Extract function arguments with their type annotations
@@ -404,6 +415,7 @@ impl Visit for FunctionDefinitionExtractor {
                         .as_ref()
                         .and_then(|b| self.extract_source(b.span));
                     let line_number = self.line_number(fn_expr.function.span);
+                    let end_line_number = self.end_line_number(fn_expr.function.span);
                     self.function_definitions.insert(
                         name.clone(),
                         FunctionDefinition {
@@ -416,6 +428,7 @@ impl Visit for FunctionDefinitionExtractor {
                             body_source,
                             is_exported: true,
                             line_number,
+                            end_line_number,
                             intent: None,
                             calls: vec![],
                         },
@@ -465,6 +478,7 @@ impl Visit for FunctionDefinitionExtractor {
             .as_ref()
             .and_then(|b| self.extract_source(b.span));
         let line_number = self.line_number(fn_decl.function.span);
+        let end_line_number = self.end_line_number(fn_decl.function.span);
 
         self.function_definitions.insert(
             name.clone(),
@@ -476,6 +490,7 @@ impl Visit for FunctionDefinitionExtractor {
                 body_source,
                 is_exported: false, // Updated in a post-pass
                 line_number,
+                end_line_number,
                 intent: None,
                 calls: vec![],
             },
@@ -497,6 +512,7 @@ impl Visit for FunctionDefinitionExtractor {
                         let arguments = self.extract_arrow_arguments(&arrow.params);
                         let body_source = self.extract_source(arrow.span);
                         let line_number = self.line_number(arrow.span);
+                        let end_line_number = self.end_line_number(arrow.span);
                         self.function_definitions.insert(
                             name.clone(),
                             FunctionDefinition {
@@ -507,6 +523,7 @@ impl Visit for FunctionDefinitionExtractor {
                                 body_source,
                                 is_exported: false,
                                 line_number,
+                                end_line_number,
                                 intent: None,
                                 calls: vec![],
                             },
@@ -520,6 +537,7 @@ impl Visit for FunctionDefinitionExtractor {
                             .as_ref()
                             .and_then(|b| self.extract_source(b.span));
                         let line_number = self.line_number(fn_expr.function.span);
+                        let end_line_number = self.end_line_number(fn_expr.function.span);
                         self.function_definitions.insert(
                             name.clone(),
                             FunctionDefinition {
@@ -532,6 +550,7 @@ impl Visit for FunctionDefinitionExtractor {
                                 body_source,
                                 is_exported: false,
                                 line_number,
+                                end_line_number,
                                 intent: None,
                                 calls: vec![],
                             },
@@ -562,6 +581,7 @@ impl Visit for FunctionDefinitionExtractor {
                             let arguments = self.extract_arrow_arguments(&arrow.params);
                             let body_source = self.extract_source(arrow.span);
                             let line_number = self.line_number(arrow.span);
+                            let end_line_number = self.end_line_number(arrow.span);
                             self.function_definitions.insert(
                                 synthetic_name.clone(),
                                 FunctionDefinition {
@@ -574,6 +594,7 @@ impl Visit for FunctionDefinitionExtractor {
                                     body_source,
                                     is_exported: false,
                                     line_number,
+                                    end_line_number,
                                     intent: None,
                                     calls: vec![],
                                 },
@@ -591,6 +612,7 @@ impl Visit for FunctionDefinitionExtractor {
                                 .as_ref()
                                 .and_then(|b| self.extract_source(b.span));
                             let line_number = self.line_number(fn_expr.function.span);
+                            let end_line_number = self.end_line_number(fn_expr.function.span);
                             self.function_definitions.insert(
                                 synthetic_name.clone(),
                                 FunctionDefinition {
@@ -603,6 +625,7 @@ impl Visit for FunctionDefinitionExtractor {
                                     body_source,
                                     is_exported: false,
                                     line_number,
+                                    end_line_number,
                                     intent: None,
                                     calls: vec![],
                                 },
@@ -806,6 +829,31 @@ mod tests {
         let defs = extract("function first() { return 1; }");
         let def = defs.get("first").expect("should find first");
         assert!(def.line_number > 0, "line_number should be positive");
+    }
+
+    #[test]
+    fn captures_end_line_number() {
+        let defs = extract("function multi() {\n  const a = 1;\n  return a;\n}");
+        let def = defs.get("multi").expect("should find multi");
+        assert!(def.line_number > 0, "start line should be positive");
+        assert!(
+            def.end_line_number >= def.line_number,
+            "end_line_number ({}) should be >= line_number ({})",
+            def.end_line_number,
+            def.line_number
+        );
+    }
+
+    #[test]
+    fn captures_end_line_number_for_arrow() {
+        let defs = extract("const handler = (x: number) => {\n  return x * 2;\n};");
+        let def = defs.get("handler").expect("should find handler");
+        assert!(
+            def.end_line_number >= def.line_number,
+            "arrow end_line ({}) should be >= start ({})",
+            def.end_line_number,
+            def.line_number
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Rust (AST scanning)**: Captures `end_line_number` for all function/handler types during SWC AST scanning, enabling line-precise source extraction
- **MCP server**: New `get_function_source` tool that returns structured metadata (route, resolved types, external/internal calls, intent) and commit-pinned GitHub coordinates for a specific function
- **Utility**: Adds `extractPathParams` to `path-matcher.ts` supporting both `:id` and `{id}` parameter styles

### Detail levels

- `signature` — Returns metadata only. An agent can write a correctly-typed API call from this alone, without any GitHub fetch or follow-up tool calls
- `full` (default) — Adds source coordinates (`repo`, `path`, `ref`, `start_line`, `end_line`) so the agent can fetch just the function body instead of the entire file

### External call resolution

External API calls are resolved to actual Carrick service names by matching call URLs against known endpoints across the org.

## Test plan

- [x] 2 new Rust unit tests for `end_line_number` (function declarations and arrow functions)
- [x] 16 new vitest tests covering: service/function lookup errors, signature metadata (route, params, types, calls, intent), type resolution (response types, null request body, non-endpoint functions), external call file scoping and service resolution, source coordinate generation, detail level behavior
- [x] All 177 Rust unit tests pass
- [x] All 65 MCP server tests pass
- [x] Pre-commit hook passes (formatting, clippy, full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)