### PR TITLE
feat: drop carrick-org input; cloud derives org from API key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,6 @@ jobs:
       - name: Test basic endpoint detection (test-repo)
         env:
           CARRICK_MOCK_ALL: "true"
-          CARRICK_ORG: "test-org"
           CARRICK_API_KEY: "mock-key"
         run: |
           mkdir -p test-repo/output
@@ -193,7 +192,6 @@ jobs:
       - name: Test imported router resolution
         env:
           CARRICK_MOCK_ALL: "true"
-          CARRICK_ORG: "test-org"
           CARRICK_API_KEY: "mock-key"
         run: |
           mkdir -p tests/fixtures/imported-routers/output

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 cargo build
 cargo build --release
 cargo run -- /path/to/repo
-CARRICK_MOCK_ALL=1 CARRICK_ORG=test-org cargo run -- test-repo
+CARRICK_MOCK_ALL=1 cargo run -- test-repo
 
 # Tests and checks
 cargo test
@@ -55,5 +55,5 @@ Install hooks once per clone: `./scripts/install-hooks.sh`.
 - PRs should include a short summary, rationale, test commands run, and links to relevant issues. Include sample Action output when it changes.
 
 ## Configuration & Infrastructure Notes
-- Runtime env vars: `CARRICK_API_KEY` (required when calling the cloud), `CARRICK_ORG` (cache namespace), `CARRICK_MOCK_ALL` (test-only, returns canned responses without hitting the cloud), `CARRICK_API_ENDPOINT` (override the default `https://api.carrick.tools` endpoint at build time; optional).
+- Runtime env vars: `CARRICK_API_KEY` (required when calling the cloud; org is derived server-side from this key), `CARRICK_MOCK_ALL` (test-only, returns canned responses without hitting the cloud), `CARRICK_API_ENDPOINT` (override the default `https://api.carrick.tools` endpoint at build time; optional).
 - Never run Terraform commands in this repository.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,6 @@ jobs:
         id: carrick-analysis
         uses: daveymoores/carrick@v1
         with:
-          carrick-org: your-org-name
           carrick-api-key: ${{ secrets.CARRICK_API_KEY }}
 
       - name: Comment PR with Results

--- a/WARP.md
+++ b/WARP.md
@@ -23,7 +23,7 @@ cargo run
 cargo run -- /path/to/repo
 
 # Run with mock storage (for testing without AWS)
