### PR TITLE
fix(logging): unblock CI log uploads and improve diagnostics

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -877,6 +877,18 @@ impl FileOrchestrator {
             );
         }
 
+        // Per-symbol failures carry the actual diagnostic detail (which symbol,
+        // which file, why). Surface them individually so an uploaded log shows
+        // *what* failed, not just that something did.
+        for failure in &result.symbol_failures {
+            warn!(
+                symbol = %failure.symbol_name,
+                source_file = %failure.source_file,
+                reason = %failure.reason,
+                "[FileOrchestrator] Symbol failed to resolve"
+            );
+        }
+
         Ok(result)
     }
 

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -878,15 +878,36 @@ impl FileOrchestrator {
         }
 
         // Per-symbol failures carry the actual diagnostic detail (which symbol,
-        // which file, why). Surface them individually so an uploaded log shows
-        // *what* failed, not just that something did.
-        for failure in &result.symbol_failures {
+        // which file, why). Cap warn-level emissions so a TS-loose codebase
+        // with hundreds of unresolvable types doesn't dominate the 5 MB log
+        // tail and evict the actually-novel diagnostic in a failed run.
+        // Spillover stays at debug — visible with --verbose or in the file
+        // log, but doesn't push noise into uploaded artifacts.
+        const SYMBOL_FAILURE_WARN_CAP: usize = 20;
+        let total = result.symbol_failures.len();
+        let cap = SYMBOL_FAILURE_WARN_CAP.min(total);
+        for failure in &result.symbol_failures[..cap] {
             warn!(
                 symbol = %failure.symbol_name,
                 source_file = %failure.source_file,
                 reason = %failure.reason,
                 "[FileOrchestrator] Symbol failed to resolve"
             );
+        }
+        if total > cap {
+            warn!(
+                shown = cap,
+                suppressed = total - cap,
+                "[FileOrchestrator] Additional symbol failures (run with --verbose to see all)"
+            );
+            for failure in &result.symbol_failures[cap..] {
+                debug!(
+                    symbol = %failure.symbol_name,
+                    source_file = %failure.source_file,
+                    reason = %failure.reason,
+                    "[FileOrchestrator] Symbol failed to resolve"
+                );
+            }
         }
 
         Ok(result)

--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -363,7 +363,24 @@ impl CloudStorage for AwsStorage {
         };
 
         let resp: UploadLogsResponse = self.call_lambda_generic(&request).await?;
-        self.upload_to_s3(&resp.upload_url, log_content).await?;
+
+        let response = self
+            .http_client
+            .put(&resp.upload_url)
+            .header("Content-Type", "text/plain")
+            .body(log_content.to_string())
+            .send()
+            .await
+            .map_err(|e| StorageError::ConnectionError(format!("S3 log upload failed: {}", e)))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(StorageError::ConnectionError(format!(
+                "S3 log upload returned {}: {}",
+                status, body
+            )));
+        }
 
         Ok(())
     }

--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -181,9 +181,14 @@ impl AwsStorage {
             .map_err(|e| StorageError::ConnectionError(format!("S3 upload failed: {}", e)))?;
 
         if !response.status().is_success() {
+            // Always include the response body — S3 returns the actual cause
+            // (AccessDenied, signature mismatch, missing header, etc.) in the
+            // XML error document. A bare status code is rarely actionable.
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
             return Err(StorageError::ConnectionError(format!(
-                "S3 upload returned error: {}",
-                response.status()
+                "S3 upload returned {}: {}",
+                status, body
             )));
         }
 
@@ -363,24 +368,7 @@ impl CloudStorage for AwsStorage {
         };
 
         let resp: UploadLogsResponse = self.call_lambda_generic(&request).await?;
-
-        let response = self
-            .http_client
-            .put(&resp.upload_url)
-            .header("Content-Type", "text/plain")
-            .body(log_content.to_string())
-            .send()
-            .await
-            .map_err(|e| StorageError::ConnectionError(format!("S3 log upload failed: {}", e)))?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(StorageError::ConnectionError(format!(
-                "S3 log upload returned {}: {}",
-                status, body
-            )));
-        }
+        self.upload_to_s3(&resp.upload_url, log_content).await?;
 
         Ok(())
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -192,8 +192,10 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
     let results = analyzer.get_results();
     print_results(results);
 
