### PR TITLE
Send workflow run_id with PR comment for cross-repo re-runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Lets Carrick re-trigger this repo's main scan when a sibling repo in the
+  # project changes. Optional today and dormant unless enabled server-side —
+  # included here so it's already wired if you ever turn it on.
+  repository_dispatch:
+    types: [carrick-sibling-updated]
 
 permissions:
   id-token: write

--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -372,18 +372,22 @@ impl CloudStorage for AwsStorage {
         &self,
         repo: &str,
         pr_number: u64,
+        run_id: &str,
         body: &str,
     ) -> Result<(), StorageError> {
         // Dedicated action: unlike store-metadata/complete-upload it writes no
         // index data — the cloud only gates on the project's pr_comments_enabled
         // toggle and upserts the marked comment via the GitHub App. We keep the
         // rendered markdown as the source of truth here and let the cloud relay
-        // it verbatim.
+        // it verbatim. `run_id` lets the cloud re-run this PR's workflow later
+        // when a sibling repo's main changes.
         #[derive(Serialize)]
         struct PostPrCommentRequest<'a> {
             action: &'a str,
             repo: &'a str,
             pr_number: u64,
+            #[serde(skip_serializing_if = "str::is_empty")]
+            run_id: &'a str,
             pr_comment_body: &'a str,
         }
 
@@ -391,6 +395,7 @@ impl CloudStorage for AwsStorage {
             action: "post-pr-comment",
             repo,
             pr_number,
+            run_id,
             pr_comment_body: body,
         };
 

--- a/src/cloud_storage/mock_storage.rs
+++ b/src/cloud_storage/mock_storage.rs
@@ -39,6 +39,7 @@ impl CloudStorage for MockStorage {
         &self,
         repo: &str,
         pr_number: u64,
+        _run_id: &str,
         _body: &str,
     ) -> Result<(), StorageError> {
         debug!("MOCK: post_pr_comment for {} (PR #{})", repo, pr_number);

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -287,10 +287,15 @@ pub trait CloudStorage {
     /// updates in place on later pushes) a single GitHub App comment on the
     /// PR. Only called on `pull_request` runs — index data is deliberately
     /// not uploaded there, so this is the one signal a PR run sends.
+    ///
+    /// `run_id` is the GitHub Actions run id of this PR check; the cloud
+    /// records it so a later sibling main change can re-run this exact run and
+    /// refresh the comment (see carrick-cloud docs/internal/fanout-pr-rerun.md).
     async fn post_pr_comment(
         &self,
         repo: &str,
         pr_number: u64,
+        run_id: &str,
         body: &str,
     ) -> Result<(), StorageError>;
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -93,6 +93,13 @@ fn pr_number_from_env() -> Option<u64> {
     rest.split('/').next()?.parse::<u64>().ok()
 }
 
+/// This run's GitHub Actions run id (`GITHUB_RUN_ID`), or empty if unset. The
+/// cloud records it against the PR so a later sibling main change can re-run
+/// this exact workflow run and refresh the comment.
+fn run_id_from_env() -> String {
+    env::var("GITHUB_RUN_ID").unwrap_or_default()
+}
+
 #[allow(dead_code)]
 pub async fn run_analysis_engine<T: CloudStorage>(
     storage: T,
@@ -229,7 +236,11 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     // Best-effort: a comment failure is logged, never fatal.
     if let Some(pr_number) = pr_number_from_env() {
         let body = formatted.pr_comment_body();
-        if let Err(e) = storage.post_pr_comment(&repo_name, pr_number, &body).await {
+        let run_id = run_id_from_env();
+        if let Err(e) = storage
+            .post_pr_comment(&repo_name, pr_number, &run_id, &body)
+            .await
+        {
             warn!("Failed to post PR comment: {}", e);
         }
     }

--- a/tests/intent_incremental_test.rs
+++ b/tests/intent_incremental_test.rs
@@ -43,9 +43,10 @@ impl CloudStorage for SharedMock {
         &self,
         repo: &str,
         pr_number: u64,
+        run_id: &str,
         body: &str,
     ) -> Result<(), StorageError> {
-        self.0.post_pr_comment(repo, pr_number, body).await
+        self.0.post_pr_comment(repo, pr_number, run_id, body).await
     }
 }
 
@@ -86,6 +87,7 @@ impl CloudStorage for StubStorage {
         &self,
         _repo: &str,
         _pr_number: u64,
+        _run_id: &str,
         _body: &str,
     ) -> Result<(), StorageError> {
         Ok(())


### PR DESCRIPTION
## What

On a `pull_request` run the scanner already relays its drift findings to the cloud's `post-pr-comment` action; it now also sends `run_id` (`GITHUB_RUN_ID`). The cloud records it so a later sibling main change can re-run this exact workflow run and refresh the comment.

## Changes
- `CloudStorage::post_pr_comment` gains a `run_id` arg (threaded through the `AwsStorage` impl + mocks); `PostPrCommentRequest` sends `run_id`, omitted when empty (local / non-CI).
- `engine`: `run_id_from_env()` (`GITHUB_RUN_ID`), passed at the post-comment call site.
- `README`: add the dormant `repository_dispatch: [carrick-sibling-updated]` trigger to the onboarding workflow so the main→main fallback is pre-wired — no future per-repo edit needed if it's ever enabled server-side.

## Companion
Pairs with `carrick-cloud` (the `CarrickPrChecks` registry + `repo-fanout` replay). The cloud ignores the extra field if deployed first, so order is safe.

## Testing
Pre-commit hook: `cargo fmt`, clippy, full `cargo test` (255 lib + integration), `ts_check` (60) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)