### PR TITLE
Post PR drift comments from the cloud App

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The recommended authentication is sign-in-with-Carrick: your agent opens a brows
 
 ## Populate the index
 
-The index is populated by running the Carrick GitHub Action on each TypeScript repo you want indexed. On the main branch the action refreshes that repo's contribution to the index. On pull requests it can optionally post a drift comment.
+The index is populated by running the Carrick GitHub Action on each TypeScript repo you want indexed. On the main branch the action refreshes that repo's contribution to the index. On pull requests the Carrick App posts a drift comment for you (no extra workflow steps required).
 
 ```yaml
 name: Carrick
@@ -51,8 +51,6 @@ on:
 permissions:
   id-token: write
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   carrick:
@@ -60,60 +58,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - id: carrick
-        uses: daveymoores/carrick@v1
-
-      - if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        env:
-          COMMENT_BODY: ${{ steps.carrick.outputs.pr-comment }}
-        with:
-          script: |
-            const body = process.env.COMMENT_BODY;
-            if (!body || !body.trim()) return;
-            const marker = '<!-- CARRICK_OUTPUT_START -->';
-            const iterator = github.paginate.iterator(
-              github.rest.issues.listComments,
-              {
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                per_page: 100,
-              }
-            );
-            let previous = null;
-            for await (const { data: page } of iterator) {
-              previous = page.find(c =>
-                c.user && c.user.type === 'Bot' &&
-                c.user.login === 'github-actions[bot]' &&
-                c.body && c.body.includes(marker)
-              );
-              if (previous) break;
-            }
-            const createNew = () => github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body,
-            });
-            if (previous) {
-              try {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: previous.id,
-                  body,
-                });
-              } catch (err) {
-                core.warning(`updateComment failed (${err.status}); creating a fresh comment instead.`);
-                await createNew();
-              }
-            } else {
-              await createNew();
-            }
+      - uses: daveymoores/carrick@v1
 ```
 
-No secrets required. The `id-token: write` permission lets the action mint a short-lived GitHub Actions OIDC token, which Carrick uses to verify the repo's identity and authorize the upload. Just make sure the Carrick GitHub App is installed on the org and the repo is connected to a project in the dashboard.
+No secrets required. The `id-token: write` permission lets the action mint a short-lived GitHub Actions OIDC token, which Carrick uses to verify the repo's identity and authorize the upload. On pull requests the Carrick App posts the drift comment itself, so the workflow needs no `pull-requests: write` permission and no comment-posting step. Just make sure the Carrick GitHub App is installed on the org and the repo is connected to a project in the dashboard.
 
 ## MCP tools
 
@@ -131,7 +79,7 @@ The MCP endpoint exposes the index as structured tools your agent can call direc
 
 ## On pull requests
 
-The Carrick action can also post a comment on pull requests. The comment summarises drift detected against the indexed services: type mismatches between producers and consumers, mismatched HTTP verbs, missing or orphaned routes, and npm-dependency-version conflicts.
+On pull requests the Carrick App posts a comment summarising drift detected against the indexed services: type mismatches between producers and consumers, mismatched HTTP verbs, missing or orphaned routes, and npm-dependency-version conflicts. It updates the same comment in place on each push to the PR. Enable it per project with the PR comments toggle in the dashboard; PR runs never alter the index.
 
 ## Configuration
 

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,6 @@ outputs:
   issues-found:
     description: "Number of API issues detected"
     value: ${{ steps.analysis.outputs.issues-found }}
-  pr-comment:
-    description: "Formatted PR comment with cross-repo analysis"
-    value: ${{ steps.analysis.outputs.pr-comment }}
 
 runs:
   using: "composite"
@@ -76,27 +73,11 @@ runs:
 
         echo "issues-found=$ISSUES" >> $GITHUB_OUTPUT
 
-        # Extract formatted markdown output between delimiters
-        if grep -q "CARRICK_OUTPUT_START" analysis.log; then
-          # Extract content between delimiters
-          sed -n '/<!-- CARRICK_OUTPUT_START -->/,/<!-- CARRICK_OUTPUT_END -->/p' analysis.log | \
-            grep -v "CARRICK_OUTPUT_START\|CARRICK_OUTPUT_END\|CARRICK_ISSUE_COUNT" > pr_comment.md
-
-          # Set multiline output for PR comment
-          {
-            echo "pr-comment<<EOF"
-            cat pr_comment.md
-            echo "EOF"
-          } >> $GITHUB_OUTPUT
-        else
-          {
-            echo "pr-comment<<EOF"
-            echo "### 🪢 Carrick: Cross-repo analysis"
-            echo ""
-            echo "⚠️ No API analysis results found in output."
-            echo "EOF"
-          } >> $GITHUB_OUTPUT
-        fi
+        # PR comments are posted by the Carrick GitHub App from the cloud, not
+        # by this workflow: on pull_request runs the scanner relays the
+        # rendered findings to api.carrick.tools, which upserts one marked
+        # comment (gated on the project's pr_comments_enabled toggle). No
+        # github-script step or pull-requests:write permission is needed here.
 
         cat analysis.log
         exit $EXIT_CODE

