### PR TITLE
chore: copilot follow-ups from PR #68

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,7 @@
+# RUSTSEC-2026-0009: time 0.3.44 DoS via parsing attacker-controlled
+# date strings. We only use `time` transitively via tracing-appender
+# for internal timestamp formatting, so the vector does not apply.
+# Fix requires time >=0.3.47, which forces serde >=1.0.228 and breaks
+# swc_common 12. Revisit when the swc stack is bumped.
+[advisories]
+ignore = ["RUSTSEC-2026-0009"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: |
             test-repo/package.json
@@ -160,7 +160,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Install test-repo dependencies
         run: cd test-repo && npm install
@@ -241,9 +241,4 @@ jobs:
         run: cargo install cargo-audit
 
       - name: Run security audit
-        # RUSTSEC-2026-0009: time 0.3.44 DoS via parsing attacker-controlled
-        # date strings. We only use `time` transitively via tracing-appender
-        # for internal timestamp formatting, so the vector does not apply.
-        # Fix requires time >=0.3.47, which forces serde >=1.0.228 and breaks
-        # swc_common 12. Revisit when the swc stack is bumped.
-        run: cargo audit --ignore RUSTSEC-2026-0009
+        run: cargo audit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: src/sidecar/package-lock.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.1.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -304,16 +304,6 @@ dependencies = [
  "once_cell",
  "unicode-width 0.2.2",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -436,15 +426,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,27 +446,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -645,25 +605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,7 +695,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -782,22 +722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,11 +739,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1135,12 +1057,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,23 +1074,6 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1257,50 +1156,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "openssl"
-version = "0.10.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -1409,12 +1264,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -1652,20 +1501,15 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1676,7 +1520,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -1799,15 +1642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,29 +1658,6 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2355,27 +2166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,35 +2328,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -2788,12 +2555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,9 +2717,9 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.1",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -2990,38 +2751,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link 0.1.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3030,16 +2765,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link 0.1.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ indicatif = "0.17"
 
 matchit = "0.8.6"
 regex = "1.11.1"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 semver = "1.0"
 serde = "1.0.219"
 serde_json = "1.0.140"

--- a/src/agent_service.rs
+++ b/src/agent_service.rs
@@ -479,21 +479,20 @@ fn extract_from_code_block(text: &str) -> &str {
         if let Some(end) = text[start + 7..].find("```") {
             return text[start + 7..start + 7 + end].trim();
         }
-    } else if let Some(start) = text.find("```") {
-        if let Some(end) = text[start + 3..].find("```") {
-            return text[start + 3..start + 3 + end].trim();
-        }
+    } else if let Some(start) = text.find("```")
+        && let Some(end) = text[start + 3..].find("```")
+    {
+        return text[start + 3..start + 3 + end].trim();
     }
     text
 }
 
 fn extract_json_array(text: &str) -> &str {
-    if let Some(start) = text.find('[') {
-        if let Some(end) = text.rfind(']') {
-            if end > start {
-                return &text[start..=end];
-            }
-        }
+    if let Some(start) = text.find('[')
+        && let Some(end) = text.rfind(']')
+        && end > start
+    {
+        return &text[start..=end];
     }
     "[]"
 }
@@ -513,28 +512,28 @@ fn generate_mock_response(schema: &Option<serde_json::Value>, prompt: &str) -> S
             // Check if schema is for an array
             if schema_val.get("type").and_then(|t| t.as_str()) == Some("ARRAY") {
                 // Check what kind of array based on the items schema
-                if let Some(items) = schema_val.get("items") {
-                    if let Some(props) = items.get("properties") {
-                        // Triage schema - has location, classification, confidence
-                        if props.get("classification").is_some() {
-                            return generate_mock_triage_response(prompt);
-                        }
-                        // Endpoint schema - has method, path, handler, node_name
-                        if props.get("node_name").is_some() && props.get("path").is_some() {
-                            return generate_mock_endpoint_response(prompt);
-                        }
-                        // Consumer schema - has library, url, method
-                        if props.get("library").is_some() {
-                            return generate_mock_consumer_response(prompt);
-                        }
-                        // Mount schema - has parent_node, child_node, mount_path
-                        if props.get("parent_node").is_some() && props.get("child_node").is_some() {
-                            return generate_mock_mount_response(prompt);
-                        }
-                        // Middleware schema - has middleware_type
-                        if props.get("middleware_type").is_some() {
-                            return generate_mock_middleware_response(prompt);
-                        }
+                if let Some(items) = schema_val.get("items")
+                    && let Some(props) = items.get("properties")
+                {
+                    // Triage schema - has location, classification, confidence
+                    if props.get("classification").is_some() {
+                        return generate_mock_triage_response(prompt);
+                    }
+                    // Endpoint schema - has method, path, handler, node_name
+                    if props.get("node_name").is_some() && props.get("path").is_some() {
+                        return generate_mock_endpoint_response(prompt);
+                    }
+                    // Consumer schema - has library, url, method
+                    if props.get("library").is_some() {
+                        return generate_mock_consumer_response(prompt);
+                    }
+                    // Mount schema - has parent_node, child_node, mount_path
+                    if props.get("parent_node").is_some() && props.get("child_node").is_some() {
+                        return generate_mock_mount_response(prompt);
+                    }
+                    // Middleware schema - has middleware_type
+                    if props.get("middleware_type").is_some() {
+                        return generate_mock_middleware_response(prompt);
                     }
                 }
                 // Default array response
@@ -683,12 +682,12 @@ fn generate_mock_file_analysis_response(prompt: &str) -> String {
             return entry.clone();
         }
         let trimmed_line = line_text.trim();
-        if !trimmed_line.is_empty() {
-            if let Some(entry) = candidate_snippets.iter().find(|(_, _, _, snippet)| {
+        if !trimmed_line.is_empty()
+            && let Some(entry) = candidate_snippets.iter().find(|(_, _, _, snippet)| {
                 snippet.contains(trimmed_line) || trimmed_line.contains(snippet)
-            }) {
-                return (entry.0.clone(), entry.1, entry.2);
-            }
+            })
+        {
+            return (entry.0.clone(), entry.1, entry.2);
         }
         (format!("line:{}", line_number), None, None)
     };
@@ -937,21 +936,21 @@ fn generate_mock_file_analysis_response(prompt: &str) -> String {
 /// Helper to extract path from a line like: app.get("/users", handler)
 fn extract_path_from_line(line: &str) -> Option<String> {
     // Try double quotes first
-    if let Some(start) = line.find("\"") {
-        if let Some(end) = line[start + 1..].find("\"") {
-            let path = &line[start + 1..start + 1 + end];
-            if path.starts_with('/') {
-                return Some(path.to_string());
-            }
+    if let Some(start) = line.find("\"")
+        && let Some(end) = line[start + 1..].find("\"")
+    {
+        let path = &line[start + 1..start + 1 + end];
+        if path.starts_with('/') {
+            return Some(path.to_string());
         }
     }
     // Try single quotes
-    if let Some(start) = line.find("'") {
-        if let Some(end) = line[start + 1..].find("'") {
-            let path = &line[start + 1..start + 1 + end];
-            if path.starts_with('/') {
-                return Some(path.to_string());
-            }
+    if let Some(start) = line.find("'")
+        && let Some(end) = line[start + 1..].find("'")
+    {
+        let path = &line[start + 1..start + 1 + end];
+        if path.starts_with('/') {
+            return Some(path.to_string());
         }
     }
     None
@@ -982,10 +981,10 @@ fn extract_url_from_line(line: &str) -> Option<String> {
         return Some(path);
     }
     // Handle backtick template literals
-    if let Some(start) = line.find('`') {
-        if let Some(end) = line[start + 1..].find('`') {
-            return Some(line[start + 1..start + 1 + end].to_string());
-        }
+    if let Some(start) = line.find('`')
+        && let Some(end) = line[start + 1..].find('`')
+    {
+        return Some(line[start + 1..start + 1 + end].to_string());
     }
     None
 }
@@ -1476,13 +1475,12 @@ fn extract_call_sites_from_prompt(prompt: &str) -> Vec<serde_json::Value> {
         let abs_start = current_pos + start;
         if let Some(end_offset) = find_matching_bracket(&prompt[abs_start..]) {
             let json_str = &prompt[abs_start..abs_start + end_offset];
-            if let Ok(parsed) = serde_json::from_str::<Vec<serde_json::Value>>(json_str) {
-                if !parsed.is_empty()
-                    && parsed[0].get("callee_object").is_some()
-                    && parsed[0].get("location").is_some()
-                {
-                    return parsed;
-                }
+            if let Ok(parsed) = serde_json::from_str::<Vec<serde_json::Value>>(json_str)
+                && !parsed.is_empty()
+                && parsed[0].get("callee_object").is_some()
+                && parsed[0].get("location").is_some()
+            {
+                return parsed;
             }
         }
         current_pos = abs_start + 1;

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -362,10 +362,10 @@ impl FileAnalyzerAgent {
             if normalize_import_source(&mut endpoint.type_import_source) {
                 needs_retry = true;
             }
-            if let Some(ref symbol) = endpoint.primary_type_symbol {
-                if !is_valid_identifier(symbol) {
-                    endpoint.primary_type_symbol = None;
-                }
+            if let Some(ref symbol) = endpoint.primary_type_symbol
+                && !is_valid_identifier(symbol)
+            {
+                endpoint.primary_type_symbol = None;
             }
         }
 
@@ -384,10 +384,10 @@ impl FileAnalyzerAgent {
             if normalize_import_source(&mut data_call.type_import_source) {
                 needs_retry = true;
             }
-            if let Some(ref symbol) = data_call.primary_type_symbol {
-                if !is_valid_identifier(symbol) {
-                    data_call.primary_type_symbol = None;
-                }
+            if let Some(ref symbol) = data_call.primary_type_symbol
+                && !is_valid_identifier(symbol)
+            {
+                data_call.primary_type_symbol = None;
             }
         }
 

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -507,10 +507,8 @@ impl FileOrchestrator {
                         span_end: endpoint.call_expression_span_end,
                     },
                 );
-                if !response_inferred {
-                    if let Some(symbol) = endpoint.primary_type_symbol.as_ref() {
-                        inline_aliases.push((response_alias.clone(), symbol.clone()));
-                    }
+                if !response_inferred && let Some(symbol) = endpoint.primary_type_symbol.as_ref() {
+                    inline_aliases.push((response_alias.clone(), symbol.clone()));
                 }
 
                 if should_infer_request_body(&method) {
@@ -647,10 +645,8 @@ impl FileOrchestrator {
                         span_end: data_call.call_expression_span_end,
                     },
                 );
-                if !call_inferred {
-                    if let Some(symbol) = data_call.primary_type_symbol.as_ref() {
-                        inline_aliases.push((response_alias.clone(), symbol.clone()));
-                    }
+                if !call_inferred && let Some(symbol) = data_call.primary_type_symbol.as_ref() {
+                    inline_aliases.push((response_alias.clone(), symbol.clone()));
                 }
 
                 if should_infer_request_body(&method) {
@@ -757,12 +753,12 @@ impl FileOrchestrator {
     fn normalize_unusable_types(result: &mut FileAnalysisResult, frameworks: &[String]) {
         let scrub = |primary: &mut Option<String>, source: &mut Option<String>| {
             // Check type_import_source against ALL detected frameworks
-            if let Some(src) = source.as_deref() {
-                if frameworks.iter().any(|f| f == src) {
-                    *primary = None;
-                    *source = None;
-                    return;
-                }
+            if let Some(src) = source.as_deref()
+                && frameworks.iter().any(|f| f == src)
+            {
+                *primary = None;
+                *source = None;
+                return;
             }
             // Check primary_type_symbol: if it matches a framework package name
             // (the default import), it's a framework namespace, not a payload type

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -545,15 +545,15 @@ impl Analyzer {
         }
 
         // Handle ${process.env.VAR} or ${VAR} patterns
-        if let Some(start) = route.find("${") {
-            if let Some(end) = route[start..].find('}') {
-                let inner = &route[start + 2..start + end];
-                // Handle process.env.VAR -> VAR
-                if let Some(last_dot) = inner.rfind('.') {
-                    return inner[last_dot + 1..].to_string();
-                }
-                return inner.to_string();
+        if let Some(start) = route.find("${")
+            && let Some(end) = route[start..].find('}')
+        {
+            let inner = &route[start + 2..start + end];
+            // Handle process.env.VAR -> VAR
+            if let Some(last_dot) = inner.rfind('.') {
+                return inner[last_dot + 1..].to_string();
             }
+            return inner.to_string();
         }
 
         // Handle process.env.VAR patterns (without ${})
@@ -568,14 +568,14 @@ impl Analyzer {
         }
 
         // Handle start-of-string variable (e.g. API_URL + "/path")
-        if let Some(first_char) = route.chars().next() {
-            if first_char.is_uppercase() {
-                let end = route
-                    .find(|c: char| !c.is_alphanumeric() && c != '_')
-                    .unwrap_or(route.len());
-                if end > 0 {
-                    return route[..end].to_string();
-                }
+        if let Some(first_char) = route.chars().next()
+            && first_char.is_uppercase()
+        {
+            let end = route
+                .find(|c: char| !c.is_alphanumeric() && c != '_')
+                .unwrap_or(route.len());
+            if end > 0 {
+                return route[..end].to_string();
             }
         }
 
@@ -604,41 +604,41 @@ impl Analyzer {
         }
 
         // Check for ${...} at the START of the route (not in the middle)
-        if route.starts_with("${") {
-            if let Some(end) = route.find('}') {
-                let var_name = &route[2..end];
-                // If it contains a dot (like process.env.X) or is UPPER_CASE, it's an env var
-                if var_name.contains('.')
-                    || var_name
-                        .chars()
-                        .all(|c| c.is_uppercase() || c == '_' || c.is_ascii_digit())
-                {
-                    return true;
-                }
+        if route.starts_with("${")
+            && let Some(end) = route.find('}')
+        {
+            let var_name = &route[2..end];
+            // If it contains a dot (like process.env.X) or is UPPER_CASE, it's an env var
+            if var_name.contains('.')
+                || var_name
+                    .chars()
+                    .all(|c| c.is_uppercase() || c == '_' || c.is_ascii_digit())
+            {
+                return true;
             }
         }
 
         // Check for start-of-string variables (e.g. API_URL + "/path")
         // If it starts with an uppercase letter and is not a path (doesn't start with /),
         // we treat it as a potential environment variable or constant base URL.
-        if let Some(first_char) = route.chars().next() {
-            if first_char.is_uppercase() {
-                // Extract the first identifier
-                let end = route
-                    .find(|c: char| !c.is_alphanumeric() && c != '_')
-                    .unwrap_or(route.len());
+        if let Some(first_char) = route.chars().next()
+            && first_char.is_uppercase()
+        {
+            // Extract the first identifier
+            let end = route
+                .find(|c: char| !c.is_alphanumeric() && c != '_')
+                .unwrap_or(route.len());
 
-                // If the identifier is non-empty and looks like a constant (mostly uppercase/digits/underscore)
-                // we treat it as an env var.
-                // We verify it's at least 2 chars to avoid single letters being treated as vars excessively
-                if end >= 2 {
-                    let ident = &route[..end];
-                    if ident
-                        .chars()
-                        .all(|c| c.is_uppercase() || c == '_' || c.is_ascii_digit())
-                    {
-                        return true;
-                    }
+            // If the identifier is non-empty and looks like a constant (mostly uppercase/digits/underscore)
+            // we treat it as an env var.
+            // We verify it's at least 2 chars to avoid single letters being treated as vars excessively
+            if end >= 2 {
+                let ident = &route[..end];
+                if ident
+                    .chars()
+                    .all(|c| c.is_uppercase() || c == '_' || c.is_ascii_digit())
+                {
+                    return true;
                 }
             }
         }
@@ -729,50 +729,45 @@ impl Analyzer {
         });
 
         for endpoint in &self.endpoints {
-            if let Some(handler_name) = &endpoint.handler_name {
-                if let Some(func_def) = self.function_definitions.get(handler_name) {
-                    if func_def.arguments.len() >= 2 {
-                        // Process Request Type (argument 0)
-                        if let Some(req_type_ann_swc) = &func_def.arguments[0].type_ann {
-                            let alias = Self::generate_common_type_alias_name(
-                                &endpoint.route,
-                                &endpoint.method,
-                                true,  // is_request_type
-                                false, // is_consumer = false (endpoints are producers)
-                            );
-                            if let Some(type_ref) = Self::create_type_reference_from_swc(
-                                req_type_ann_swc,
-                                &cm,
-                                &func_def.file_path,
-                                alias,
-                            ) {
-                                request_types_map.insert(
-                                    (endpoint.route.clone(), endpoint.method.clone()),
-                                    type_ref,
-                                );
-                            }
-                        }
+            if let Some(handler_name) = &endpoint.handler_name
+                && let Some(func_def) = self.function_definitions.get(handler_name)
+                && func_def.arguments.len() >= 2
+            {
+                // Process Request Type (argument 0)
+                if let Some(req_type_ann_swc) = &func_def.arguments[0].type_ann {
+                    let alias = Self::generate_common_type_alias_name(
+                        &endpoint.route,
+                        &endpoint.method,
+                        true,  // is_request_type
+                        false, // is_consumer = false (endpoints are producers)
+                    );
+                    if let Some(type_ref) = Self::create_type_reference_from_swc(
+                        req_type_ann_swc,
+                        &cm,
+                        &func_def.file_path,
+                        alias,
+                    ) {
+                        request_types_map
+                            .insert((endpoint.route.clone(), endpoint.method.clone()), type_ref);
+                    }
+                }
 
-                        // Process Response Type (argument 1)
-                        if let Some(res_type_ann_swc) = &func_def.arguments[1].type_ann {
-                            let alias = Self::generate_common_type_alias_name(
-                                &endpoint.route,
-                                &endpoint.method,
-                                false, // is_request_type = false
-                                false, // is_consumer = false (endpoints are producers)
-                            );
-                            if let Some(type_ref) = Self::create_type_reference_from_swc(
-                                res_type_ann_swc,
-                                &cm,
-                                &func_def.file_path,
-                                alias,
-                            ) {
-                                response_types_map.insert(
-                                    (endpoint.route.clone(), endpoint.method.clone()),
-                                    type_ref,
-                                );
-                            }
-                        }
+                // Process Response Type (argument 1)
+                if let Some(res_type_ann_swc) = &func_def.arguments[1].type_ann {
+                    let alias = Self::generate_common_type_alias_name(
+                        &endpoint.route,
+                        &endpoint.method,
+                        false, // is_request_type = false
+                        false, // is_consumer = false (endpoints are producers)
+                    );
+                    if let Some(type_ref) = Self::create_type_reference_from_swc(
+                        res_type_ann_swc,
+                        &cm,
+                        &func_def.file_path,
+                        alias,
+                    ) {
+                        response_types_map
+                            .insert((endpoint.route.clone(), endpoint.method.clone()), type_ref);
                     }
                 }
             }
@@ -1411,7 +1406,7 @@ impl Analyzer {
                 }
                 let path = &caps[1];
                 // Extract just the filename without path for readability
-                if let Some(filename) = path.split('/').last() {
+                if let Some(filename) = path.split('/').next_back() {
                     format!("{}.{}", filename, type_name)
                 } else {
                     format!("{}.{}", path, type_name)

--- a/src/call_site_extractor.rs
+++ b/src/call_site_extractor.rs
@@ -436,34 +436,33 @@ impl CallSiteExtractor {
                 };
 
                 // Get type annotation if present
-                if let Pat::Ident(ident) = &param.pat {
-                    if let Some(type_ann) = &ident.type_ann {
-                        let type_string = self
-                            .source_map
-                            .span_to_snippet(type_ann.type_ann.span())
-                            .unwrap_or_else(|_| "unknown".to_string());
+                if let Pat::Ident(ident) = &param.pat
+                    && let Some(type_ann) = &ident.type_ann
+                {
+                    let type_string = self
+                        .source_map
+                        .span_to_snippet(type_ann.type_ann.span())
+                        .unwrap_or_else(|_| "unknown".to_string());
 
-                        // Calculate file-relative UTF-16 offset
-                        let span = type_ann.type_ann.span();
-                        let loc = self.source_map.lookup_char_pos(span.lo);
-                        let file_start = loc.file.start_pos;
-                        let file_relative_byte = (span.lo - file_start).0 as usize;
+                    // Calculate file-relative UTF-16 offset
+                    let span = type_ann.type_ann.span();
+                    let loc = self.source_map.lookup_char_pos(span.lo);
+                    let file_start = loc.file.start_pos;
+                    let file_relative_byte = (span.lo - file_start).0 as usize;
 
-                        // Read file content to convert to UTF-16
-                        let utf16_offset = if let Ok(content) =
-                            std::fs::read_to_string(&self.current_file)
-                        {
+                    // Read file content to convert to UTF-16
+                    let utf16_offset =
+                        if let Ok(content) = std::fs::read_to_string(&self.current_file) {
                             Self::byte_offset_to_utf16_offset(&content, file_relative_byte) as u32
                         } else {
                             file_relative_byte as u32
                         };
 
-                        return Some(HandlerParamType {
-                            param_name: name,
-                            type_string,
-                            utf16_offset,
-                        });
-                    }
+                    return Some(HandlerParamType {
+                        param_name: name,
+                        type_string,
+                        utf16_offset,
+                    });
                 }
                 None
             })
@@ -729,10 +728,10 @@ impl CallSiteExtractor {
 
     fn extract_http_method_from_call(&self, call: &CallExpr) -> Option<String> {
         for arg in &call.args {
-            if let Expr::Object(obj) = &*arg.expr {
-                if let Some(method) = self.extract_http_method_from_object(obj) {
-                    return Some(method);
-                }
+            if let Expr::Object(obj) = &*arg.expr
+                && let Some(method) = self.extract_http_method_from_object(obj)
+            {
+                return Some(method);
             }
         }
 
@@ -776,13 +775,13 @@ impl CallSiteExtractor {
 
         let mut merged: Vec<Span> = Vec::new();
         for span in spans {
-            if let Some(last) = merged.last_mut() {
-                if span.lo <= last.hi {
-                    if span.hi > last.hi {
-                        last.hi = span.hi;
-                    }
-                    continue;
+            if let Some(last) = merged.last_mut()
+                && span.lo <= last.hi
+            {
+                if span.hi > last.hi {
+                    last.hi = span.hi;
                 }
+                continue;
             }
 
             merged.push(span);
@@ -972,10 +971,10 @@ impl Visit for CallSiteExtractor {
                         _ => {}
                     }
 
-                    if let Some(call_expr) = Self::find_call_expr_in_expr(init) {
-                        if let Some(info) = self.build_correlated_call_info(call_expr) {
-                            self.call_result_vars.insert(var_name.clone(), info);
-                        }
+                    if let Some(call_expr) = Self::find_call_expr_in_expr(init)
+                        && let Some(info) = self.build_correlated_call_info(call_expr)
+                    {
+                        self.call_result_vars.insert(var_name.clone(), info);
                     }
 
                     // Extract type annotation and link to call expression if present
@@ -1199,10 +1198,10 @@ mod definition_index_tests {
     impl Visit for IdFinder {
         fn visit_import_decl(&mut self, import: &ImportDecl) {
             for spec in &import.specifiers {
-                if let ImportSpecifier::Named(named) = spec {
-                    if named.local.sym.as_ref() == "r" {
-                        self.import_r = Some(named.local.to_id());
-                    }
+                if let ImportSpecifier::Named(named) = spec
+                    && named.local.sym.as_ref() == "r"
+                {
+                    self.import_r = Some(named.local.to_id());
                 }
             }
 
@@ -1225,11 +1224,11 @@ mod definition_index_tests {
         fn visit_arrow_expr(&mut self, arrow: &ArrowExpr) {
             if self.arrow_param_r.is_none() {
                 for param in &arrow.params {
-                    if let Pat::Ident(binding) = param {
-                        if binding.id.sym.as_ref() == "r" {
-                            self.arrow_param_r = Some(binding.id.to_id());
-                            break;
-                        }
+                    if let Pat::Ident(binding) = param
+                        && binding.id.sym.as_ref() == "r"
+                    {
+                        self.arrow_param_r = Some(binding.id.to_id());
+                        break;
                     }
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,12 +124,12 @@ pub fn create_dynamic_tsconfig(output_dir: &std::path::Path) -> Value {
     // Scan for actual type files and create specific mappings
     if let Ok(entries) = std::fs::read_dir(output_dir) {
         for entry in entries.flatten() {
-            if let Some(file_name) = entry.file_name().to_str() {
-                if file_name.ends_with("_types.ts") || file_name.ends_with("_types.d.ts") {
-                    let base_name = file_name.trim_end_matches(".d.ts").trim_end_matches(".ts");
-                    let module_name = base_name.replace("_", "-");
-                    paths.insert(module_name, vec![format!("./{}", base_name)]);
-                }
+            if let Some(file_name) = entry.file_name().to_str()
+                && (file_name.ends_with("_types.ts") || file_name.ends_with("_types.d.ts"))
+            {
+                let base_name = file_name.trim_end_matches(".d.ts").trim_end_matches(".ts");
+                let module_name = base_name.replace("_", "-");
+                paths.insert(module_name, vec![format!("./{}", base_name)]);
             }
         }
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -59,10 +59,10 @@ type FileDiscoveryResult = Result<
 /// Only upload on main/master branch, not on PRs
 fn should_upload_data() -> bool {
     // Check if we're in a pull request
-    if let Ok(event_name) = env::var("GITHUB_EVENT_NAME") {
-        if event_name == "pull_request" {
-            return false;
-        }
+    if let Ok(event_name) = env::var("GITHUB_EVENT_NAME")
+        && event_name == "pull_request"
+    {
+        return false;
     }
 
     // Check if we're on a feature branch (not main/master)
@@ -195,26 +195,24 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
     print_results(results);
 
     // 7. Best-effort log upload (only on main/master, same policy as data upload)
-    if should_upload {
-        if let Some(log_path) = logging::get_log_file_path() {
-            const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024;
+    if should_upload && let Some(log_path) = logging::get_log_file_path() {
+        const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024;
 
-            if let Ok(mut file) = std::fs::File::open(&log_path) {
-                use std::io::{Read, Seek};
-                if let Ok(metadata) = file.metadata() {
-                    let file_len = metadata.len();
-                    let start = file_len.saturating_sub(MAX_LOG_BYTES);
-                    if file.seek(std::io::SeekFrom::Start(start)).is_ok() {
-                        let mut buf = Vec::with_capacity((file_len - start) as usize);
-                        if file.read_to_end(&mut buf).is_ok() {
-                            let log_content = String::from_utf8_lossy(&buf);
-                            let repo_name = get_repository_name(repo_path);
-                            if let Err(e) = storage
-                                .upload_logs(&carrick_org, &repo_name, &log_content)
-                                .await
-                            {
-                                debug!("Failed to upload logs: {:?}", e);
-                            }
+        if let Ok(mut file) = std::fs::File::open(&log_path) {
+            use std::io::{Read, Seek};
+            if let Ok(metadata) = file.metadata() {
+                let file_len = metadata.len();
+                let start = file_len.saturating_sub(MAX_LOG_BYTES);
+                if file.seek(std::io::SeekFrom::Start(start)).is_ok() {
+                    let mut buf = Vec::with_capacity((file_len - start) as usize);
+                    if file.read_to_end(&mut buf).is_ok() {
+                        let log_content = String::from_utf8_lossy(&buf);
+                        let repo_name = get_repository_name(repo_path);
+                        if let Err(e) = storage
+                            .upload_logs(&carrick_org, &repo_name, &log_content)
+                            .await
+                        {
+                            debug!("Failed to upload logs: {:?}", e);
                         }
                     }
                 }
@@ -272,10 +270,10 @@ where
 
     // For non-Config types, use the first found (original behavior)
     for repo_data in all_repo_data {
-        if let Some(json_str) = extractor(repo_data) {
-            if let Ok(data) = serde_json::from_str::<T>(json_str) {
-                return Ok(data);
-            }
+        if let Some(json_str) = extractor(repo_data)
+            && let Ok(data) = serde_json::from_str::<T>(json_str)
+        {
+            return Ok(data);
         }
     }
     Ok(T::default())
@@ -295,17 +293,17 @@ fn strip_ast_nodes(mut data: CloudRepoData) -> CloudRepoData {
     // Payload size guard: Lambda function URLs have a 6MB request payload limit.
     // If serialized data exceeds ~5MB, drop file_results to stay under the limit.
     const MAX_PAYLOAD_BYTES: usize = 5 * 1024 * 1024; // 5MB safety margin
-    if let Ok(serialized) = serde_json::to_string(&data) {
-        if serialized.len() > MAX_PAYLOAD_BYTES {
-            warn!(
-                "Payload size {}KB exceeds {}KB limit, dropping file_results cache for this upload",
-                serialized.len() / 1024,
-                MAX_PAYLOAD_BYTES / 1024
-            );
-            data.file_results = None;
-            data.cached_detection = None;
-            data.cached_guidance = None;
-        }
+    if let Ok(serialized) = serde_json::to_string(&data)
+        && serialized.len() > MAX_PAYLOAD_BYTES
+    {
+        warn!(
+            "Payload size {}KB exceeds {}KB limit, dropping file_results cache for this upload",
+            serialized.len() / 1024,
+            MAX_PAYLOAD_BYTES / 1024
+        );
+        data.file_results = None;
+        data.cached_detection = None;
+        data.cached_guidance = None;
     }
 
     data

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -41,19 +41,18 @@ pub trait CoreExtractor {
             // For arrow functions with block bodies: (req, res) => { ... }
             BlockStmtOrExpr::BlockStmt(block) => {
                 for stmt in &block.stmts {
-                    if let Stmt::Expr(expr_stmt) = stmt {
-                        if let Some(json) = self.extract_json_fields_from_call(expr_stmt) {
-                            return json;
-                        }
+                    if let Stmt::Expr(expr_stmt) = stmt
+                        && let Some(json) = self.extract_json_fields_from_call(expr_stmt)
+                    {
+                        return json;
                     }
 
                     // Look for return statements
-                    if let Stmt::Return(ret) = stmt {
-                        if let Some(expr) = &ret.arg {
-                            if let Some(json) = self.extract_json_fields_from_return(expr) {
-                                return json;
-                            }
-                        }
+                    if let Stmt::Return(ret) = stmt
+                        && let Some(expr) = &ret.arg
+                        && let Some(json) = self.extract_json_fields_from_return(expr)
+                    {
+                        return json;
                     }
                 }
             }
@@ -84,19 +83,19 @@ pub trait CoreExtractor {
                     }
                     // For return statements like return res.json({...})
                     Stmt::Return(return_stmt) => {
-                        if let Some(expr) = &return_stmt.arg {
-                            if let Some(json) = self.extract_json_fields_from_return(expr) {
-                                return json;
-                            }
+                        if let Some(expr) = &return_stmt.arg
+                            && let Some(json) = self.extract_json_fields_from_return(expr)
+                        {
+                            return json;
                         }
                     }
                     // Handle nested blocks like if/else statements
                     Stmt::Block(block) => {
                         for nested_stmt in &block.stmts {
-                            if let Stmt::Expr(expr_stmt) = nested_stmt {
-                                if let Some(json) = self.extract_json_fields_from_call(expr_stmt) {
-                                    return json;
-                                }
+                            if let Stmt::Expr(expr_stmt) = nested_stmt
+                                && let Some(json) = self.extract_json_fields_from_call(expr_stmt)
+                            {
+                                return json;
                             }
                         }
                     }
@@ -126,20 +125,20 @@ pub trait CoreExtractor {
 
                     // For return statements like return res.json({...})
                     Stmt::Return(return_stmt) => {
-                        if let Some(expr) = &return_stmt.arg {
-                            if let Some(json) = self.extract_json_fields_from_return(expr) {
-                                return json;
-                            }
+                        if let Some(expr) = &return_stmt.arg
+                            && let Some(json) = self.extract_json_fields_from_return(expr)
+                        {
+                            return json;
                         }
                     }
 
                     // Handle nested blocks like if/else statements
                     Stmt::Block(block) => {
                         for nested_stmt in &block.stmts {
-                            if let Stmt::Expr(expr_stmt) = nested_stmt {
-                                if let Some(json) = self.extract_json_fields_from_call(expr_stmt) {
-                                    return json;
-                                }
+                            if let Stmt::Expr(expr_stmt) = nested_stmt
+                                && let Some(json) = self.extract_json_fields_from_call(expr_stmt)
+                            {
+                                return json;
                             }
                         }
                     }
@@ -159,12 +158,12 @@ pub trait CoreExtractor {
         let callee = call.callee.as_expr()?;
         let member = callee.as_member()?;
 
-        if let Some(ident) = member.obj.as_ident() {
-            if ident.sym == "res" || ident.sym == "json" {
-                let arg = call.args.first()?;
-                // Extract the JSON structure from the argument
-                return Some(self.expr_to_json(&arg.expr));
-            }
+        if let Some(ident) = member.obj.as_ident()
+            && (ident.sym == "res" || ident.sym == "json")
+        {
+            let arg = call.args.first()?;
+            // Extract the JSON structure from the argument
+            return Some(self.expr_to_json(&arg.expr));
         }
 
         None
@@ -197,20 +196,20 @@ pub trait CoreExtractor {
                 let mut map = HashMap::new();
 
                 for prop in &obj.props {
-                    if let PropOrSpread::Prop(boxed_prop) = prop {
-                        if let Prop::KeyValue(kv) = &**boxed_prop {
-                            // Extract key
-                            let key = match &kv.key {
-                                PropName::Ident(ident) => ident.sym.to_string(),
-                                PropName::Str(str) => str.value.to_string(),
-                                _ => continue, // Skip computed keys
-                            };
+                    if let PropOrSpread::Prop(boxed_prop) = prop
+                        && let Prop::KeyValue(kv) = &**boxed_prop
+                    {
+                        // Extract key
+                        let key = match &kv.key {
+                            PropName::Ident(ident) => ident.sym.to_string(),
+                            PropName::Str(str) => str.value.to_string(),
+                            _ => continue, // Skip computed keys
+                        };
 
-                            // Extract value
-                            let value = self.expr_to_json(&kv.value);
+                        // Extract value
+                        let value = self.expr_to_json(&kv.value);
 
-                            map.insert(key, value);
-                        }
+                        map.insert(key, value);
                     }
                 }
 
@@ -226,24 +225,24 @@ pub trait CoreExtractor {
         // Examine each statement in the function body
         for stmt in &function_body.stmts {
             // Look for variable declarations that extract from req.body
-            if let Stmt::Decl(Decl::Var(var_decl)) = stmt {
-                if let Some(json) = self.extract_req_body_from_var_decl(var_decl) {
-                    return Some(json);
-                }
+            if let Stmt::Decl(Decl::Var(var_decl)) = stmt
+                && let Some(json) = self.extract_req_body_from_var_decl(var_decl)
+            {
+                return Some(json);
             }
 
             // Look for direct req.body usage
-            if let Stmt::Expr(expr_stmt) = stmt {
-                if let Some(json) = self.extract_req_body_from_expr(&expr_stmt.expr) {
-                    return Some(json);
-                }
+            if let Stmt::Expr(expr_stmt) = stmt
+                && let Some(json) = self.extract_req_body_from_expr(&expr_stmt.expr)
+            {
+                return Some(json);
             }
 
             // Check if statements for validation logic
-            if let Stmt::If(if_stmt) = stmt {
-                if let Some(json) = self.extract_req_body_from_condition(&if_stmt.test) {
-                    return Some(json);
-                }
+            if let Stmt::If(if_stmt) = stmt
+                && let Some(json) = self.extract_req_body_from_condition(&if_stmt.test)
+            {
+                return Some(json);
             }
         }
 
@@ -254,37 +253,33 @@ pub trait CoreExtractor {
     fn extract_req_body_from_var_decl(&self, var_decl: &VarDecl) -> Option<Json> {
         for decl in &var_decl.decls {
             // Check if initialization is from req.body
-            if let Some(init) = &decl.init {
-                if let Expr::Member(member) = &**init {
-                    if let Expr::Ident(obj) = &*member.obj {
-                        if obj.sym == "req" {
-                            if let MemberProp::Ident(prop) = &member.prop {
-                                if prop.sym == "body" {
-                                    // Found req.body assignment
+            if let Some(init) = &decl.init
+                && let Expr::Member(member) = &**init
+                && let Expr::Ident(obj) = &*member.obj
+                && obj.sym == "req"
+                && let MemberProp::Ident(prop) = &member.prop
+                && prop.sym == "body"
+            {
+                // Found req.body assignment
 
-                                    // Extract fields from destructuring pattern
-                                    if let Pat::Object(obj_pat) = &decl.name {
-                                        let mut fields = HashMap::new();
+                // Extract fields from destructuring pattern
+                if let Pat::Object(obj_pat) = &decl.name {
+                    let mut fields = HashMap::new();
 
-                                        for prop in &obj_pat.props {
-                                            if let ObjectPatProp::Assign(assign_prop) = prop {
-                                                let field_name = assign_prop.key.sym.to_string();
-                                                fields.insert(field_name, Json::Null); // We don't know types yet
-                                            } else if let ObjectPatProp::KeyValue(kv_prop) = prop {
-                                                if let PropName::Ident(key) = &kv_prop.key {
-                                                    let field_name = key.sym.to_string();
-                                                    fields.insert(field_name, Json::Null);
-                                                }
-                                            }
-                                        }
-
-                                        if !fields.is_empty() {
-                                            return Some(Json::Object(fields));
-                                        }
-                                    }
-                                }
-                            }
+                    for prop in &obj_pat.props {
+                        if let ObjectPatProp::Assign(assign_prop) = prop {
+                            let field_name = assign_prop.key.sym.to_string();
+                            fields.insert(field_name, Json::Null); // We don't know types yet
+                        } else if let ObjectPatProp::KeyValue(kv_prop) = prop
+                            && let PropName::Ident(key) = &kv_prop.key
+                        {
+                            let field_name = key.sym.to_string();
+                            fields.insert(field_name, Json::Null);
                         }
+                    }
+
+                    if !fields.is_empty() {
+                        return Some(Json::Object(fields));
                     }
                 }
             }
@@ -295,23 +290,19 @@ pub trait CoreExtractor {
 
     // Handle direct access: if(req.body.field)
     fn extract_req_body_from_expr(&self, expr: &Expr) -> Option<Json> {
-        if let Expr::Member(member) = expr {
-            if let Expr::Member(inner_member) = &*member.obj {
-                if let Expr::Ident(obj) = &*inner_member.obj {
-                    if obj.sym == "req" {
-                        if let MemberProp::Ident(body_prop) = &inner_member.prop {
-                            if body_prop.sym == "body" {
-                                // Found req.body.something
-                                if let MemberProp::Ident(field_prop) = &member.prop {
-                                    let field_name = field_prop.sym.to_string();
-                                    let mut fields = HashMap::new();
-                                    fields.insert(field_name, Json::Null);
-                                    return Some(Json::Object(fields));
-                                }
-                            }
-                        }
-                    }
-                }
+        if let Expr::Member(member) = expr
+            && let Expr::Member(inner_member) = &*member.obj
+            && let Expr::Ident(obj) = &*inner_member.obj
+            && obj.sym == "req"
+            && let MemberProp::Ident(body_prop) = &inner_member.prop
+            && body_prop.sym == "body"
+        {
+            // Found req.body.something
+            if let MemberProp::Ident(field_prop) = &member.prop {
+                let field_name = field_prop.sym.to_string();
+                let mut fields = HashMap::new();
+                fields.insert(field_name, Json::Null);
+                return Some(Json::Object(fields));
             }
         }
 
@@ -445,14 +436,12 @@ pub trait RouteExtractor: CoreExtractor {
 
                     // Find the property in the object
                     for prop in &obj_lit.props {
-                        if let PropOrSpread::Prop(box_prop) = prop {
-                            if let Prop::KeyValue(kv) = &**box_prop {
-                                if let PropName::Ident(key_ident) = &kv.key {
-                                    if key_ident.sym == prop_name {
-                                        return self.extract_string_from_expr(&kv.value);
-                                    }
-                                }
-                            }
+                        if let PropOrSpread::Prop(box_prop) = prop
+                            && let Prop::KeyValue(kv) = &**box_prop
+                            && let PropName::Ident(key_ident) = &kv.key
+                            && key_ident.sym == prop_name
+                        {
+                            return self.extract_string_from_expr(&kv.value);
                         }
                     }
                 }
@@ -515,13 +504,12 @@ pub trait RouteExtractor: CoreExtractor {
 
                         // Extract response fields (using existing logic)
                         for stmt in &block.stmts {
-                            if let Stmt::Expr(expr_stmt) = stmt {
-                                if let Expr::Call(call) = &*expr_stmt.expr {
-                                    if let Some(json) = self.extract_res_json_fields(call) {
-                                        response_json = json;
-                                        break;
-                                    }
-                                }
+                            if let Stmt::Expr(expr_stmt) = stmt
+                                && let Expr::Call(call) = &*expr_stmt.expr
+                                && let Some(json) = self.extract_res_json_fields(call)
+                            {
+                                response_json = json;
+                                break;
                             }
                         }
                     }
@@ -546,13 +534,12 @@ pub trait RouteExtractor: CoreExtractor {
 
                         // Extract response fields (existing logic)
                         for stmt in &body.stmts {
-                            if let Stmt::Expr(expr_stmt) = stmt {
-                                if let Expr::Call(call) = &*expr_stmt.expr {
-                                    if let Some(json) = self.extract_res_json_fields(call) {
-                                        response_json = json;
-                                        break;
-                                    }
-                                }
+                            if let Stmt::Expr(expr_stmt) = stmt
+                                && let Expr::Call(call) = &*expr_stmt.expr
+                                && let Some(json) = self.extract_res_json_fields(call)
+                            {
+                                response_json = json;
+                                break;
                             }
                         }
                     }

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -397,31 +397,31 @@ fn group_similar_issues(issues: &[String]) -> HashMap<String, Vec<String>> {
 
 fn extract_issue_type(issue: &str) -> String {
     if issue.contains("Request body mismatch") {
-        if let Some(start) = issue.find("for ") {
-            if let Some(end) = issue.find(" ->") {
-                return format!("Request Body Mismatch: `{}`", &issue[start + 4..end]);
-            }
+        if let Some(start) = issue.find("for ")
+            && let Some(end) = issue.find(" ->")
+        {
+            return format!("Request Body Mismatch: `{}`", &issue[start + 4..end]);
         }
         "Request Body Mismatch".to_string()
     } else if issue.contains(": Type '") {
         // Parse any TypeScript compiler error to extract endpoint
         let methods = ["GET ", "POST ", "PUT ", "DELETE ", "PATCH "];
         for method in &methods {
-            if let Some(start) = issue.find(method) {
-                if let Some(end) = issue.find(": Type '") {
-                    let endpoint = &issue[start..end];
-                    return format!("TypeScript Error: `{}`", endpoint);
-                }
+            if let Some(start) = issue.find(method)
+                && let Some(end) = issue.find(": Type '")
+            {
+                let endpoint = &issue[start..end];
+                return format!("TypeScript Error: `{}`", endpoint);
             }
         }
         "TypeScript Error".to_string()
     } else if issue.contains("Type mismatch on ") {
         // Parse structured type mismatch errors
-        if let Some(start) = issue.find("Type mismatch on ") {
-            if let Some(end) = issue.find(": Producer") {
-                let endpoint = &issue[start + 17..end];
-                return format!("Type Compatibility Issue: `{}`", endpoint);
-            }
+        if let Some(start) = issue.find("Type mismatch on ")
+            && let Some(end) = issue.find(": Producer")
+        {
+            let endpoint = &issue[start + 17..end];
+            return format!("Type Compatibility Issue: `{}`", endpoint);
         }
         "Type Compatibility Issue".to_string()
     } else if issue.contains("Type mismatch") {
@@ -479,11 +479,11 @@ fn parse_generic_typescript_error(issue: &str) -> (String, String) {
         let mut found_endpoint = "Unknown".to_string();
 
         for method in &methods {
-            if let Some(start) = issue.find(method) {
-                if let Some(end) = issue.find(": Type '") {
-                    found_endpoint = issue[start..end].to_string();
-                    break;
-                }
+            if let Some(start) = issue.find(method)
+                && let Some(end) = issue.find(": Type '")
+            {
+                found_endpoint = issue[start..end].to_string();
+                break;
             }
         }
         found_endpoint

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -45,15 +45,15 @@ pub async fn generate_function_intents(
     let mut deps: HashMap<String, Vec<String>> = HashMap::new();
 
     for name in &eligible {
-        if let Some(def) = function_definitions.get(name) {
-            if let Some(ref body) = def.body_source {
-                let called: Vec<String> = local_fn_names
-                    .iter()
-                    .filter(|&&fn_name| fn_name != name.as_str() && body.contains(fn_name))
-                    .map(|&s| s.to_string())
-                    .collect();
-                deps.insert(name.clone(), called);
-            }
+        if let Some(def) = function_definitions.get(name)
+            && let Some(ref body) = def.body_source
+        {
+            let called: Vec<String> = local_fn_names
+                .iter()
+                .filter(|&&fn_name| fn_name != name.as_str() && body.contains(fn_name))
+                .map(|&s| s.to_string())
+                .collect();
+            deps.insert(name.clone(), called);
         }
     }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -30,21 +30,21 @@ pub fn init(verbose: bool) {
     // Try to set up file logging to ~/.carrick/logs/
     let log_dir = dirs::home_dir().map(|h| h.join(".carrick").join("logs"));
 
-    if let Some(ref dir) = log_dir {
-        if std::fs::create_dir_all(dir).is_ok() {
-            let file_appender = rolling::daily(dir, "carrick.log");
-            let file_layer = fmt::layer()
-                .with_writer(file_appender)
-                .with_ansi(false)
-                .with_target(true)
-                .with_filter(EnvFilter::new("debug"));
+    if let Some(ref dir) = log_dir
+        && std::fs::create_dir_all(dir).is_ok()
+    {
+        let file_appender = rolling::daily(dir, "carrick.log");
+        let file_layer = fmt::layer()
+            .with_writer(file_appender)
+            .with_ansi(false)
+            .with_target(true)
+            .with_filter(EnvFilter::new("debug"));
 
-            let _ = tracing_subscriber::registry()
-                .with(terminal_layer)
-                .with(file_layer)
-                .try_init();
-            return;
-        }
+        let _ = tracing_subscriber::registry()
+            .with(terminal_layer)
+            .with(file_layer)
+            .try_init();
+        return;
     }
 
     // Fallback: terminal only

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,10 +294,10 @@ fn discover_sidecar_path() -> Option<PathBuf> {
 
 /// Get a path relative to the executable location
 fn get_executable_relative_path(relative: &str) -> PathBuf {
-    if let Ok(exe_path) = env::current_exe() {
-        if let Some(exe_dir) = exe_path.parent() {
-            return exe_dir.join(relative);
-        }
+    if let Ok(exe_path) = env::current_exe()
+        && let Some(exe_dir) = exe_path.parent()
+    {
+        return exe_dir.join(relative);
     }
     PathBuf::from(relative)
 }

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -156,10 +156,10 @@ impl MountGraph {
     #[allow(dead_code)]
     fn build_mount_edges(&mut self, classified_sites: &[ClassifiedCallSite]) {
         for site in classified_sites {
-            if matches!(site.classification, CallSiteType::RouterMount) {
-                if let Some(mount) = self.extract_mount_relationship(site) {
-                    self.mounts.push(mount);
-                }
+            if matches!(site.classification, CallSiteType::RouterMount)
+                && let Some(mount) = self.extract_mount_relationship(site)
+            {
+                self.mounts.push(mount);
             }
         }
     }
@@ -190,10 +190,10 @@ impl MountGraph {
     #[allow(dead_code)]
     fn collect_endpoints(&mut self, classified_sites: &[ClassifiedCallSite]) {
         for site in classified_sites {
-            if matches!(site.classification, CallSiteType::HttpEndpoint) {
-                if let Some(endpoint) = self.extract_endpoint(site) {
-                    self.endpoints.push(endpoint);
-                }
+            if matches!(site.classification, CallSiteType::HttpEndpoint)
+                && let Some(endpoint) = self.extract_endpoint(site)
+            {
+                self.endpoints.push(endpoint);
             }
         }
     }
@@ -238,10 +238,10 @@ impl MountGraph {
     #[allow(dead_code)]
     fn collect_data_calls(&mut self, classified_sites: &[ClassifiedCallSite]) {
         for site in classified_sites {
-            if matches!(site.classification, CallSiteType::DataFetchingCall) {
-                if let Some(call) = self.extract_data_call(site) {
-                    self.data_calls.push(call);
-                }
+            if matches!(site.classification, CallSiteType::DataFetchingCall)
+                && let Some(call) = self.extract_data_call(site)
+            {
+                self.data_calls.push(call);
             }
         }
     }
@@ -306,10 +306,10 @@ impl MountGraph {
             current_node = &mount.parent;
 
             // Stop if we reach a root node (top-level application)
-            if let Some(node) = self.nodes.get(current_node) {
-                if matches!(node.node_type, NodeType::Root) {
-                    break;
-                }
+            if let Some(node) = self.nodes.get(current_node)
+                && matches!(node.node_type, NodeType::Root)
+            {
+                break;
             }
         }
 

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -2,12 +2,6 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, io, path::PathBuf};
 
-#[derive(Debug, Serialize)]
-pub struct PackagesDataForTypeScript {
-    pub name: String,
-    pub dependencies: HashMap<String, String>,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PackageJson {
     pub name: Option<String>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -106,12 +106,11 @@ mod tests {
 
     impl Visit for BindingIdCollector {
         fn visit_var_declarator(&mut self, var_decl: &VarDeclarator) {
-            if self.global_var_i.is_none() {
-                if let Pat::Ident(binding) = &var_decl.name {
-                    if binding.id.sym.as_ref() == "i" {
-                        self.global_var_i = Some(binding.id.to_id());
-                    }
-                }
+            if self.global_var_i.is_none()
+                && let Pat::Ident(binding) = &var_decl.name
+                && binding.id.sym.as_ref() == "i"
+            {
+                self.global_var_i = Some(binding.id.to_id());
             }
 
             var_decl.visit_children_with(self);
@@ -120,11 +119,11 @@ mod tests {
         fn visit_arrow_expr(&mut self, arrow: &ArrowExpr) {
             if self.arrow_param_i.is_none() {
                 for param in &arrow.params {
-                    if let Pat::Ident(binding) = param {
-                        if binding.id.sym.as_ref() == "i" {
-                            self.arrow_param_i = Some(binding.id.to_id());
-                            break;
-                        }
+                    if let Pat::Ident(binding) = param
+                        && binding.id.sym.as_ref() == "i"
+                    {
+                        self.arrow_param_i = Some(binding.id.to_id());
+                        break;
                     }
                 }
             }

--- a/src/services/type_sidecar.rs
+++ b/src/services/type_sidecar.rs
@@ -678,10 +678,10 @@ impl TypeSidecar {
         // infer / failure-fallback loops below never shadow them with `= unknown`.
         if had_explicit_dts {
             for req in explicit {
-                if let Some(alias) = &req.alias {
-                    if Self::dts_defines_alias(&combined_dts, alias) {
-                        appended_aliases.insert(alias.clone());
-                    }
+                if let Some(alias) = &req.alias
+                    && Self::dts_defines_alias(&combined_dts, alias)
+                {
+                    appended_aliases.insert(alias.clone());
                 }
                 if Self::dts_defines_alias(&combined_dts, &req.symbol_name) {
                     appended_aliases.insert(req.symbol_name.clone());
@@ -737,10 +737,10 @@ impl TypeSidecar {
 
         if !infer.is_empty() {
             for request in infer {
-                if let Some(alias) = &request.alias {
-                    if !inferred_aliases.contains(alias) {
-                        append_alias(alias, "unknown");
-                    }
+                if let Some(alias) = &request.alias
+                    && !inferred_aliases.contains(alias)
+                {
+                    append_alias(alias, "unknown");
                 }
             }
         }
@@ -1122,10 +1122,10 @@ mod tests {
 
         if had_explicit_dts {
             for req in &explicit {
-                if let Some(alias) = &req.alias {
-                    if TypeSidecar::dts_defines_alias(&combined_dts, alias) {
-                        appended_aliases.insert(alias.clone());
-                    }
+                if let Some(alias) = &req.alias
+                    && TypeSidecar::dts_defines_alias(&combined_dts, alias)
+                {
+                    appended_aliases.insert(alias.clone());
                 }
                 if TypeSidecar::dts_defines_alias(&combined_dts, &req.symbol_name) {
                     appended_aliases.insert(req.symbol_name.clone());

--- a/src/sidecar/package.json
+++ b/src/sidecar/package.json
@@ -19,7 +19,7 @@
     "typescript": "^5.8.0"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "private": true
 }

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -330,10 +330,10 @@ impl CandidateVisitor {
 
     /// Check if this is a global fetch call
     fn is_global_fetch(&self, callee: &Callee) -> bool {
-        if let Callee::Expr(expr) = callee {
-            if let Expr::Ident(ident) = &**expr {
-                return ident.sym.as_ref() == "fetch";
-            }
+        if let Callee::Expr(expr) = callee
+            && let Expr::Ident(ident) = &**expr
+        {
+            return ident.sym.as_ref() == "fetch";
         }
         false
     }
@@ -452,28 +452,28 @@ impl Visit for CandidateVisitor {
         // framework-agnostic path for class-method routing (NestJS) — the
         // scanner stays free of framework names; the LLM classifies the
         // decorator by its identifier via the Import Table.
-        if let Expr::Call(call) = &*node.expr {
-            if let Callee::Expr(callee_expr) = &call.callee {
-                let callee_name = Self::extract_callee_object(callee_expr);
-                if let Some(name) = callee_name {
-                    let line_number = self.get_line_number(call.span);
-                    let (span_start, span_end) = self.span_range(call.span);
-                    let candidate_id = self.candidate_id(span_start, span_end);
-                    let code_snippet = self.get_code_snippet(call.span);
-                    let path_snippet = self.extract_first_arg_snippet(call);
+        if let Expr::Call(call) = &*node.expr
+            && let Callee::Expr(callee_expr) = &call.callee
+        {
+            let callee_name = Self::extract_callee_object(callee_expr);
+            if let Some(name) = callee_name {
+                let line_number = self.get_line_number(call.span);
+                let (span_start, span_end) = self.span_range(call.span);
+                let candidate_id = self.candidate_id(span_start, span_end);
+                let code_snippet = self.get_code_snippet(call.span);
+                let path_snippet = self.extract_first_arg_snippet(call);
 
-                    self.candidates.push(CandidateTarget {
-                        candidate_id,
-                        span_start,
-                        span_end,
-                        line_number,
-                        callee_object: name,
-                        callee_property: None,
-                        enclosing_function: self.current_function(),
-                        path_snippet,
-                        code_snippet,
-                    });
-                }
+                self.candidates.push(CandidateTarget {
+                    candidate_id,
+                    span_start,
+                    span_end,
+                    line_number,
+                    callee_object: name,
+                    callee_property: None,
+                    enclosing_function: self.current_function(),
+                    path_snippet,
+                    code_snippet,
+                });
             }
         }
         node.visit_children_with(self);
@@ -502,53 +502,52 @@ impl Visit for CandidateVisitor {
         }
 
         // Check for method calls (obj.method())
-        if let Callee::Expr(callee_expr) = &call.callee {
-            if let Expr::Member(member) = &**callee_expr {
-                // Extract method name
-                let method_name = match &member.prop {
-                    MemberProp::Ident(ident) => Some(ident.sym.to_string()),
-                    MemberProp::Computed(computed) => {
-                        if let Expr::Lit(Lit::Str(s)) = &*computed.expr {
-                            Some(s.value.to_string())
-                        } else {
-                            None
-                        }
+        if let Callee::Expr(callee_expr) = &call.callee
+            && let Expr::Member(member) = &**callee_expr
+        {
+            // Extract method name
+            let method_name = match &member.prop {
+                MemberProp::Ident(ident) => Some(ident.sym.to_string()),
+                MemberProp::Computed(computed) => {
+                    if let Expr::Lit(Lit::Str(s)) = &*computed.expr {
+                        Some(s.value.to_string())
+                    } else {
+                        None
                     }
-                    MemberProp::PrivateName(_) => None,
+                }
+                MemberProp::PrivateName(_) => None,
+            };
+
+            if let Some(method) = method_name {
+                // Extract object name
+                let obj_name = Self::extract_callee_object(&member.obj);
+
+                // Check if this looks like an API call
+                let is_api_call = match &obj_name {
+                    Some(name) => {
+                        self.is_potential_api_object(name) || self.is_potential_api_method(&method)
+                    }
+                    None => self.is_potential_api_method(&method),
                 };
 
-                if let Some(method) = method_name {
-                    // Extract object name
-                    let obj_name = Self::extract_callee_object(&member.obj);
+                if is_api_call {
+                    let line_number = self.get_line_number(call.span);
+                    let (span_start, span_end) = self.span_range(call.span);
+                    let candidate_id = self.candidate_id(span_start, span_end);
+                    let code_snippet = self.get_code_snippet(call.span);
+                    let path_snippet = self.extract_first_arg_snippet(call);
 
-                    // Check if this looks like an API call
-                    let is_api_call = match &obj_name {
-                        Some(name) => {
-                            self.is_potential_api_object(name)
-                                || self.is_potential_api_method(&method)
-                        }
-                        None => self.is_potential_api_method(&method),
-                    };
-
-                    if is_api_call {
-                        let line_number = self.get_line_number(call.span);
-                        let (span_start, span_end) = self.span_range(call.span);
-                        let candidate_id = self.candidate_id(span_start, span_end);
-                        let code_snippet = self.get_code_snippet(call.span);
-                        let path_snippet = self.extract_first_arg_snippet(call);
-
-                        self.candidates.push(CandidateTarget {
-                            candidate_id,
-                            span_start,
-                            span_end,
-                            line_number,
-                            callee_object: obj_name.unwrap_or_else(|| "<chain>".to_string()),
-                            callee_property: Some(method),
-                            enclosing_function: self.current_function(),
-                            path_snippet,
-                            code_snippet,
-                        });
-                    }
+                    self.candidates.push(CandidateTarget {
+                        candidate_id,
+                        span_start,
+                        span_end,
+                        line_number,
+                        callee_object: obj_name.unwrap_or_else(|| "<chain>".to_string()),
+                        callee_property: Some(method),
+                        enclosing_function: self.current_function(),
+                        path_snippet,
+                        code_snippet,
+                    });
                 }
             }
         }

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -234,20 +234,20 @@ impl UrlNormalizer {
         let mut is_external = false;
 
         // Check if starts with a variable that might be a base URL
-        if url.starts_with("${") {
-            if let Some(end) = url.find('}') {
-                let var_name = &url[2..end];
-                // Check if this is a known env var
-                if self.internal_env_vars.contains(var_name) {
-                    is_internal = true;
-                    stripped_host = Some(format!("${{{}}}", var_name));
-                } else if self.external_env_vars.contains(var_name) {
-                    is_external = true;
-                    stripped_host = Some(format!("${{{}}}", var_name));
-                }
-                // Remove the base URL variable
-                result = url[end + 1..].to_string();
+        if url.starts_with("${")
+            && let Some(end) = url.find('}')
+        {
+            let var_name = &url[2..end];
+            // Check if this is a known env var
+            if self.internal_env_vars.contains(var_name) {
+                is_internal = true;
+                stripped_host = Some(format!("${{{}}}", var_name));
+            } else if self.external_env_vars.contains(var_name) {
+                is_external = true;
+                stripped_host = Some(format!("${{{}}}", var_name));
             }
+            // Remove the base URL variable
+            result = url[end + 1..].to_string();
         }
 
         // Convert remaining ${varName} to :varName for path parameter matching

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,10 +16,10 @@ pub fn join_prefix_and_path(prefix: &str, path: &str) -> String {
 /// Get repository name, checking GITHUB_REPOSITORY environment variable first
 pub fn get_repository_name(repo_path: &str) -> String {
     // Check for GitHub Actions environment variable (format: "owner/repo")
-    if let Ok(github_repo) = env::var("GITHUB_REPOSITORY") {
-        if let Some(repo_name) = github_repo.split('/').last() {
-            return repo_name.to_string();
-        }
+    if let Ok(github_repo) = env::var("GITHUB_REPOSITORY")
+        && let Some(repo_name) = github_repo.split('/').next_back()
+    {
+        return repo_name.to_string();
     }
 
     // Fall back to extracting from path
@@ -30,12 +30,11 @@ pub fn get_repository_name(repo_path: &str) -> String {
         .unwrap_or(".");
 
     // If we got "." (current directory), use the actual directory name
-    if path_name == "." {
-        if let Ok(current_dir) = env::current_dir() {
-            if let Some(dir_name) = current_dir.file_name() {
-                return dir_name.to_string_lossy().to_string();
-            }
-        }
+    if path_name == "."
+        && let Ok(current_dir) = env::current_dir()
+        && let Some(dir_name) = current_dir.file_name()
+    {
+        return dir_name.to_string_lossy().to_string();
     }
 
     path_name.to_string()


### PR DESCRIPTION
## Summary
- reqwest: `default-features = false` + explicit `json`/`rustls-tls` (drops native-tls stack from Cargo.lock)
- Move RUSTSEC-2026-0009 ignore from `ci.yml` into `.cargo/audit.toml`
- Bump Node 22→24 (CI workflows + sidecar `engines`)
- Fix rustc 1.95 `collapsible_if` and `double_ended_iterator_last` lints across pre-existing sites
- Drop unused `PackagesDataForTypeScript` struct

## Notes on the reqwest trim
Default features dropped: `default-tls` (replaced with explicit `rustls-tls`), `http2`, `charset`, `macos-system-configuration`.
- HTTP/1.1-only is fine for the carrick proxy and S3 endpoints we hit.
- JSON responses are UTF-8 by spec, so `charset` auto-decoding is unused.
- `macos-system-configuration` only matters on macOS when `CARRICK_USE_SYSTEM_PROXY=1`; default path uses `no_proxy()`.

## Test plan
- [ ] CI green (test + lint + security audit)
- [ ] `cargo audit` step succeeds reading `.cargo/audit.toml`
- [ ] Sidecar build/test on Node 24