### PR TITLE
fix(test): integration parser counts endpoints from new "Indexed" header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           echo "=== Test-repo output ==="
           cat test-repo/output/test_output.txt
           # Check that we find the expected 3 endpoints
-          if ! grep -q "Analyzed \*\*3 endpoints\*\*" test-repo/output/test_output.txt; then
+          if ! grep -q "Indexed \*\*3 endpoints\*\*" test-repo/output/test_output.txt; then
             echo "ERROR: Expected to find 3 endpoints in test-repo"
             exit 1
           fi
@@ -204,11 +204,11 @@ jobs:
             exit 1
           fi
           # Check that we find a reasonable number of endpoints (at least 10)
-          if ! grep -E "Analyzed \*\*[0-9]+ endpoints\*\*" tests/fixtures/imported-routers/output/test_output.txt; then
+          if ! grep -E "Indexed \*\*[0-9]+ endpoints\*\*" tests/fixtures/imported-routers/output/test_output.txt; then
             echo "ERROR: Expected to find some endpoints in imported router test, but found none"
             exit 1
           fi
-          ENDPOINT_COUNT=$(grep -E "Analyzed \*\*[0-9]+ endpoints\*\*" tests/fixtures/imported-routers/output/test_output.txt | sed -E 's/.*Analyzed \*\*([0-9]+) endpoints\*\*.*/\1/')
+          ENDPOINT_COUNT=$(grep -E "Indexed \*\*[0-9]+ endpoints\*\*" tests/fixtures/imported-routers/output/test_output.txt | sed -E 's/.*Indexed \*\*([0-9]+) endpoints\*\*.*/\1/')
           if [ "$ENDPOINT_COUNT" -lt 10 ]; then
             echo "ERROR: Expected at least 10 endpoints, but found $ENDPOINT_COUNT"
             exit 1

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,12 +14,12 @@ impl TestOutput {
     fn parse(stdout: &str) -> Self {
         let raw_output = stdout.to_string();
 
-        // Extract endpoint count from "Analyzed **X endpoints**" in new formatted output
+        // Extract endpoint count from "Indexed **X endpoints**" in formatted output
         let endpoint_count = stdout
             .lines()
-            .find(|line| line.contains("Analyzed **") && line.contains(" endpoints**"))
+            .find(|line| line.contains("Indexed **") && line.contains(" endpoints**"))
             .and_then(|line| {
-                // Parse "Analyzed **4 endpoints** and **5 API calls**"
+                // Parse "Indexed **4 endpoints** and **5 cross-repo calls**"
                 let parts: Vec<&str> = line.split("**").collect();
                 if parts.len() >= 2 {
                     parts[1]


### PR DESCRIPTION
## Summary

- Update `TestOutput::parse` to look for the formatter's current `Indexed **X endpoints**` header instead of the old `Analyzed **X endpoints**` wording.
- Unblocks CI on `main` — `test_basic_endpoint_detection` and `test_imported_router_endpoint_resolution` were panicking with "found 0 endpoints" even though the scanner was fine.

## Why

`b905618` renamed the formatter header but only updated the `has_success` check in the test parser, missing the `endpoint_count` parser two lines above. The `find()` matched no line and `endpoint_count` silently fell back to `0` via `unwrap_or(0)`, so any assertion against the count failed regardless of what the scanner actually produced.

## Test plan

- [x] `cargo test --test integration_test` — 3/3 passing locally
- [x] Full `cargo test` — 190 Rust tests + ts_check suite all green