### PR TITLE
feat(parser): enable jsx parsing for .jsx files

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 use swc_common::{FileName, GLOBALS, Globals, Mark, SourceMap, errors::Handler, sync::Lrc};
 use swc_ecma_ast::Module;
-use swc_ecma_parser::{Parser, StringInput, Syntax, TsSyntax, lexer::Lexer};
+use swc_ecma_parser::{EsSyntax, Parser, StringInput, Syntax, TsSyntax, lexer::Lexer};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_visit::VisitMutWith;
 use tracing::warn;
@@ -32,6 +32,13 @@ pub fn parse_file(
                     ..Default::default()
                 }),
                 true,
+            ),
+            "jsx" => (
+                Syntax::Es(EsSyntax {
+                    jsx: true,
+                    ..Default::default()
+                }),
+                false,
             ),
             _ => (Syntax::Es(Default::default()), false),
         }

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -21,7 +21,7 @@ use swc_common::{
     sync::Lrc,
 };
 use swc_ecma_ast::*;
-use swc_ecma_parser::TsSyntax;
+use swc_ecma_parser::{EsSyntax, TsSyntax};
 use swc_ecma_visit::{Visit, VisitWith};
 
 use crate::parser::parse_file;
@@ -172,6 +172,13 @@ impl SwcScanner {
                         ..Default::default()
                     }),
                     true,
+                ),
+                "jsx" => (
+                    Syntax::Es(EsSyntax {
+                        jsx: true,
+                        ..Default::default()
+                    }),
+                    false,
                 ),
                 _ => (Syntax::Es(Default::default()), false),
             }

--- a/tests/fixtures/react-app/package.json
+++ b/tests/fixtures/react-app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "react-app",
+  "version": "1.0.0",
+  "description": "React app fixture exercising tsx/jsx parsing in the scanner",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/tests/fixtures/react-app/src/components/UserList.tsx
+++ b/tests/fixtures/react-app/src/components/UserList.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+interface User {
+  id: number;
+  name: string;
+}
+
+export function UserList() {
+  const [users, setUsers] = useState<User[]>([]);
+
+  useEffect(() => {
+    fetch('/api/users')
+      .then((res) => res.json())
+      .then((data: User[]) => setUsers(data));
+  }, []);
+
+  return (
+    <ul>
+      {users.map((u) => (
+        <li key={u.id}>{u.name}</li>
+      ))}
+    </ul>
+  );
+}

--- a/tests/fixtures/react-app/src/legacy/LegacyWidget.jsx
+++ b/tests/fixtures/react-app/src/legacy/LegacyWidget.jsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export function LegacyWidget() {
+  const [order, setOrder] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/orders/latest')
+      .then((res) => res.json())
+      .then(setOrder);
+  }, []);
+
+  const submit = async () => {
+    await fetch('/api/orders', {
+      method: 'POST',
+      body: JSON.stringify({ ok: true }),
+    });
+  };
+
+  return (
+    <div>
+      <pre>{JSON.stringify(order)}</pre>
+      <button onClick={submit}>Reorder</button>
+    </div>
+  );
+}

--- a/tests/fixtures/react-app/tsconfig.json
+++ b/tests/fixtures/react-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowJs": true
+  },
+  "include": ["src"]
+}

--- a/tests/framework_coverage_test.rs
+++ b/tests/framework_coverage_test.rs
@@ -187,6 +187,51 @@ fn nestjs_controller_fixture_emits_decorator_candidates() {
 }
 
 // ---------------------------------------------------------------------------
+// React — verifies tsx/jsx parsing surfaces client-side fetch candidates
+// ---------------------------------------------------------------------------
+
+#[test]
+fn react_tsx_fixture_captures_fetch_calls() {
+    let file = fixture_path("react-app/src/components/UserList.tsx");
+    let result = scan(&file);
+
+    assert!(
+        result.should_analyze,
+        "react-app/UserList.tsx should produce at least one candidate"
+    );
+
+    assert!(
+        result
+            .candidates
+            .iter()
+            .any(|c| c.callee_object == "fetch" && c.callee_property.is_none()),
+        "expected global fetch() call inside a tsx component"
+    );
+}
+
+#[test]
+fn react_jsx_fixture_captures_fetch_calls() {
+    let file = fixture_path("react-app/src/legacy/LegacyWidget.jsx");
+    let result = scan(&file);
+
+    assert!(
+        result.should_analyze,
+        "react-app/LegacyWidget.jsx should produce at least one candidate"
+    );
+
+    let fetch_count = result
+        .candidates
+        .iter()
+        .filter(|c| c.callee_object == "fetch" && c.callee_property.is_none())
+        .count();
+    assert!(
+        fetch_count >= 2,
+        "expected >=2 fetch() candidates inside a jsx component, got {}",
+        fetch_count
+    );
+}
+
+// ---------------------------------------------------------------------------
 // End-to-end (LLM-dependent) acceptance
 // ---------------------------------------------------------------------------
 //


### PR DESCRIPTION
## Summary

`.tsx` already parses correctly via `Syntax::Typescript { tsx: true, .. }`, but `.jsx` fell through to `Syntax::Es(Default::default())` where `jsx` defaults to `false` — so JSX in plain-JS React files failed to parse silently. This adds a dedicated `.jsx` arm that enables `EsSyntax { jsx: true, .. }` in both `parse_file` (`src/parser.rs`) and `SwcScanner::scan_content` (`src/swc_scanner.rs`).

A new `tests/fixtures/react-app/` fixture contains one `.tsx` component and one `.jsx` component, each with client-side `fetch()` calls. Two new tests in `tests/framework_coverage_test.rs` assert the SWC candidate scanner surfaces those fetches.

The function-definition extractor and intent generator are AST-shape agnostic (they walk `FnDecl` / `VarDeclarator` / `ExportDecl`, not JSX nodes) — so once a `.jsx` file parses, functions in it are captured and intents generated identically to `.ts`. JSX node *semantics* (`<form action>`, `<Link href>`) remain uninspected; that's a separate feature if it ever matters.

### Out of scope (intentional)
- Next.js App Router (`app/api/*/route.ts`) and Pages Router (`pages/api/*`) route handlers — the URL lives in the filesystem path, not in code, so there's no source-level call site to match. Needs a dedicated framework-aware pass; deferred until dogfooding hits it.
- Server Actions, middleware matchers, rewrites/redirects.
- JSX-attribute API surfaces (`<form action="...">`, `<Link href="...">`).

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --test framework_coverage_test` — 6/6 pass, including new `react_tsx_fixture_captures_fetch_calls` and `react_jsx_fixture_captures_fetch_calls`
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [ ] Manual: point `cargo run -- /path/to/react-repo` at a real React project and confirm `.jsx` files no longer parse-error

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfpEvNR1AZpgAvam1zs8yn)_