### PR TITLE
feat(file-based-routing): add Astro convention + real Next.js/Astro fixtures

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -958,7 +958,7 @@ impl FileOrchestrator {
     /// type is recovered downstream in `collect_type_requests`, which asks the
     /// sidecar for the handler's (Promise-unwrapped) return type — the response
     /// contract for a file-based route.
-    fn file_based_endpoints(
+    pub fn file_based_endpoints(
         scanner: &SwcScanner,
         rel_path: &Path,
         file_path: &Path,
@@ -2418,6 +2418,54 @@ export const runtime = "edge";
         assert_eq!(endpoints.len(), 1);
         assert_eq!(endpoints[0].method, "GET");
         assert_eq!(endpoints[0].path, "/users/:id");
+    }
+
+    #[test]
+    fn test_file_based_endpoints_astro_filename_with_export_methods() {
+        // Astro is the FileName + ExportName combination: the path comes from
+        // the filename (like pages-router) but methods come from named exports
+        // (like app-router). Both `export function` and `export const` forms
+        // must be recognized.
+        let scanner = SwcScanner::new();
+        let content = r#"
+export async function GET() { return new Response("[]"); }
+export const POST = async (ctx) => new Response("{}");
+export const prerender = false;
+"#;
+        let mut endpoints = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            Path::new("src/pages/api/users.ts"),
+            Path::new("src/pages/api/users.ts"),
+            content,
+            &builtin_conventions(&["Astro".to_string()]),
+        );
+        endpoints.sort_by(|a, b| a.method.cmp(&b.method));
+
+        // GET + POST become endpoints; `prerender` is not an HTTP method.
+        assert_eq!(endpoints.len(), 2, "expected GET and POST only");
+        assert_eq!(endpoints[0].method, "GET");
+        assert_eq!(endpoints[1].method, "POST");
+        for ep in &endpoints {
+            assert_eq!(ep.path, "/api/users");
+            assert_eq!(ep.owner_node, FILE_BASED_ROUTE_OWNER);
+            assert_eq!(ep.pattern_matched, "astro");
+        }
+    }
+
+    #[test]
+    fn test_file_based_endpoints_astro_dynamic_segment() {
+        let scanner = SwcScanner::new();
+        let content = "export function GET() {}\n";
+        let endpoints = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            Path::new("src/pages/posts/[id].ts"),
+            Path::new("src/pages/posts/[id].ts"),
+            content,
+            &builtin_conventions(&["Astro".to_string()]),
+        );
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].method, "GET");
+        assert_eq!(endpoints[0].path, "/posts/:id");
     }
 
     #[test]

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -958,6 +958,11 @@ impl FileOrchestrator {
     /// type is recovered downstream in `collect_type_requests`, which asks the
     /// sidecar for the handler's (Promise-unwrapped) return type — the response
     /// contract for a file-based route.
+    ///
+    /// `pub` + `#[doc(hidden)]`: this is exposed only so the end-to-end fixture
+    /// test (`tests/file_based_routing_test.rs`) can drive the real synthesis
+    /// path. It is not part of the supported crate API.
+    #[doc(hidden)]
     pub fn file_based_endpoints(
         scanner: &SwcScanner,
         rel_path: &Path,

--- a/src/file_based_router.rs
+++ b/src/file_based_router.rs
@@ -138,7 +138,7 @@ impl RoutingConvention {
     /// `src/pages` — and methods come from export names, not a single default
     /// export. Only `.ts`/`.js` files are endpoints; `.astro` files are HTML
     /// pages and are deliberately excluded. (Astro's `ALL` fallback export is
-    /// not an HTTP method per [`is_http_method`](crate::type_manifest), so a
+    /// not an HTTP method per [`crate::type_manifest::is_http_method`], so a
     /// route defined solely via `ALL` is not synthesized.)
     pub fn astro() -> Self {
         Self {

--- a/src/file_based_router.rs
+++ b/src/file_based_router.rs
@@ -145,12 +145,11 @@ impl RoutingConvention {
             name: "astro".to_string(),
             root_globs: vec!["src/pages".to_string()],
             segment_source: SegmentSource::FileName {
-                extensions: vec![
-                    "ts".to_string(),
-                    "js".to_string(),
-                    "mts".to_string(),
-                    "mjs".to_string(),
-                ],
+                // Astro routes only `.ts`/`.js` endpoint files under src/pages
+                // (`.astro` files are HTML pages, handled elsewhere). `.mts`/
+                // `.mjs` are not Astro route extensions, and the SWC handler
+                // extractor doesn't parse TS syntax in `.mts` anyway.
+                extensions: vec!["ts".to_string(), "js".to_string()],
             },
             path_prefix: String::new(),
             dynamic_open: "[".to_string(),

--- a/src/file_based_router.rs
+++ b/src/file_based_router.rs
@@ -131,6 +131,39 @@ impl RoutingConvention {
         }
     }
 
+    /// Astro endpoints: `src/pages/**` where the filename is the last path
+    /// segment and methods are named exports (`export function GET() {}`,
+    /// `export const POST = ...`). Unlike Next.js pages-router, Astro has no
+    /// forced `/api` prefix — the route is literally the file's path under
+    /// `src/pages` — and methods come from export names, not a single default
+    /// export. Only `.ts`/`.js` files are endpoints; `.astro` files are HTML
+    /// pages and are deliberately excluded. (Astro's `ALL` fallback export is
+    /// not an HTTP method per [`is_http_method`](crate::type_manifest), so a
+    /// route defined solely via `ALL` is not synthesized.)
+    pub fn astro() -> Self {
+        Self {
+            name: "astro".to_string(),
+            root_globs: vec!["src/pages".to_string()],
+            segment_source: SegmentSource::FileName {
+                extensions: vec![
+                    "ts".to_string(),
+                    "js".to_string(),
+                    "mts".to_string(),
+                    "mjs".to_string(),
+                ],
+            },
+            path_prefix: String::new(),
+            dynamic_open: "[".to_string(),
+            dynamic_close: "]".to_string(),
+            catch_all_marker: "...".to_string(),
+            // Astro has no route-group syntax; leave the delimiters empty so the
+            // group check in `transform_segment` never fires.
+            group_open: String::new(),
+            group_close: String::new(),
+            method_source: MethodSource::ExportName,
+        }
+    }
+
     /// Strip the longest matching root prefix from a `/`-normalized relative
     /// path. Returns the remainder, or `None` if no root matches.
     fn strip_root<'a>(&self, rel: &'a str) -> Option<&'a str> {
@@ -287,6 +320,9 @@ pub fn builtin_conventions(frameworks: &[String]) -> Vec<RoutingConvention> {
         out.push(RoutingConvention::nextjs_app());
         out.push(RoutingConvention::nextjs_pages());
     }
+    if mentions("astro") {
+        out.push(RoutingConvention::astro());
+    }
     out
 }
 
@@ -415,6 +451,72 @@ mod tests {
     #[test]
     fn pages_api_skips_private_files() {
         assert!(route("pages/api/_middleware.ts").is_none());
+    }
+
+    // --- Astro ---
+
+    fn astro_route(p: &str) -> Option<DerivedRoute> {
+        derive_route(&PathBuf::from(p), &[RoutingConvention::astro()])
+    }
+
+    #[test]
+    fn astro_static_endpoint() {
+        // No forced /api prefix: "api" here is just a literal directory segment.
+        let r = astro_route("src/pages/api/users.ts").unwrap();
+        assert_eq!(r.path, "/api/users");
+        // Methods come from named exports, not a single default handler.
+        assert_eq!(r.method_source, MethodSource::ExportName);
+        assert_eq!(r.convention, "astro");
+    }
+
+    #[test]
+    fn astro_top_level_endpoint() {
+        assert_eq!(astro_route("src/pages/health.ts").unwrap().path, "/health");
+    }
+
+    #[test]
+    fn astro_index_collapses() {
+        assert_eq!(astro_route("src/pages/index.ts").unwrap().path, "/");
+        assert_eq!(astro_route("src/pages/api/index.ts").unwrap().path, "/api");
+    }
+
+    #[test]
+    fn astro_dynamic_filename() {
+        assert_eq!(
+            astro_route("src/pages/posts/[id].ts").unwrap().path,
+            "/posts/:id"
+        );
+    }
+
+    #[test]
+    fn astro_rest_param() {
+        assert_eq!(
+            astro_route("src/pages/files/[...path].ts").unwrap().path,
+            "/files/**"
+        );
+    }
+
+    #[test]
+    fn astro_javascript_endpoint() {
+        assert_eq!(astro_route("src/pages/ping.js").unwrap().path, "/ping");
+    }
+
+    #[test]
+    fn astro_ignores_page_components_and_private_files() {
+        // `.astro` files are HTML pages, not API endpoints.
+        assert!(astro_route("src/pages/about.astro").is_none());
+        // `_`-prefixed files are excluded from Astro routing.
+        assert!(astro_route("src/pages/_helpers.ts").is_none());
+        // Pages outside `src/pages` are not endpoints.
+        assert!(astro_route("src/lib/db.ts").is_none());
+    }
+
+    #[test]
+    fn astro_gated_on_framework_detection() {
+        assert!(builtin_conventions(&["express".to_string()]).is_empty());
+        let astro = builtin_conventions(&["Astro".to_string()]);
+        assert_eq!(astro.len(), 1);
+        assert_eq!(astro[0].name, "astro");
     }
 
     // --- Negative / boundary ---

--- a/tests/file_based_routing_test.rs
+++ b/tests/file_based_routing_test.rs
@@ -51,6 +51,23 @@ fn synthesized_routes(fixture: &str, conventions: &[RoutingConvention]) -> BTree
         let endpoints =
             FileOrchestrator::file_based_endpoints(&scanner, rel, file, &content, conventions);
         for ep in endpoints {
+            // Every synthesized file-based endpoint must carry the metadata the
+            // downstream sidecar type-resolution relies on: a convention label,
+            // the file-based owner marker, and a declaration span. Asserting it
+            // here means a regression that produced the right method+path but
+            // dropped this metadata is caught, not silently projected away.
+            assert!(
+                !ep.pattern_matched.is_empty(),
+                "{rel:?}: endpoint missing convention label"
+            );
+            assert_eq!(
+                ep.owner_node, "__file_based_route__",
+                "{rel:?}: endpoint not tagged as file-based"
+            );
+            assert!(
+                ep.call_expression_span_start.is_some(),
+                "{rel:?}: endpoint missing handler declaration span"
+            );
             routes.insert(format!("{} {}", ep.method, ep.path));
         }
     }
@@ -102,11 +119,25 @@ fn astro_fixture_derives_expected_routes() {
 
 #[test]
 fn file_based_pass_is_noop_without_matching_framework() {
-    // With no convention-bearing framework detected, the same on-disk Astro
-    // project must produce nothing: framework knowledge is the only gate.
+    // No convention-bearing framework detected → empty conventions → no routes,
+    // regardless of what's on disk.
     let routes = synthesized_routes("astro", &builtin_conventions(&["express".to_string()]));
     assert!(
         routes.is_empty(),
         "no endpoints expected when no file-based framework is detected, got {routes:?}"
+    );
+}
+
+#[test]
+fn astro_convention_rejects_a_non_astro_layout() {
+    // Stronger than the empty-conventions gate: run a *non-empty* Astro
+    // convention set over the Next.js app-router tree (which has no `src/pages`).
+    // The matcher must reject every file via strip_root/raw_segments and yield
+    // nothing — proving the convention is correctly scoped, not just that an
+    // empty slice produces nothing.
+    let routes = synthesized_routes("nextjs-app", &builtin_conventions(&["Astro".to_string()]));
+    assert!(
+        routes.is_empty(),
+        "astro conventions must not match app-router files, got {routes:?}"
     );
 }

--- a/tests/file_based_routing_test.rs
+++ b/tests/file_based_routing_test.rs
@@ -1,0 +1,112 @@
+//! End-to-end coverage for file-based routing against *real on-disk fixtures*.
+//!
+//! The unit tests in `src/file_based_router.rs` and `src/agents/file_orchestrator.rs`
+//! feed synthetic string paths into the deriver. These tests instead walk the
+//! actual fixture trees under `tests/fixtures/{nextjs-app,astro}` and run them
+//! through the same deterministic synthesis the orchestrator uses in production
+//! (`FileOrchestrator::file_based_endpoints` over `builtin_conventions`), so a
+//! regression in route derivation, the SWC handler extractor, or the framework
+//! gate is caught with files that look like a user's repository.
+
+use carrick::agents::file_orchestrator::FileOrchestrator;
+use carrick::file_based_router::{RoutingConvention, builtin_conventions};
+use carrick::swc_scanner::SwcScanner;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn fixture_root(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+/// Recursively collect every file under `dir`.
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries =
+        fs::read_dir(dir).unwrap_or_else(|e| panic!("failed to read {}: {}", dir.display(), e));
+    for entry in entries {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            walk(&path, out);
+        } else {
+            out.push(path);
+        }
+    }
+}
+
+/// Derive every `METHOD path` pair the file-based pass would synthesize for a
+/// fixture, exactly as the orchestrator does: relativize against the repo root,
+/// run the SWC gatekeeper's handler extractor, gate on `builtin_conventions`.
+fn synthesized_routes(fixture: &str, conventions: &[RoutingConvention]) -> BTreeSet<String> {
+    let root = fixture_root(fixture);
+    let scanner = SwcScanner::new();
+    let mut files = Vec::new();
+    walk(&root, &mut files);
+
+    let mut routes = BTreeSet::new();
+    for file in &files {
+        let rel = file.strip_prefix(&root).expect("file under fixture root");
+        let content = fs::read_to_string(file).expect("read fixture file");
+        let endpoints =
+            FileOrchestrator::file_based_endpoints(&scanner, rel, file, &content, conventions);
+        for ep in endpoints {
+            routes.insert(format!("{} {}", ep.method, ep.path));
+        }
+    }
+    routes
+}
+
+#[test]
+fn nextjs_app_router_fixture_derives_expected_routes() {
+    let routes = synthesized_routes("nextjs-app", &builtin_conventions(&["Next.js".to_string()]));
+
+    let expected: BTreeSet<String> = [
+        "GET /users",
+        "POST /users",
+        "GET /users/:id",
+        "DELETE /users/:id",
+        "GET /health",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+    assert_eq!(
+        routes, expected,
+        "app-router fixture should yield exactly the route handlers, \
+         and skip page.tsx / non-HTTP exports like `runtime`"
+    );
+}
+
+#[test]
+fn astro_fixture_derives_expected_routes() {
+    let routes = synthesized_routes("astro", &builtin_conventions(&["Astro".to_string()]));
+
+    let expected: BTreeSet<String> = [
+        "GET /api/users",
+        "POST /api/users",
+        "GET /posts/:id",
+        "GET /health",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+    assert_eq!(
+        routes, expected,
+        "astro fixture should yield endpoints from .ts/.js files only — \
+         skipping index.astro, _helpers.ts, and the `prerender` export"
+    );
+}
+
+#[test]
+fn file_based_pass_is_noop_without_matching_framework() {
+    // With no convention-bearing framework detected, the same on-disk Astro
+    // project must produce nothing: framework knowledge is the only gate.
+    let routes = synthesized_routes("astro", &builtin_conventions(&["express".to_string()]));
+    assert!(
+        routes.is_empty(),
+        "no endpoints expected when no file-based framework is detected, got {routes:?}"
+    );
+}

--- a/tests/fixtures/astro/src/pages/_helpers.ts
+++ b/tests/fixtures/astro/src/pages/_helpers.ts
@@ -1,0 +1,6 @@
+// `_`-prefixed files are excluded from Astro routing, so even though this
+// exports something named like an HTTP method it must NOT become an endpoint.
+
+export function GET() {
+  return new Response("not a route");
+}

--- a/tests/fixtures/astro/src/pages/api/users.ts
+++ b/tests/fixtures/astro/src/pages/api/users.ts
@@ -1,0 +1,26 @@
+// Astro endpoint: src/pages/api/users.ts → /api/users
+// Astro has no forced /api prefix — "api" here is just a directory segment.
+// Methods come from named exports (mix of `function` and `const` forms).
+
+import type { APIRoute } from "astro";
+
+interface User {
+  id: string;
+  name: string;
+}
+
+export const GET: APIRoute = () => {
+  const users: User[] = [{ id: "1", name: "Ada" }];
+  return new Response(JSON.stringify(users), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+export async function POST({ request }: { request: Request }): Promise<Response> {
+  const body = (await request.json()) as { name: string };
+  const created: User = { id: "2", name: body.name };
+  return new Response(JSON.stringify(created), { status: 201 });
+}
+
+// Not an HTTP method — must be ignored by the deriver.
+export const prerender = false;

--- a/tests/fixtures/astro/src/pages/health.js
+++ b/tests/fixtures/astro/src/pages/health.js
@@ -1,0 +1,7 @@
+// Astro endpoint in plain JavaScript: src/pages/health.js → /health
+
+export function GET() {
+  return new Response(JSON.stringify({ status: "ok" }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/tests/fixtures/astro/src/pages/index.astro
+++ b/tests/fixtures/astro/src/pages/index.astro
@@ -1,0 +1,10 @@
+---
+// An Astro page component — NOT an API endpoint. Only `.ts`/`.js` files under
+// src/pages are endpoints; `.astro` files render HTML and must be skipped.
+const title = "Home";
+---
+
+<html>
+  <head><title>{title}</title></head>
+  <body><h1>{title}</h1></body>
+</html>

--- a/tests/fixtures/astro/src/pages/posts/[id].ts
+++ b/tests/fixtures/astro/src/pages/posts/[id].ts
@@ -1,0 +1,15 @@
+// Astro dynamic endpoint: src/pages/posts/[id].ts → /posts/:id
+
+import type { APIRoute } from "astro";
+
+interface Post {
+  id: string;
+  title: string;
+}
+
+export const GET: APIRoute = ({ params }) => {
+  const post: Post = { id: params.id ?? "0", title: "Hello" };
+  return new Response(JSON.stringify(post), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/tests/fixtures/nextjs-app/app/health/route.ts
+++ b/tests/fixtures/nextjs-app/app/health/route.ts
@@ -1,0 +1,5 @@
+// Next.js App Router: app/health/route.ts → /health
+
+export async function GET(): Promise<Response> {
+  return Response.json({ status: "ok" });
+}

--- a/tests/fixtures/nextjs-app/app/users/[id]/route.ts
+++ b/tests/fixtures/nextjs-app/app/users/[id]/route.ts
@@ -1,0 +1,21 @@
+// Next.js App Router dynamic segment: app/users/[id]/route.ts → /users/:id
+
+interface User {
+  id: string;
+  name: string;
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+): Promise<Response> {
+  const user: User = { id: params.id, name: "Ada" };
+  return Response.json(user);
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } },
+): Promise<Response> {
+  return Response.json({ deleted: params.id });
+}

--- a/tests/fixtures/nextjs-app/app/users/page.tsx
+++ b/tests/fixtures/nextjs-app/app/users/page.tsx
@@ -1,0 +1,6 @@
+// A page component — NOT an API route. The deriver must skip this file
+// (only `route.{ts,js,tsx,mts}` are terminal markers for the app router).
+
+export default function UsersPage() {
+  return <div>Users</div>;
+}

--- a/tests/fixtures/nextjs-app/app/users/route.ts
+++ b/tests/fixtures/nextjs-app/app/users/route.ts
@@ -1,0 +1,21 @@
+// Next.js App Router: app/users/route.ts → /users
+// Methods are named exports; GET and POST below become two endpoints.
+
+interface User {
+  id: string;
+  name: string;
+}
+
+export async function GET(): Promise<Response> {
+  const users: User[] = [{ id: "1", name: "Ada" }];
+  return Response.json(users);
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const body = (await req.json()) as { name: string };
+  const created: User = { id: "2", name: body.name };
+  return Response.json(created, { status: 201 });
+}
+
+// Not an HTTP method — must be ignored by the deriver.
+export const runtime = "edge";


### PR DESCRIPTION
## What

Adds **Astro** support to file-based routing and closes the "no real fixture" gap for file-based routes.

## Background

The file-based routing **engine** (`derive_route` + the `RoutingConvention` data model) is already framework-agnostic — it executes plain convention data with no per-framework branching. But the only conventions that ever got *created* were the two Next.js ones, so an Astro project produced nothing. The "or `carrick.json`" override gestured at in the module docs is not wired up.

## Changes

- **`RoutingConvention::astro()`** — endpoints under `src/pages/**`, path from the filename, methods from named exports (`export function GET` / `export const POST`). This is the `FileName` + `ExportName` combination the engine supports but nothing exercised. `.ts`/`.js` only (`.astro` pages and `_`-prefixed files excluded); no forced `/api` prefix. Gated on Astro detection in `builtin_conventions()`, mirroring the Next.js bootstrap. **No engine changes.**
- **Real on-disk fixtures** — `tests/fixtures/nextjs-app/` (app-router: static, dynamic `[id]`, a `page.tsx` that must be skipped, a non-HTTP `runtime` export) and `tests/fixtures/astro/` (`.ts`/`.js` endpoints, dynamic `[id]`, plus `index.astro` and `_helpers.ts` that must be skipped).
- **Integration test** (`tests/file_based_routing_test.rs`) walks those trees through the production synthesis path (`FileOrchestrator::file_based_endpoints`, now `pub` for testing) and asserts the exact `METHOD path` sets — the previously missing end-to-end coverage.
- Unit tests for the Astro convention and the `FileName` + `ExportName` synthesis.

## Known limitation (deferred)

Astro's `export const ALL` fallback handler is not synthesized, because `is_http_method` doesn't list `ALL` and adding it would change behavior elsewhere (e.g. Express `router.all()`). Deferred as MVP — tracked in a separate low-priority issue.

## Testing

- New unit + integration tests pass; clippy/fmt clean; no prompt-leak patterns.
- One pre-existing, environmental failure (`test_get_changed_files_with_real_git_repo`) is unrelated — it fails on clean `main` in this container too (git config the test assumes is absent).

https://claude.ai/code/session_018AqvKCKF3fNRRgEKu37S4v

---
_Generated by [Claude Code](https://claude.ai/code/session_018AqvKCKF3fNRRgEKu37S4v)_