### PR TITLE
feat(observability): emit X-Carrick-Run-Id on every cloud call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "uuid",
  "walkdir",
 ]
 
@@ -2547,6 +2548,9 @@ name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.3",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+uuid = { version = "1", features = ["v4"] }
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/src/agent_service.rs
+++ b/src/agent_service.rs
@@ -100,6 +100,7 @@ impl AgentService {
             .json(body)
             .timeout(std::time::Duration::from_secs(60))
             .header("X-Carrick-Scanner-Version", env!("CARGO_PKG_VERSION"))
+            .header("X-Carrick-Run-Id", crate::logging::run_id())
             .header("Authorization", format!("Bearer {}", self.api_key));
 
         // Retry logic for transient failures with exponential backoff.

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -11,6 +11,18 @@ use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::Subs
 /// could include unrelated repos analyzed earlier on the same machine).
 static RUN_START_OFFSET: OnceLock<u64> = OnceLock::new();
 
+/// UUID v4 generated once per scanner invocation. Sent on every cloud
+/// request as `X-Carrick-Run-Id` and logged in the run preamble so the
+/// same key joins customer-side and CloudWatch logs for one scan.
+static RUN_ID: OnceLock<String> = OnceLock::new();
+
+/// Stable identifier for this scanner run. Initializes lazily on first
+/// call to a fresh UUID v4, then returns the same string for the rest
+/// of the process.
+pub fn run_id() -> &'static str {
+    RUN_ID.get_or_init(|| uuid::Uuid::new_v4().to_string())
+}
+
 /// Initialize the global tracing subscriber with two layers:
 ///
 /// 1. **Terminal layer** (stderr): Shows `INFO` by default, `DEBUG` with `--verbose`.
@@ -96,6 +108,7 @@ fn emit_run_preamble() {
     }
 
     info!(
+        run_id = run_id(),
         scanner_version = env!("CARGO_PKG_VERSION"),
         api_endpoint = env!("CARRICK_API_ENDPOINT"),
         os = std::env::consts::OS,


### PR DESCRIPTION
## Summary
- Adds `uuid = { version = "1", features = ["v4"] }` (already a transitive dep) and a process-global `OnceLock<String>` in `src/logging.rs` so the run id is generated once and shared across every `AgentService` constructed during a scan.
- Sends `X-Carrick-Run-Id: <uuid>` on every request to the cloud lambdas alongside the existing `X-Carrick-Scanner-Version`, via the single chokepoint in `agent_service.rs::post_with_retry`.
- Logs the `run_id` field in `emit_run_preamble()` so the same key joins customer-side and CloudWatch logs.

Pairs with daveymoores/carrick-cloud#35 / daveymoores/carrick-cloud#36 — without the cloud-side handler the header is just silently accepted and ignored, so the two PRs can land in either order.

## Why
PR daveymoores/carrick-cloud#33 added structured CloudWatch logging keyed on the API Gateway `requestId`, which uniquely identifies one HTTP call. A single scanner run fans out to dozens of file-analyzer / framework-detect / framework-guidance / generate-intent calls, so `requestId` is the wrong correlation key. This change gives both sides a single id per scan.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test --lib` — 178 passed
- [x] Pre-commit hook (fmt + clippy + full test matrix) — all passing
- [ ] Manual: run scanner against a fixture repo, grep `~/.carrick/logs/carrick.log.*` for the `run_id=` field on the preamble line
- [ ] Manual: confirm CloudWatch shows the same `run_id` on every lambda log line for that scan once daveymoores/carrick-cloud#36 is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)