### PR TITLE
feat: typed function signatures (scanner + sidecar)

### DIFF
--- a/docs/function-signature-types.md
+++ b/docs/function-signature-types.md
@@ -1,0 +1,261 @@
+# Function-Signature Types
+
+## Goal
+
+When an agent asks the MCP layer for a function (via `list_function_intents` or
+`search_by_intent`), the result should carry the function's **typed signature**
+so the agent can call it confidently without a second round trip or a source
+fetch. This is the TypeScript-community selling point: every intent the agent
+gets back is typed.
+
+Sibling design to [per-endpoint-resolved-types.md](./per-endpoint-resolved-types.md).
+Function signatures reuse that pipeline rather than inventing a parallel one.
+
+## The core insight: provenance is metadata, not a routing decision
+
+Two **independent** axes describe a slot's type:
+
+- **Provenance** — was it annotated (`is_explicit: true`) or inferred by the
+  compiler (`false`)?
+- **Shape/depth** — is it a *named* type (`AuthResult`) or an *anonymous
+  structural* type (`{ userId: string; roles: Role[] }`), and how deep?
+
+They do not correlate: ts-morph can infer a clean named type
+(`Promise<AuthResult>` — implicit + named), and a human can annotate an ugly
+deep inline type (explicit + structural). Therefore **serving strategy keys on
+shape/depth, never on provenance.** `is_explicit` rides along only as a
+confidence flag the agent reads.
+
+This corrects an earlier wrong idea ("inline implicit types, drill-down explicit
+types"). A deep inferred type could pull in half a library's `.d.ts`, so it must
+never be inlined — same as a deep explicit type. Both follow the same
+hint-and-link pattern.
+
+## Serving model (locked)
+
+Two tiers, identical for every type regardless of provenance:
+
+1. **Hint (inline, bounded).** A compact one-line signature, composed at CI time
+   by the scanner, surfaced inline in the intent tools. It uses ts-morph's
+   *default* `getText()` form, which keeps named types as names and auto-truncates
+   deep structures (`AxiosResponse<…>`). The hint is bounded by the compiler
+   itself — it is never the full expansion.
+2. **Link (drill-down).** `get_type_definition(service, alias)` returns the full
+   resolved + transitively-expanded form. Opt-in, per type the agent actually
+   cares about. **No change to this tool is needed — it already resolves by
+   alias.**
+
+### MCP output shape (target)
+
+```json
+{
+  "name": "verifyToken",
+  "intent": "Validates the caller's JWT and returns the resolved user...",
+  "signature": "(token: string, opts?: VerifyOpts) => Promise<AuthResult>",
+  "types_explicit": { "token": true, "opts": true, "return": false },
+  "file_path": "src/auth.ts",
+  "line_number": 42,
+  "hint": "get_type_definition(service, 'AuthResult') to expand a named type"
+}
+```
+
+`signature` is the composed hint. `types_explicit` is built from the per-slot
+`is_explicit` flags. Both `list_function_intents` and `search_by_intent` carry
+these fields.
+
+## Scope of THIS work (Phases 1+2 — explicit + inferred hints)
+
+The first change ships the **hint** for both explicit and inferred signatures,
+plus the `is_explicit` provenance. It does **not** yet bundle signature named
+types for drill-down — that is follow-up issue 1.
+
+In scope:
+
+- Capture explicit param/return types (already captured — see "What exists").
+- Infer the gaps via the sidecar (un-annotated params and returns), marked
+  `is_explicit: false`.
+- Compose the one-line `signature` hint at CI time.
+- Surface `signature` + `types_explicit` in both intent tools.
+
+Out of scope (tracked as follow-up issues, see end):
+
+- Bundling signature **named** types into `bundled_types` so
+  `get_type_definition` can drill into them.
+- Discovering named-type references *inside* inferred type strings.
+
+## What exists today (verified)
+
+- **Explicit signature types are already captured and uploaded.**
+  `FunctionDefinition.return_type: Option<String>` (visitor.rs:117) and
+  `FunctionArgument.type_string: Option<String>` (visitor.rs:18-22) hold raw TS
+  annotation text. These serialize into `function_definitions` inside
+  `CloudRepoData` and are already stored in DynamoDB. The MCP layer currently
+  **discards** them.
+- **The MCP type model drops them.** `lambdas/mcp-server/src/types.ts`:
+  `FunctionArgument` is `{ name }` only (line 162-164); `FunctionDefinition` has
+  no `return_type` (line 139-160).
+- **The sidecar can already infer a function's return type.**
+  `type-inferrer.ts:188 inferFunctionReturn` resolves the containing function,
+  reads `getReturnTypeNode()` to set `isExplicit`, and uses
+  `returnType.getText(func)` for the string. There is **no** param-inference path.
+  NOTE: `inferFunctionReturn` applies Promise/wrapper unwrapping for
+  endpoint-payload purposes. **Signature inference must NOT unwrap** — a function
+  that returns `Promise<AuthResult>` should show exactly that. Use a distinct
+  path/flag that skips `unwrapTypeWithConfig` / `unwrapPromise`.
+- **Type-request collection is endpoint-only.**
+  `file_orchestrator.rs:272 collect_type_requests` walks endpoints/data-calls
+  only (`endpoint_lookup`, `data_call_lookup`, `should_infer_request_body`).
+  There is no function-signature collection pass. This is the main new code.
+- **The intent `calls` field is unrelated.** `FunctionDefinition.calls` is built
+  by substring matching (`intent_generator.rs:53 body.contains(fn_name)`) and is
+  not part of this work. (See issues #55/#58.)
+
+## Data model changes
+
+### Scanner (`carrick`)
+
+`FunctionArgument` (visitor.rs:13-23):
+
+```rust
+pub struct FunctionArgument {
+    pub name: String,
+    #[serde(skip)]
+    pub type_ann: Option<TsTypeAnn>,
+    /// Explicit annotation text OR inferred type text (filled by the
+    /// signature pass). `None` only if both annotation and inference failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_string: Option<String>,
+    /// true = from a source annotation; false = compiler-inferred.
+    #[serde(default)]
+    pub is_explicit: bool,
+}
+```
+
+`FunctionDefinition` (visitor.rs:92-118) gains:
+
+```rust
+/// true = return type from a source annotation; false = inferred.
+#[serde(default)]
+pub return_is_explicit: bool,
+/// One-line signature hint composed at CI time, e.g.
+/// "(token: string, opts?: VerifyOpts) => Promise<AuthResult>".
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub signature: Option<String>,
+```
+
+`return_type` already exists. After the signature pass, `return_type` holds the
+explicit annotation if present, else the inferred type; `return_is_explicit`
+records which.
+
+Composing `signature` at CI time keeps the MCP a pure serving layer (the same
+philosophy as per-endpoint-resolved-types.md). Best-effort optional markers
+(`?`) come from param optionality; if not readily available, omit them in the
+first cut — the types are the important part.
+
+### MCP (`carrick-cloud`)
+
+`lambdas/mcp-server/src/types.ts`:
+
+```ts
+export interface FunctionArgument {
+  name: string;
+  type_string?: string;
+  is_explicit?: boolean;
+}
+export interface FunctionDefinition {
+  // ...existing...
+  return_type?: string;
+  return_is_explicit?: boolean;
+  signature?: string;
+}
+```
+
+## Implementation
+
+### 1. Scanner: signature-collection pass (`carrick`)
+
+Add a pass (alongside `collect_type_requests` in `file_orchestrator.rs`, sharing
+its sidecar `infer` batch) that, for each entry in `function_definitions`:
+
+- For each parameter: if `type_string` is `Some` → `is_explicit = true`. Else
+  emit an `InferRequestItem` (new `InferKind::FunctionParam`) to infer it;
+  `is_explicit = false`.
+- For the return: if `return_type` is `Some` → `return_is_explicit = true`.
+  Else emit an `InferRequestItem` with `InferKind::FunctionReturn` (skipping the
+  wrapper/Promise unwrapping — see sidecar note below); `return_is_explicit =
+  false`.
+- After the batched `infer` call returns, merge inferred strings back onto the
+  `FunctionDefinition` and compose `signature`.
+
+Decide which functions to include: at minimum every exported function with a
+captured definition. Closures captured as `*_handler` (visitor.rs:600-665) are
+in `function_definitions` too; including them is fine and gives typed handler
+signatures, but expect implicit-any params for genuinely untyped standalone
+functions (still an honest signal — emit `any`, `is_explicit: false`).
+
+`InferRequestItem` (type_sidecar.rs:105) needs a way to identify which parameter
+a `FunctionParam` request targets — add `param_name: Option<String>` (one
+request per param, resolved by name within the function located by line/span).
+
+### 2. Sidecar: param inference (`carrick/src/sidecar`)
+
+- Add `FunctionParam` to `InferKind` (Rust `type_sidecar.rs:49`, TS
+  `type-inferrer.ts` + `validators.ts` + `types.ts`).
+- Add `inferFunctionParams` in `type-inferrer.ts`, modeled on
+  `inferFunctionReturn` (line 188): resolve the containing function via
+  `resolveContainingFunction`, then for the named parameter use
+  `param.getTypeNode()` (explicit) vs `param.getType().getText(param)`
+  (inferred/contextual). Set `is_explicit` from whether `getTypeNode()` exists.
+- For signature **return** inference, do NOT reuse the unwrapping branch of
+  `inferFunctionReturn`. Either add a flag to skip
+  `unwrapTypeWithConfig`/`unwrapPromise`, or a thin `inferSignatureReturn` that
+  returns `func.getReturnType().getText(func)` with `isExplicit` from
+  `getReturnTypeNode()`.
+
+### 3. MCP serving (`carrick-cloud`)
+
+- `lambdas/mcp-server/src/types.ts` — add the fields above.
+- `lambdas/mcp-server/src/tools/find-similar.ts` (`list_function_intents`,
+  line ~41-49) — add `signature` and `types_explicit` to each
+  `FunctionIntentEntry`.
+- `lambdas/check-or-upload/index.js` — the `search-by-intent` action projection
+  (lines 708-714) builds `{ name, file_path, line_number, intent, similarity }`.
+  Add `signature: def.signature` and `types_explicit` (from
+  `def.arguments[].is_explicit` + `def.return_is_explicit`). Then widen
+  `SearchByIntentResult` in `mcp-server/src/types.ts` and pass through in
+  `tools/search-by-intent.ts`.
+
+No `get_type_definition` change. No `get_endpoint_types` change.
+
+## Cross-repo coordination
+
+- `carrick` work on branch `feat/function-signature-types` (this branch).
+- `carrick-cloud` work needs its own parallel `feat/function-signature-types`
+  branch. NOTE: `carrick-cloud` is currently on `feat/workspaces-projects`
+  (an unrelated feature) — branch from `main`/the appropriate base, not from it.
+- The new `FunctionDefinition` fields serialize automatically into the uploaded
+  `CloudRepoData`; no upload-format coordination needed beyond shipping the
+  scanner first (the MCP fields are optional, so an older store is handled).
+
+## Non-goals
+
+- No backwards-compat shims (Carrick has no users) — ship the new shape, delete
+  any old shape in the same commit.
+- No drill-down of signature named types yet (follow-up issue 1).
+- No changes to the `calls`/`called_intents` substring matching (issues #55/#58).
+
+## Follow-up issues (filed separately)
+
+1. **Make function-signature named types resolvable via `get_type_definition`.**
+   Extend the signature pass to emit `SymbolRequest`s for explicit named
+   param/return types, widening the symbol-set sent to the sidecar `bundle`
+   action. dts-bundle-generator pulls transitive deps automatically; reuse the
+   `DefinitionResolver` so each gets `resolved_definition` + `expanded_definition`,
+   served via the existing `get_type_definition`.
+
+2. **Discover named-type references inside inferred signature types.** When the
+   sidecar infers a slot that references a named type (e.g. inferred return
+   `Promise<AuthResult>`), parse/walk out the named references and feed them into
+   the symbol-set so the inferred named sub-type gets the same drill-down as an
+   explicit one. Depends on issue 1.
+</content>

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -355,6 +355,7 @@ impl FileOrchestrator {
                         expression_text: None,
                         expression_line: None,
                         alias: Some(alias),
+                        param_name: None,
                     });
                     true
                 }
@@ -378,6 +379,7 @@ impl FileOrchestrator {
                         expression_line: expression_line
                             .map(|l| if l > 0 { l as u32 } else { line_number }),
                         alias: Some(alias),
+                        param_name: None,
                     });
                     true
                 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -19,6 +19,7 @@ use crate::services::{
     TypeSidecar,
     type_sidecar::{InferKind, TypeResolutionResult},
 };
