### PR TITLE
chore: onboard repo onto Carrick (workflow + agent docs)

### DIFF
--- a/.github/workflows/carrick.yml
+++ b/.github/workflows/carrick.yml
@@ -1,0 +1,21 @@
+name: Carrick
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  repository_dispatch:
+    types: [carrick-sibling-updated]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  carrick:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: daveymoores/carrick@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,28 @@ Install hooks once per clone: `./scripts/install-hooks.sh`.
 - `carrick.json` is resolved by `Config::load_services` into one `Config` per service. A flat config (or none) is a single service rooted at the repo root; a `services` array fans out per directory (`directory`, `include`, `tsconfig` + the call-classification fields). The engine runs the analysis pipeline, per-service type extraction, and upload once per service. Multi-service index upload is gated on `CloudStorage::supports_multi_service`, driven by the cloud's `multiService` capability flag. See the README "Monorepos" section for the user-facing shape.
 - Runtime env vars: `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` (auto-set by GitHub Actions when the job grants `id-token: write`; the scanner mints an OIDC token from these and sends it as the `X-Carrick-OIDC` header — the cloud derives repo identity from the signed claims, so no API key is needed), `CARRICK_MOCK_ALL` (test-only, returns canned responses without hitting the cloud), `CARRICK_API_ENDPOINT` (override the default `https://api.carrick.tools` endpoint at build time; optional).
 - Terraform, Lambdas, and dashboard code live in `carrick-cloud`. No infrastructure or server-side code belongs in this repo.
+
+## Carrick
+
+This repo is part of the **daveymoores / carrick-ci** Carrick
+project. Carrick indexes every service in the project — exported functions
+(with intent descriptions), dependencies, and API endpoints with real
+request/response types.
+
+### Connect the agent
+
+```
+claude mcp add --transport http carrick-carrick-ci https://api.carrick.tools/mcp/p/carrick-ci
+```
+
+### When to reach for Carrick
+
+- Before writing a helper/parser/validator/formatter: `search_by_intent` to
+  find an existing implementation in a sibling repo.
+- Before calling another service's API: `get_api_endpoints` +
+  `get_endpoint_types` instead of guessing the JSON shape.
+- Before changing a response shape, removing an endpoint, or renaming a path:
+  `check_compatibility` against each consumer.
+- Before adding/bumping an npm dependency: `get_service_dependencies`.
+
+Carrick is read-only; data reflects the most recent scan of each repo.


### PR DESCRIPTION
## What

Onboards this repo onto Carrick (the `daveymoores / carrick-ci` project) via the scaffold tool:

- **`.github/workflows/carrick.yml`** — the Carrick GitHub Action, keyless (uploads authenticate via GitHub Actions OIDC). Runs on push/PR to `main` and on `carrick-sibling-updated` dispatch.
- **`AGENTS.md`** — folds the Carrick agent guidance in as a new `## Carrick` section (rather than adding a separate `carrick.md`, since this repo already has an AGENTS.md).
- **`carrick.json`** — already present and unchanged; it declares the two TypeScript components as services (`ts-check`, `type-sidecar`).

## Scope of the scan

The `services` array scopes the scan to `ts_check/` and `src/sidecar/` only (`find_service_files` joins each service `directory`; `resolve_services` reads the root `carrick.json` directly to avoid walking into nested fixture configs). The Rust tree and all `tests/fixtures/**` TS apps — with their fake domains like `https://evil.example` — are excluded. Neither service makes outbound HTTP calls, so there are no internal/external env vars or domains to classify.

## Before this goes green

The `carrick` job's upload authenticates via OIDC **only once this repo is connected to the `carrick-ci` project in the Carrick dashboard**. If it isn't connected yet, that step will fail the check — connect it before/after merge as needed.

## Notes

- The workflow pins `daveymoores/carrick@v1`, which runs the *released* scanner artifact against the repo (dogfooding) — it does not build this PR's source; `ci.yml` remains the real build/test gate.
- `ts_check/` is labelled legacy but is still load-bearing (runtime + Action + packaging). Removing it is tracked separately in #136 and intentionally out of scope here.
