### PR TITLE
ci(release): force-update @v1 moving tag on every stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,3 +73,11 @@ jobs:
           make_latest: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update v1 moving tag
+        if: ${{ !contains(needs.release-please.outputs.tag_name, '-') }}
+        run: |
+          git tag -f v1 ${{ needs.release-please.outputs.tag_name }}
+          git push -f origin v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Append a step to the existing `publish` job in `.github/workflows/release.yml` that retags `v1` to the just-released `vX.Y.Z` tag after the artifact upload succeeds. Pre-release tags (`vX.Y.Z-rc1` style) are excluded via `!contains(..., '-')`.

Why: the carrick-cloud dashboard prefills users' `.github/workflows/carrick.yml` with `uses: daveymoores/carrick@v1`, so that tag must exist and track the latest stable release. Otherwise new signups either get a "tag not found" error or pin to whatever `v1` happened to point at on signup day.

Closes #82.

## Test plan
- [x] YAML validates locally
- [x] Step appears inside `publish` job after the artifact upload
- [x] Pre-release guard (`!contains(..., '-')`) present
- [ ] Post-merge: cut a release (`release-please` PR merge → publish workflow runs); confirm `git ls-remote --tags origin v1` resolves to the latest release SHA. (Manual user verification.)