### PR TITLE
fix(release): tag v1 from github.sha to avoid 'unresolved ref' error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
             echo "Pre-release version ($VERSION) — skipping v1 update"
             exit 0
           fi
-          git tag -f v1 "$TAG"
+          git tag -f v1 ${{ github.sha }}
           git push -f origin v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
The v0.1.15 publish failed at the new `Update v1 moving tag` step with `fatal: Failed to resolve 'carrick-v0.1.15' as a valid ref`. softprops/action-gh-release creates the release tag on the GitHub side, but the runner's local clone never fetches it, so `git tag -f v1 carrick-v0.1.15` couldn't resolve the target.

Tag from `${{ github.sha }}` instead — softprops uses the same SHA when creating the release tag, so v1 ends up at the identical commit. No fetch needed, and v1 is still pinned to the released commit (not whatever HEAD on main is when the push runs, which was the original concern in #85).

## Test plan
- [x] YAML structure preserved
- [ ] Post-merge: cut next release; confirm `git ls-remote --tags origin v1` returns the SHA of that release