+use crate::signature_pass::populate_function_signatures;
 use crate::type_manifest::{
     build_call_site_id, build_manifest_type_alias_with_call_id, is_http_method,
     normalize_manifest_method, parse_file_location,
@@ -643,6 +644,9 @@ async fn analyze_current_repo_incremental(
             )
             .await;
 
+            // Compose function signatures, inferring unannotated slots via sidecar.
+            populate_function_signatures(sidecar, &mut function_definitions, repo_path);
+
             let elapsed = start.elapsed();
             debug!(
                 "Incremental analysis complete in {:.1}s",
@@ -1265,6 +1269,9 @@ async fn analyze_current_repo(
         )
         .await;
     }
+
+    // 4c. Compose function signatures, inferring unannotated slots via sidecar.
+    populate_function_signatures(sidecar, &mut function_definitions, repo_path);
 
     // 5. Build CloudRepoData directly from multi-agent results (bypassing Analyzer adapter layer)
     let mut cloud_data = CloudRepoData::from_multi_agent_results(

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -324,6 +324,8 @@ mod tests {
                 intent: Some("returns one".to_string()),
                 calls: vec![],
                 return_type: None,
+                return_is_explicit: false,
+                signature: None,
             },
         );
         strip_body_source(&mut defs);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod packages;
 pub mod parser;
 pub mod router_context;
 pub mod services;
+pub mod signature_pass;
 pub mod swc_scanner;
 pub mod type_manifest;
 pub mod url_normalizer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod packages;
 mod parser;
 mod router_context;
 mod services;
+mod signature_pass;
 mod swc_scanner;
 mod type_manifest;
 mod url_normalizer;

--- a/src/services/type_sidecar.rs
+++ b/src/services/type_sidecar.rs
@@ -59,6 +59,10 @@ pub enum InferKind {
     ResponseBody,
     /// Find request body (req.body/ctx.request.body or call payloads)
     RequestBody,
+    /// Function return for the signature hint — NO Promise/wrapper unwrapping
+    SignatureReturn,
+    /// Type of a single named parameter (explicit or contextually inferred)
+    FunctionParam,
 }
 
 /// Wrapper unwrap strategy
@@ -125,6 +129,9 @@ pub struct InferRequestItem {
     /// Optional alias for the inferred type
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
+    /// Target parameter name for `FunctionParam` inference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub param_name: Option<String>,
 }
 
 // ============================================================================
@@ -999,6 +1006,7 @@ mod tests {
             expression_line: None,
             infer_kind: InferKind::ResponseBody,
             alias: None,
+            param_name: None,
         };
         let json = serde_json::to_string(&request).unwrap();
         assert!(json.contains(r#""file_path":"src/routes.ts""#));

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -1355,7 +1355,47 @@ export class TypeInferrer {
       if (!node) return undefined;
       return this.findContainingFunctionForNode(node);
     }
-    return undefined;
+    // Signature requests carry only the function's start line (FunctionDefinition
+    // has no byte span). Fall back to locating the function by that line.
+    return this.findFunctionByLine(sourceFile, request.line_number);
+  }
+
+  /**
+   * Find the function whose declaration starts at (or within a couple of lines
+   * of) the given line. Used for signature inference, where the only locator is
+   * the function's start line as recorded by the scanner. Ties break toward the
+   * innermost (smallest) function. Returns undefined if nothing is close enough,
+   * to avoid binding to an unrelated function.
+   */
+  private findFunctionByLine(
+    sourceFile: SourceFile,
+    line: number
+  ): FunctionLike | undefined {
+    const LINE_TOLERANCE = 2;
+    const functions = sourceFile.getDescendants().filter(
+      (node): node is FunctionLike =>
+        Node.isFunctionDeclaration(node) ||
+        Node.isArrowFunction(node) ||
+        Node.isFunctionExpression(node) ||
+        Node.isMethodDeclaration(node)
+    );
+
+    let best: FunctionLike | undefined;
+    let bestDelta = Infinity;
+    for (const fn of functions) {
+      const delta = Math.abs(fn.getStartLineNumber() - line);
+      if (delta > LINE_TOLERANCE) continue;
+      const isCloser = delta < bestDelta;
+      const isInnermostTie =
+        delta === bestDelta &&
+        best !== undefined &&
+        fn.getEnd() - fn.getStart() < best.getEnd() - best.getStart();
+      if (isCloser || isInnermostTie) {
+        best = fn;
+        bestDelta = delta;
+      }
+    }
+    return best;
   }
 
   /**

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -157,6 +157,10 @@ export class TypeInferrer {
         return this.inferExpression(sourceFile, request, wrappers, extractionConfig);
       case 'request_body':
         return this.inferRequestBody(sourceFile, request, wrappers, extractionConfig);
+      case 'signature_return':
+        return this.inferSignatureReturn(sourceFile, request);
+      case 'function_param':
+        return this.inferFunctionParam(sourceFile, request);
       default:
         this.logError(`Unknown infer kind: ${request.infer_kind}`);
         return null;
@@ -222,6 +226,80 @@ export class TypeInferrer {
       isExplicit,
       this.getNodeLocation(func),
       unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined
+    );
+  }
+
+  /**
+   * Infer a function's return type for the signature hint. Unlike
+   * `inferFunctionReturn`, this does NOT unwrap Promise or apply wrapper
+   * rules — a function that returns `Promise<AuthResult>` should show exactly
+   * that in its signature. Used by the function-signature collection pass.
+   */
+  private inferSignatureReturn(
+    sourceFile: SourceFile,
+    request: InferRequestItem
+  ): InferredType | null {
+    const func = this.resolveContainingFunction(sourceFile, request);
+
+    if (!func) {
+      this.log(`No function found for request at ${request.file_path}:${request.line_number}`);
+      return null;
+    }
+
+    const isExplicit = func.getReturnTypeNode() !== undefined;
+    const typeString = func.getReturnType().getText(func);
+
+    return this.createInferredType(
+      request,
+      typeString,
+      isExplicit,
+      this.getNodeLocation(func)
+    );
+  }
+
+  /**
+   * Infer the type of a single named parameter. `is_explicit` reflects whether
+   * the parameter carries a source annotation; the type string is the
+   * compiler's view either way (so contextually-typed callback params resolve
+   * even without an annotation). Uses ts-morph's default `getText()` form,
+   * which keeps named types as names and bounds depth via the compiler's own
+   * truncation.
+   */
+  private inferFunctionParam(
+    sourceFile: SourceFile,
+    request: InferRequestItem
+  ): InferredType | null {
+    const func = this.resolveContainingFunction(sourceFile, request);
+
+    if (!func) {
+      this.log(`No function found for request at ${request.file_path}:${request.line_number}`);
+      return null;
+    }
+
+    if (!request.param_name) {
+      this.logError(`function_param request missing param_name at ${request.file_path}:${request.line_number}`);
+      return null;
+    }
+
+    const param = func
+      .getParameters()
+      .find((p) => p.getName() === request.param_name);
+
+    if (!param) {
+      this.log(
+        `Parameter "${request.param_name}" not found at ${request.file_path}:${request.line_number}`
+      );
+      return null;
+    }
+
+    const isExplicit = param.getTypeNode() !== undefined;
+    const typeString = param.getType().getText(param);
+
+    return this.createInferredType(
+      request,
+      typeString,
+      isExplicit,
+      this.getNodeLocation(param)
     );
   }
 
@@ -1616,6 +1694,10 @@ export class TypeInferrer {
         return 'Expr';
       case 'request_body':
         return 'Request';
+      case 'signature_return':
+        return 'SigReturn';
+      case 'function_param':
+        return 'Param';
       default:
         return 'Type';
     }

--- a/src/sidecar/src/types.ts
+++ b/src/sidecar/src/types.ts
@@ -16,7 +16,9 @@ export type InferKind =
   | 'call_result'       // Get return type of a call expression
   | 'variable'          // Get type of a variable declaration
   | 'response_body'     // Find response body (.json()/.send()/ctx.body)
-  | 'request_body';     // Find request body (req.body/ctx.request.body or call payloads)
+  | 'request_body'      // Find request body (req.body/ctx.request.body or call payloads)
+  | 'signature_return'  // Function return for the signature hint — NO Promise/wrapper unwrapping
+  | 'function_param';   // Type of a single named parameter (explicit or contextually inferred)
 
 // ============================================================================
 // Extraction Config Types (Agent-Informed Payload Unwrapping)
@@ -348,6 +350,8 @@ export interface InferRequestItem {
   infer_kind: InferKind;
   /** Optional alias for the inferred type */
   alias?: string;
+  /** Target parameter name for `function_param` inference. */
+  param_name?: string;
 }
 
 // ============================================================================

--- a/src/sidecar/src/validators.ts
+++ b/src/sidecar/src/validators.ts
@@ -22,6 +22,8 @@ export const InferKindSchema = z.enum([
   'variable',
   'response_body',
   'request_body',
+  'signature_return',
+  'function_param',
 ]);
 
 // ============================================================================
@@ -142,6 +144,7 @@ export const InferRequestItemSchema = z
     expression_line: z.number().int().positive('Expression line must be positive').optional(),
     infer_kind: InferKindSchema,
     alias: z.string().optional(),
+    param_name: z.string().optional(),
   })
   .superRefine((value, ctx) => {
     if (

--- a/src/sidecar/src/validators.ts
+++ b/src/sidecar/src/validators.ts
@@ -160,7 +160,11 @@ export const InferRequestItemSchema = z
     }
     const hasSpan = value.span_start !== undefined && value.span_end !== undefined;
     const hasText = value.expression_text !== undefined;
-    if (!hasSpan && !hasText) {
+    // Signature inference (signature_return / function_param) locates the
+    // function by line_number alone, so it does not require a span or text.
+    const lineOnlyOk =
+      value.infer_kind === 'signature_return' || value.infer_kind === 'function_param';
+    if (!hasSpan && !hasText && !lineOnlyOk) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'At least one of (span_start + span_end) or expression_text must be provided',

--- a/src/sidecar/test/fixtures/sample-repo/src/routes.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/routes.ts
@@ -157,3 +157,15 @@ export const koaGetUser = async (ctx: KoaContext) => {
   }
   ctx.body = user;
 };
+
+// ===========================================================================
+// SIGNATURE TYPES - For function-signature inference testing
+// ===========================================================================
+
+/**
+ * Function with an UNANNOTATED parameter — exercises contextual/implicit
+ * parameter inference (param has no type node, compiler view is used).
+ */
+export function doubleIt(n) {
+  return n * 2;
+}

--- a/src/sidecar/test/sidecar.test.ts
+++ b/src/sidecar/test/sidecar.test.ts
@@ -1071,6 +1071,32 @@ describe('Type Sidecar Integration Tests', () => {
       assert.strictEqual(inferred!.is_explicit, false);
       assert.ok(inferred!.type_string.length > 0);
     });
+
+    it('resolves a function by line number alone (no span or text)', async () => {
+      const response = await client.send<{
+        inferred_types?: Array<{
+          type_string: string;
+          is_explicit: boolean;
+          infer_kind: string;
+        }>;
+      }>({
+        action: 'infer',
+        request_id: 'line-1',
+        requests: [
+          {
+            file_path: path.join(FIXTURES_PATH, 'src/routes.ts'),
+            line_number: 169, // doubleIt declaration line — only locator provided
+            infer_kind: 'signature_return',
+          },
+        ],
+      });
+
+      const inferred = response.inferred_types?.[0];
+      assert.ok(inferred, 'should locate doubleIt by line alone');
+      assert.strictEqual(inferred!.infer_kind, 'signature_return');
+      assert.strictEqual(inferred!.is_explicit, false);
+      assert.ok(inferred!.type_string.length > 0);
+    });
   });
 
   describe('resolve_definitions action', () => {

--- a/src/sidecar/test/sidecar.test.ts
+++ b/src/sidecar/test/sidecar.test.ts
@@ -957,6 +957,120 @@ describe('Type Sidecar Integration Tests', () => {
         assert.ok(inferred.type_string !== 'unknown');
       }
     });
+
+    it('signature_return keeps Promise wrapper and reports explicit', async () => {
+      const response = await client.send<{
+        inferred_types?: Array<{
+          type_string: string;
+          is_explicit: boolean;
+          infer_kind: string;
+        }>;
+      }>({
+        action: 'infer',
+        request_id: 'sig-1',
+        requests: [
+          {
+            file_path: path.join(FIXTURES_PATH, 'src/routes.ts'),
+            line_number: 61,
+            expression_text: 'res.json(user)',
+            expression_line: 61,
+            infer_kind: 'signature_return',
+          },
+        ],
+      });
+
+      const inferred = response.inferred_types?.[0];
+      assert.ok(inferred, 'should infer getUser return');
+      assert.strictEqual(inferred!.infer_kind, 'signature_return');
+      // getUser is annotated `: Promise<void>` — must NOT be unwrapped to void.
+      assert.strictEqual(inferred!.type_string, 'Promise<void>');
+      assert.strictEqual(inferred!.is_explicit, true);
+    });
+
+    it('signature_return infers an unannotated return as implicit', async () => {
+      const response = await client.send<{
+        inferred_types?: Array<{
+          type_string: string;
+          is_explicit: boolean;
+          infer_kind: string;
+        }>;
+      }>({
+        action: 'infer',
+        request_id: 'sig-2',
+        requests: [
+          {
+            file_path: path.join(FIXTURES_PATH, 'src/routes.ts'),
+            line_number: 87,
+            expression_text: "console.log('Fetching orders for user:', userId)",
+            expression_line: 87,
+            infer_kind: 'signature_return',
+          },
+        ],
+      });
+
+      const inferred = response.inferred_types?.[0];
+      assert.ok(inferred, 'should infer getOrders return');
+      assert.strictEqual(inferred!.is_explicit, false);
+      // Inferred return is a Promise (async handler) — wrapper preserved.
+      assert.ok(inferred!.type_string.includes('Promise'));
+    });
+
+    it('function_param reads an annotated parameter as explicit', async () => {
+      const response = await client.send<{
+        inferred_types?: Array<{
+          type_string: string;
+          is_explicit: boolean;
+          infer_kind: string;
+        }>;
+      }>({
+        action: 'infer',
+        request_id: 'param-1',
+        requests: [
+          {
+            file_path: path.join(FIXTURES_PATH, 'src/routes.ts'),
+            line_number: 61,
+            expression_text: 'res.json(user)',
+            expression_line: 61,
+            infer_kind: 'function_param',
+            param_name: 'req',
+          },
+        ],
+      });
+
+      const inferred = response.inferred_types?.[0];
+      assert.ok(inferred, 'should infer getUser req param');
+      assert.strictEqual(inferred!.infer_kind, 'function_param');
+      assert.strictEqual(inferred!.type_string, 'Request');
+      assert.strictEqual(inferred!.is_explicit, true);
+    });
+
+    it('function_param infers an unannotated parameter as implicit', async () => {
+      const response = await client.send<{
+        inferred_types?: Array<{
+          type_string: string;
+          is_explicit: boolean;
+          infer_kind: string;
+        }>;
+      }>({
+        action: 'infer',
+        request_id: 'param-2',
+        requests: [
+          {
+            file_path: path.join(FIXTURES_PATH, 'src/routes.ts'),
+            line_number: 170,
+            expression_text: 'n * 2',
+            expression_line: 170,
+            infer_kind: 'function_param',
+            param_name: 'n',
+          },
+        ],
+      });
+
+      const inferred = response.inferred_types?.[0];
+      assert.ok(inferred, 'should infer doubleIt n param');
+      assert.strictEqual(inferred!.is_explicit, false);
+      assert.ok(inferred!.type_string.length > 0);
+    });
   });
 
   describe('resolve_definitions action', () => {

--- a/src/signature_pass.rs
+++ b/src/signature_pass.rs
@@ -1,0 +1,358 @@
+//! Function-signature pass.
+//!
+//! Composes a one-line signature hint for every function definition and, where
+//! a sidecar is available, fills in param/return types that lack source
+//! annotations via compiler inference.
+//!
+//! Provenance is metadata, not a routing decision: each slot carries
+//! `is_explicit` (annotated vs inferred). The hint is composed for every
+//! function regardless of whether inference ran, so explicit-typed code is
+//! fully served even without a sidecar. Deep type resolution is intentionally
+//! out of scope here — the named types in a signature become drill-downable via
+//! the bundle pipeline in follow-up work (issues #116/#117).
+
+use crate::services::type_sidecar::{InferKind, InferRequestItem, TypeSidecar};
+use crate::visitor::FunctionDefinition;
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Duration;
+use tracing::{debug, warn};
+
+/// Shown in the signature hint when a return type is neither annotated nor
+/// successfully inferred.
+const RETURN_UNKNOWN: &str = "unknown";
+
+/// How long to wait for the sidecar to become ready before giving up on
+/// signature inference (matches the type-resolution path).
+const SIDECAR_READY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Which slot of a function signature an inference request targets.
+#[derive(Debug, Clone, PartialEq)]
+enum SigSlot {
+    Return,
+    Param(usize),
+}
+
+/// Maps a generated inference alias back to the function + slot it fills.
+#[derive(Debug, Clone)]
+struct SigTarget {
+    fn_name: String,
+    slot: SigSlot,
+}
+
+/// Populate `signature` on every function definition, filling unannotated
+/// param/return types via the sidecar when one is available and ready.
+pub fn populate_function_signatures(
+    sidecar: Option<&TypeSidecar>,
+    function_definitions: &mut HashMap<String, FunctionDefinition>,
+    repo_path: &str,
+) {
+    if let Some(sidecar) = sidecar {
+        match sidecar.wait_ready(SIDECAR_READY_TIMEOUT) {
+            Ok(()) => infer_missing_types(sidecar, function_definitions, repo_path),
+            Err(e) => debug!("Sidecar not ready for signature inference: {e}"),
+        }
+    }
+
+    for def in function_definitions.values_mut() {
+        def.signature = Some(compose_signature(def));
+    }
+}
+
+/// Build infer requests for unannotated slots, call the sidecar, and merge the
+/// results back onto the function definitions.
+fn infer_missing_types(
+    sidecar: &TypeSidecar,
+    function_definitions: &mut HashMap<String, FunctionDefinition>,
+    repo_path: &str,
+) {
+    let repo_root_absolute = absolute_repo_root(repo_path);
+    let (requests, targets) = build_infer_requests(function_definitions, &repo_root_absolute);
+    if requests.is_empty() {
+        return;
+    }
+
+    debug!("Inferring {} unannotated signature slot(s)", requests.len());
+
+    let response = match sidecar.infer_types(&requests, &[]) {
+        Ok(response) => response,
+        Err(e) => {
+            warn!("Signature inference failed: {e}");
+            return;
+        }
+    };
+
+    let Some(inferred) = response.inferred_types else {
+        return;
+    };
+
+    for ty in &inferred {
+        let Some(target) = targets.get(&ty.alias) else {
+            continue;
+        };
+        let Some(def) = function_definitions.get_mut(&target.fn_name) else {
+            continue;
+        };
+        match target.slot {
+            SigSlot::Return => {
+                def.return_type = Some(ty.type_string.clone());
+                def.return_is_explicit = ty.is_explicit;
+            }
+            SigSlot::Param(index) => {
+                if let Some(arg) = def.arguments.get_mut(index) {
+                    arg.is_explicit = ty.is_explicit;
+                    arg.type_string = Some(ty.type_string.clone());
+                }
+            }
+        }
+    }
+}
+
+/// Build one infer request per unannotated slot, with a generated alias keyed
+/// back to its (function, slot) target. Iterates in name order so request
+/// generation is deterministic.
+fn build_infer_requests(
+    function_definitions: &HashMap<String, FunctionDefinition>,
+    repo_root_absolute: &Path,
+) -> (Vec<InferRequestItem>, HashMap<String, SigTarget>) {
+    let mut requests = Vec::new();
+    let mut targets = HashMap::new();
+    let mut counter = 0usize;
+
+    let mut names: Vec<&String> = function_definitions.keys().collect();
+    names.sort();
+
+    for name in names {
+        let def = &function_definitions[name];
+        let file_path = to_absolute_path(&def.file_path.to_string_lossy(), repo_root_absolute);
+
+        if def.return_type.is_none() {
+            let alias = format!("__sig{counter}");
+            counter += 1;
+            requests.push(InferRequestItem {
+                file_path: file_path.clone(),
+                line_number: def.line_number,
+                span_start: None,
+                span_end: None,
+                expression_text: None,
+                expression_line: None,
+                infer_kind: InferKind::SignatureReturn,
+                alias: Some(alias.clone()),
+                param_name: None,
+            });
+            targets.insert(
+                alias,
+                SigTarget {
+                    fn_name: name.clone(),
+                    slot: SigSlot::Return,
+                },
+            );
+        }
+
+        for (index, arg) in def.arguments.iter().enumerate() {
+            if arg.type_string.is_some() {
+                continue;
+            }
+            let alias = format!("__sig{counter}");
+            counter += 1;
+            requests.push(InferRequestItem {
+                file_path: file_path.clone(),
+                line_number: def.line_number,
+                span_start: None,
+                span_end: None,
+                expression_text: None,
+                expression_line: None,
+                infer_kind: InferKind::FunctionParam,
+                alias: Some(alias.clone()),
+                // ts-morph matches by getName(), which drops the rest `...`.
+                param_name: Some(arg.name.trim_start_matches("...").to_string()),
+            });
+            targets.insert(
+                alias,
+                SigTarget {
+                    fn_name: name.clone(),
+                    slot: SigSlot::Param(index),
+                },
+            );
+        }
+    }
+
+    (requests, targets)
+}
+
+/// Compose the one-line signature hint, e.g.
+/// `(token: string, opts?: VerifyOpts) => Promise<AuthResult>`. Params without a
+/// known type render as the bare name; an unknown return renders as `unknown`.
+fn compose_signature(def: &FunctionDefinition) -> String {
+    let params = def
+        .arguments
+        .iter()
+        .map(|arg| match &arg.type_string {
+            Some(ty) => format!("{}: {}", arg.name, ty),
+            None => arg.name.clone(),
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let ret = def.return_type.as_deref().unwrap_or(RETURN_UNKNOWN);
+    format!("({params}) => {ret}")
+}
+
+/// Resolve the repo root to an absolute, canonicalized path (mirrors
+/// FileOrchestrator's resolution so the sidecar sees consistent paths).
+fn absolute_repo_root(repo_path: &str) -> std::path::PathBuf {
+    let repo_root = Path::new(repo_path);
+    if repo_root.is_absolute() {
+        return repo_root.to_path_buf();
+    }
+    std::env::current_dir()
+        .map(|cwd| cwd.join(repo_root))
+        .unwrap_or_else(|_| repo_root.to_path_buf())
+        .canonicalize()
+        .unwrap_or_else(|_| repo_root.to_path_buf())
+}
+
+/// Convert a (possibly relative) file path to an absolute path the sidecar can
+/// open. Mirrors `FileOrchestrator::to_absolute_path`.
+fn to_absolute_path(file_path: &str, repo_root_absolute: &Path) -> String {
+    let path = Path::new(file_path);
+    if path.is_absolute() {
+        return file_path.to_string();
+    }
+    let resolved = std::env::current_dir()
+        .map(|cwd| cwd.join(path))
+        .unwrap_or_else(|_| path.to_path_buf());
+    resolved
+        .canonicalize()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| repo_root_absolute.join(path).to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::visitor::{FunctionArgument, FunctionDefinition, FunctionNodeType};
+
+    fn arg(name: &str, ty: Option<&str>) -> FunctionArgument {
+        FunctionArgument {
+            name: name.to_string(),
+            type_ann: None,
+            is_explicit: ty.is_some(),
+            type_string: ty.map(|t| t.to_string()),
+        }
+    }
+
+    fn def(args: Vec<FunctionArgument>, return_type: Option<&str>) -> FunctionDefinition {
+        FunctionDefinition {
+            name: "fn".to_string(),
+            file_path: "src/auth.ts".into(),
+            node_type: FunctionNodeType::Placeholder,
+            arguments: args,
+            body_source: None,
+            is_exported: true,
+            line_number: 10,
+            intent: None,
+            calls: vec![],
+            return_type: return_type.map(|t| t.to_string()),
+            return_is_explicit: return_type.is_some(),
+            signature: None,
+        }
+    }
+
+    #[test]
+    fn composes_fully_typed_signature() {
+        let d = def(
+            vec![
+                arg("token", Some("string")),
+                arg("opts", Some("VerifyOpts")),
+            ],
+            Some("Promise<AuthResult>"),
+        );
+        assert_eq!(
+            compose_signature(&d),
+            "(token: string, opts: VerifyOpts) => Promise<AuthResult>"
+        );
+    }
+
+    #[test]
+    fn composes_untyped_signature_with_unknown_return() {
+        let d = def(vec![arg("x", None)], None);
+        assert_eq!(compose_signature(&d), "(x) => unknown");
+    }
+
+    #[test]
+    fn composes_mixed_signature() {
+        let d = def(
+            vec![arg("id", Some("string")), arg("flag", None)],
+            Some("void"),
+        );
+        assert_eq!(compose_signature(&d), "(id: string, flag) => void");
+    }
+
+    #[test]
+    fn composes_zero_arg_signature() {
+        let d = def(vec![], Some("number"));
+        assert_eq!(compose_signature(&d), "() => number");
+    }
+
+    #[test]
+    fn build_requests_targets_only_unannotated_slots() {
+        let mut defs = HashMap::new();
+        // one annotated param, one unannotated param, no return annotation
+        defs.insert(
+            "verify".to_string(),
+            def(vec![arg("token", Some("string")), arg("opts", None)], None),
+        );
+        let repo_root = Path::new("/tmp/repo");
+        let (requests, targets) = build_infer_requests(&defs, repo_root);
+
+        // 1 return gap + 1 param gap = 2 requests (the annotated param is skipped)
+        assert_eq!(requests.len(), 2);
+        assert_eq!(targets.len(), 2);
+
+        let return_req = requests
+            .iter()
+            .find(|r| r.infer_kind == InferKind::SignatureReturn)
+            .expect("return request");
+        assert_eq!(return_req.line_number, 10);
+        assert_eq!(return_req.param_name, None);
+
+        let param_req = requests
+            .iter()
+            .find(|r| r.infer_kind == InferKind::FunctionParam)
+            .expect("param request");
+        assert_eq!(param_req.param_name.as_deref(), Some("opts"));
+
+        // every request alias maps back to a target
+        for req in &requests {
+            let alias = req.alias.as_ref().expect("alias");
+            assert!(targets.contains_key(alias), "alias {alias} should map");
+        }
+    }
+
+    #[test]
+    fn build_requests_skips_fully_annotated_functions() {
+        let mut defs = HashMap::new();
+        defs.insert(
+            "greet".to_string(),
+            def(vec![arg("name", Some("string"))], Some("string")),
+        );
+        let (requests, targets) = build_infer_requests(&defs, Path::new("/tmp/repo"));
+        assert!(requests.is_empty());
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn build_requests_strips_rest_param_dots() {
+        let mut defs = HashMap::new();
+        defs.insert(
+            "variadic".to_string(),
+            def(vec![arg("...args", None)], Some("void")),
+        );
+        let (requests, _) = build_infer_requests(&defs, Path::new("/tmp/repo"));
+        let param_req = requests
+            .iter()
+            .find(|r| r.infer_kind == InferKind::FunctionParam)
+            .expect("param request");
+        assert_eq!(param_req.param_name.as_deref(), Some("args"));
+    }
+}

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -17,9 +17,14 @@ pub struct FunctionArgument {
     pub type_ann: Option<TsTypeAnn>, // swc_ecma_ast::TsTypeAnn
     /// Raw TS source text of the type annotation, e.g. "Request<{id: string}>".
     /// `None` when the parameter has no annotation. Serialized so the cloud /
-    /// MCP layer can surface function signatures.
+    /// MCP layer can surface function signatures. May be filled by the
+    /// signature pass with a compiler-inferred type when no annotation exists.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub type_string: Option<String>,
+    /// `true` when `type_string` came from a source annotation, `false` when
+    /// it was inferred by the sidecar. Serves as a confidence signal to agents.
+    #[serde(default)]
+    pub is_explicit: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -112,9 +117,19 @@ pub struct FunctionDefinition {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub calls: Vec<FunctionCallRef>,
     /// Raw TS source text of the return type annotation, e.g. "Promise<User>".
-    /// `None` when the function has no annotated return type.
+    /// `None` when the function has no annotated return type. May be filled by
+    /// the signature pass with a compiler-inferred type when no annotation exists.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub return_type: Option<String>,
+    /// `true` when `return_type` came from a source annotation, `false` when
+    /// it was inferred by the sidecar.
+    #[serde(default)]
+    pub return_is_explicit: bool,
+    /// One-line signature hint composed at scan time, e.g.
+    /// "(token: string, opts?: VerifyOpts) => Promise<AuthResult>". `None`
+    /// until the signature pass runs. The MCP layer surfaces this verbatim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
 }
 
 /// A reference to a called function, for navigating to its source via GitHub.
@@ -350,6 +365,7 @@ impl FunctionDefinitionExtractor {
                 FunctionArgument {
                     name,
                     type_ann,
+                    is_explicit: type_string.is_some(),
                     type_string,
                 }
             })
@@ -380,6 +396,7 @@ impl FunctionDefinitionExtractor {
                 FunctionArgument {
                     name,
                     type_ann,
+                    is_explicit: type_string.is_some(),
                     type_string,
                 }
             })
@@ -451,7 +468,9 @@ impl Visit for FunctionDefinitionExtractor {
                             line_number,
                             intent: None,
                             calls: vec![],
+                            return_is_explicit: return_type.is_some(),
                             return_type,
+                            signature: None,
                         },
                     );
                 }
@@ -517,7 +536,9 @@ impl Visit for FunctionDefinitionExtractor {
                 line_number,
                 intent: None,
                 calls: vec![],
+                return_is_explicit: return_type.is_some(),
                 return_type,
+                signature: None,
             },
         );
 
@@ -553,7 +574,9 @@ impl Visit for FunctionDefinitionExtractor {
                                 line_number,
                                 intent: None,
                                 calls: vec![],
+                                return_is_explicit: return_type.is_some(),
                                 return_type,
+                                signature: None,
                             },
                         );
                     }
