### PR TITLE
fix(matcher+ux): trim wrapper chars, surface verified matches, expose stages in CI

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -22,6 +22,9 @@ use tracing::{debug, warn};
 
 // Type aliases to reduce complexity
 type RouteFieldMap = HashMap<(String, String), Json>;
+/// Result of `analyze_matches_with_mount_graph`:
+///   `(call_issues, endpoint_issues, env_var_calls, verified_endpoints)`.
+type MountGraphMatches = (Vec<String>, Vec<String>, Vec<String>, Vec<(String, String)>);
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum ConflictSeverity {
@@ -89,6 +92,11 @@ pub struct ApiAnalysisResult {
     pub endpoints: Vec<ApiEndpointDetails>,
     pub calls: Vec<ApiEndpointDetails>,
     pub issues: ApiIssues,
+    /// Endpoints that were successfully matched by at least one consumer
+    /// call, with their method + canonical path. Surfaced so users see
+    /// what *worked* in the PR comment, not just what's broken — clean
+    /// runs otherwise produce no positive signal.
+    pub verified_endpoints: Vec<(String, String)>,
     /// GraphQL libraries detected across all scanned repos (subset of
     /// `detected_data_fetchers`). Populated so the formatter can show a
     /// "REST-only for v1" banner; Carrick doesn't analyze GraphQL schemas.
@@ -871,12 +879,12 @@ impl Analyzer {
         self
     }
 
-    /// Framework-agnostic analysis using mount graph
-    /// Finds orphaned endpoints and missing API calls without pattern matching
-    fn analyze_matches_with_mount_graph(
-        &self,
-        mount_graph: &MountGraph,
-    ) -> (Vec<String>, Vec<String>, Vec<String>) {
+    /// Framework-agnostic analysis using mount graph.
+    /// Returns `(call_issues, endpoint_issues, env_var_calls, verified_endpoints)`
+    /// — the fourth element captures (method, path) of every endpoint that
+    /// at least one consumer call successfully matched, so the formatter can
+    /// surface them as positive signal in the PR comment.
+    fn analyze_matches_with_mount_graph(&self, mount_graph: &MountGraph) -> MountGraphMatches {
         let mut call_issues = Vec::new();
         let mut endpoint_issues = Vec::new();
         let mut env_var_calls = Vec::new();
@@ -988,18 +996,24 @@ impl Analyzer {
             }
         }
 
-        // Find orphaned endpoints (not matched by any call)
+        // Find orphaned endpoints (not matched by any call), and capture
+        // verified matches as (method, path) tuples for the formatter.
+        let mut verified: Vec<(String, String)> = Vec::new();
         for endpoint in mount_graph.get_resolved_endpoints() {
             let key = format!("{}:{}", endpoint.method, endpoint.full_path);
-            if !matched_endpoints.contains(&key) {
+            if matched_endpoints.contains(&key) {
+                verified.push((endpoint.method.clone(), endpoint.full_path.clone()));
+            } else {
                 endpoint_issues.push(format!(
                     "Orphaned endpoint: {} {} in {}",
                     endpoint.method, endpoint.full_path, endpoint.file_location
                 ));
             }
         }
+        verified.sort();
+        verified.dedup();
 
-        (call_issues, endpoint_issues, env_var_calls)
+        (call_issues, endpoint_issues, env_var_calls, verified)
     }
 
     pub fn compute_full_paths_for_endpoint(
@@ -1176,7 +1190,7 @@ impl Analyzer {
         let mount_graph = self.mount_graph.as_ref()
             .expect("Mount graph must be set before calling get_results(). This is a framework-agnostic requirement.");
 
-        let (call_issues, endpoint_issues, env_var_calls) =
+        let (call_issues, endpoint_issues, env_var_calls, verified_endpoints) =
             self.analyze_matches_with_mount_graph(mount_graph);
         // Note: JSON body comparison removed - type checking is done via TypeScript (ts_check/)
         let mismatches = Vec::new();
@@ -1196,6 +1210,7 @@ impl Analyzer {
                 type_mismatches,
                 dependency_conflicts,
             },
+            verified_endpoints,
             detected_graphql_libraries,
         }
     }
@@ -1785,7 +1800,7 @@ mod tests {
         let mount_graph = MountGraph::new(); // Empty graph
 
         // Run analysis
-        let (call_issues, _, env_var_calls) =
+        let (call_issues, _, env_var_calls, _verified) =
             analyzer.analyze_matches_with_mount_graph(&mount_graph);
 
         // Check results

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -121,12 +121,12 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     debug!(upload = should_upload, "Running Carrick in CI mode");
 
     // 1. Health check
-    let sp = logging::spinner("Connecting to AWS...");
+    let sp = logging::spinner("Connecting to Carrick Cloud...");
     storage
         .health_check()
         .await
-        .map_err(|e| format!("Failed to connect to AWS services: {}", e))?;
-    logging::finish_spinner(&sp, "AWS connectivity verified");
+        .map_err(|e| format!("Failed to connect to Carrick Cloud: {}", e))?;
+    logging::finish_spinner(&sp, "Connected to Carrick Cloud");
 
     // 2. Download all repos (moved earlier for incremental cache lookup)
     let sp = logging::spinner("Downloading cross-repo data...");
@@ -186,7 +186,7 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
             .upload_repo_data(&cloud_data_serialized)
             .await
             .map_err(|e| format!("Failed to upload repo data: {}", e))?;
-        logging::finish_spinner(&sp, "Uploaded results to cloud storage");
+        logging::finish_spinner(&sp, "Uploaded results to Carrick Cloud");
     } else {
         debug!("Skipping upload (PR/branch mode)");
     }

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -47,6 +47,14 @@ pub fn format_analysis_results(result: ApiAnalysisResult) -> String {
 
     output.push_str(&format_graphql_banner(&result.detected_graphql_libraries));
 
+    // Verified-matches section runs first so users see what *worked* before
+    // the failure list — clean runs would otherwise produce no positive
+    // signal, and noisy runs would bury the matches under orphans.
+    if !result.verified_endpoints.is_empty() {
+        output.push_str(&format_verified_section(&result.verified_endpoints));
+        output.push_str("\n<hr>\n\n");
+    }
+
     // Critical Issues Section
     if !categorized_issues.critical.is_empty() {
         output.push_str(&format_critical_section(&categorized_issues.critical));
@@ -84,12 +92,40 @@ pub fn format_analysis_results(result: ApiAnalysisResult) -> String {
 }
 
 fn format_no_issues(result: &ApiAnalysisResult) -> String {
+    let verified = if result.verified_endpoints.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", format_verified_section(&result.verified_endpoints))
+    };
     format!(
-        "<!-- CARRICK_OUTPUT_START -->\n<!-- CARRICK_ISSUE_COUNT:0 -->\n### 🪢 CARRICK: API Analysis Results\n\nAnalyzed **{} endpoints** and **{} API calls** across all repositories.\n\n✅ **No API inconsistencies detected!**\n\n{}<!-- CARRICK_OUTPUT_END -->\n",
+        "<!-- CARRICK_OUTPUT_START -->\n<!-- CARRICK_ISSUE_COUNT:0 -->\n### 🪢 CARRICK: API Analysis Results\n\nAnalyzed **{} endpoints** and **{} API calls** across all repositories.\n\n✅ **No API inconsistencies detected!**\n\n{}{}<!-- CARRICK_OUTPUT_END -->\n",
         result.endpoints.len(),
         result.calls.len(),
         format_graphql_banner(&result.detected_graphql_libraries),
+        verified,
     )
+}
+
+/// Render a "Verified Endpoints" details block listing every endpoint that
+/// at least one consumer call successfully matched. Surfaced so PR comments
+/// communicate what's *working*, not just what's broken — without it, a
+/// clean cross-repo run produces no positive signal at all.
+fn format_verified_section(verified: &[(String, String)]) -> String {
+    let mut output = String::new();
+    output.push_str(&format!(
+        "<details>\n<summary>\n<strong style=\"font-size: 1.1em;\">✅ {} Verified Endpoint{}</strong>\n</summary>\n\n",
+        verified.len(),
+        if verified.len() == 1 { "" } else { "s" }
+    ));
+    output.push_str(
+        "> These endpoints have at least one matching consumer call across the analyzed repos. Types were resolved and compared via the TypeScript compiler pass.\n\n",
+    );
+    output.push_str("| Method | Path |\n| :--- | :--- |\n");
+    for (method, path) in verified {
+        output.push_str(&format!("| `{}` | `{}` |\n", method, path));
+    }
+    output.push_str("</details>");
+    output
 }
 
 /// Render a banner noting that GraphQL usage was detected but is out of scope
@@ -732,6 +768,7 @@ mod tests {
             endpoints: vec![],
             calls: vec![],
             issues,
+            verified_endpoints: vec![],
             detected_graphql_libraries: vec![],
         };
 
@@ -765,6 +802,7 @@ mod tests {
             endpoints: vec![],
             calls: vec![],
             issues,
+            verified_endpoints: vec![],
             detected_graphql_libraries: vec![],
         };
 
@@ -792,6 +830,7 @@ mod tests {
             endpoints: vec![],
             calls: vec![],
             issues,
+            verified_endpoints: vec![],
             detected_graphql_libraries: vec![
                 "graphql-request".to_string(),
                 "@apollo/client".to_string(),
@@ -818,6 +857,7 @@ mod tests {
             endpoints: vec![],
             calls: vec![],
             issues,
+            verified_endpoints: vec![],
             detected_graphql_libraries: vec![],
         };
         let output = format_analysis_results(result);
@@ -839,6 +879,7 @@ mod tests {
             endpoints: vec![],
             calls: vec![],
             issues,
+            verified_endpoints: vec![],
             detected_graphql_libraries: vec![],
         };
 
@@ -847,6 +888,86 @@ mod tests {
         // Check that no issues message is displayed
         assert!(output.contains("No API inconsistencies detected"));
         assert!(output.contains("CARRICK_ISSUE_COUNT:0"));
+    }
+
+    #[test]
+    fn test_verified_section_renders_when_matches_present() {
+        let issues = ApiIssues {
+            call_issues: vec![],
+            endpoint_issues: vec![],
+            env_var_calls: vec![],
+            mismatches: vec![],
+            type_mismatches: vec![],
+            dependency_conflicts: vec![],
+        };
+        let result = ApiAnalysisResult {
+            endpoints: vec![],
+            calls: vec![],
+            issues,
+            verified_endpoints: vec![
+                ("GET".to_string(), "/api/users".to_string()),
+                ("POST".to_string(), "/api/orders".to_string()),
+            ],
+            detected_graphql_libraries: vec![],
+        };
+
+        let output = format_analysis_results(result);
+
+        assert!(output.contains("✅ 2 Verified Endpoints"));
+        assert!(output.contains("`GET` | `/api/users`"));
+        assert!(output.contains("`POST` | `/api/orders`"));
+    }
+
+    #[test]
+    fn test_verified_section_singular_label() {
+        let issues = ApiIssues {
+            call_issues: vec![],
+            endpoint_issues: vec![],
+            env_var_calls: vec![],
+            mismatches: vec![],
+            type_mismatches: vec![],
+            dependency_conflicts: vec![],
+        };
+        let result = ApiAnalysisResult {
+            endpoints: vec![],
+            calls: vec![],
+            issues,
+            verified_endpoints: vec![("GET".to_string(), "/api/users".to_string())],
+            detected_graphql_libraries: vec![],
+        };
+
+        let output = format_analysis_results(result);
+
+        assert!(output.contains("✅ 1 Verified Endpoint"));
+        // Must not pluralize on a single match.
+        assert!(!output.contains("✅ 1 Verified Endpoints"));
+    }
+
+    #[test]
+    fn test_verified_section_renders_on_clean_run() {
+        // Even when there are zero issues, a clean run with verified
+        // matches must surface them — that's the whole point of the
+        // section. Pre-fix, `format_no_issues` ignored verified entirely.
+        let issues = ApiIssues {
+            call_issues: vec![],
+            endpoint_issues: vec![],
+            env_var_calls: vec![],
+            mismatches: vec![],
+            type_mismatches: vec![],
+            dependency_conflicts: vec![],
+        };
+        let result = ApiAnalysisResult {
+            endpoints: vec![],
+            calls: vec![],
+            issues,
+            verified_endpoints: vec![("GET".to_string(), "/api/users".to_string())],
+            detected_graphql_libraries: vec![],
+        };
+
+        let output = format_analysis_results(result);
+
+        assert!(output.contains("No API inconsistencies detected"));
+        assert!(output.contains("✅ 1 Verified Endpoint"));
     }
 
     #[test]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,5 @@
 use indicatif::{ProgressBar, ProgressStyle};
+use std::io::IsTerminal;
 use std::sync::OnceLock;
 use std::time::Duration;
 use tracing::info;
@@ -139,8 +140,25 @@ pub fn get_log_file_path() -> Option<std::path::PathBuf> {
     }
 }
 
+/// True when stderr is attached to a terminal (TTY). False under CI redirects
+/// like `./carrick . > analysis.log 2>&1`, where indicatif renders nothing
+/// and the user sees a long silent gap between stage transitions.
+fn is_tty() -> bool {
+    std::io::stderr().is_terminal()
+}
+
 /// Create a spinner with a message. Call `finish_with_message` when done.
+///
+/// In non-TTY environments (CI, piped output) the animated spinner is
+/// suppressed and a plain `▸ <msg>` line is emitted to stderr so the user
+/// still sees the stage start. `finish_spinner` mirrors with `✓ <msg>`.
 pub fn spinner(msg: &str) -> ProgressBar {
+    if !is_tty() {
+        eprintln!("▸ {}", msg);
+        // Returning a hidden ProgressBar keeps the call sites uniform; no
+        // ticks are drawn and `finish_*` will be a no-op via the same gate.
+        return ProgressBar::hidden();
+    }
     let pb = ProgressBar::new_spinner();
     pb.set_style(
         ProgressStyle::with_template("{spinner:.cyan} {msg}")
@@ -154,12 +172,20 @@ pub fn spinner(msg: &str) -> ProgressBar {
 
 /// Finish a spinner with a success checkmark.
 pub fn finish_spinner(pb: &ProgressBar, msg: &str) {
+    if !is_tty() {
+        eprintln!("✓ {}", msg);
+        return;
+    }
     pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
     pb.finish_with_message(format!("\x1b[32m✓\x1b[0m {}", msg));
 }
 
 /// Finish a spinner with a warning marker.
 pub fn finish_spinner_warn(pb: &ProgressBar, msg: &str) {
+    if !is_tty() {
+        eprintln!("⚠ {}", msg);
+        return;
+    }
     pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
     pb.finish_with_message(format!("\x1b[33m⚠\x1b[0m {}", msg));
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -155,8 +155,10 @@ fn is_tty() -> bool {
 pub fn spinner(msg: &str) -> ProgressBar {
     if !is_tty() {
         eprintln!("▸ {}", msg);
-        // Returning a hidden ProgressBar keeps the call sites uniform; no
-        // ticks are drawn and `finish_*` will be a no-op via the same gate.
+        // Returning a hidden ProgressBar keeps the call sites uniform — no
+        // ticks are drawn and `finish_*` skips its rendering path. The
+        // matching `✓ <msg>` line is still emitted by the same is_tty()
+        // gate inside `finish_spinner`.
         return ProgressBar::hidden();
     }
     let pb = ProgressBar::new_spinner();

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ OPTIONS:
 
 ENVIRONMENT VARIABLES:
     CARRICK_API_KEY         API key for the LLM service (required)
-    CARRICK_MOCK_ALL        Use mock storage instead of AWS
+    CARRICK_MOCK_ALL        Use mock storage instead of Carrick Cloud
     CARRICK_API_ENDPOINT    API endpoint for the carrick service (build-time)
 "#
         );

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -80,6 +80,14 @@ impl UrlNormalizer {
     pub fn normalize(&self, url: &str) -> NormalizedUrl {
         let original = url.to_string();
 
+        // The LLM sometimes returns URL targets verbatim from source — including
+        // the JS template-literal backticks or string-literal quotes. Strip
+        // those wrapper chars before pattern dispatch so a target like
+        // `${USER_SERVICE_URL}/api/users` (with literal backticks) hits the
+        // template-literal branch via `starts_with("${")` instead of
+        // falling through and producing `:USER_SERVICE_URL/api/users`.
+        let url = url.trim_matches(|c| c == '`' || c == '"' || c == '\'');
+
         // Handle ENV_VAR: pattern first
         if url.starts_with("ENV_VAR:") {
             return self.normalize_env_var_pattern(url, original);
@@ -534,6 +542,38 @@ mod tests {
 
         assert_eq!(result.path, "/orders/:orderId/items/:itemId");
         assert!(result.is_internal);
+    }
+
+    /// Regression: the file-analyzer LLM intermittently emits URL targets
+    /// wrapped in JS template-literal backticks (e.g. `${API_URL}/users`),
+    /// copying the source verbatim. Pre-trim, the leading backtick made
+    /// `starts_with("${")` fail, so the host strip was skipped and the URL
+    /// came out as `:API_URL/users` — never matching a producer's `/users`.
+    #[test]
+    fn test_normalize_strips_template_literal_backticks() {
+        let config = create_test_config();
+        let normalizer = UrlNormalizer::new(&config);
+
+        let result = normalizer.normalize("`${API_URL}/users/${userId}`");
+
+        assert_eq!(result.path, "/users/:userId");
+        assert!(result.is_internal);
+        assert_eq!(result.stripped_host, Some("${API_URL}".to_string()));
+    }
+
+    /// Same defence applies to single- and double-quoted string literals if
+    /// the LLM ever emits those — the wrapper chars must not affect dispatch.
+    #[test]
+    fn test_normalize_strips_string_literal_quotes() {
+        let config = create_test_config();
+        let normalizer = UrlNormalizer::new(&config);
+
+        let dq = normalizer.normalize("\"ENV_VAR:API_URL:/users\"");
+        assert_eq!(dq.path, "/users");
+        assert!(dq.is_internal);
+
+        let sq = normalizer.normalize("'/users/:id'");
+        assert_eq!(sq.path, "/users/:id");
     }
 
     #[test]

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -83,9 +83,14 @@ impl UrlNormalizer {
         // The LLM sometimes returns URL targets verbatim from source — including
         // the JS template-literal backticks or string-literal quotes. Strip
         // those wrapper chars before pattern dispatch so a target like
-        // `${USER_SERVICE_URL}/api/users` (with literal backticks) hits the
-        // template-literal branch via `starts_with("${")` instead of
-        // falling through and producing `:USER_SERVICE_URL/api/users`.
+        // `${USER_SERVICE_URL}/api/users` (with literal backticks) reaches
+        // `normalize_template_literal::starts_with("${")`, which strips the
+        // base URL host. Without the trim the dispatch *does* still hit the
+        // template-literal branch (the URL contains "${"), but the host strip
+        // is skipped and `convert_interpolations_to_params` rewrites every
+        // `${VAR}` to `:VAR`; `clean_path` then prefixes a leading "/", and
+        // the final path becomes `/:USER_SERVICE_URL/api/users` — never
+        // matching a producer's `/api/users`.
         let url = url.trim_matches(|c| c == '`' || c == '"' || c == '\'');
 
         // Handle ENV_VAR: pattern first
@@ -545,10 +550,12 @@ mod tests {
     }
 
     /// Regression: the file-analyzer LLM intermittently emits URL targets
-    /// wrapped in JS template-literal backticks (e.g. `${API_URL}/users`),
-    /// copying the source verbatim. Pre-trim, the leading backtick made
-    /// `starts_with("${")` fail, so the host strip was skipped and the URL
-    /// came out as `:API_URL/users` — never matching a producer's `/users`.
+    /// wrapped in JS template-literal backticks (e.g. `` `${API_URL}/users` ``),
+    /// copying the source verbatim. Pre-trim, the leading backtick made the
+    /// inner `starts_with("${")` host-strip check fail, so only the inner
+    /// `${VAR}` → `:VAR` conversion ran; with `clean_path`'s leading-slash
+    /// guarantee the path came out as `/:API_URL/users` — never matching
+    /// a producer's `/users`.
     #[test]
     fn test_normalize_strips_template_literal_backticks() {
         let config = create_test_config();


### PR DESCRIPTION
## Summary

Three workflow-output fixes that share one theme: **a clean PR comment was hiding what's working**.

### 1. `url_normalizer` — trim leading/trailing backticks + quotes

The file-analyzer LLM intermittently emits URL targets verbatim from source — e.g. `` `${USER_SERVICE_URL}/api/users` `` with literal backticks. Pre-fix, the leading backtick made `starts_with("${")` fail in `normalize_template_literal`, so the host strip was skipped and `convert_interpolations_to_params` ran over the whole URL, producing `:USER_SERVICE_URL/api/users` — never matching a producer's bare `/api/users`. Demo runs showed `Found 0 endpoint matches` even with carrick.json correctly classifying the env vars.

Now `normalize()` trims any of `` ` ``, `"`, `'` from the URL before pattern dispatch. Defence-in-depth against any LLM that returns wrapper chars.

### 2. `formatter` — render a "✅ Verified Endpoints" section

The matcher's `Compatible: N` count was discarded after producing issue lists. Clean runs surfaced no positive signal — users saw "X connectivity issues" but never which endpoints had been verified. Now `analyze_matches_with_mount_graph` returns `Vec<(method, path)>` of matched endpoints alongside the issue lists, plumbed through `ApiAnalysisResult.verified_endpoints`. Renders as the first section after the header — positive-first, then negatives. Also surfaces in `format_no_issues` so a fully-clean run shows what the matcher actually verified.

### 3. `logging` — emit plain stage lines under non-TTY

`spinner` / `finish_spinner` / `finish_spinner_warn` use indicatif's `ProgressBar`, which detects non-TTY and stays silent. CI users running `./carrick . > analysis.log 2>&1` saw a 50-second silent gap between the preamble and the markdown output, with no visibility into which stage was executing. Now each helper checks `stderr().is_terminal()` — TTY keeps the existing animated behaviour; non-TTY falls back to `eprintln!("▸ {msg}")` on start and `eprintln!("✓ {msg}")` on finish.

## Pairs with

`daveymoores/carrick-cloud#NEXT` — file-analyzer prompt addendum that tells the LLM not to wrap URL targets in backticks. Either fix alone is a partial defense; together they close the regression.

## Tests

- `url_normalizer::tests::test_normalize_strips_template_literal_backticks` — `` `${API_URL}/users/${userId}` `` → `/users/:userId`, `is_internal=true`.
- `url_normalizer::tests::test_normalize_strips_string_literal_quotes` — covers double + single.
- `formatter::tests::test_verified_section_renders_when_matches_present` — both kinds in one batch.
- `formatter::tests::test_verified_section_singular_label` — pluralization guard.
- `formatter::tests::test_verified_section_renders_on_clean_run` — verified surfaces through the no-issues path.

185 → 190 passing.

## Test plan
- [x] `cargo test --lib` — 190 passing.
- [x] Pre-commit (fmt + clippy + full matrix) — clean.
- [ ] Once `carrick-cloud#NEXT` deploys + a release of this is cut, re-run order-service CI; confirm the surface output renders the "✅ Verified Endpoints" section and the orphaned-consumers list no longer contains `:USER_SERVICE_URL/...`-shaped paths.
- [ ] CI smoke: confirm the GitHub Actions log for that run now shows `▸ Connecting to AWS…` / `✓ Connected to AWS` lines in `analysis.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)