### PR TITLE
fix(release): handle release-please component-prefixed tags in v1 guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update v1 moving tag
-        if: ${{ !contains(needs.release-please.outputs.tag_name, '-') }}
         run: |
-          git tag -f v1 ${{ needs.release-please.outputs.tag_name }}
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          VERSION="${TAG##*v}"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "Pre-release version ($VERSION) — skipping v1 update"
+            exit 0
+          fi
+          git tag -f v1 "$TAG"
           git push -f origin v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fix a bug introduced in #85: the pre-release guard `!contains(tag_name, '-')` rejected `carrick-v0.1.14` because of the `carrick-` component prefix that release-please applies to this repo's tags. Result: the v1 retag step was silently skipped on the v0.1.14 stable release, and `v1` still points at the pre-existing `v1.0.0-beta.4`.

Replace the GHA-expression guard with a shell-side check that strips everything up to the last `v` before looking for the `-` discriminator. Works for `carrick-v0.1.14`, `v0.1.14`, and their `-rc1` variants.

## Test plan
- [x] Guard logic verified locally for all four tag shapes (stable/pre-release × prefixed/bare)
- [x] YAML structure preserved (step still in `publish` job, after the artifact upload)
- [ ] Post-merge: cut next release; confirm `git ls-remote --tags origin v1` resolves to that release's SHA

## Follow-up
The current `v1` tag is stale (still pointing at `v1.0.0-beta.4` from before the carrick-cloud split). Will need a one-off manual retag after this lands, or wait for the next release to fix it forward.