-    // 7. Best-effort log upload (only on main/master, same policy as data upload)
-    if should_upload && let Some(log_path) = logging::get_log_file_path() {
+    // 7. Best-effort log upload — runs unconditionally (PRs, feature branches, local).
+    // Logs are independent of the data-upload policy: they're a debugging aid that should
+    // be available for every run, especially the failing PR runs we need to diagnose.
+    if let Some(log_path) = logging::get_log_file_path() {
         const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024;
 
         if let Ok(mut file) = std::fs::File::open(&log_path) {
@@ -206,8 +208,17 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
                     if file.read_to_end(&mut buf).is_ok() {
                         let log_content = String::from_utf8_lossy(&buf);
                         let repo_name = get_repository_name(repo_path);
-                        if let Err(e) = storage.upload_logs(&repo_name, &log_content).await {
-                            debug!("Failed to upload logs: {:?}", e);
+                        match storage.upload_logs(&repo_name, &log_content).await {
+                            Ok(()) => {
+                                debug!(
+                                    bytes = log_content.len(),
+                                    repo = %repo_name,
+                                    "Uploaded run logs to S3"
+                                );
+                            }
+                            Err(e) => {
+                                warn!("Failed to upload logs: {:?}", e);
+                            }
                         }
                     }
                 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -91,9 +91,27 @@ pub async fn run_analysis_engine<T: CloudStorage>(
     run_analysis_engine_with_sidecar(storage, repo_path, None, false, None).await
 }
 
-/// Run analysis engine with optional sidecar for type extraction
+/// Run analysis engine with optional sidecar for type extraction.
+///
+/// Always attempts log upload before returning, including on the error path —
+/// the failing runs are exactly the ones whose logs we need. The inner
+/// pipeline lives in `run_analysis_engine_inner` so `?`-propagated errors
+/// don't bypass the upload.
 pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
     storage: T,
+    repo_path: &str,
+    sidecar: Option<&TypeSidecar>,
+    no_cache: bool,
+    ts_check_dir: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result =
+        run_analysis_engine_inner(&storage, repo_path, sidecar, no_cache, ts_check_dir).await;
+    upload_run_logs(&storage, repo_path).await;
+    result
+}
+
+async fn run_analysis_engine_inner<T: CloudStorage>(
+    storage: &T,
     repo_path: &str,
     sidecar: Option<&TypeSidecar>,
     no_cache: bool,
@@ -192,41 +210,68 @@ pub async fn run_analysis_engine_with_sidecar<T: CloudStorage>(
     let results = analyzer.get_results();
     print_results(results);
 
-    // 7. Best-effort log upload — runs unconditionally (PRs, feature branches, local).
-    // Logs are independent of the data-upload policy: they're a debugging aid that should
-    // be available for every run, especially the failing PR runs we need to diagnose.
-    if let Some(log_path) = logging::get_log_file_path() {
-        const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024;
+    Ok(())
+}
 
-        if let Ok(mut file) = std::fs::File::open(&log_path) {
-            use std::io::{Read, Seek};
-            if let Ok(metadata) = file.metadata() {
-                let file_len = metadata.len();
-                let start = file_len.saturating_sub(MAX_LOG_BYTES);
-                if file.seek(std::io::SeekFrom::Start(start)).is_ok() {
-                    let mut buf = Vec::with_capacity((file_len - start) as usize);
-                    if file.read_to_end(&mut buf).is_ok() {
-                        let log_content = String::from_utf8_lossy(&buf);
-                        let repo_name = get_repository_name(repo_path);
-                        match storage.upload_logs(&repo_name, &log_content).await {
-                            Ok(()) => {
-                                debug!(
-                                    bytes = log_content.len(),
-                                    repo = %repo_name,
-                                    "Uploaded run logs to S3"
-                                );
-                            }
-                            Err(e) => {
-                                warn!("Failed to upload logs: {:?}", e);
-                            }
-                        }
-                    }
-                }
-            }
-        }
+/// Best-effort upload of the current run's log tail to S3.
+///
+/// Reads from the byte offset captured at `logging::init` time so the upload
+/// only contains *this run's* output — not the day's accumulated tail, which
+/// on a developer machine could include unrelated repos analyzed earlier.
+/// Capped at 5 MB in case a single run is unusually verbose.
+///
+/// Runs on both success and failure paths — failing runs are exactly the
+/// ones whose logs we need. Errors here are non-fatal: a failed upload is
+/// logged at warn but never propagated.
+async fn upload_run_logs<T: CloudStorage>(storage: &T, repo_path: &str) {
+    const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024;
+
+    let Some(log_path) = logging::get_log_file_path() else {
+        return;
+    };
+    let Ok(mut file) = std::fs::File::open(&log_path) else {
+        return;
+    };
+    let Ok(metadata) = file.metadata() else {
+        return;
+    };
+
+    use std::io::{Read, Seek};
+
+    let file_len = metadata.len();
+    // Start from this run's offset, but cap at 5 MB worth from the end so a
+    // pathologically chatty run doesn't ship hundreds of megabytes.
+    let run_start = logging::get_run_log_offset().unwrap_or(0);
+    let cap_start = file_len.saturating_sub(MAX_LOG_BYTES);
+    let start = run_start.max(cap_start);
+
+    if file.seek(std::io::SeekFrom::Start(start)).is_err() {
+        return;
     }
 
-    Ok(())
+    let mut buf = Vec::with_capacity((file_len - start) as usize);
+    if file.read_to_end(&mut buf).is_err() {
+        return;
+    }
+
+    // Note: `from_utf8_lossy` replaces invalid sequences with U+FFFD (3 bytes
+    // in UTF-8), so the resulting `log_content.len()` may exceed the original
+    // raw byte count when the file contains non-UTF-8 noise. Close enough for
+    // a logged size hint.
+    let log_content = String::from_utf8_lossy(&buf);
+    let repo_name = get_repository_name(repo_path);
+    match storage.upload_logs(&repo_name, &log_content).await {
+        Ok(()) => {
+            debug!(
+                bytes = log_content.len(),
+                repo = %repo_name,
+                "Uploaded run logs to S3"
+            );
+        }
+        Err(e) => {
+            warn!("Failed to upload logs: {}", e);
+        }
+    }
 }
 
 /// Serialize CloudRepoData without AST nodes in ApiEndpointDetails
@@ -788,12 +833,8 @@ fn resolve_types_if_available(
                             type_resolution.dts_content.as_deref(),
                         );
                     }
-                    for failure in &type_resolution.symbol_failures {
-                        debug!(
-                            "Failed to resolve symbol '{}' from '{}': {}",
-                            failure.symbol_name, failure.source_file, failure.reason
-                        );
-                    }
+                    // Per-symbol failures are logged in FileOrchestrator at the
+                    // resolution call site (with capped warn + spillover to debug).
                 }
                 Err(e) => {
                     warn!("Type resolution failed: {}", e);

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,19 +1,26 @@
 use indicatif::{ProgressBar, ProgressStyle};
+use std::sync::OnceLock;
 use std::time::Duration;
 use tracing::info;
 use tracing_appender::rolling;
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Byte offset into today's log file at which *this run* started writing.
+/// Captured during `init()` and used by `get_run_log_offset()` so log uploads
+/// only ship the current run's content, not the day's accumulated tail (which
+/// could include unrelated repos analyzed earlier on the same machine).
+static RUN_START_OFFSET: OnceLock<u64> = OnceLock::new();
 
 /// Initialize the global tracing subscriber with two layers:
 ///
 /// 1. **Terminal layer** (stderr): Shows `INFO` by default, `DEBUG` with `--verbose`.
 ///    Uses a minimal format without timestamps or targets for a clean look.
 ///
-/// 2. **File layer**: Always writes `DEBUG`-level logs with timestamps to
-///    `~/.carrick/logs/carrick.log` (daily rotation).
-///
-/// The file layer is best-effort — if the log directory can't be created, only
-/// the terminal layer is active.
+/// 2. **File layer** (best effort): when `~/.carrick/logs/` is writable, appends
+///    `DEBUG`-level logs with timestamps to `carrick.log.YYYY-MM-DD` (daily
+///    rotation). If the directory can't be created the file layer is skipped
+///    and only the terminal layer is active — in that case the run preamble
+///    only reaches stderr.
 pub fn init(verbose: bool) {
     let terminal_filter = if verbose {
         EnvFilter::new("debug")
@@ -34,6 +41,10 @@ pub fn init(verbose: bool) {
     if let Some(ref dir) = log_dir
         && std::fs::create_dir_all(dir).is_ok()
     {
+        // Capture the current size of today's log file *before* we write
+        // anything. Anything past this offset belongs to this run.
+        let _ = RUN_START_OFFSET.set(current_log_file_size());
+
         let file_appender = rolling::daily(dir, "carrick.log");
         let file_layer = fmt::layer()
             .with_writer(file_appender)
@@ -56,18 +67,33 @@ pub fn init(verbose: bool) {
     emit_run_preamble();
 }
 
+fn current_log_file_size() -> u64 {
+    get_log_file_path()
+        .and_then(|p| std::fs::metadata(&p).ok())
+        .map(|m| m.len())
+        .unwrap_or(0)
+}
+
+/// Byte offset into the daily log file at which this run began. `None` if
+/// the file layer wasn't initialized (terminal-only fallback).
+pub fn get_run_log_offset() -> Option<u64> {
+    RUN_START_OFFSET.get().copied()
+}
+
 /// Emit a structured preamble at the start of every run. Goes through `tracing`
-/// so it lands in both the rolling file log (always) and the terminal (info+).
+/// so it lands in the file log (when available) and the terminal (info+).
 /// This is the "what was the environment when this ran" record that makes
 /// uploaded logs interpretable after the fact.
+///
+/// Intentionally omits absolute filesystem paths (e.g. cwd) — this preamble is
+/// uploaded to S3 from local runs as well as CI, and workstation paths often
+/// contain usernames or internal directory names that aren't needed to
+/// identify a run. GitHub repo/sha are sufficient for CI; for local runs the
+/// repository name from the carrick.json + scanner version are enough.
 fn emit_run_preamble() {
     fn env(name: &str) -> String {
         std::env::var(name).unwrap_or_else(|_| "<unset>".to_string())
     }
-
-    let cwd = std::env::current_dir()
-        .map(|p| p.display().to_string())
-        .unwrap_or_default();
 
     info!(
         scanner_version = env!("CARGO_PKG_VERSION"),
@@ -82,7 +108,6 @@ fn emit_run_preamble() {
         github_run_id = %env("GITHUB_RUN_ID"),
         github_workflow = %env("GITHUB_WORKFLOW"),
         runner_os = %env("RUNNER_OS"),
-        cwd = %cwd,
         "Carrick run starting"
     );
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,6 @@
 use indicatif::{ProgressBar, ProgressStyle};
 use std::time::Duration;
+use tracing::info;
 use tracing_appender::rolling;
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -44,6 +45,7 @@ pub fn init(verbose: bool) {
             .with(terminal_layer)
             .with(file_layer)
             .try_init();
+        emit_run_preamble();
         return;
     }
 
@@ -51,6 +53,38 @@ pub fn init(verbose: bool) {
     let _ = tracing_subscriber::registry()
         .with(terminal_layer)
         .try_init();
+    emit_run_preamble();
+}
+
+/// Emit a structured preamble at the start of every run. Goes through `tracing`
+/// so it lands in both the rolling file log (always) and the terminal (info+).
+/// This is the "what was the environment when this ran" record that makes
+/// uploaded logs interpretable after the fact.
+fn emit_run_preamble() {
+    fn env(name: &str) -> String {
+        std::env::var(name).unwrap_or_else(|_| "<unset>".to_string())
+    }
+
+    let cwd = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+
+    info!(
+        scanner_version = env!("CARGO_PKG_VERSION"),
+        api_endpoint = env!("CARRICK_API_ENDPOINT"),
+        os = std::env::consts::OS,
+        arch = std::env::consts::ARCH,
+        ci = %env("CI"),
+        github_event = %env("GITHUB_EVENT_NAME"),
+        github_ref = %env("GITHUB_REF"),
+        github_repo = %env("GITHUB_REPOSITORY"),
+        github_sha = %env("GITHUB_SHA"),
+        github_run_id = %env("GITHUB_RUN_ID"),
+        github_workflow = %env("GITHUB_WORKFLOW"),
+        runner_os = %env("RUNNER_OS"),
+        cwd = %cwd,
+        "Carrick run starting"
+    );
 }
 
 /// Return the path to today's log file, if it exists.


### PR DESCRIPTION
## Summary

The scanner has an end-of-run path that ships the tail of `~/.carrick/logs/carrick.log` to S3 so failing CI runs can be diagnosed after the fact. It hasn't actually been working: the bucket has zero objects under any `logs/` prefix across all customers since the feature shipped. Two reasons:

1. **The upload was gated to `main`/`master` pushes only** — exactly the runs we *don't* need to debug. PRs (where flakiness lives) never uploaded.
2. **A 403 was being surfaced as just `"403 Forbidden"`** — no body, no diagnostic. The real cause turned out to be the `carrick-check-or-upload` lambda presigning the PUT with `Tagging: "log=true"` while its IAM role lacks `s3:PutObjectTagging`. That's being fixed in carrick-cloud separately; this PR makes the failure mode loud enough to find next time.

While I was in there, I also added a structured run-preamble (so an uploaded log is interpretable without correlating with a CI run by hand) and made the FileOrchestrator's symbol-resolution warning carry the actual per-symbol failures rather than the opaque `"All requested symbols failed to resolve"` we've been staring at.

## Changes

- `src/engine/mod.rs` — drop the `should_upload &&` gate on log upload. Log outcome at debug on success, warn on failure.
- `src/cloud_storage/aws_storage.rs` — `upload_logs` now surfaces the S3 error body (status + XML) on PUT failure instead of swallowing to `"403 Forbidden"`.
- `src/logging.rs` — `emit_run_preamble()` at startup logs scanner version, API endpoint, OS/arch, all relevant `GITHUB_*` env, and cwd.
- `src/agents/file_orchestrator.rs` — per-symbol resolution failures (`symbol_name`, `source_file`, `reason`) are now logged individually instead of being collapsed into a single warning.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] `cargo test` — 178 + 185 + 4 + 14 + 4 + 3 + 8 + 4 + 7 + 10 + 1 passing
- [x] `ts_check` Node test suite — 60 passing
- [x] Local end-to-end run against `test-repo` confirms preamble is emitted with full GitHub context fields and the new error path surfaces the real `AccessDenied` body that previously was hidden.
- [ ] After the carrick-cloud IAM/Tagging fix lands, verify a PR run from a consumer repo produces an object under `s3://carrick-type-cache/<org>/<repo>/logs/`.