-CARRICK_MOCK_ALL=1 CARRICK_ORG=test-org cargo run -- test-repo
+CARRICK_MOCK_ALL=1 cargo run -- test-repo
 ```
 
 ### Testing
@@ -115,8 +115,7 @@ Carrick follows a modular architecture with clear separation of concerns:
 
 ## Environment Variables
 
-- `CARRICK_ORG`: Organization name for grouping repositories (required in CI)
-- `CARRICK_API_KEY`: API key for cloud storage access (required in CI)
+- `CARRICK_API_KEY`: API key for cloud storage access (required in CI). The cloud lambda derives the owning organization from this key — there is no client-supplied org.
 - `CARRICK_MOCK_ALL`: Use mock storage instead of AWS (for local testing)
 - `GITHUB_EVENT_NAME`: Determines upload behavior (no upload on pull_request)
 - `GITHUB_REF`: Branch information for determining when to upload data

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,6 @@ inputs:
     description: "Path to analyze"
     required: false
     default: "."
-  carrick-org:
-    description: "Organization name"
-    required: true
   carrick-api-key:
     description: "API key"
     required: true
@@ -58,7 +55,6 @@ runs:
       id: analysis
       shell: bash
       env:
-        CARRICK_ORG: ${{ inputs.carrick-org }}
         CARRICK_API_KEY: ${{ inputs.carrick-api-key }}
         CI: "true"
       run: |

--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -16,7 +16,6 @@ pub struct AwsStorage {
 struct LambdaRequest {
     action: String,
     repo: String,
-    org: String,
     hash: String,
     filename: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -73,7 +72,6 @@ struct CrossRepoResponse {
 #[derive(Serialize)]
 struct GetCrossRepoRequest {
     action: String,
-    org: String,
 }
 
 impl AwsStorage {
@@ -192,24 +190,14 @@ impl AwsStorage {
         Ok(())
     }
 
-    fn extract_org_and_repo(&self, repo_name: &str) -> (String, String) {
-        if let Some((org, repo)) = repo_name.split_once('/') {
-            (org.to_string(), repo.to_string())
-        } else {
-            ("default".to_string(), repo_name.to_string())
-        }
-    }
-
     async fn store_repo_metadata(
         &self,
         data: &CloudRepoData,
         s3_url: &str,
-        org: &str, // Add org parameter
     ) -> Result<(), StorageError> {
         let request = LambdaRequest {
             action: "store-metadata".to_string(),
-            repo: data.repo_name.clone(), // Use repo name as-is
-            org: org.to_string(),         // Use passed org
+            repo: data.repo_name.clone(),
             hash: data.commit_hash.clone(),
             filename: "types.d.ts".to_string(),
             cloud_repo_data: Some(data.clone()),
@@ -225,14 +213,13 @@ impl AwsStorage {
 
 #[async_trait]
 impl CloudStorage for AwsStorage {
-    async fn upload_repo_data(&self, org: &str, data: &CloudRepoData) -> Result<(), StorageError> {
+    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<(), StorageError> {
         let repo = &data.repo_name;
 
         // Step 1: Check if we need to upload type file
         let check_request = LambdaRequest {
             action: "check-or-upload".to_string(),
             repo: repo.clone(),
-            org: org.to_string(),
             hash: data.commit_hash.clone(),
             filename: "types.d.ts".to_string(),
             cloud_repo_data: None,
@@ -251,7 +238,6 @@ impl CloudStorage for AwsStorage {
                 let complete_request = LambdaRequest {
                     action: "complete-upload".to_string(),
                     repo: repo.clone(),
-                    org: org.to_string(),
                     hash: data.commit_hash.clone(),
                     filename: "types.d.ts".to_string(),
                     cloud_repo_data: Some(data.clone()),
@@ -266,12 +252,12 @@ impl CloudStorage for AwsStorage {
                     "No bundled types available for {}; storing metadata only",
                     repo
                 );
-                self.store_repo_metadata(data, &lambda_response.s3_url, org)
+                self.store_repo_metadata(data, &lambda_response.s3_url)
                     .await?;
             }
         } else {
             debug!("Type file already exists, just updating metadata");
-            self.store_repo_metadata(data, &lambda_response.s3_url, org)
+            self.store_repo_metadata(data, &lambda_response.s3_url)
                 .await?;
         }
 
@@ -284,13 +270,11 @@ impl CloudStorage for AwsStorage {
         file_name: &str,
         content: &str,
     ) -> Result<(), StorageError> {
-        let (org, repo) = self.extract_org_and_repo(repo_name);
         let commit_hash = crate::cloud_storage::get_current_commit_hash(".");
 
         let request = LambdaRequest {
             action: "check-or-upload".to_string(),
-            repo,
-            org,
+            repo: repo_name.to_string(),
             hash: commit_hash,
             filename: file_name.to_string(),
             cloud_repo_data: None,
@@ -308,11 +292,9 @@ impl CloudStorage for AwsStorage {
 
     async fn download_all_repo_data(
         &self,
-        org: &str,
     ) -> Result<(Vec<CloudRepoData>, HashMap<String, String>), StorageError> {
         let request = GetCrossRepoRequest {
             action: "get-cross-repo-data".to_string(),
-            org: org.to_string(),
         };
 
         let response: CrossRepoResponse = self.call_lambda_generic(&request).await?;
@@ -358,18 +340,12 @@ impl CloudStorage for AwsStorage {
         Ok((all_repo_data, repo_s3_urls))
     }
 
-    async fn upload_logs(
-        &self,
-        org: &str,
-        repo: &str,
-        log_content: &str,
-    ) -> Result<(), StorageError> {
+    async fn upload_logs(&self, repo: &str, log_content: &str) -> Result<(), StorageError> {
         let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H-%M-%S").to_string();
 
         #[derive(Serialize)]
         struct UploadLogsRequest {
             action: String,
-            org: String,
             repo: String,
             timestamp: String,
         }
@@ -382,7 +358,6 @@ impl CloudStorage for AwsStorage {
 
         let request = UploadLogsRequest {
             action: "upload-logs".to_string(),
-            org: org.to_string(),
             repo: repo.to_string(),
             timestamp,
         };
@@ -397,7 +372,6 @@ impl CloudStorage for AwsStorage {
         let request = LambdaRequest {
             action: "check-or-upload".to_string(),
             repo: "health".to_string(),
-            org: "check".to_string(),
             hash: "health-check".to_string(),
             filename: "health.ts".to_string(),
             cloud_repo_data: None,

--- a/src/cloud_storage/mock_storage.rs
+++ b/src/cloud_storage/mock_storage.rs
@@ -8,8 +8,7 @@ use std::sync::Mutex;
 use tracing::debug;
 
 pub struct MockStorage {
-    // Group data by org, then store repos
-    data: Mutex<HashMap<String, Vec<CloudRepoData>>>,
+    data: Mutex<Vec<CloudRepoData>>,
     type_files: Mutex<HashMap<String, String>>,
 }
 
@@ -22,7 +21,7 @@ impl Default for MockStorage {
 impl MockStorage {
     pub fn new() -> Self {
         Self {
-            data: Mutex::new(HashMap::new()),
+            data: Mutex::new(Vec::new()),
             type_files: Mutex::new(HashMap::new()),
         }
     }
@@ -30,16 +29,9 @@ impl MockStorage {
 
 #[async_trait]
 impl CloudStorage for MockStorage {
-    async fn upload_repo_data(&self, org: &str, data: &CloudRepoData) -> Result<(), StorageError> {
-        debug!(
-            "MOCK: Uploading repo data for org: {}, repo: {}",
-            org, data.repo_name
-        );
-        let mut storage = self.data.lock().unwrap();
-        storage
-            .entry(org.to_string())
-            .or_default()
-            .push(data.clone());
+    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<(), StorageError> {
+        debug!("MOCK: Uploading repo data for repo: {}", data.repo_name);
+        self.data.lock().unwrap().push(data.clone());
         Ok(())
     }
 
@@ -61,11 +53,10 @@ impl CloudStorage for MockStorage {
 
     async fn download_all_repo_data(
         &self,
-        org: &str,
     ) -> Result<(Vec<CloudRepoData>, HashMap<String, String>), StorageError> {
-        debug!("MOCK: Downloading all repo data for org: {}", org);
+        debug!("MOCK: Downloading all repo data");
         let storage = self.data.lock().unwrap();
-        let mut result = storage.get(org).cloned().unwrap_or_default();
+        let mut result = storage.clone();
 
         // Add some mock repos to simulate cross-repo scenario
         if result.len() <= 1 {
@@ -134,7 +125,7 @@ impl CloudStorage for MockStorage {
             );
         }
 
-        debug!("MOCK: Found {} repos for org {}", result.len(), org);
+        debug!("MOCK: Found {} repos", result.len());
         Ok((result, mock_s3_urls))
     }
 
@@ -143,13 +134,8 @@ impl CloudStorage for MockStorage {
         Ok(())
     }
 
-    async fn upload_logs(
-        &self,
-        org: &str,
-        repo: &str,
-        _log_content: &str,
-    ) -> Result<(), StorageError> {
-        debug!("MOCK: Skipping log upload for {}/{}", org, repo);
+    async fn upload_logs(&self, repo: &str, _log_content: &str) -> Result<(), StorageError> {
+        debug!("MOCK: Skipping log upload for {}", repo);
         Ok(())
     }
 }

--- a/src/cloud_storage/mock_storage.rs
+++ b/src/cloud_storage/mock_storage.rs
@@ -55,8 +55,10 @@ impl CloudStorage for MockStorage {
         &self,
     ) -> Result<(Vec<CloudRepoData>, HashMap<String, String>), StorageError> {
         debug!("MOCK: Downloading all repo data");
-        let storage = self.data.lock().unwrap();
-        let mut result = storage.clone();
+        // Drop the lock as soon as we have a clone — concurrent
+        // upload_repo_data calls would otherwise block on us while we
+        // build the synthetic mock repos and S3-URL map below.
+        let mut result = self.data.lock().unwrap().clone();
 
         // Add some mock repos to simulate cross-repo scenario
         if result.len() <= 1 {

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -269,11 +269,10 @@ impl Error for StorageError {}
 
 #[async_trait]
 pub trait CloudStorage {
-    async fn upload_repo_data(&self, org: &str, data: &CloudRepoData) -> Result<(), StorageError>;
+    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<(), StorageError>;
     async fn download_all_repo_data(
         &self,
-        org: &str,
-    ) -> Result<(Vec<CloudRepoData>, HashMap<String, String>), StorageError>; // Updated return type
+    ) -> Result<(Vec<CloudRepoData>, HashMap<String, String>), StorageError>;
     #[allow(dead_code)]
     async fn upload_type_file(
         &self,
@@ -282,12 +281,7 @@ pub trait CloudStorage {
         content: &str,
     ) -> Result<(), StorageError>;
     async fn health_check(&self) -> Result<(), StorageError>;
-    async fn upload_logs(
-        &self,
-        org: &str,
-        repo: &str,
-        log_content: &str,
-    ) -> Result<(), StorageError>;
+    async fn upload_logs(&self, repo: &str, log_content: &str) -> Result<(), StorageError>;
 }
 
 pub fn get_current_commit_hash(repo_path: &str) -> String {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -99,10 +99,8 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
     no_cache: bool,
     ts_check_dir: Option<&std::path::Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let carrick_org = env::var("CARRICK_ORG").map_err(|_| "CARRICK_ORG must be set in CI mode")?;
-
     let should_upload = should_upload_data();
-    debug!(org = %carrick_org, upload = should_upload, "Running Carrick in CI mode");
+    debug!(upload = should_upload, "Running Carrick in CI mode");
 
     // 1. Health check
     let sp = logging::spinner("Connecting to AWS...");
@@ -115,7 +113,7 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
     // 2. Download all repos (moved earlier for incremental cache lookup)
     let sp = logging::spinner("Downloading cross-repo data...");
     let (mut all_repo_data, _repo_s3_urls) = storage
-        .download_all_repo_data(&carrick_org)
+        .download_all_repo_data()
         .await
         .map_err(|e| format!("Failed to download cross-repo data: {}", e))?;
 
@@ -167,7 +165,7 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
         let sp = logging::spinner("Uploading results...");
         let cloud_data_serialized = strip_ast_nodes(current_repo_data.clone());
         storage
-            .upload_repo_data(&carrick_org, &cloud_data_serialized)
+            .upload_repo_data(&cloud_data_serialized)
             .await
             .map_err(|e| format!("Failed to upload repo data: {}", e))?;
         logging::finish_spinner(&sp, "Uploaded results to cloud storage");
@@ -208,10 +206,7 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
                     if file.read_to_end(&mut buf).is_ok() {
                         let log_content = String::from_utf8_lossy(&buf);
                         let repo_name = get_repository_name(repo_path);
-                        if let Err(e) = storage
-                            .upload_logs(&carrick_org, &repo_name, &log_content)
-                            .await
-                        {
+                        if let Err(e) = storage.upload_logs(&repo_name, &log_content).await {
                             debug!("Failed to upload logs: {:?}", e);
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,6 @@ OPTIONS:
 
 ENVIRONMENT VARIABLES:
     CARRICK_API_KEY         API key for the LLM service (required)
-    CARRICK_ORG             Organization name for cloud storage (required in CI)
     CARRICK_MOCK_ALL        Use mock storage instead of AWS
     CARRICK_API_ENDPOINT    API endpoint for the carrick service (build-time)
 "#

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -68,7 +68,6 @@ fn test_imported_router_endpoint_resolution() {
     let output = Command::new(env!("CARGO_BIN_EXE_carrick"))
         .arg(test_project_path.to_str().unwrap())
         .env("CARRICK_MOCK_ALL", "1")
-        .env("CARRICK_ORG", "test-org")
         .env("CARRICK_API_KEY", "mock")
         .output()
         .expect("Failed to execute carrick");
@@ -131,7 +130,6 @@ fn test_basic_endpoint_detection() {
     let output = Command::new(env!("CARGO_BIN_EXE_carrick"))
         .arg(test_repo_path.to_str().unwrap())
         .env("CARRICK_MOCK_ALL", "1")
-        .env("CARRICK_ORG", "test-org")
         .env("CARRICK_API_KEY", "mock")
         .output()
         .expect("Failed to execute carrick");
@@ -200,7 +198,6 @@ fn test_no_duplicate_processing_regression() {
     let output = Command::new(env!("CARGO_BIN_EXE_carrick"))
         .arg(fixture_path.to_str().unwrap())
         .env("CARRICK_MOCK_ALL", "1")
-        .env("CARRICK_ORG", "test-org")
         .env("CARRICK_API_KEY", "mock")
         .output()
         .expect("Failed to execute carrick");

--- a/tests/mock_storage_test.rs
+++ b/tests/mock_storage_test.rs
@@ -55,13 +55,13 @@ async fn test_upload_and_download_single_repo() {
     // When: we upload repo data
     let repo_data = create_test_repo_data("test-repo", "abc123");
     storage
-        .upload_repo_data("test-org", &repo_data)
+        .upload_repo_data(&repo_data)
         .await
         .expect("Upload should succeed");
 
     // Then: we can download it back
     let (downloaded, _s3_urls) = storage
-        .download_all_repo_data("test-org")
+        .download_all_repo_data()
         .await
         .expect("Download should succeed");
 
@@ -81,31 +81,31 @@ async fn test_upload_and_download_single_repo() {
 }
 
 #[tokio::test]
-async fn test_upload_multiple_repos_same_org() {
+async fn test_upload_multiple_repos() {
     // Given: a MockStorage instance
     let storage = MockStorage::new();
 
-    // When: we upload multiple repos for the same org
+    // When: we upload multiple repos
     let repo1 = create_test_repo_data("repo-1", "hash1");
     let repo2 = create_test_repo_data("repo-2", "hash2");
     let repo3 = create_test_repo_data("repo-3", "hash3");
 
     storage
-        .upload_repo_data("test-org", &repo1)
+        .upload_repo_data(&repo1)
         .await
         .expect("Upload repo1 should succeed");
     storage
-        .upload_repo_data("test-org", &repo2)
+        .upload_repo_data(&repo2)
         .await
         .expect("Upload repo2 should succeed");
     storage
-        .upload_repo_data("test-org", &repo3)
+        .upload_repo_data(&repo3)
         .await
         .expect("Upload repo3 should succeed");
 
     // Then: we can download all of them
     let (downloaded, _s3_urls) = storage
-        .download_all_repo_data("test-org")
+        .download_all_repo_data()
         .await
         .expect("Download should succeed");
 
@@ -125,55 +125,6 @@ async fn test_upload_multiple_repos_same_org() {
     assert!(our_repos.iter().any(|r| r.repo_name == "repo-1"));
     assert!(our_repos.iter().any(|r| r.repo_name == "repo-2"));
     assert!(our_repos.iter().any(|r| r.repo_name == "repo-3"));
-}
-
-#[tokio::test]
-async fn test_repos_isolated_by_org() {
-    // Given: a MockStorage instance
-    let storage = MockStorage::new();
-
-    // When: we upload repos to different orgs
-    let repo_org1 = create_test_repo_data("repo-org1", "hash1");
-    let repo_org2 = create_test_repo_data("repo-org2", "hash2");
-
-    storage
-        .upload_repo_data("org1", &repo_org1)
-        .await
-        .expect("Upload to org1 should succeed");
-    storage
-        .upload_repo_data("org2", &repo_org2)
-        .await
-        .expect("Upload to org2 should succeed");
-
-    // Then: each org only sees its own repos
-    let (org1_data, _) = storage
-        .download_all_repo_data("org1")
-        .await
-        .expect("Download org1 should succeed");
-    let (org2_data, _) = storage
-        .download_all_repo_data("org2")
-        .await
-        .expect("Download org2 should succeed");
-
-    // Org1 should have repo-org1 but not repo-org2
-    assert!(
-        org1_data.iter().any(|r| r.repo_name == "repo-org1"),
-        "Org1 should have its repo"
-    );
-    assert!(
-        !org1_data.iter().any(|r| r.repo_name == "repo-org2"),
-        "Org1 should not have org2's repo"
-    );
-
-    // Org2 should have repo-org2 but not repo-org1
-    assert!(
-        org2_data.iter().any(|r| r.repo_name == "repo-org2"),
-        "Org2 should have its repo"
-    );
-    assert!(
-        !org2_data.iter().any(|r| r.repo_name == "repo-org1"),
-        "Org2 should not have org1's repo"
-    );
 }
 
 #[tokio::test]
@@ -217,7 +168,7 @@ async fn test_concurrent_uploads() {
             let repo =
                 create_test_repo_data(&format!("concurrent-repo-{}", i), &format!("hash{}", i));
             storage_clone
-                .upload_repo_data("concurrent-org", &repo)
+                .upload_repo_data(&repo)
                 .await
                 .expect("Concurrent upload should succeed");
         });
@@ -231,7 +182,7 @@ async fn test_concurrent_uploads() {
 
     // Then: all repos should be present
     let (downloaded, _) = storage
-        .download_all_repo_data("concurrent-org")
+        .download_all_repo_data()
         .await
         .expect("Download should succeed");
 
@@ -248,24 +199,19 @@ async fn test_concurrent_uploads() {
 }
 
 #[tokio::test]
-async fn test_empty_org_returns_empty_or_mock_data() {
-    // Given: a MockStorage instance
+async fn test_empty_storage_returns_mock_data() {
+    // Given: a fresh MockStorage instance with nothing uploaded
     let storage = MockStorage::new();
 
-    // When: we try to download from an org with no data
+    // When: we download cross-repo data
     let (downloaded, _) = storage
-        .download_all_repo_data("non-existent-org")
+        .download_all_repo_data()
         .await
-        .expect("Download should succeed even for empty org");
+        .expect("Download should succeed for empty storage");
 
-    // Then: should return data without crashing
-    // MockStorage returns mock data for testing purposes (2 repos when result.len() <= 1)
-    // We verify the operation succeeds and returns the expected mock data
-    assert_eq!(
-        downloaded.len(),
-        2,
-        "MockStorage should return mock data for non-existent org"
-    );
+    // Then: MockStorage seeds two synthetic repos when fewer than 2
+    // entries exist, so cross-repo analysis has data to work with.
+    assert_eq!(downloaded.len(), 2);
 }
 
 #[tokio::test]
@@ -275,20 +221,20 @@ async fn test_update_existing_repo() {
 
     let repo_v1 = create_test_repo_data("versioned-repo", "hash1");
     storage
-        .upload_repo_data("test-org", &repo_v1)
+        .upload_repo_data(&repo_v1)
         .await
         .expect("Upload v1 should succeed");
 
     // When: we upload the same repo with a different commit hash
     let repo_v2 = create_test_repo_data("versioned-repo", "hash2");
     storage
-        .upload_repo_data("test-org", &repo_v2)
+        .upload_repo_data(&repo_v2)
         .await
         .expect("Upload v2 should succeed");
 
     // Then: both versions exist (MockStorage appends, doesn't replace)
     let (downloaded, _) = storage
-        .download_all_repo_data("test-org")
+        .download_all_repo_data()
         .await
         .expect("Download should succeed");
 
@@ -313,12 +259,12 @@ async fn test_packages_preserved_in_upload_download_cycle() {
 
     // When: we upload and download
     storage
-        .upload_repo_data("test-org", &repo_data)
+        .upload_repo_data(&repo_data)
         .await
         .expect("Upload should succeed");
 
     let (downloaded, _) = storage
-        .download_all_repo_data("test-org")
+        .download_all_repo_data()
         .await
         .expect("Download should succeed");
 

--- a/tests/sidecar_integration_test.rs
+++ b/tests/sidecar_integration_test.rs
@@ -682,7 +682,6 @@ fn test_full_carrick_analysis_with_sidecar() {
     let output = Command::new(env!("CARGO_BIN_EXE_carrick"))
         .arg(producer_path.to_str().unwrap())
         .env("CARRICK_MOCK_ALL", "1")
-        .env("CARRICK_ORG", "test-org")
         .env("CARRICK_API_KEY", "mock")
         .env("CARRICK_SIDECAR_TYPE_EXTRACTION", "1")
         .output()


### PR DESCRIPTION
## Summary

- Drops the `carrick-org:` action input and the `CARRICK_ORG` env var. The cloud lambda now resolves the owning org from the authenticated API key, so nothing client-supplied is trusted for org partitioning.
- `CloudStorage` trait methods (`upload_repo_data`, `download_all_repo_data`, `upload_logs`) lose their `org` parameter. `MockStorage` becomes single-tenant — the per-org HashMap simulated a partitioning the lambda no longer exposes.
- Docs (README, WARP, AGENTS), the CI workflow, and integration test harnesses drop their `CARRICK_ORG` references in step.

Closes #37. Pairs with [carrick-cloud#21](https://github.com/daveymoores/carrick-cloud/pull/21) (server-side org derivation).

## Deploy ordering

**carrick-cloud#21 must deploy before this PR ships.** The lambda is forgiving of older scanners that still send `org` in the body (silently ignored), so the gap is one-way safe. After the lambda is live, this scanner PR can land.

## Test plan

- [x] `cargo test` — all green (178 lib + 185 unit + 8 mock_storage + integration suites; 0 failures, 1 ignored).
- [x] `cargo clippy --all-targets` — clean.
- [x] `cargo fmt` — clean (enforced by pre-commit hook).
- [x] `grep -r "CARRICK_ORG\|carrick-org\|carrick_org"` across `src/`, `tests/`, `action.yml`, `README.md`, `WARP.md`, `AGENTS.md`, `CLAUDE.md`, `build.rs`, `.github/` → zero matches.
- [ ] After deploy of carrick-cloud#21: run scanner from a test repo with no `carrick-org:` input; confirm S3 keys land under `<your-github-login>/...` and the PR comment posts cleanly. (Manual.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)