### PR TITLE
docs(readme): include carrick-sibling-updated dispatch trigger in example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  repository_dispatch:
+    types: [carrick-sibling-updated]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds `repository_dispatch: types: [carrick-sibling-updated]` to the example workflow in the README. Mirrors the dashboard template change in `daveymoores/carrick-cloud#39`.

Until cross-repo fanout (`carrick-cloud#37`) actually fires events, the trigger is inert. Including it now means no follow-up "every existing setup must edit their workflow" migration when fanout ships.

## Test plan
- [x] One-line README YAML edit, no code paths touched.
- [ ] Render check on GitHub: confirm the YAML block still highlights cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)