### PR TITLE
feat: framework-agnostic file-based routing

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     cloud_storage::{ManifestRole, ManifestTypeKind},
     config::Config,
-    file_based_router::{builtin_conventions, derive_route, MethodSource, RoutingConvention},
+    file_based_router::{MethodSource, RoutingConvention, builtin_conventions, derive_route},
     framework_detector::DetectionResult,
     mount_graph::{DataFetchingCall, GraphNode, MountEdge, MountGraph, NodeType, ResolvedEndpoint},
     packages::Packages,
@@ -2405,9 +2405,11 @@ export const runtime = "edge";
 
         assert_eq!(added, 1);
         assert_eq!(result.endpoints.len(), 2);
-        assert!(result
-            .endpoints
-            .iter()
-            .any(|e| e.method == "POST" && e.path == "/users"));
+        assert!(
+            result
+                .endpoints
+                .iter()
+                .any(|e| e.method == "POST" && e.path == "/users")
+        );
     }
 }

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -19,11 +19,12 @@
 use crate::{
     agent_service::AgentService,
     agents::{
-        file_analyzer_agent::{FileAnalysisResult, FileAnalyzerAgent},
+        file_analyzer_agent::{EndpointResult, FileAnalysisResult, FileAnalyzerAgent},
         framework_guidance_agent::FrameworkGuidance,
     },
     cloud_storage::{ManifestRole, ManifestTypeKind},
     config::Config,
+    file_based_router::{builtin_conventions, derive_route, MethodSource, RoutingConvention},
     framework_detector::DetectionResult,
     mount_graph::{DataFetchingCall, GraphNode, MountEdge, MountGraph, NodeType, ResolvedEndpoint},
     packages::Packages,
@@ -75,9 +76,18 @@ pub struct ProcessingStats {
     pub files_skipped_no_candidates: usize,
     pub total_mounts: usize,
     pub total_endpoints: usize,
+    /// Endpoints derived structurally from file-based routing conventions
+    /// (Next.js app router, etc.) rather than from a call-site scan. A subset
+    /// of `total_endpoints`.
+    pub file_based_endpoints: usize,
     pub total_data_calls: usize,
     pub errors: Vec<String>,
 }
+
+/// Owner assigned to endpoints declared by file location (file-based routing).
+/// These routes have no mount chain — their derived path is already absolute —
+/// so the owner is a sentinel that matches no mount during path resolution.
+const FILE_BASED_ROUTE_OWNER: &str = "__file_based_route__";
 
 type EndpointLookup = HashMap<(String, u32), Vec<(String, String)>>;
 type DataCallLookup = HashMap<(String, u32), Vec<(String, String, String)>>;
@@ -128,6 +138,7 @@ impl FileOrchestrator {
         files: &[PathBuf],
         guidance: &FrameworkGuidance,
         framework_detection: &DetectionResult,
+        repo_root: &Path,
     ) -> Result<FileCentricAnalysisResult, Box<dyn std::error::Error>> {
         debug!("=== AST-GATED FILE-CENTRIC ORCHESTRATOR ===");
         debug!("Processing {} files with SWC gatekeeper", files.len());
@@ -136,6 +147,11 @@ impl FileOrchestrator {
         let mut stats = ProcessingStats::default();
         let cm: Lrc<SourceMap> = Default::default();
         let handler = Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(cm.clone()));
+
+        // Routing conventions for file-based routes (Next.js app/pages router,
+        // etc.). Empty when no convention-bearing framework is detected, in
+        // which case the file-based pass below is a no-op.
+        let conventions = builtin_conventions(&framework_detection.frameworks);
 
         // A file that passed the SWC gatekeeper and is ready for the (expensive) LLM call.
         // The CPU-bound preprocessing (read, scan, symbol table) is done serially up front;
@@ -147,6 +163,9 @@ impl FileOrchestrator {
             candidate_contexts: Vec<String>,
             candidate_map: HashMap<String, CandidateTarget>,
             symbol_table: SymbolTable,
+            /// Endpoints derived from file-based routing conventions, merged in
+            /// after the LLM pass. Empty for non-route files.
+            route_endpoints: Vec<EndpointResult>,
         }
 
         // PHASE 1 (serial, CPU-bound): run the SWC gatekeeper on every file and build the
@@ -183,13 +202,50 @@ impl FileOrchestrator {
                 &framework_detection.data_fetchers,
             );
 
-            // STEP 2: Check Relevance - if no candidates, SKIP (zero LLM cost)
+            // File-based routing: routes declared by file location (Next.js app
+            // router, etc.) have no call-site candidate — the endpoint *is* the
+            // exported handler declaration. The path comes from the layout and the
+            // methods from exported handler names; both are invisible to a
+            // call-site scan, so they are derived deterministically here.
+            let route_endpoints = if conventions.is_empty() {
+                Vec::new()
+            } else {
+                let rel_path = file_path.strip_prefix(repo_root).unwrap_or(file_path);
+                Self::file_based_endpoints(
+                    &self.swc_scanner,
+                    rel_path,
+                    file_path,
+                    &content,
+                    &conventions,
+                )
+            };
+
+            // STEP 2: Check Relevance - if no candidates, SKIP the (expensive) LLM
+            // call. File-based route endpoints are still recorded: they're derived
+            // structurally and need no LLM.
             if !scan_result.should_analyze {
-                debug!("Skipped (no API patterns): {} [0 candidates]", path_str);
-                stats.files_skipped += 1;
-                stats.files_skipped_no_candidates += 1;
-                // Store empty result so incremental cache knows this file was processed
-                file_results.insert(path_str, FileAnalysisResult::default());
+                if route_endpoints.is_empty() {
+                    debug!("Skipped (no API patterns): {} [0 candidates]", path_str);
+                    stats.files_skipped += 1;
+                    stats.files_skipped_no_candidates += 1;
+                    // Store empty result so incremental cache knows this file was processed
+                    file_results.insert(path_str, FileAnalysisResult::default());
+                } else {
+                    debug!(
+                        "File-based route (no call-site candidates): {} [{} endpoint(s)]",
+                        path_str,
+                        route_endpoints.len()
+                    );
+                    stats.total_endpoints += route_endpoints.len();
+                    stats.file_based_endpoints += route_endpoints.len();
+                    file_results.insert(
+                        path_str,
+                        FileAnalysisResult {
+                            endpoints: route_endpoints,
+                            ..Default::default()
+                        },
+                    );
+                }
                 continue;
             }
 
@@ -225,6 +281,7 @@ impl FileOrchestrator {
                 candidate_contexts,
                 candidate_map,
                 symbol_table,
+                route_endpoints,
             });
         }
 