--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -368,6 +368,39 @@ impl CloudStorage for AwsStorage {
         Ok(())
     }
 
+    async fn post_pr_comment(
+        &self,
+        repo: &str,
+        pr_number: u64,
+        body: &str,
+    ) -> Result<(), StorageError> {
+        // Dedicated action: unlike store-metadata/complete-upload it writes no
+        // index data — the cloud only gates on the project's pr_comments_enabled
+        // toggle and upserts the marked comment via the GitHub App. We keep the
+        // rendered markdown as the source of truth here and let the cloud relay
+        // it verbatim.
+        #[derive(Serialize)]
+        struct PostPrCommentRequest<'a> {
+            action: &'a str,
+            repo: &'a str,
+            pr_number: u64,
+            pr_comment_body: &'a str,
+        }
+
+        let request = PostPrCommentRequest {
+            action: "post-pr-comment",
+            repo,
+            pr_number,
+            pr_comment_body: body,
+        };
+
+        // Best-effort by contract (caller logs and swallows), but surface the
+        // transport error so the caller can log a useful message.
+        self.send_lambda(&request).await?;
+        debug!("Posted PR comment for {} (PR #{})", repo, pr_number);
+        Ok(())
+    }
+
     async fn health_check(&self) -> Result<(), StorageError> {
         let request = LambdaRequest {
             action: "check-or-upload".to_string(),

--- a/src/cloud_storage/mock_storage.rs
+++ b/src/cloud_storage/mock_storage.rs
@@ -35,6 +35,16 @@ impl CloudStorage for MockStorage {
         Ok(())
     }
 
+    async fn post_pr_comment(
+        &self,
+        repo: &str,
+        pr_number: u64,
+        _body: &str,
+    ) -> Result<(), StorageError> {
+        debug!("MOCK: post_pr_comment for {} (PR #{})", repo, pr_number);
+        Ok(())
+    }
+
     async fn upload_type_file(
         &self,
         repo_name: &str,

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -282,6 +282,17 @@ pub trait CloudStorage {
     ) -> Result<(), StorageError>;
     async fn health_check(&self) -> Result<(), StorageError>;
     async fn upload_logs(&self, repo: &str, log_content: &str) -> Result<(), StorageError>;
+
+    /// Relay a rendered PR-comment body to the cloud, which posts (and
+    /// updates in place on later pushes) a single GitHub App comment on the
+    /// PR. Only called on `pull_request` runs — index data is deliberately
+    /// not uploaded there, so this is the one signal a PR run sends.
+    async fn post_pr_comment(
+        &self,
+        repo: &str,
+        pr_number: u64,
+        body: &str,
+    ) -> Result<(), StorageError>;
 }
 
 pub fn get_current_commit_hash(repo_path: &str) -> String {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -84,6 +84,15 @@ fn should_upload_data() -> bool {
     true
 }
 
+/// The PR number for a `pull_request` run, or None on push/dispatch/local
+/// runs. GitHub sets GITHUB_REF to `refs/pull/<n>/merge` (or `/head`) on PRs;
+/// returning None on any other ref is exactly the "only post on PR runs" gate.
+fn pr_number_from_env() -> Option<u64> {
+    let ref_name = env::var("GITHUB_REF").ok()?;
+    let rest = ref_name.strip_prefix("refs/pull/")?;
+    rest.split('/').next()?.parse::<u64>().ok()
+}
+
 #[allow(dead_code)]
 pub async fn run_analysis_engine<T: CloudStorage>(
     storage: T,
@@ -209,7 +218,21 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     logging::finish_spinner(&sp, "Cross-repo analysis complete");
 
     let results = analyzer.get_results();
-    print_results(results);
+    let formatted = crate::formatter::FormattedOutput::new(results);
+    formatted.print();
+
+    // On pull_request runs we deliberately skip the index upload (see
+    // should_upload_data — PR-branch data must not pollute the cross-repo
+    // index), but we still relay the rendered findings to the cloud, which
+    // posts (and updates in place on later pushes) a single PR comment via
+    // the GitHub App, gated on the project's pr_comments_enabled toggle.
+    // Best-effort: a comment failure is logged, never fatal.
+    if let Some(pr_number) = pr_number_from_env() {
+        let body = formatted.pr_comment_body();
+        if let Err(e) = storage.post_pr_comment(&repo_name, pr_number, &body).await {
+            warn!("Failed to post PR comment: {}", e);
+        }
+    }
 
     Ok(())
 }
@@ -1606,11 +1629,6 @@ fn recreate_package_and_tsconfig(
     debug!("Recreated tsconfig.json at {}", tsconfig_path.display());
 
     Ok(())
-}
-
-fn print_results(result: crate::analyzer::ApiAnalysisResult) {
-    let formatted_output = crate::formatter::FormattedOutput::new(result);
-    formatted_output.print();
 }
 
 #[cfg(test)]

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -14,6 +14,25 @@ impl FormattedOutput {
     pub fn print(&self) {
         println!("{}", self.content);
     }
+
+    /// The comment body to relay to the cloud: the rendered markdown without
+    /// the machine-only marker lines (`CARRICK_OUTPUT_START`/`_END` and
+    /// `CARRICK_ISSUE_COUNT`). The cloud adds its own idempotency marker, so
+    /// these would only be noise in the posted comment. Mirrors the `grep -v`
+    /// the GitHub Action previously applied before posting.
+    pub fn pr_comment_body(&self) -> String {
+        self.content
+            .lines()
+            .filter(|line| {
+                !line.contains("CARRICK_OUTPUT_START")
+                    && !line.contains("CARRICK_OUTPUT_END")
+                    && !line.contains("CARRICK_ISSUE_COUNT")
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string()
+    }
 }
 
 pub fn format_analysis_results(result: ApiAnalysisResult) -> String {
@@ -882,6 +901,38 @@ mod tests {
         // Check that no issues message is displayed
         assert!(output.contains("All cross-repo calls match the indexed contracts"));
         assert!(output.contains("CARRICK_ISSUE_COUNT:0"));
+    }
+
+    #[test]
+    fn test_pr_comment_body_strips_machine_markers() {
+        let issues = ApiIssues {
+            call_issues: vec![],
+            endpoint_issues: vec![],
+            env_var_calls: vec![],
+            mismatches: vec![],
+            type_mismatches: vec![],
+            dependency_conflicts: vec![],
+        };
+        let result = ApiAnalysisResult {
+            endpoints: vec![],
+            calls: vec![],
+            issues,
+            verified_endpoints: vec![],
+            detected_graphql_libraries: vec![],
+        };
+
+        let formatted = FormattedOutput::new(result);
+        let body = formatted.pr_comment_body();
+
+        // The marker lines the old Action stripped before posting must not
+        // leak into the comment the cloud relays.
+        assert!(!body.contains("CARRICK_OUTPUT_START"));
+        assert!(!body.contains("CARRICK_OUTPUT_END"));
+        assert!(!body.contains("CARRICK_ISSUE_COUNT"));
+        // The human-facing content is preserved.
+        assert!(body.contains("All cross-repo calls match the indexed contracts"));
+        // No leading/trailing blank lines left behind by the stripped markers.
+        assert_eq!(body, body.trim());
     }
 
     #[test]

--- a/tests/intent_incremental_test.rs
+++ b/tests/intent_incremental_test.rs
@@ -39,6 +39,14 @@ impl CloudStorage for SharedMock {
     async fn upload_logs(&self, repo: &str, log_content: &str) -> Result<(), StorageError> {
         self.0.upload_logs(repo, log_content).await
     }
+    async fn post_pr_comment(
+        &self,
+        repo: &str,
+        pr_number: u64,
+        body: &str,
+    ) -> Result<(), StorageError> {
+        self.0.post_pr_comment(repo, pr_number, body).await
+    }
 }
 
 /// Plain in-memory storage with no synthetic seed-repos and direct write
@@ -72,6 +80,14 @@ impl CloudStorage for StubStorage {
         Ok(())
     }
     async fn upload_logs(&self, _repo: &str, _log_content: &str) -> Result<(), StorageError> {
+        Ok(())
+    }
+    async fn post_pr_comment(
+        &self,
+        _repo: &str,
+        _pr_number: u64,
+        _body: &str,
+    ) -> Result<(), StorageError> {
         Ok(())
     }
 }


### PR DESCRIPTION
## What

On `pull_request` runs the scanner now relays its rendered drift findings to `check-or-upload` via a dedicated, data-free `post-pr-comment` action. The Carrick App posts (and updates in place on later pushes) a single marked comment — gated cloud-side on the project's `pr_comments_enabled` toggle. PR-branch data is still never uploaded to the cross-repo index (`should_upload_data()` unchanged).

This replaces the old `pr-comment` Action output + the manual `actions/github-script` posting step in the README workflow, which would otherwise double-post now that the App posts directly.

## Changes
- `CloudStorage::post_pr_comment` trait method + `AwsStorage` impl (posts the `post-pr-comment` action; no-op in the mocks).
- `engine`: `pr_number_from_env()` (parses `refs/pull/<n>/…`); on PR runs only, relays `FormattedOutput::pr_comment_body()` best-effort — a failure is logged, never fatal.
- `formatter::pr_comment_body()` strips the machine-only marker lines (`CARRICK_OUTPUT_START/_END`, `CARRICK_ISSUE_COUNT`) — mirrors the `grep -v` the Action used to apply. Covered by a new unit test.
- `action.yml` / `README.md`: drop the `pr-comment` output and the manual github-script comment step, and the no-longer-needed `pull-requests: write` / `issues: write` permissions.

## Companion
Requires the cloud side (`carrick-cloud`) `post-pr-comment` handler. See the parallel PR on that repo.

## Testing
`cargo fmt --check`, `cargo clippy --all-targets`, full `cargo test` (255 lib + integration), and `ts_check` suite all pass (run by the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)