### PR TITLE
feat(intent): content-hash caching for generate-intent

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -9,7 +9,7 @@ use crate::cloud_storage::{
 use crate::config::{Config, create_dynamic_tsconfig};
 use crate::file_finder::find_service_files;
 use crate::framework_detector::{DetectionResult, FrameworkDetector};
-use crate::intent_generator::generate_function_intents;
+use crate::intent_generator::{generate_function_intents, intents_by_hash};
 use crate::logging;
 use crate::mount_graph::MountGraph;
 use crate::multi_agent_orchestrator::MultiAgentOrchestrator;
@@ -685,34 +685,20 @@ async fn analyze_current_repo_incremental(
             // Run on the same path as the full analysis so incremental scans
             // populate FunctionDefinition.intent in DDB (issue #110).
             //
-            // Optimization: copy intents from `prev.function_definitions` for
-            // functions whose source file did not change. The intent generator
-            // skips entries that already have `intent` set, so this avoids
-            // re-calling /generate-intent for code that hasn't moved. Caveat:
-            // if a function in an unchanged file calls a function in a
-            // changed file, the cached intent may be slightly stale relative
-            // to its callee's new behavior — acceptable trade-off; a full
-            // scan or a touch of the caller's file refreshes it.
+            // Caching is content-addressed: a `content_hash -> intent` map from
+            // the previous scan lets the generator reuse an intent whenever a
+            // function's body and its callees' intents are unchanged — without
+            // re-calling /generate-intent. Unlike the old name+file seeding,
+            // this also refreshes a caller in an unchanged file when one of its
+            // callees changed (the caller's hash includes its callee intents),
+            // so cross-file staleness no longer slips through.
             let mut function_definitions = function_definitions;
-            for (name, def) in function_definitions.iter_mut() {
-                if def.intent.is_some() {
-                    continue;
-                }
-                let rel = normalize_path(&def.file_path);
-                if changed_set.contains(&rel) {
-                    continue;
-                }
-                if let Some(prev_def) = prev.function_definitions.get(name)
-                    && prev_def.intent.is_some()
-                    && normalize_path(&prev_def.file_path) == rel
-                {
-                    def.intent = prev_def.intent.clone();
-                }
-            }
+            let prev_intents = intents_by_hash(&prev.function_definitions);
             generate_function_intents(
                 &agent_service,
                 &mut function_definitions,
                 &all_imported_symbols,
+                &prev_intents,
             )
             .await;
 
@@ -1403,10 +1389,13 @@ async fn analyze_current_repo(
     let mut function_definitions = function_definitions;
     {
         let intent_agent = AgentService::new();
+        // Full scan: no previous data, so nothing to reuse — every intent is
+        // generated fresh and its content hash recorded for the next scan.
         generate_function_intents(
             &intent_agent,
             &mut function_definitions,
             &all_imported_symbols,
+            &HashMap::new(),
         )
         .await;
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2461,6 +2461,70 @@ mod tests {
     }
 
     #[test]
+    fn test_function_definition_intent_hash_roundtrips() {
+        // The content-hash cache only works if `intent` and `intent_input_hash`
+        // survive the upload/download JSON round-trip. A silently-dropped hash
+        // would turn every incremental scan into a full cache miss.
+        let mut function_definitions = HashMap::new();
+        function_definitions.insert(
+            "getUser".to_string(),
+            crate::visitor::FunctionDefinition {
+                name: "getUser".to_string(),
+                file_path: "src/users.ts".into(),
+                node_type: Default::default(),
+                arguments: vec![],
+                body_source: None, // stripped before upload
+                is_exported: true,
+                line_number: 1,
+                intent: Some("fetches a user by id".to_string()),
+                calls: vec![],
+                return_type: None,
+                return_is_explicit: false,
+                signature: None,
+                intent_input_hash: Some("deadbeef".to_string()),
+            },
+        );
+
+        let data = CloudRepoData {
+            repo_name: "svc".to_string(),
+            service_name: None,
+            endpoints: vec![],
+            calls: vec![],
+            mounts: vec![],
+            apps: HashMap::new(),
+            imported_handlers: vec![],
+            function_definitions,
+            config_json: None,
+            package_json: None,
+            packages: None,
+            last_updated: chrono::Utc::now(),
+            commit_hash: "abc123".to_string(),
+            mount_graph: None,
+            bundled_types: None,
+            type_manifest: None,
+            file_results: None,
+            cached_detection: None,
+            cached_guidance: None,
+            package_json_hash: None,
+            cache_version: Some(CACHE_VERSION),
+        };
+
+        let json = serde_json::to_string(&data).expect("should serialize");
+        let deserialized: CloudRepoData = serde_json::from_str(&json).expect("should deserialize");
+
+        let def = &deserialized.function_definitions["getUser"];
+        assert_eq!(def.intent.as_deref(), Some("fetches a user by id"));
+        assert_eq!(def.intent_input_hash.as_deref(), Some("deadbeef"));
+
+        // And the map feeding the cache is rebuilt correctly from that blob.
+        let by_hash = crate::intent_generator::intents_by_hash(&deserialized.function_definitions);
+        assert_eq!(
+            by_hash.get("deadbeef").map(String::as_str),
+            Some("fetches a user by id")
+        );
+    }
+
+    #[test]
     fn test_cloud_repo_data_without_cache_fields_deserializes() {
         // Old CloudRepoData without cache fields should still deserialize (backwards compat)
         let json = r#"{

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -12,19 +12,73 @@
 
 use crate::agent_service::AgentService;
 use crate::visitor::{FunctionCallRef, FunctionDefinition, ImportedSymbol};
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use tracing::{debug, warn};
+
+/// Bump when the `/generate-intent` model or prompt template changes so that
+/// intents cached by content hash are regenerated rather than reused. The model
+/// and prompt live in the lambda (carrick-cloud), invisible to this crate, so
+/// this constant is the manual invalidation lever.
+const INTENT_CACHE_VERSION: u32 = 1;
+
+/// Content hash of the exact inputs that determine a function's generated
+/// intent: the cache version, the function body, and its callees' intents.
+/// Callee intents are sorted so set-equal contexts hash identically regardless
+/// of discovery order. Fields are length-delimited so concatenation is
+/// unambiguous.
+fn compute_intent_hash(body: &str, called_intents: &[String]) -> String {
+    let mut sorted: Vec<&String> = called_intents.iter().collect();
+    sorted.sort();
+
+    let mut hasher = Sha256::new();
+    hasher.update(INTENT_CACHE_VERSION.to_le_bytes());
+    hasher.update((body.len() as u64).to_le_bytes());
+    hasher.update(body.as_bytes());
+    hasher.update((sorted.len() as u64).to_le_bytes());
+    for ci in sorted {
+        hasher.update((ci.len() as u64).to_le_bytes());
+        hasher.update(ci.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Build a `content_hash -> intent` map from a previous scan's function
+/// definitions, keeping only entries that carry both an intent and the hash of
+/// the inputs that produced it. Passed into [`generate_function_intents`] so an
+/// unchanged function (same body + same callee intents) reuses its prior intent
+/// without another `/generate-intent` call. Definitions from a scan that
+/// predates content hashing simply lack `intent_input_hash` and are skipped
+/// (treated as cache misses).
+pub fn intents_by_hash(
+    function_definitions: &HashMap<String, FunctionDefinition>,
+) -> HashMap<String, String> {
+    function_definitions
+        .values()
+        .filter_map(|def| match (&def.intent_input_hash, &def.intent) {
+            (Some(hash), Some(intent)) => Some((hash.clone(), intent.clone())),
+            _ => None,
+        })
+        .collect()
+}
 
 /// Generate intents for all exported functions that have body source.
 ///
 /// After generation:
 /// - Each function's `intent` is populated with a 1-2 sentence description
+/// - Each function's `intent_input_hash` records the content hash that produced it
 /// - Each function's `calls` is populated with references to local callees
 /// - `body_source` is stripped from ALL functions (source stays in GitHub, not AWS)
+///
+/// `prev_intents_by_hash` is a `content_hash -> intent` map from the previous
+/// scan (see [`intents_by_hash`]). A function whose freshly-computed hash is
+/// present in the map reuses that intent without calling `/generate-intent`.
+/// Pass an empty map for a full (non-incremental) scan.
 pub async fn generate_function_intents(
     agent_service: &AgentService,
     function_definitions: &mut HashMap<String, FunctionDefinition>,
     _imported_symbols: &HashMap<String, ImportedSymbol>,
+    prev_intents_by_hash: &HashMap<String, String>,
 ) {
     // Process all named functions with body source
     let eligible: Vec<String> = function_definitions
@@ -82,73 +136,101 @@ pub async fn generate_function_intents(
     let levels = topological_levels(&eligible, &deps);
 
     // Generate intents level by level — within each level, calls run in parallel.
-    // Both the system instruction and user-prompt template now live in the
+    // Both the system instruction and user-prompt template live in the
     // /generate-intent lambda (carrick-cloud/lambdas/generate-intent/index.js).
     //
-    // Seed `intents` with any intent already present on a function definition.
-    // The incremental path uses this to carry intents forward for functions
-    // whose source file did not change, avoiding redundant lambda calls.
-    // Seeded entries also feed the `called_intents` prompt context so
-    // dependent functions get composed prompts even when their callees were
-    // cached.
-    let mut intents: HashMap<String, String> = function_definitions
-        .iter()
-        .filter_map(|(name, def)| def.intent.as_ref().map(|i| (name.clone(), i.clone())))
-        .collect();
-    let reused = intents.len();
+    // Caching is content-addressed: for each function we compute a hash over its
+    // body and its callees' (already-resolved) intents. If that hash was seen in
+    // the previous scan, we reuse the prior intent without a lambda call. This
+    // both avoids redundant calls for unchanged code AND correctly invalidates a
+    // caller when a callee's intent changed (its `called_intents` differ, so its
+    // hash differs). Processing leaves-first guarantees callee intents are
+    // resolved before their callers are hashed.
+    //
+    // `intents` holds the resolved intent per function (reused or freshly
+    // generated); `hashes` holds the content hash that produced each one, to be
+    // persisted on the definition for the next scan.
+    let mut intents: HashMap<String, String> = HashMap::new();
+    let mut hashes: HashMap<String, String> = HashMap::new();
+    let mut reused = 0usize;
+    let mut generated = 0usize;
 
     for level in &levels {
-        // Build payloads only for functions in this level that don't already
-        // have an intent (skip cache hits — saves lambda calls).
-        let tasks: Vec<(String, String, String, Vec<String>)> = level
+        // Compute each function's called_intents context and content hash, then
+        // split into cache hits (reuse) and misses (call the lambda).
+        struct Pending {
+            name: String,
+            body: String,
+            called_intents: Vec<String>,
+            hash: String,
+        }
+        let mut to_generate: Vec<Pending> = Vec::new();
+
+        for name in level {
+            let Some(def) = function_definitions.get(name) else {
+                continue;
+            };
+            let Some(body) = def.body_source.as_ref() else {
+                continue;
+            };
+
+            let called_intents: Vec<String> = deps
+                .get(name)
+                .map(|called| {
+                    called
+                        .iter()
+                        .filter_map(|callee| {
+                            intents
+                                .get(callee)
+                                .map(|intent| format!("- {}: {}", callee, intent))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let hash = compute_intent_hash(body, &called_intents);
+
+            if let Some(prev_intent) = prev_intents_by_hash.get(&hash) {
+                // Identical body + callee context as a prior scan — reuse.
+                intents.insert(name.clone(), prev_intent.clone());
+                hashes.insert(name.clone(), hash);
+                reused += 1;
+            } else {
+                to_generate.push(Pending {
+                    name: name.clone(),
+                    body: body.clone(),
+                    called_intents,
+                    hash,
+                });
+            }
+        }
+
+        // Run all cache-miss lambda calls for this level in parallel.
+        let futures: Vec<_> = to_generate
             .iter()
-            .filter(|name| !intents.contains_key(name.as_str()))
-            .filter_map(|name| {
-                let def = function_definitions.get(name)?;
-                let body = def.body_source.as_ref()?;
-
-                let called_intents: Vec<String> = deps
-                    .get(name)
-                    .map(|called| {
-                        called
-                            .iter()
-                            .filter_map(|callee| {
-                                intents
-                                    .get(callee)
-                                    .map(|intent| format!("- {}: {}", callee, intent))
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-
-                Some((name.clone(), name.clone(), body.clone(), called_intents))
-            })
-            .collect();
-
-        // Run all lambda calls for this level in parallel
-        let futures: Vec<_> = tasks
-            .iter()
-            .map(|(key, name, body, called_intents)| async move {
+            .map(|pending| async move {
                 let payload = serde_json::json!({
-                    "name": name,
-                    "body": body,
-                    "called_intents": called_intents,
+                    "name": pending.name,
+                    "body": pending.body,
+                    "called_intents": pending.called_intents,
                 });
                 let result = agent_service
-                    .post_to_lambda("/generate-intent", &payload, name)
+                    .post_to_lambda("/generate-intent", &payload, &pending.name)
                     .await;
-                (key.clone(), result)
+                (pending.name.clone(), pending.hash.clone(), result)
             })
             .collect();
 
         let results = futures::future::join_all(futures).await;
 
-        for (name, result) in results {
+        for (name, hash, result) in results {
             match result {
                 Ok(intent) => {
                     let intent = intent.trim().to_string();
                     if !intent.is_empty() && intent.len() < 500 {
+                        hashes.insert(name.clone(), hash);
                         intents.insert(name, intent);
+                        generated += 1;
                     }
                 }
                 Err(e) => {
@@ -158,20 +240,18 @@ pub async fn generate_function_intents(
         }
     }
 
-    // Write intents back to function definitions. Reused entries already
-    // have the same value on the def — assigning is idempotent.
+    // Write resolved intents and their content hashes back to the definitions.
     let total = intents.len();
     for (name, intent) in intents {
         if let Some(def) = function_definitions.get_mut(&name) {
             def.intent = Some(intent);
+            def.intent_input_hash = hashes.get(&name).cloned();
         }
     }
 
     debug!(
-        "Intents: {} total ({} reused from cache, {} freshly generated)",
-        total,
-        reused,
-        total.saturating_sub(reused)
+        "Intents: {} total ({} reused from content-hash cache, {} freshly generated)",
+        total, reused, generated
     );
 
     // Strip body_source — source code stays in GitHub, not AWS
@@ -326,11 +406,172 @@ mod tests {
                 return_type: None,
                 return_is_explicit: false,
                 signature: None,
+                intent_input_hash: None,
             },
         );
         strip_body_source(&mut defs);
         assert!(defs.get("foo").unwrap().body_source.is_none());
         // Intent should be preserved
         assert!(defs.get("foo").unwrap().intent.is_some());
+    }
+
+    #[test]
+    fn intent_hash_is_deterministic() {
+        let called = vec!["- a: does a".to_string(), "- b: does b".to_string()];
+        let h1 = compute_intent_hash("return 1;", &called);
+        let h2 = compute_intent_hash("return 1;", &called);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn intent_hash_ignores_called_intents_order() {
+        let a = vec!["- a: does a".to_string(), "- b: does b".to_string()];
+        let b = vec!["- b: does b".to_string(), "- a: does a".to_string()];
+        assert_eq!(
+            compute_intent_hash("return 1;", &a),
+            compute_intent_hash("return 1;", &b),
+            "reordered callee intents must hash identically"
+        );
+    }
+
+    #[test]
+    fn intent_hash_changes_with_body() {
+        let called: Vec<String> = vec![];
+        assert_ne!(
+            compute_intent_hash("return 1;", &called),
+            compute_intent_hash("return 2;", &called)
+        );
+    }
+
+    #[test]
+    fn intent_hash_changes_when_callee_intent_changes() {
+        // A caller whose callee's intent shifts must get a new hash so the
+        // stale cached intent is regenerated rather than reused.
+        let before = vec!["- helper: validates the token".to_string()];
+        let after = vec!["- helper: parses the token".to_string()];
+        assert_ne!(
+            compute_intent_hash("return helper();", &before),
+            compute_intent_hash("return helper();", &after)
+        );
+    }
+
+    #[test]
+    fn intents_by_hash_keeps_only_complete_entries() {
+        let mut defs = HashMap::new();
+        let base = FunctionDefinition {
+            name: "f".to_string(),
+            file_path: "test.ts".into(),
+            node_type: Default::default(),
+            arguments: vec![],
+            body_source: None,
+            is_exported: true,
+            line_number: 1,
+            intent: None,
+            calls: vec![],
+            return_type: None,
+            return_is_explicit: false,
+            signature: None,
+            intent_input_hash: None,
+        };
+
+        // Complete: both intent and hash present → kept.
+        defs.insert(
+            "complete".to_string(),
+            FunctionDefinition {
+                intent: Some("does the thing".to_string()),
+                intent_input_hash: Some("abc123".to_string()),
+                ..base.clone()
+            },
+        );
+        // Intent but no hash (pre-content-hash scan) → skipped.
+        defs.insert(
+            "no_hash".to_string(),
+            FunctionDefinition {
+                intent: Some("does another thing".to_string()),
+                ..base.clone()
+            },
+        );
+        // Hash but no intent (generation failed) → skipped.
+        defs.insert(
+            "no_intent".to_string(),
+            FunctionDefinition {
+                intent_input_hash: Some("def456".to_string()),
+                ..base.clone()
+            },
+        );
+
+        let map = intents_by_hash(&defs);
+        assert_eq!(map.len(), 1);
+        assert_eq!(
+            map.get("abc123").map(String::as_str),
+            Some("does the thing")
+        );
+    }
+
+    fn def_with_body(name: &str, body: &str) -> FunctionDefinition {
+        FunctionDefinition {
+            name: name.to_string(),
+            file_path: "test.ts".into(),
+            node_type: Default::default(),
+            arguments: vec![],
+            body_source: Some(body.to_string()),
+            is_exported: true,
+            line_number: 1,
+            intent: None,
+            calls: vec![],
+            return_type: None,
+            return_is_explicit: false,
+            signature: None,
+            intent_input_hash: None,
+        }
+    }
+
+    /// When every function's content hash is present in the previous-scan map,
+    /// all intents are reused and NO `/generate-intent` call is made (the test
+    /// would otherwise hit the network and fail). Also exercises the caller's
+    /// hash composing its callee's resolved intent.
+    #[tokio::test]
+    async fn full_cache_hit_makes_no_lambda_calls() {
+        // `main` calls `helper`; helper is the leaf (level 0).
+        let mut defs = HashMap::new();
+        defs.insert("helper".to_string(), def_with_body("helper", "return 1;"));
+        defs.insert(
+            "main".to_string(),
+            def_with_body("main", "return helper();"),
+        );
+
+        // Reconstruct the exact hashes the generator will compute.
+        let helper_intent = "returns the number one";
+        let helper_hash = compute_intent_hash("return 1;", &[]);
+        let caller_context = vec![format!("- helper: {}", helper_intent)];
+        let main_hash = compute_intent_hash("return helper();", &caller_context);
+
+        let mut prev = HashMap::new();
+        prev.insert(helper_hash.clone(), helper_intent.to_string());
+        prev.insert(main_hash.clone(), "calls the helper".to_string());
+
+        let agent = AgentService::new();
+        generate_function_intents(
+            &agent,
+            &mut defs,
+            &HashMap::<String, ImportedSymbol>::new(),
+            &prev,
+        )
+        .await;
+
+        // Both intents came from the cache, with their hashes recorded.
+        assert_eq!(defs["helper"].intent.as_deref(), Some(helper_intent));
+        assert_eq!(defs["main"].intent.as_deref(), Some("calls the helper"));
+        assert_eq!(
+            defs["helper"].intent_input_hash.as_deref(),
+            Some(helper_hash.as_str())
+        );
+        assert_eq!(
+            defs["main"].intent_input_hash.as_deref(),
+            Some(main_hash.as_str())
+        );
+        // body_source is stripped before upload.
+        assert!(defs["helper"].body_source.is_none());
+        assert!(defs["main"].body_source.is_none());
     }
 }

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -231,6 +231,16 @@ pub async fn generate_function_intents(
                         hashes.insert(name.clone(), hash);
                         intents.insert(name, intent);
                         generated += 1;
+                    } else {
+                        // Empty or over-long response: drop it. The function
+                        // keeps `intent = None`, so it (and its callers) retry
+                        // next scan. Log it — otherwise this is a silent,
+                        // permanent cache miss.
+                        warn!(
+                            "Discarding intent for {} ({} chars, expected 1..500)",
+                            name,
+                            intent.len()
+                        );
                     }
                 }
                 Err(e) => {

--- a/src/signature_pass.rs
+++ b/src/signature_pass.rs
@@ -255,6 +255,7 @@ mod tests {
             return_type: return_type.map(|t| t.to_string()),
             return_is_explicit: return_type.is_some(),
             signature: None,
+            intent_input_hash: None,
         }
     }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -130,6 +130,12 @@ pub struct FunctionDefinition {
     /// until the signature pass runs. The MCP layer surfaces this verbatim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
+    /// Content hash of the exact inputs that produced `intent` (cache version +
+    /// function body + callees' intents). Lets a later scan reuse the cached
+    /// intent when nothing affecting it changed, and regenerate it when a
+    /// callee's intent shifts. `None` until an intent is generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent_input_hash: Option<String>,
 }
 
 /// A reference to a called function, for navigating to its source via GitHub.
@@ -471,6 +477,7 @@ impl Visit for FunctionDefinitionExtractor {
                             return_is_explicit: return_type.is_some(),
                             return_type,
                             signature: None,
+                            intent_input_hash: None,
                         },
                     );
                 }
@@ -539,6 +546,7 @@ impl Visit for FunctionDefinitionExtractor {
                 return_is_explicit: return_type.is_some(),
                 return_type,
                 signature: None,
+                intent_input_hash: None,
             },
         );
 
@@ -577,6 +585,7 @@ impl Visit for FunctionDefinitionExtractor {
                                 return_is_explicit: return_type.is_some(),
                                 return_type,
                                 signature: None,
+                                intent_input_hash: None,
                             },
                         );
                     }
@@ -610,6 +619,7 @@ impl Visit for FunctionDefinitionExtractor {
                                 return_is_explicit: return_type.is_some(),
                                 return_type,
                                 signature: None,
+                                intent_input_hash: None,
                             },
                         );
                     }
@@ -659,6 +669,7 @@ impl Visit for FunctionDefinitionExtractor {
                                     return_is_explicit: return_type.is_some(),
                                     return_type,
                                     signature: None,
+                                    intent_input_hash: None,
                                 },
                             );
                         }
@@ -696,6 +707,7 @@ impl Visit for FunctionDefinitionExtractor {
                                     return_is_explicit: return_type.is_some(),
                                     return_type,
                                     signature: None,
+                                    intent_input_hash: None,
                                 },
                             );
                         }


### PR DESCRIPTION
## What

Reuse a previously-generated function intent whenever its prompt inputs are unchanged, keyed on a **content hash** instead of the function name.

Each `FunctionDefinition` gains `intent_input_hash` — a SHA-256 over `INTENT_CACHE_VERSION` + function body + the function's callees' (sorted) intents. `generate_function_intents` resolves intents leaves-first and, per function, reuses the prior scan's intent when the freshly-computed hash matches; otherwise it calls `/generate-intent` and records the new hash.

## Why

The old reuse was keyed on function **name + file** (copy the prior intent if the source file was unchanged). That had two problems:

1. It reused an intent even when the body changed within an unchanged-considered context (stale).
2. A caller in an unchanged file kept a stale intent when one of its callees (in a changed file) got a *new* intent — a limitation the previous code documented as an "acceptable trade-off."

Because a caller's hash now includes its callees' intents, a callee change invalidates the caller too. Net effect: intent-generation cost scales with *changed code* rather than repo size, and cross-file staleness no longer slips through.

This is the higher-leverage half of the scanner fan-out problem (the `generate-intent` 429 storm): once intents are content-cached, steady-state scans regenerate only genuinely changed functions.

## Scope

Scanner-only. The new field rides through the existing S3 metadata blob with **no cloud-side change** — verified: `check-or-upload` stores the blob opaquely (`JSON.stringify(cloudRepoData)`) and its TS interfaces use `[key: string]: any`; the lambda only reads `intent`/`embedding`. Runs independently of the now-merged DynamoDB item-size fix (#104, carrick-cloud).

## One-time cost

The first scan after this lands sees prior data with no stored hashes, so every intent regenerates once; subsequent scans reuse. No back-compat shim (no users) — definitions lacking the field deserialize to `None` and are treated as cache misses.

## Tests

- `compute_intent_hash`: determinism, callee-order independence, body-change sensitivity, **callee-intent-change invalidation**.
- `intents_by_hash`: filters to entries with both intent and hash.
- `full_cache_hit_makes_no_lambda_calls`: end-to-end proof that a full cache hit makes **zero** `/generate-intent` calls (would hit the network otherwise) and composes a caller's hash from its callee's resolved intent.
- `test_function_definition_intent_hash_roundtrips`: `intent` + `intent_input_hash` survive `CloudRepoData` JSON round-trip and rebuild the cache map.

All 287 tests + clippy (`-D warnings`) + rustfmt pass.

## Reviewed by three adversarial agents — follow-ups (not blockers)

- **Live two-pass verification** is now unblocked (#104 merged). Recommend confirming a second consecutive scan reports incremental reuse before relying on it in steady state.
- **End-to-end cache-*miss*/cascade test** is missing because `AgentService` has no mock seam (concrete `reqwest::Client`, no trait). Adding the seam + test is a follow-up.
- **`body.contains(fn_name)` call-graph heuristic** (pre-existing) can over-match callee names; the content hash now amplifies its cost (a caller may regenerate when an unrelated same-named function's intent changes). Follow-up: resolve callees from real call references.
- **Callee generation-failure flip**: if a callee's generation fails one scan and succeeds the next, its callers regenerate once (self-correcting, documented in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