@@ -273,6 +330,11 @@ impl FileOrchestrator {
                     Self::validate_type_hints(&mut adjusted, &pf.symbol_table);
                     Self::normalize_unusable_types(&mut adjusted, &framework_detection.frameworks);
 
+                    // Merge file-based route endpoints the LLM pass didn't already
+                    // produce. The structural (method, path) facts are authoritative.
+                    stats.file_based_endpoints +=
+                        Self::merge_file_based_endpoints(&mut adjusted, pf.route_endpoints);
+
                     stats.total_mounts += adjusted.mounts.len();
                     stats.total_endpoints += adjusted.endpoints.len();
                     stats.total_data_calls += adjusted.data_calls.len();
@@ -297,6 +359,10 @@ impl FileOrchestrator {
         );
         debug!("  - Total mounts: {}", stats.total_mounts);
         debug!("  - Total endpoints: {}", stats.total_endpoints);
+        debug!(
+            "  - File-based route endpoints: {}",
+            stats.file_based_endpoints
+        );
         debug!("  - Total data calls: {}", stats.total_data_calls);
 
         // STEP 5: Build aggregated mount graph from all file results
@@ -835,6 +901,85 @@ impl FileOrchestrator {
         for call in &mut result.data_calls {
             scrub(&mut call.primary_type_symbol, &mut call.type_import_source);
         }
+    }
+
+    /// Derive endpoints for a file whose route is declared by its location in
+    /// the project layout (file-based routing) rather than by a call expression
+    /// the SWC gatekeeper can see. `derive_route` supplies the path from the
+    /// filesystem; the exported handler extractor supplies the HTTP methods and
+    /// declaration spans. Neither is recoverable from a call-site scan, so these
+    /// endpoints are built deterministically.
+    ///
+    /// Payload/response type fields are left empty: the structural facts
+    /// (method and path) are owned here, while type enrichment stays the job of
+    /// the LLM/sidecar pipeline.
+    fn file_based_endpoints(
+        scanner: &SwcScanner,
+        rel_path: &Path,
+        file_path: &Path,
+        content: &str,
+        conventions: &[RoutingConvention],
+    ) -> Vec<EndpointResult> {
+        let Some(route) = derive_route(rel_path, conventions) else {
+            return Vec::new();
+        };
+
+        match route.method_source {
+            // App-router style: one exported function per HTTP method. The export
+            // name *is* the method (GET/POST/...), and its declaration span lets
+            // the sidecar locate the handler body later.
+            MethodSource::ExportName => scanner
+                .exported_handlers(file_path, content)
+                .into_iter()
+                .filter(|h| is_http_method(&h.name))
+                .map(|h| {
+                    let method = h.name.to_uppercase();
+                    EndpointResult {
+                        candidate_id: format!("file-route:{}:{}", method, h.span_start),
+                        line_number: h.line_number as i32,
+                        owner_node: FILE_BASED_ROUTE_OWNER.to_string(),
+                        method,
+                        path: route.path.clone(),
+                        handler_name: h.name.clone(),
+                        pattern_matched: route.convention.clone(),
+                        call_expression_span_start: Some(h.span_start),
+                        call_expression_span_end: Some(h.span_end),
+                        payload_expression_text: None,
+                        payload_expression_line: None,
+                        response_expression_text: None,
+                        response_expression_line: None,
+                        primary_type_symbol: None,
+                        type_import_source: None,
+                    }
+                })
+                .collect(),
+            // Pages-router style: a single default export serves every method. The
+            // concrete method set isn't recoverable from the layout alone, so we
+            // leave these to a follow-up rather than emit an endpoint with an
+            // unknown method (which the mount graph would drop anyway).
+            MethodSource::DefaultExport => Vec::new(),
+        }
+    }
+
+    /// Append file-based route endpoints the LLM pass didn't already produce
+    /// (matched by method + path), keeping the deterministic structural entries.
+    /// Returns the number actually added.
+    fn merge_file_based_endpoints(
+        result: &mut FileAnalysisResult,
+        route_endpoints: Vec<EndpointResult>,
+    ) -> usize {
+        let mut added = 0;
+        for ep in route_endpoints {
+            let duplicate = result
+                .endpoints
+                .iter()
+                .any(|e| e.method.eq_ignore_ascii_case(&ep.method) && e.path == ep.path);
+            if !duplicate {
+                result.endpoints.push(ep);
+                added += 1;
+            }
+        }
+        added
     }
 
     fn apply_candidate_map(
@@ -2117,6 +2262,152 @@ mod tests {
         assert_eq!(stats.total_mounts, 0);
         assert_eq!(stats.total_endpoints, 0);
         assert_eq!(stats.total_data_calls, 0);
+        assert_eq!(stats.file_based_endpoints, 0);
         assert!(stats.errors.is_empty());
+    }
+
+    fn next_conventions() -> Vec<RoutingConvention> {
+        builtin_conventions(&["Next.js".to_string()])
+    }
+
+    #[test]
+    fn test_file_based_endpoints_app_router_method_per_export() {
+        let scanner = SwcScanner::new();
+        let content = r#"
+export async function GET() { return Response.json([]); }
+export async function POST(req: Request) { return Response.json({}); }
+export const runtime = "edge";
+"#;
+        let mut endpoints = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            Path::new("app/users/route.ts"),
+            Path::new("app/users/route.ts"),
+            content,
+            &next_conventions(),
+        );
+        endpoints.sort_by(|a, b| a.method.cmp(&b.method));
+
+        // GET + POST become endpoints; `runtime` is not an HTTP method.
+        assert_eq!(endpoints.len(), 2, "expected GET and POST only");
+        assert_eq!(endpoints[0].method, "GET");
+        assert_eq!(endpoints[1].method, "POST");
+        for ep in &endpoints {
+            assert_eq!(ep.path, "/users");
+            assert_eq!(ep.owner_node, FILE_BASED_ROUTE_OWNER);
+            assert_eq!(ep.pattern_matched, "nextjs-app");
+            assert!(ep.call_expression_span_start.is_some());
+            assert!(ep.call_expression_span_end.is_some());
+            // Type enrichment is deferred to the LLM/sidecar pass.
+            assert!(ep.response_expression_text.is_none());
+        }
+    }
+
+    #[test]
+    fn test_file_based_endpoints_dynamic_segment() {
+        let scanner = SwcScanner::new();
+        let content = "export async function GET() {}\n";
+        let endpoints = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            Path::new("app/users/[id]/route.ts"),
+            Path::new("app/users/[id]/route.ts"),
+            content,
+            &next_conventions(),
+        );
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].method, "GET");
+        assert_eq!(endpoints[0].path, "/users/:id");
+    }
+
+    #[test]
+    fn test_file_based_endpoints_pages_router_default_export_deferred() {
+        // Pages-router default export serves every method; the method set isn't
+        // recoverable from the layout, so no endpoint is synthesized (yet).
+        let scanner = SwcScanner::new();
+        let content = "export default function handler(req, res) {}\n";
+        let endpoints = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            Path::new("pages/api/users.ts"),
+            Path::new("pages/api/users.ts"),
+            content,
+            &next_conventions(),
+        );
+        assert!(endpoints.is_empty());
+    }
+
+    #[test]
+    fn test_file_based_endpoints_non_route_file() {
+        let scanner = SwcScanner::new();
+        let content = "export async function GET() {}\n";
+        let endpoints = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            Path::new("src/services/users.ts"),
+            Path::new("src/services/users.ts"),
+            content,
+            &next_conventions(),
+        );
+        assert!(
+            endpoints.is_empty(),
+            "non-route files should yield no file-based endpoints"
+        );
+    }
+
+    #[test]
+    fn test_file_based_endpoints_no_conventions_is_noop() {
+        let scanner = SwcScanner::new();
+        let content = "export async function GET() {}\n";
+        // No convention-bearing framework detected → empty conventions.
+        let endpoints = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            Path::new("app/users/route.ts"),
+            Path::new("app/users/route.ts"),
+            content,
+            &builtin_conventions(&["express".to_string()]),
+        );
+        assert!(endpoints.is_empty());
+    }
+
+    fn synthetic_endpoint(method: &str, path: &str) -> EndpointResult {
+        EndpointResult {
+            candidate_id: format!("file-route:{}:0", method),
+            line_number: 1,
+            owner_node: FILE_BASED_ROUTE_OWNER.to_string(),
+            method: method.to_string(),
+            path: path.to_string(),
+            handler_name: method.to_string(),
+            pattern_matched: "nextjs-app".to_string(),
+            call_expression_span_start: Some(0),
+            call_expression_span_end: Some(1),
+            payload_expression_text: None,
+            payload_expression_line: None,
+            response_expression_text: None,
+            response_expression_line: None,
+            primary_type_symbol: None,
+            type_import_source: None,
+        }
+    }
+
+    #[test]
+    fn test_merge_file_based_endpoints_dedups_by_method_and_path() {
+        let mut result = FileAnalysisResult {
+            // The LLM pass already produced GET /users (e.g. via a Response.json
+            // candidate). The structural entry for it must not be duplicated.
+            endpoints: vec![synthetic_endpoint("GET", "/users")],
+            ..Default::default()
+        };
+
+        let added = FileOrchestrator::merge_file_based_endpoints(
+            &mut result,
+            vec![
+                synthetic_endpoint("get", "/users"), // duplicate (case-insensitive method)
+                synthetic_endpoint("POST", "/users"), // new method, same path
+            ],
+        );
+
+        assert_eq!(added, 1);
+        assert_eq!(result.endpoints.len(), 2);
+        assert!(result
+            .endpoints
+            .iter()
+            .any(|e| e.method == "POST" && e.path == "/users"));
     }
 }

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -174,8 +174,14 @@ impl FileOrchestrator {
                 continue;
             }
 