@@ -584,7 +607,9 @@ impl Visit for FunctionDefinitionExtractor {
                                 line_number,
                                 intent: None,
                                 calls: vec![],
+                                return_is_explicit: return_type.is_some(),
                                 return_type,
+                                signature: None,
                             },
                         );
                     }
@@ -631,7 +656,9 @@ impl Visit for FunctionDefinitionExtractor {
                                     line_number,
                                     intent: None,
                                     calls: vec![],
+                                    return_is_explicit: return_type.is_some(),
                                     return_type,
+                                    signature: None,
                                 },
                             );
                         }
@@ -666,7 +693,9 @@ impl Visit for FunctionDefinitionExtractor {
                                     line_number,
                                     intent: None,
                                     calls: vec![],
+                                    return_is_explicit: return_type.is_some(),
                                     return_type,
+                                    signature: None,
                                 },
                             );
                         }
@@ -990,6 +1019,46 @@ mod tests {
         let defs = extract("function bare(x) { return x; }");
         let def = defs.get("bare").expect("should find bare");
         assert!(def.arguments[0].type_string.is_none());
+    }
+
+    #[test]
+    fn annotated_argument_is_marked_explicit() {
+        let defs = extract("function greet(name: string) { return name; }");
+        let def = defs.get("greet").expect("should find greet");
+        assert!(
+            def.arguments[0].is_explicit,
+            "annotated param should be explicit"
+        );
+    }
+
+    #[test]
+    fn unannotated_argument_is_not_explicit() {
+        let defs = extract("function bare(x) { return x; }");
+        let def = defs.get("bare").expect("should find bare");
+        assert!(
+            !def.arguments[0].is_explicit,
+            "unannotated param should not be explicit at parse time"
+        );
+    }
+
+    #[test]
+    fn annotated_return_is_marked_explicit() {
+        let defs = extract("function greet(name: string): string { return name; }");
+        let def = defs.get("greet").expect("should find greet");
+        assert!(
+            def.return_is_explicit,
+            "annotated return should be explicit"
+        );
+    }
+
+    #[test]
+    fn unannotated_return_is_not_explicit() {
+        let defs = extract("function bare() { return 1; }");
+        let def = defs.get("bare").expect("should find bare");
+        assert!(
+            !def.return_is_explicit,
+            "unannotated return should not be explicit at parse time"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Surfaces typed signatures for functions so the MCP intent layer can serve argument + return types alongside intents. **Scanner + sidecar half** of the feature; the carrick-cloud serving layer lands in a companion PR.

Plan: `docs/function-signature-types.md`. Phases 1+2 (explicit + inferred hints). Drill-down bundling is tracked as #116/#117.

## What's here
- **visitor**: type-provenance fields — `is_explicit` on `FunctionArgument`, `return_is_explicit` + `signature` on `FunctionDefinition`.
- **sidecar**: two infer kinds — `signature_return` (return type *without* Promise/wrapper unwrapping) and `function_param` (single named param, explicit or contextually inferred); plus a line-number locator fallback (FunctionDefinition has no byte span).
- **engine**: new `signature_pass` composes a one-line signature hint for every function and infers unannotated slots via the sidecar (`is_explicit=false`). Wired into full + incremental paths. Composes even without a sidecar, so explicit-typed code is fully served.

## Design
Provenance is metadata, not a routing decision; serving keys on shape/depth. The hint is bounded (ts-morph default `getText()`); deep resolution stays behind drill-down (#116/#117).

## Tests
Rust unit tests for provenance capture + signature composition/request-building; sidecar tests for both new infer kinds and the line locator. Full suite green.

## Not in this PR
- carrick-cloud serving layer (companion PR): MCP `types.ts` fields, `list_function_intents`, and the `search-by-intent` projection.
- Automated engine→sidecar integration test for the live signature path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)