-            // STEP 1: Run SWC Scanner (Gatekeeper)
-            let scan_result = self.swc_scanner.scan_content(file_path, &content);
+            // STEP 1: Run SWC Scanner (Gatekeeper). Pass the LLM-detected
+            // data-fetching packages so import-based recall uses detection's
+            // decision rather than a hardcoded package list.
+            let scan_result = self.swc_scanner.scan_content(
+                file_path,
+                &content,
+                &framework_detection.data_fetchers,
+            );
 
             // STEP 2: Check Relevance - if no candidates, SKIP (zero LLM cost)
             if !scan_result.should_analyze {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -574,7 +574,12 @@ async fn analyze_current_repo_incremental(
 
             let new_file_results = if !files_to_analyze.is_empty() {
                 let result = file_orchestrator
-                    .analyze_files(&files_to_analyze, &guidance, &detection)
+                    .analyze_files(
+                        &files_to_analyze,
+                        &guidance,
+                        &detection,
+                        Path::new(repo_path),
+                    )
                     .await?;
                 result.file_results
             } else {
@@ -1247,7 +1252,7 @@ async fn analyze_current_repo(
 
     // 4. Run the complete multi-agent analysis
     let analysis_result = orchestrator
-        .run_complete_analysis(files, &packages, &all_imported_symbols)
+        .run_complete_analysis(files, &packages, &all_imported_symbols, repo_path)
         .await?;
 
     // 4b. Generate function intents using LLM

--- a/src/file_based_router.rs
+++ b/src/file_based_router.rs
@@ -1,0 +1,453 @@
+//! Generic file-based routing: derive HTTP route paths from filesystem layout.
+//!
+//! Some frameworks (Next.js, Remix, SvelteKit, Nuxt, ...) declare API routes by
+//! *file location* rather than by a path string in code. The route `/users/:id`
+//! for `app/users/[id]/route.ts` appears nowhere in that file's bytes — it lives
+//! in the directory structure. The LLM pipeline cannot recover information that
+//! is absent from the source it reads, so this module supplies that one
+//! structural fact deterministically.
+//!
+//! The module is framework-agnostic: it executes a [`RoutingConvention`] (plain
+//! data), never a hardcoded framework branch. Built-in conventions
+//! ([`builtin_conventions`]) exist only as a *bootstrap* so common stacks work
+//! out of the box; a convention supplied by framework detection (carrick-cloud)
+//! or by `carrick.json` overrides them. This keeps framework knowledge out of
+//! the scanner core while still shipping value today.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// How the HTTP method of a file-based endpoint is determined.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MethodSource {
+    /// The HTTP method is the name of an exported handler function, e.g.
+    /// Next.js app-router `export async function GET(...) {}`.
+    ExportName,
+    /// A single default-exported handler serves every method and branches on the
+    /// request at runtime (e.g. pages-router `req.method`). The concrete method
+    /// is not derivable from structure and is left to the LLM / downstream.
+    DefaultExport,
+}
+
+/// Whether route path segments come from the directory chain (with a fixed
+/// terminal filename) or from the filename itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum SegmentSource {
+    /// App-router style: the endpoint is marked by a fixed terminal filename
+    /// (e.g. `route.ts`); the path is built from the enclosing directory chain.
+    DirectoryChain { terminal_files: Vec<String> },
+    /// Pages-router style: the filename (minus extension) is the final path
+    /// segment. `index` collapses to its directory.
+    FileName { extensions: Vec<String> },
+}
+
+/// A declarative description of a file-based routing scheme. Executed by
+/// [`derive_route`]; never branched on by framework name.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoutingConvention {
+    /// Human label (e.g. "nextjs-app"). Diagnostic only — not matched against.
+    pub name: String,
+    /// Directory prefixes (repo-relative, `/`-separated) under which route files
+    /// live, e.g. `["app", "src/app"]`. The longest matching root wins.
+    pub root_globs: Vec<String>,
+    /// Where path segments come from.
+    pub segment_source: SegmentSource,
+    /// Prefix prepended to every derived path, e.g. `""` or `"/api"`.
+    #[serde(default)]
+    pub path_prefix: String,
+    /// Opening delimiter for a dynamic segment, e.g. `"["`.
+    pub dynamic_open: String,
+    /// Closing delimiter for a dynamic segment, e.g. `"]"`.
+    pub dynamic_close: String,
+    /// Marker that turns a dynamic segment into a catch-all, e.g. `"..."`.
+    pub catch_all_marker: String,
+    /// Opening delimiter for a non-path "group" segment, e.g. `"("`.
+    pub group_open: String,
+    /// Closing delimiter for a non-path "group" segment, e.g. `")"`.
+    pub group_close: String,
+    /// How the HTTP method is determined for endpoints under this convention.
+    pub method_source: MethodSource,
+}
+
+/// A route successfully derived from a file's location.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivedRoute {
+    /// The normalized route path (leading slash, `:param` for dynamic segments,
+    /// `*` for catch-alls).
+    pub path: String,
+    /// How to determine the HTTP method(s) for this endpoint.
+    pub method_source: MethodSource,
+    /// The convention name that matched (diagnostic).
+    pub convention: String,
+}
+
+impl RoutingConvention {
+    /// Next.js App Router: `app/**/route.{ts,js,tsx}` with method-per-export.
+    pub fn nextjs_app() -> Self {
+        Self {
+            name: "nextjs-app".to_string(),
+            root_globs: vec!["app".to_string(), "src/app".to_string()],
+            segment_source: SegmentSource::DirectoryChain {
+                terminal_files: vec![
+                    "route.ts".to_string(),
+                    "route.js".to_string(),
+                    "route.tsx".to_string(),
+                    "route.mts".to_string(),
+                ],
+            },
+            path_prefix: String::new(),
+            dynamic_open: "[".to_string(),
+            dynamic_close: "]".to_string(),
+            catch_all_marker: "...".to_string(),
+            group_open: "(".to_string(),
+            group_close: ")".to_string(),
+            method_source: MethodSource::ExportName,
+        }
+    }
+
+    /// Next.js Pages Router API: `pages/api/**` (or `src/pages/api/**`) where the
+    /// filename is the last segment and a single default export serves the route.
+    pub fn nextjs_pages() -> Self {
+        Self {
+            name: "nextjs-pages".to_string(),
+            root_globs: vec!["pages/api".to_string(), "src/pages/api".to_string()],
+            segment_source: SegmentSource::FileName {
+                extensions: vec![
+                    "ts".to_string(),
+                    "js".to_string(),
+                    "tsx".to_string(),
+                    "jsx".to_string(),
+                ],
+            },
+            path_prefix: "/api".to_string(),
+            dynamic_open: "[".to_string(),
+            dynamic_close: "]".to_string(),
+            catch_all_marker: "...".to_string(),
+            group_open: "(".to_string(),
+            group_close: ")".to_string(),
+            method_source: MethodSource::DefaultExport,
+        }
+    }
+
+    /// Strip the longest matching root prefix from a `/`-normalized relative
+    /// path. Returns the remainder, or `None` if no root matches.
+    fn strip_root<'a>(&self, rel: &'a str) -> Option<&'a str> {
+        self.root_globs
+            .iter()
+            .filter_map(|root| {
+                let root = root.trim_matches('/');
+                if root.is_empty() {
+                    return Some(rel);
+                }
+                if let Some(rest) = rel.strip_prefix(root) {
+                    // Require a clean segment boundary so "apple/" doesn't match
+                    // root "app".
+                    if rest.is_empty() {
+                        Some("")
+                    } else {
+                        rest.strip_prefix('/')
+                    }
+                } else {
+                    None
+                }
+            })
+            // Longest matching root wins (e.g. "src/pages/api" over "pages/api").
+            .max_by_key(|rest| rest.len().wrapping_neg())
+    }
+
+    /// Transform a single raw directory/file segment into its route form.
+    /// Returns `None` for group segments (which contribute no path segment).
+    fn transform_segment(&self, raw: &str) -> Option<String> {
+        // Group segment, e.g. "(marketing)" → omitted.
+        if !self.group_open.is_empty()
+            && raw.starts_with(&self.group_open)
+            && raw.ends_with(&self.group_close)
+        {
+            return None;
+        }
+
+        // Optional catch-all "[[...slug]]" → also handled as catch-all (we emit a
+        // single concrete route; the optional/empty case is a superset match).
+        let double_open = format!("{}{}", self.dynamic_open, self.dynamic_open);
+        let double_close = format!("{}{}", self.dynamic_close, self.dynamic_close);
+        if raw.starts_with(&double_open) && raw.ends_with(&double_close) {
+            let inner = &raw[double_open.len()..raw.len() - double_close.len()];
+            let name = inner.strip_prefix(&self.catch_all_marker).unwrap_or(inner);
+            return Some(format!("*{}", sanitize_param(name)));
+        }
+
+        // Dynamic segment "[id]" or catch-all "[...slug]".
+        if raw.starts_with(&self.dynamic_open) && raw.ends_with(&self.dynamic_close) {
+            let inner = &raw[self.dynamic_open.len()..raw.len() - self.dynamic_close.len()];
+            if let Some(name) = inner.strip_prefix(&self.catch_all_marker) {
+                return Some(format!("*{}", sanitize_param(name)));
+            }
+            return Some(format!(":{}", sanitize_param(inner)));
+        }
+
+        // Literal segment.
+        Some(raw.to_string())
+    }
+
+    /// Build the list of raw segments for a relative path under this convention,
+    /// or `None` if the file is not a route file for this convention.
+    fn raw_segments(&self, rel_after_root: &str) -> Option<Vec<String>> {
+        let components: Vec<&str> = rel_after_root
+            .split('/')
+            .filter(|c| !c.is_empty())
+            .collect();
+        let (file, dirs) = components.split_last()?;
+
+        match &self.segment_source {
+            SegmentSource::DirectoryChain { terminal_files } => {
+                // The file must be one of the terminal markers (e.g. route.ts).
+                if !terminal_files.iter().any(|t| t == file) {
+                    return None;
+                }
+                Some(dirs.iter().map(|s| s.to_string()).collect())
+            }
+            SegmentSource::FileName { extensions } => {
+                // Skip framework-private files like _app / _document / _middleware.
+                if file.starts_with('_') {
+                    return None;
+                }
+                let (stem, ext) = file.rsplit_once('.')?;
+                if !extensions.iter().any(|e| e == ext) {
+                    return None;
+                }
+                let mut segs: Vec<String> = dirs.iter().map(|s| s.to_string()).collect();
+                // `index` collapses to its directory; otherwise the stem is the
+                // final segment.
+                if stem != "index" {
+                    segs.push(stem.to_string());
+                }
+                Some(segs)
+            }
+        }
+    }
+}
+
+/// Replace characters illegal in a route param name (e.g. catch-all dots).
+fn sanitize_param(name: &str) -> String {
+    name.trim().replace('.', "")
+}
+
+/// Normalize OS path separators to `/` and strip any leading `./` or `/`.
+fn normalize_rel(rel: &Path) -> String {
+    let s = rel.to_string_lossy().replace('\\', "/");
+    s.trim_start_matches("./")
+        .trim_start_matches('/')
+        .to_string()
+}
+
+/// Derive a route from a repo-relative file path using the first convention that
+/// claims it. Returns `None` when no convention recognizes the file.
+pub fn derive_route(rel_path: &Path, conventions: &[RoutingConvention]) -> Option<DerivedRoute> {
+    let rel = normalize_rel(rel_path);
+    for convention in conventions {
+        let Some(after_root) = convention.strip_root(&rel) else {
+            continue;
+        };
+        let Some(raw_segments) = convention.raw_segments(after_root) else {
+            continue;
+        };
+
+        let mut path = String::new();
+        for seg in &raw_segments {
+            if let Some(transformed) = convention.transform_segment(seg) {
+                path.push('/');
+                path.push_str(&transformed);
+            }
+        }
+
+        let prefix = convention.path_prefix.trim_end_matches('/');
+        let mut full = format!("{}{}", prefix, path);
+        if full.is_empty() {
+            full = "/".to_string();
+        }
+        return Some(DerivedRoute {
+            path: full,
+            method_source: convention.method_source.clone(),
+            convention: convention.name.clone(),
+        });
+    }
+    None
+}
+
+/// Bootstrap conventions for detected frameworks. This is the *only* place a
+/// framework name appears in the scanner; a convention supplied by detection or
+/// `carrick.json` should be preferred over these (see module docs).
+pub fn builtin_conventions(frameworks: &[String]) -> Vec<RoutingConvention> {
+    let mentions = |needle: &str| frameworks.iter().any(|f| f.to_lowercase().contains(needle));
+    let mut out = Vec::new();
+    if mentions("next") {
+        out.push(RoutingConvention::nextjs_app());
+        out.push(RoutingConvention::nextjs_pages());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn next() -> Vec<RoutingConvention> {
+        vec![
+            RoutingConvention::nextjs_app(),
+            RoutingConvention::nextjs_pages(),
+        ]
+    }
+
+    fn route(p: &str) -> Option<DerivedRoute> {
+        derive_route(&PathBuf::from(p), &next())
+    }
+
+    // --- App Router ---
+
+    #[test]
+    fn app_router_static() {
+        let r = route("app/users/route.ts").unwrap();
+        assert_eq!(r.path, "/users");
+        assert_eq!(r.method_source, MethodSource::ExportName);
+        assert_eq!(r.convention, "nextjs-app");
+    }
+
+    #[test]
+    fn app_router_root() {
+        assert_eq!(route("app/route.ts").unwrap().path, "/");
+    }
+
+    #[test]
+    fn app_router_dynamic() {
+        assert_eq!(route("app/users/[id]/route.ts").unwrap().path, "/users/:id");
+    }
+
+    #[test]
+    fn app_router_nested_dynamic() {
+        assert_eq!(
+            route("app/teams/[teamId]/members/[userId]/route.ts")
+                .unwrap()
+                .path,
+            "/teams/:teamId/members/:userId"
+        );
+    }
+
+    #[test]
+    fn app_router_catch_all() {
+        assert_eq!(
+            route("app/files/[...slug]/route.ts").unwrap().path,
+            "/files/*slug"
+        );
+    }
+
+    #[test]
+    fn app_router_optional_catch_all() {
+        assert_eq!(
+            route("app/shop/[[...slug]]/route.ts").unwrap().path,
+            "/shop/*slug"
+        );
+    }
+
+    #[test]
+    fn app_router_strips_route_groups() {
+        assert_eq!(
+            route("app/(marketing)/about/route.ts").unwrap().path,
+            "/about"
+        );
+    }
+
+    #[test]
+    fn app_router_src_prefix() {
+        assert_eq!(route("src/app/health/route.ts").unwrap().path, "/health");
+    }
+
+    #[test]
+    fn app_router_ignores_non_route_files() {
+        assert!(route("app/users/page.tsx").is_none());
+        assert!(route("app/users/layout.tsx").is_none());
+        assert!(route("app/users/component.ts").is_none());
+    }
+
+    // --- Pages Router ---
+
+    #[test]
+    fn pages_api_static() {
+        let r = route("pages/api/users.ts").unwrap();
+        assert_eq!(r.path, "/api/users");
+        assert_eq!(r.method_source, MethodSource::DefaultExport);
+        assert_eq!(r.convention, "nextjs-pages");
+    }
+
+    #[test]
+    fn pages_api_index_collapses() {
+        assert_eq!(
+            route("pages/api/users/index.ts").unwrap().path,
+            "/api/users"
+        );
+        assert_eq!(route("pages/api/index.ts").unwrap().path, "/api");
+    }
+
+    #[test]
+    fn pages_api_dynamic_filename() {
+        assert_eq!(
+            route("pages/api/users/[id].ts").unwrap().path,
+            "/api/users/:id"
+        );
+    }
+
+    #[test]
+    fn pages_api_catch_all_filename() {
+        assert_eq!(
+            route("pages/api/proxy/[...path].ts").unwrap().path,
+            "/api/proxy/*path"
+        );
+    }
+
+    #[test]
+    fn pages_api_src_prefix() {
+        assert_eq!(route("src/pages/api/ping.ts").unwrap().path, "/api/ping");
+    }
+
+    #[test]
+    fn pages_api_skips_private_files() {
+        assert!(route("pages/api/_middleware.ts").is_none());
+    }
+
+    // --- Negative / boundary ---
+
+    #[test]
+    fn non_route_paths_return_none() {
+        assert!(route("lib/db.ts").is_none());
+        assert!(route("components/Button.tsx").is_none());
+        // "app" prefix must respect segment boundaries.
+        assert!(route("application/route.ts").is_none());
+        // pages routes that aren't under /api are not API endpoints here.
+        assert!(route("pages/about.tsx").is_none());
+    }
+
+    #[test]
+    fn longest_root_wins() {
+        // Both "pages/api" and "src/pages/api" exist; the src-prefixed file must
+        // resolve via the longer root, not leave "src" in the path.
+        assert_eq!(route("src/pages/api/x.ts").unwrap().path, "/api/x");
+    }
+
+    #[test]
+    fn builtin_conventions_gated_on_framework() {
+        assert!(builtin_conventions(&["express".to_string()]).is_empty());
+        let next = builtin_conventions(&["Next.js".to_string()]);
+        assert_eq!(next.len(), 2);
+    }
+
+    #[test]
+    fn convention_roundtrips_through_serde() {
+        // The B-contract: a cloud/config-supplied convention must deserialize.
+        let c = RoutingConvention::nextjs_app();
+        let json = serde_json::to_string(&c).unwrap();
+        let back: RoutingConvention = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+    }
+}

--- a/src/file_based_router.rs
+++ b/src/file_based_router.rs
@@ -168,21 +168,22 @@ impl RoutingConvention {
             return None;
         }
 
-        // Optional catch-all "[[...slug]]" → also handled as catch-all (we emit a
-        // single concrete route; the optional/empty case is a superset match).
+        // Catch-all "[...slug]" / optional catch-all "[[...slug]]" → `**`, the
+        // multi-segment wildcard the mount graph matcher recognizes as a suffix
+        // catch-all (see `path_matches_with_wildcards` in src/mount_graph.rs).
+        // The param name plays no part in matching, so it is dropped. Catch-alls
+        // are always terminal in these conventions, so `**` lands at the end.
         let double_open = format!("{}{}", self.dynamic_open, self.dynamic_open);
         let double_close = format!("{}{}", self.dynamic_close, self.dynamic_close);
         if raw.starts_with(&double_open) && raw.ends_with(&double_close) {
-            let inner = &raw[double_open.len()..raw.len() - double_close.len()];
-            let name = inner.strip_prefix(&self.catch_all_marker).unwrap_or(inner);
-            return Some(format!("*{}", sanitize_param(name)));
+            return Some("**".to_string());
         }
 
         // Dynamic segment "[id]" or catch-all "[...slug]".
         if raw.starts_with(&self.dynamic_open) && raw.ends_with(&self.dynamic_close) {
             let inner = &raw[self.dynamic_open.len()..raw.len() - self.dynamic_close.len()];
-            if let Some(name) = inner.strip_prefix(&self.catch_all_marker) {
-                return Some(format!("*{}", sanitize_param(name)));
+            if inner.starts_with(&self.catch_all_marker) {
+                return Some("**".to_string());
             }
             return Some(format!(":{}", sanitize_param(inner)));
         }
@@ -339,7 +340,7 @@ mod tests {
     fn app_router_catch_all() {
         assert_eq!(
             route("app/files/[...slug]/route.ts").unwrap().path,
-            "/files/*slug"
+            "/files/**"
         );
     }
 
@@ -347,7 +348,7 @@ mod tests {
     fn app_router_optional_catch_all() {
         assert_eq!(
             route("app/shop/[[...slug]]/route.ts").unwrap().path,
-            "/shop/*slug"
+            "/shop/**"
         );
     }
 
@@ -402,7 +403,7 @@ mod tests {
     fn pages_api_catch_all_filename() {
         assert_eq!(
             route("pages/api/proxy/[...path].ts").unwrap().path,
-            "/api/proxy/*path"
+            "/api/proxy/**"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cloud_storage;
 pub mod config;
 pub mod engine;
 pub mod extractor;
+pub mod file_based_router;
 pub mod file_finder;
 pub mod formatter;
 pub mod framework_detector;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod cloud_storage;
 mod config;
 mod engine;
 mod extractor;
+mod file_based_router;
 mod file_finder;
 mod formatter;
 mod framework_detector;

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -1219,6 +1219,15 @@ mod tests {
         assert!(graph.path_matches_with_wildcards("/api/*", "/api/users"));
         assert!(graph.path_matches_with_wildcards("/api/**", "/api/users/123/orders"));
         assert!(graph.path_matches_with_wildcards("/files/(.*)", "/files/path/to/file.txt"));
+
+        // Regression: file-based routing synthesizes Next.js catch-all routes
+        // (`app/files/[...slug]/route.ts`) as `/files/**`, which must match
+        // single- and multi-segment caller URLs. A named catch-all (the old
+        // `*slug` emission) would be treated as a literal and NOT match —
+        // guards against regressing the router.
+        assert!(graph.path_matches_with_wildcards("/files/**", "/files/foo"));
+        assert!(graph.path_matches_with_wildcards("/files/**", "/files/foo/bar"));
+        assert!(!graph.path_matches_with_wildcards("/files/*slug", "/files/foo"));
     }
 
     #[test]

--- a/src/multi_agent_orchestrator.rs
+++ b/src/multi_agent_orchestrator.rs
@@ -79,6 +79,7 @@ impl MultiAgentOrchestrator {
         files: Vec<std::path::PathBuf>,
         packages: &Packages,
         imported_symbols: &HashMap<String, ImportedSymbol>,
+        repo_path: &str,
     ) -> Result<MultiAgentAnalysisResult, Box<dyn std::error::Error>> {
         debug!("Starting AST-Gated File-Centric analysis...");
 
@@ -113,7 +114,12 @@ impl MultiAgentOrchestrator {
         debug!("=== Stage 2: AST-Gated File-Centric Analysis ===");
         let file_orchestrator = FileOrchestrator::new(self.agent_service.clone());
         let file_centric_result = file_orchestrator
-            .analyze_files(&files, &framework_guidance, &framework_detection)
+            .analyze_files(
+                &files,
+                &framework_guidance,
+                &framework_detection,
+                std::path::Path::new(repo_path),
+            )
             .await?;
 
         self.print_analysis_summary(&file_centric_result);

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -14,6 +14,7 @@
 //! of the compiler sidecar architecture migration.
 
 use serde::Serialize;
+use std::collections::HashSet;
 use std::path::Path;
 use swc_common::{
     SourceMap, SourceMapper, Spanned,
@@ -129,7 +130,7 @@ impl SwcScanner {
     /// Returns a ScanResult with candidates and whether the file should be analyzed.
     /// If no candidates are found, `should_analyze` is false and the file can be skipped.
     #[allow(dead_code)]
-    pub fn scan_file(&self, file_path: &Path) -> ScanResult {
+    pub fn scan_file(&self, file_path: &Path, data_fetchers: &[String]) -> ScanResult {
         let handler = Handler::with_tty_emitter(
             ColorConfig::Never,
             true,
@@ -147,7 +148,10 @@ impl SwcScanner {
             }
         };
 
-        let mut visitor = CandidateVisitor::new(self.source_map.clone());
+        let mut visitor = CandidateVisitor::new(
+            self.source_map.clone(),
+            network_import_locals(&module, data_fetchers),
+        );
         module.visit_with(&mut visitor);
 
         let should_analyze = !visitor.candidates.is_empty();
@@ -163,7 +167,12 @@ impl SwcScanner {
     /// Creates a fresh SourceMap for each call to ensure per-file byte offsets.
     /// Previously, reusing `self.source_map` caused cumulative offset accumulation
     /// when scanning multiple files, breaking span-based type inference in the sidecar.
-    pub fn scan_content(&self, file_path: &Path, content: &str) -> ScanResult {
+    pub fn scan_content(
+        &self,
+        file_path: &Path,
+        content: &str,
+        data_fetchers: &[String],
+    ) -> ScanResult {
         use swc_common::{FileName, GLOBALS, Globals, Mark};
         use swc_ecma_parser::{Parser, StringInput, Syntax, lexer::Lexer};
         use swc_ecma_transforms_base::resolver;
@@ -238,7 +247,10 @@ impl SwcScanner {
             module.visit_mut_with(&mut pass);
         });
 
-        let mut visitor = CandidateVisitor::new(file_source_map);
+        let mut visitor = CandidateVisitor::new(
+            file_source_map,
+            network_import_locals(&module, data_fetchers),
+        );
         module.visit_with(&mut visitor);
 
         let should_analyze = !visitor.candidates.is_empty();
@@ -351,14 +363,29 @@ struct CandidateVisitor {
     candidates: Vec<CandidateTarget>,
     source_map: Lrc<SourceMap>,
     function_stack: Vec<String>,
+    /// Local binding names imported from a known network/data-fetching package
+    /// (e.g. `axios` from `import axios from 'axios'`). Calls rooted at one of
+    /// these are emitted as candidates regardless of method name, so bespoke
+    /// client wrappers (`client.users.list()`) are not missed.
+    network_import_locals: HashSet<String>,
+    /// Span ranges already emitted, so the broadened signals below don't push
+    /// the same call site twice (candidate ids are span-based).
+    seen_spans: HashSet<(u32, u32)>,
+    /// Depth of enclosing `await` expressions. An awaited call with a string
+    /// argument is a strong network-call signal even when the callee name is
+    /// unknown.
+    await_depth: usize,
 }
 
 impl CandidateVisitor {
-    fn new(source_map: Lrc<SourceMap>) -> Self {
+    fn new(source_map: Lrc<SourceMap>, network_import_locals: HashSet<String>) -> Self {
         Self {
             candidates: Vec::new(),
             source_map,
             function_stack: Vec::new(),
+            network_import_locals,
+            seen_spans: HashSet::new(),
+            await_depth: 0,
         }
     }
 
@@ -447,14 +474,95 @@ impl CandidateVisitor {
         api_methods.contains(&name.to_lowercase().as_str())
     }
 
-    /// Check if this is a global fetch call
-    fn is_global_fetch(&self, callee: &Callee) -> bool {
+    /// Check if this is a call to a global network primitive (`fetch(...)`).
+    /// Other primitives (`WebSocket`, `EventSource`, `XMLHttpRequest`) are
+    /// constructed with `new` and handled in `visit_new_expr`.
+    fn is_global_network_call(&self, callee: &Callee) -> bool {
         if let Callee::Expr(expr) = callee
             && let Expr::Ident(ident) = &**expr
         {
-            return ident.sym.as_ref() == "fetch";
+            return matches!(ident.sym.as_ref(), "fetch");
         }
         false
+    }
+
+    /// Root identifier of a callee expression, e.g. `client` in
+    /// `client.users.list()` or `client(...)`.
+    fn callee_root_ident(expr: &Expr) -> Option<String> {
+        match expr {
+            Expr::Ident(ident) => Some(ident.sym.to_string()),
+            Expr::Member(member) => Self::callee_root_ident(&member.obj),
+            Expr::Call(call) => match &call.callee {
+                Callee::Expr(e) => Self::callee_root_ident(e),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Does the first argument look like a URL (has a network scheme)? This is a
+    /// low-noise structural signal that catches bespoke clients without naming
+    /// them, e.g. `httpClient('https://api.example.com/users')`.
+    fn first_arg_has_url_scheme(call: &CallExpr) -> bool {
+        let Some(arg) = call.args.first() else {
+            return false;
+        };
+        let starts_with_scheme = |s: &str| {
+            let s = s.trim_start();
+            s.starts_with("http://")
+                || s.starts_with("https://")
+                || s.starts_with("ws://")
+                || s.starts_with("wss://")
+                || s.starts_with("//")
+        };
+        match &*arg.expr {
+            Expr::Lit(Lit::Str(s)) => starts_with_scheme(s.value.as_ref()),
+            Expr::Tpl(tpl) => tpl
+                .quasis
+                .first()
+                .map(|q| starts_with_scheme(q.raw.as_ref()))
+                .unwrap_or(false),
+            _ => false,
+        }
+    }
+
+    /// Is the first argument a string or template literal? Combined with an
+    /// enclosing `await`, this flags awaited calls like `await load('/data')`.
+    fn first_arg_is_stringish(call: &CallExpr) -> bool {
+        matches!(
+            call.args.first().map(|a| &*a.expr),
+            Some(Expr::Lit(Lit::Str(_))) | Some(Expr::Tpl(_))
+        )
+    }
+
+    /// Emit a candidate for `call`, deduplicating by span so the multiple
+    /// broadened signals never double-count one call site.
+    fn push_candidate(
+        &mut self,
+        call: &CallExpr,
+        callee_object: String,
+        callee_property: Option<String>,
+    ) {
+        let (span_start, span_end) = self.span_range(call.span);
+        if !self.seen_spans.insert((span_start, span_end)) {
+            return;
+        }
+        let line_number = self.get_line_number(call.span);
+        let candidate_id = self.candidate_id(span_start, span_end);
+        let code_snippet = self.get_code_snippet(call.span);
+        let path_snippet = self.extract_first_arg_snippet(call);
+
+        self.candidates.push(CandidateTarget {
+            candidate_id,
+            span_start,
+            span_end,
+            line_number,
+            callee_object,
+            callee_property,
+            enclosing_function: self.current_function(),
+            path_snippet,
+            code_snippet,
+        });
     }
 
     /// Extract a code snippet for the given span
@@ -574,20 +682,48 @@ impl Visit for CandidateVisitor {
         if let Expr::Call(call) = &*node.expr
             && let Callee::Expr(callee_expr) = &call.callee
         {
-            let callee_name = Self::extract_callee_object(callee_expr);
-            if let Some(name) = callee_name {
-                let line_number = self.get_line_number(call.span);
-                let (span_start, span_end) = self.span_range(call.span);
-                let candidate_id = self.candidate_id(span_start, span_end);
-                let code_snippet = self.get_code_snippet(call.span);
-                let path_snippet = self.extract_first_arg_snippet(call);
+            if let Some(name) = Self::extract_callee_object(callee_expr) {
+                self.push_candidate(call, name, None);
+            }
+        }
+        node.visit_children_with(self);
+    }
 
+    fn visit_await_expr(&mut self, node: &AwaitExpr) {
+        self.await_depth += 1;
+        node.visit_children_with(self);
+        self.await_depth -= 1;
+    }
+
+    fn visit_new_expr(&mut self, node: &NewExpr) {
+        // Network primitives constructed with `new`: `new WebSocket(url)`,
+        // `new EventSource(url)`, `new XMLHttpRequest()`. Emitting these as
+        // candidates keeps files using them from being skipped by the gate.
+        if let Expr::Ident(ident) = &*node.callee
+            && matches!(
+                ident.sym.as_ref(),
+                "WebSocket" | "EventSource" | "XMLHttpRequest"
+            )
+        {
+            // NewExpr args are optional; build a throwaway CallExpr view is not
+            // possible, so push directly with span dedup.
+            let (span_start, span_end) = self.span_range(node.span);
+            if self.seen_spans.insert((span_start, span_end)) {
+                let line_number = self.get_line_number(node.span);
+                let candidate_id = self.candidate_id(span_start, span_end);
+                let code_snippet = self.get_code_snippet(node.span);
+                let path_snippet = node
+                    .args
+                    .as_ref()
+                    .and_then(|args| args.first())
+                    .and_then(|a| self.source_map.span_to_snippet(a.expr.span()).ok())
+                    .map(|s| s.lines().next().unwrap_or("").chars().take(120).collect());
                 self.candidates.push(CandidateTarget {
                     candidate_id,
                     span_start,
                     span_end,
                     line_number,
-                    callee_object: name,
+                    callee_object: ident.sym.to_string(),
                     callee_property: None,
                     enclosing_function: self.current_function(),
                     path_snippet,
@@ -599,32 +735,54 @@ impl Visit for CandidateVisitor {
     }
 
     fn visit_call_expr(&mut self, call: &CallExpr) {
-        // Check for global fetch
-        if self.is_global_fetch(&call.callee) {
-            let line_number = self.get_line_number(call.span);
-            let (span_start, span_end) = self.span_range(call.span);
-            let candidate_id = self.candidate_id(span_start, span_end);
-            let code_snippet = self.get_code_snippet(call.span);
-            let path_snippet = self.extract_first_arg_snippet(call);
-
-            self.candidates.push(CandidateTarget {
-                candidate_id,
-                span_start,
-                span_end,
-                line_number,
-                callee_object: "fetch".to_string(),
-                callee_property: None,
-                enclosing_function: self.current_function(),
-                path_snippet,
-                code_snippet,
-            });
+        // Signal 1: global fetch primitive.
+        if self.is_global_network_call(&call.callee) {
+            self.push_candidate(call, "fetch".to_string(), None);
         }
 
-        // Check for method calls (obj.method())
+        // Signal 2: call rooted at an identifier imported from a known
+        // network/data-fetching package (covers wrappers regardless of method
+        // name), or direct invocation of such an import (`client(url)`).
+        if let Callee::Expr(callee_expr) = &call.callee
+            && let Some(root) = Self::callee_root_ident(callee_expr)
+            && self.network_import_locals.contains(&root)
+        {
+            let property = match &**callee_expr {
+                Expr::Member(member) => match &member.prop {
+                    MemberProp::Ident(id) => Some(id.sym.to_string()),
+                    _ => None,
+                },
+                _ => None,
+            };
+            self.push_candidate(call, root, property);
+        }
+
+        // Signal 3: first argument is a URL with a network scheme.
+        if Self::first_arg_has_url_scheme(call) {
+            let obj = match &call.callee {
+                Callee::Expr(e) => {
+                    Self::extract_callee_object(e).unwrap_or_else(|| "<url-call>".to_string())
+                }
+                _ => "<url-call>".to_string(),
+            };
+            self.push_candidate(call, obj, None);
+        }
+
+        // Signal 4: awaited call with a string/template argument.
+        if self.await_depth > 0 && Self::first_arg_is_stringish(call) {
+            let obj = match &call.callee {
+                Callee::Expr(e) => {
+                    Self::extract_callee_object(e).unwrap_or_else(|| "<awaited-call>".to_string())
+                }
+                _ => "<awaited-call>".to_string(),
+            };
+            self.push_candidate(call, obj, None);
+        }
+
+        // Signal 5 (existing): method calls matching the API name heuristics.
         if let Callee::Expr(callee_expr) = &call.callee
             && let Expr::Member(member) = &**callee_expr
         {
-            // Extract method name
             let method_name = match &member.prop {
                 MemberProp::Ident(ident) => Some(ident.sym.to_string()),
                 MemberProp::Computed(computed) => {
@@ -638,10 +796,8 @@ impl Visit for CandidateVisitor {
             };
 
             if let Some(method) = method_name {
-                // Extract object name
                 let obj_name = Self::extract_callee_object(&member.obj);
 
-                // Check if this looks like an API call
                 let is_api_call = match &obj_name {
                     Some(name) => {
                         self.is_potential_api_object(name) || self.is_potential_api_method(&method)
@@ -650,23 +806,11 @@ impl Visit for CandidateVisitor {
                 };
 
                 if is_api_call {
-                    let line_number = self.get_line_number(call.span);
-                    let (span_start, span_end) = self.span_range(call.span);
-                    let candidate_id = self.candidate_id(span_start, span_end);
-                    let code_snippet = self.get_code_snippet(call.span);
-                    let path_snippet = self.extract_first_arg_snippet(call);
-
-                    self.candidates.push(CandidateTarget {
-                        candidate_id,
-                        span_start,
-                        span_end,
-                        line_number,
-                        callee_object: obj_name.unwrap_or_else(|| "<chain>".to_string()),
-                        callee_property: Some(method),
-                        enclosing_function: self.current_function(),
-                        path_snippet,
-                        code_snippet,
-                    });
+                    self.push_candidate(
+                        call,
+                        obj_name.unwrap_or_else(|| "<chain>".to_string()),
+                        Some(method),
+                    );
                 }
             }
         }
@@ -676,15 +820,59 @@ impl Visit for CandidateVisitor {
     }
 }
 
+/// Collect the local binding names introduced by imports from any of the
+/// `data_fetchers` packages, covering default, named (incl. aliases), and
+/// namespace imports. Matched exactly or as a scope/subpath prefix
+/// (`pkg`, `@scope/pkg`, `pkg/sub`).
+///
+/// `data_fetchers` comes from framework detection — the LLM decides which of the
+/// repo's dependencies are data-fetching libraries — so the scanner carries no
+/// hardcoded package list. This is a recall booster for the gatekeeper, not an
+/// authoritative classification: the LLM still decides what each call is.
+fn network_import_locals(module: &Module, data_fetchers: &[String]) -> HashSet<String> {
+    let is_data_fetcher = |src: &str| {
+        data_fetchers
+            .iter()
+            .any(|pkg| src == pkg || src.starts_with(&format!("{}/", pkg)))
+    };
+    let mut locals = HashSet::new();
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
+            continue;
+        };
+        if !is_data_fetcher(import.src.value.as_ref()) {
+            continue;
+        }
+        for spec in &import.specifiers {
+            match spec {
+                ImportSpecifier::Default(d) => {
+                    locals.insert(d.local.sym.to_string());
+                }
+                ImportSpecifier::Named(n) => {
+                    locals.insert(n.local.sym.to_string());
+                }
+                ImportSpecifier::Namespace(ns) => {
+                    locals.insert(ns.local.sym.to_string());
+                }
+            }
+        }
+    }
+    locals
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;
 
     fn scan_test_content(content: &str) -> ScanResult {
+        scan_test_content_with_fetchers(content, &[])
+    }
+
+    fn scan_test_content_with_fetchers(content: &str, data_fetchers: &[String]) -> ScanResult {
         let scanner = SwcScanner::new();
         let path = PathBuf::from("test.ts");
-        scanner.scan_content(&path, content)
+        scanner.scan_content(&path, content, data_fetchers)
     }
 
     fn handler_names(content: &str) -> Vec<String> {
@@ -724,6 +912,66 @@ export default function handler() {}
     fn exported_handlers_empty_when_no_exports() {
         let content = "const x = 1; function f() {}";
         assert!(handler_names(content).is_empty());
+    }
+
+    #[test]
+    fn detects_imported_client_wrapper_calls() {
+        // `sdk`/`doThing` match none of the name heuristics; only the
+        // import-based signal catches this, and only because detection flagged
+        // `got` as a data fetcher (no hardcoded package list in the scanner).
+        let content = r#"
+import sdk from 'got';
+async function run() { return sdk.doThing(); }
+"#;
+        let fetchers = vec!["got".to_string()];
+        assert!(scan_test_content_with_fetchers(content, &fetchers).should_analyze);
+        // Without detection flagging the package, the wrapper call is invisible
+        // to the import signal (the other signals don't apply here either).
+        assert!(!scan_test_content(content).should_analyze);
+    }
+
+    #[test]
+    fn detects_url_scheme_first_arg() {
+        let content = r#"function run() { return notanapi('https://api.example.com/users'); }"#;
+        assert!(scan_test_content(content).should_analyze);
+    }
+
+    #[test]
+    fn detects_new_network_primitives() {
+        let content =
+            r#"function run() { const ws = new WebSocket('wss://example.com'); return ws; }"#;
+        assert!(scan_test_content(content).should_analyze);
+    }
+
+    #[test]
+    fn detects_awaited_stringish_call() {
+        let content = r#"async function run() { return await loadData('/data.json'); }"#;
+        assert!(scan_test_content(content).should_analyze);
+    }
+
+    #[test]
+    fn ignores_non_network_code() {
+        let content = r#"
+function run() {
+    console.log('hello');
+    const x = compute(1, 2);
+    return x;
+}
+"#;
+        assert!(!scan_test_content(content).should_analyze);
+    }
+
+    #[test]
+    fn dedupes_candidate_spans_across_signals() {
+        // `await axios.get('https://x.com/y')` matches the import-local,
+        // url-scheme, awaited-stringish, and name heuristics simultaneously,
+        // but the single call site must yield exactly one candidate.
+        let content = r#"
+import axios from 'axios';
+async function run() { return await axios.get('https://x.com/y'); }
+"#;
+        let result = scan_test_content(content);
+        assert_eq!(result.candidates.len(), 1);
     }
 
     #[test]
@@ -929,8 +1177,8 @@ createRouter()
         let file_a_content = "fetch('/api/a');";
         let file_b_content = "fetch('/api/b');";
 
-        let result_a = scanner.scan_content(&PathBuf::from("a.ts"), file_a_content);
-        let result_b = scanner.scan_content(&PathBuf::from("b.ts"), file_b_content);
+        let result_a = scanner.scan_content(&PathBuf::from("a.ts"), file_a_content, &[]);
+        let result_b = scanner.scan_content(&PathBuf::from("b.ts"), file_b_content, &[]);
 
         assert!(
             !result_a.candidates.is_empty(),

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -86,6 +86,22 @@ pub struct ScanResult {
     pub should_analyze: bool,
 }
 
+/// A value exported from a module. Used by file-based routing to recover the
+/// HTTP method of an app-router handler (`export async function GET(...)`),
+/// which is structural information the call-site scanner does not capture.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportedHandler {
+    /// The exported binding name (`GET`, `POST`, …), or `"default"` for a
+    /// default export.
+    pub name: String,
+    /// 1-based line number of the export.
+    pub line_number: usize,
+    /// Start byte offset of the exported declaration.
+    pub span_start: u32,
+    /// End byte offset of the exported declaration.
+    pub span_end: u32,
+}
+
 /// Lightweight SWC-based scanner for detecting potential API patterns.
 ///
 /// This scanner looks for method call expressions that match common
@@ -231,6 +247,102 @@ impl SwcScanner {
             candidates: visitor.candidates,
             should_analyze,
         }
+    }
+
+    /// Extract the top-level exported bindings of a module.
+    ///
+    /// This powers file-based routing: an app-router endpoint declares its HTTP
+    /// method as the *name* of an exported handler (`export function GET`), which
+    /// never appears as a call site, so the candidate scanner alone cannot see
+    /// it. Returns one [`ExportedHandler`] per exported binding; `export default`
+    /// is reported with the name `"default"`.
+    pub fn exported_handlers(&self, file_path: &Path, content: &str) -> Vec<ExportedHandler> {
+        use swc_common::{FileName, Spanned};
+        use swc_ecma_parser::{Parser, StringInput, Syntax, lexer::Lexer};
+
+        let syntax = match file_path.extension().and_then(|e| e.to_str()) {
+            Some("ts") => Syntax::Typescript(TsSyntax {
+                decorators: true,
+                ..Default::default()
+            }),
+            Some("tsx") => Syntax::Typescript(TsSyntax {
+                tsx: true,
+                decorators: true,
+                ..Default::default()
+            }),
+            Some("jsx") => Syntax::Es(EsSyntax {
+                jsx: true,
+                ..Default::default()
+            }),
+            _ => Syntax::Es(Default::default()),
+        };
+
+        let sm: Lrc<SourceMap> = Default::default();
+        let source_file = sm.new_source_file(
+            Lrc::new(FileName::Real(file_path.to_path_buf())),
+            content.to_string(),
+        );
+        let lexer = Lexer::new(
+            syntax,
+            Default::default(),
+            StringInput::from(&*source_file),
+            None,
+        );
+        let mut parser = Parser::new_from(lexer);
+        let module = match parser.parse_module() {
+            Ok(m) => m,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut out = Vec::new();
+        let mut push = |name: String, span: swc_common::Span| {
+            out.push(ExportedHandler {
+                name,
+                line_number: sm.lookup_char_pos(span.lo).line,
+                span_start: span.lo.0,
+                span_end: span.hi.0,
+            });
+        };
+
+        for item in &module.body {
+            let ModuleItem::ModuleDecl(decl) = item else {
+                continue;
+            };
+            match decl {
+                // `export function GET() {}`, `export const POST = ...`, `export class X {}`
+                ModuleDecl::ExportDecl(export) => match &export.decl {
+                    Decl::Fn(f) => push(f.ident.sym.to_string(), export.span()),
+                    Decl::Class(c) => push(c.ident.sym.to_string(), export.span()),
+                    Decl::Var(var) => {
+                        for d in &var.decls {
+                            if let Pat::Ident(ident) = &d.name {
+                                push(ident.id.sym.to_string(), export.span());
+                            }
+                        }
+                    }
+                    _ => {}
+                },
+                // `export { GET, POST as handler }`
+                ModuleDecl::ExportNamed(named) => {
+                    for spec in &named.specifiers {
+                        if let ExportSpecifier::Named(n) = spec {
+                            // Prefer the exported alias if present (`as handler`).
+                            let name = match n.exported.as_ref().unwrap_or(&n.orig) {
+                                ModuleExportName::Ident(id) => id.sym.to_string(),
+                                ModuleExportName::Str(s) => s.value.to_string(),
+                            };
+                            push(name, n.span());
+                        }
+                    }
+                }
+                // `export default function () {}` / `export default expr`
+                ModuleDecl::ExportDefaultDecl(d) => push("default".to_string(), d.span()),
+                ModuleDecl::ExportDefaultExpr(e) => push("default".to_string(), e.span()),
+                _ => {}
+            }
+        }
+
+        out
     }
 }
 
@@ -573,6 +685,55 @@ mod tests {
         let scanner = SwcScanner::new();
         let path = PathBuf::from("test.ts");
         scanner.scan_content(&path, content)
+    }
+
+    fn handler_names(content: &str) -> Vec<String> {
+        let scanner = SwcScanner::new();
+        let mut names: Vec<String> = scanner
+            .exported_handlers(&PathBuf::from("route.ts"), content)
+            .into_iter()
+            .map(|h| h.name)
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn exported_handlers_finds_app_router_methods() {
+        let content = r#"
+export async function GET(req: Request) { return Response.json({}); }
+export function POST() {}
+const helper = 1;
+function notExported() {}
+"#;
+        assert_eq!(handler_names(content), vec!["GET", "POST"]);
+    }
+
+    #[test]
+    fn exported_handlers_finds_const_and_named_and_default() {
+        let content = r#"
+export const PUT = async () => {};
+function handlePatch() {}
+export { handlePatch as PATCH };
+export default function handler() {}
+"#;
+        assert_eq!(handler_names(content), vec!["PATCH", "PUT", "default"]);
+    }
+
+    #[test]
+    fn exported_handlers_empty_when_no_exports() {
+        let content = "const x = 1; function f() {}";
+        assert!(handler_names(content).is_empty());
+    }
+
+    #[test]
+    fn exported_handlers_reports_line_numbers() {
+        let content = "\n\nexport function GET() {}\n";
+        let scanner = SwcScanner::new();
+        let handlers = scanner.exported_handlers(&PathBuf::from("route.ts"), content);
+        assert_eq!(handlers.len(), 1);
+        assert_eq!(handlers[0].name, "GET");
+        assert_eq!(handlers[0].line_number, 3);
     }
 
     #[test]

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -681,10 +681,9 @@ impl Visit for CandidateVisitor {
         // decorator by its identifier via the Import Table.
         if let Expr::Call(call) = &*node.expr
             && let Callee::Expr(callee_expr) = &call.callee
+            && let Some(name) = Self::extract_callee_object(callee_expr)
         {
-            if let Some(name) = Self::extract_callee_object(callee_expr) {
-                self.push_candidate(call, name, None);
-            }
+            self.push_candidate(call, name, None);
         }
         node.visit_children_with(self);
     }

--- a/tests/file_centric_analysis_test.rs
+++ b/tests/file_centric_analysis_test.rs
@@ -256,6 +256,7 @@ fn test_processing_stats_tracking() {
         files_skipped_no_candidates: 1,
         total_mounts: 3,
         total_endpoints: 10,
+        file_based_endpoints: 2,
         total_data_calls: 4,
         errors: vec!["Test error".to_string()],
     };
@@ -743,7 +744,7 @@ app.post('/users', (req, res) => res.json({ created: true }));
 
     let files = vec![test_file];
     let result = orchestrator
-        .analyze_files(&files, &guidance, &detection)
+        .analyze_files(&files, &guidance, &detection, temp_dir.path())
         .await;
 
     // Verify the analysis completed (even with mock responses)
@@ -776,7 +777,7 @@ async fn test_file_orchestrator_handles_empty_files() {
 
     let files = vec![empty_file];
     let result = orchestrator
-        .analyze_files(&files, &guidance, &detection)
+        .analyze_files(&files, &guidance, &detection, temp_dir.path())
         .await;
 
     assert!(result.is_ok());
@@ -804,7 +805,7 @@ async fn test_file_orchestrator_handles_missing_files() {
     // Try to analyze a non-existent file
     let files = vec![PathBuf::from("/nonexistent/file.ts")];
     let result = orchestrator
-        .analyze_files(&files, &guidance, &detection)
+        .analyze_files(&files, &guidance, &detection, PathBuf::from("/").as_path())
         .await;
 
     assert!(result.is_ok());

--- a/tests/framework_coverage_test.rs
+++ b/tests/framework_coverage_test.rs
@@ -27,7 +27,7 @@ fn fixture_path(subpath: &str) -> PathBuf {
 fn scan(path: &Path) -> ScanResult {
     let content = fs::read_to_string(path)
         .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
-    SwcScanner::new().scan_content(path, &content)
+    SwcScanner::new().scan_content(path, &content, &[])
 }
 
 fn methods(candidates: &[CandidateTarget]) -> Vec<String> {


### PR DESCRIPTION
## What & why

File-based routes (Next.js app router, etc.) declare an endpoint by **file location**, not by a call expression. The SWC gatekeeper therefore produces no candidate for them, and `apply_candidate_map` drops any endpoint the LLM emits without a matching candidate — so these routes were invisible to the contract graph. This PR adds a framework-agnostic routing engine and wires it into the orchestrator so those endpoints land in the graph with correct method + path.

## How

The two structural facts a call-site scan can't see are supplied deterministically:

- **`derive_route`** (`src/file_based_router.rs`) — turns a repo-relative path into a route path using declarative conventions (root globs, dynamic/catch-all/group segment syntax, method source). Ships with Next.js app-router and pages-router conventions, gated on detected frameworks.
- **`exported_handlers`** (`src/swc_scanner.rs`) — extracts top-level exported handler names (`GET`/`POST`/…) and their declaration spans.

The orchestrator (`file_orchestrator.rs`) synthesizes `EndpointResult`s from `derive_route` × `exported_handlers`, merges them into each file's results (deduped by method+path), and lets them flow through the mount graph at their literal derived path (a sentinel owner matches no mount, so `resolve_endpoint_paths` leaves the path intact).

Supporting changes:
- Thread the repo root into `analyze_files` / `run_complete_analysis` — `find_files` yields absolute paths, but conventions anchor on `app/` / `pages/api/`, so paths must be made repo-relative before matching.
- Register `file_based_router` as a module in the binary crate (was lib-only).

## Scope / deferrals

- **App-router** (method-per-export) is fully handled. **Pages-router default exports** are deferred — their method set isn't recoverable from the layout alone.
- Synthesized endpoints carry method + path but **no response types yet** (`Option` fields are `None`, a valid handled state). Feeding handler bodies to the sidecar for full type-level contract validation is the natural follow-up.

## Testing

- 7 new unit tests (route synthesis: method-per-export, dynamic segments, pages-router deferral, non-route/no-convention no-ops, dedup merge).
- `cargo build` + `cargo clippy` clean; full lib suite 252 pass.
- One pre-existing failure (`test_get_changed_files_with_real_git_repo`) is environmental — git can't create commits in the sandbox; it fails identically without this change.

https://claude.ai/code/session_01AvxpuiNbP4pLij3RbDcsab

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvxpuiNbP4pLij3RbDcsab)_