### PR TITLE
fix: key uploads by service; drop false-positive call extractions

### DIFF
--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -20,6 +20,14 @@ pub struct AwsStorage {
 struct LambdaRequest {
     action: String,
     repo: String,
+    /// Service discriminator for the cloud index key. Repos can declare
+    /// multiple services in carrick.json; the cloud keys each upload by
+    /// (repo, service) so they don't clobber each other. Must be sent on
+    /// every keyed action (including the bare existence check, which carries
+    /// no `cloudRepoData`), or the cloud falls back to the repo name and all
+    /// services collapse onto one row.
+    #[serde(rename = "service_name", skip_serializing_if = "Option::is_none")]
+    service_name: Option<String>,
     hash: String,
     filename: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -209,6 +217,7 @@ impl AwsStorage {
         let request = LambdaRequest {
             action: "store-metadata".to_string(),
             repo: data.repo_name.clone(),
+            service_name: data.service_name.clone(),
             hash: data.commit_hash.clone(),
             filename: "types.d.ts".to_string(),
             cloud_repo_data: Some(data.clone()),
@@ -231,6 +240,7 @@ impl CloudStorage for AwsStorage {
         let check_request = LambdaRequest {
             action: "check-or-upload".to_string(),
             repo: repo.clone(),
+            service_name: data.service_name.clone(),
             hash: data.commit_hash.clone(),
             filename: "types.d.ts".to_string(),
             cloud_repo_data: None,
@@ -249,6 +259,7 @@ impl CloudStorage for AwsStorage {
                 let complete_request = LambdaRequest {
                     action: "complete-upload".to_string(),
                     repo: repo.clone(),
+                    service_name: data.service_name.clone(),
                     hash: data.commit_hash.clone(),
                     filename: "types.d.ts".to_string(),
                     cloud_repo_data: Some(data.clone()),
@@ -286,6 +297,9 @@ impl CloudStorage for AwsStorage {
         let request = LambdaRequest {
             action: "check-or-upload".to_string(),
             repo: repo_name.to_string(),
+            // upload_type_file is not service-scoped (no CloudRepoData in scope);
+            // the cloud falls back to the repo name, matching legacy behaviour.
+            service_name: None,
             hash: commit_hash,
             filename: file_name.to_string(),
             cloud_repo_data: None,
@@ -421,6 +435,7 @@ impl CloudStorage for AwsStorage {
         let request = LambdaRequest {
             action: "check-or-upload".to_string(),
             repo: "health".to_string(),
+            service_name: None,
             hash: "health-check".to_string(),
             filename: "health.ts".to_string(),
             cloud_repo_data: None,

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -437,8 +437,10 @@ impl MountGraph {
     ) -> Option<Vec<&ResolvedEndpoint>> {
         let normalized = normalizer.normalize(url);
 
-        // Skip external calls
-        if normalized.is_external {
+        // Skip external calls and calls whose URL was a single opaque variable
+        // we couldn't resolve (e.g. `${url}`) — there's no path to match, and
+        // reporting them produces bogus "missing endpoint" noise.
+        if normalized.is_external || normalized.is_unresolved {
             return None;
         }
 

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -37,6 +37,11 @@ pub struct NormalizedUrl {
     pub original: String,
     /// Any host/domain that was stripped
     pub stripped_host: Option<String>,
+    /// True when the entire URL was a single opaque variable the scanner could
+    /// not resolve (e.g. `fetch(new Request(url))` → `${url}`). Such a "call"
+    /// has no comparable path, so callers should skip it rather than report a
+    /// bogus missing endpoint like `GET ${url}`.
+    pub is_unresolved: bool,
 }
 
 /// URL normalizer that uses configuration to identify internal/external domains
@@ -126,6 +131,7 @@ impl UrlNormalizer {
             is_external: false,
             original,
             stripped_host: None,
+            is_unresolved: false,
         }
     }
 
@@ -153,6 +159,7 @@ impl UrlNormalizer {
                 is_external,
                 original,
                 stripped_host: Some(format!("ENV_VAR:{}", env_var_name)),
+                is_unresolved: false,
             }
         } else {
             NormalizedUrl {
@@ -161,6 +168,7 @@ impl UrlNormalizer {
                 is_external: false,
                 original,
                 stripped_host: None,
+                is_unresolved: false,
             }
         }
     }
@@ -191,6 +199,7 @@ impl UrlNormalizer {
             is_external,
             original,
             stripped_host: env_var_name.map(|v| format!("process.env.{}", v)),
+            is_unresolved: false,
         }
     }
 
@@ -246,6 +255,8 @@ impl UrlNormalizer {
         let mut is_internal = false;
         let mut is_external = false;
 
+        let mut leading_var_stripped = false;
+
         // Check if starts with a variable that might be a base URL
         if url.starts_with("${")
             && let Some(end) = url.find('}')
@@ -261,7 +272,17 @@ impl UrlNormalizer {
             }
             // Remove the base URL variable
             result = url[end + 1..].to_string();
+            leading_var_stripped = true;
         }
+
+        // The whole URL was a single opaque variable (e.g. `${url}` from
+        // `fetch(new Request(url))`) when stripping the leading `${...}` left no
+        // path behind and the variable wasn't a configured internal/external
+        // host. There's nothing to match, so flag it for callers to skip.
+        let is_unresolved = leading_var_stripped
+            && !is_internal
+            && !is_external
+            && result.trim_matches('/').is_empty();
 
         // Convert remaining ${varName} to :varName for path parameter matching
         let path = self.convert_interpolations_to_params(&result);
@@ -272,6 +293,7 @@ impl UrlNormalizer {
             is_external,
             original,
             stripped_host,
+            is_unresolved,
         }
     }
 
@@ -328,6 +350,7 @@ impl UrlNormalizer {
             is_external,
             original,
             stripped_host: Some(host),
+            is_unresolved: false,
         }
     }
 
@@ -360,9 +383,27 @@ impl UrlNormalizer {
         let host_without_port = host.split(':').next().unwrap_or(host).to_ascii_lowercase();
 
         domains.iter().any(|domain| {
-            let domain = domain.to_ascii_lowercase();
+            let domain = Self::domain_host(domain);
             host_without_port == domain || host_without_port.ends_with(&format!(".{}", domain))
         })
+    }
+
+    /// Reduce a configured domain entry to a bare, comparable hostname.
+    ///
+    /// carrick.json lets users write `externalDomains`/`internalDomains` either
+    /// as bare hosts (`api.resend.com`) or full URLs (`https://api.resend.com`).
+    /// Incoming call hosts are always bare, so we normalize config entries the
+    /// same way — strip the scheme, any path/query, and the port — before
+    /// comparing. Without this, a `https://`-prefixed entry never matches and
+    /// the call is misclassified as internal (reported as a missing endpoint).
+    fn domain_host(domain: &str) -> String {
+        let without_scheme = domain
+            .strip_prefix("https://")
+            .or_else(|| domain.strip_prefix("http://"))
+            .unwrap_or(domain);
+        // Drop anything from the first '/' (path) onward, then the port.
+        let host = without_scheme.split('/').next().unwrap_or(without_scheme);
+        host.split(':').next().unwrap_or(host).to_ascii_lowercase()
     }
 
     /// Clean up a path by removing query strings, fragments, and normalizing slashes
@@ -502,6 +543,60 @@ mod tests {
         assert_eq!(result.path, "/v1/charges");
         assert!(!result.is_internal);
         assert!(result.is_external);
+    }
+
+    /// Regression: carrick.json domain lists are often written as full URLs
+    /// (`https://api.resend.com`) rather than bare hosts. The incoming call host
+    /// is always bare, so config entries must be scheme/path/port-stripped
+    /// before comparison — otherwise the external call is misclassified as
+    /// internal and reported as a bogus missing endpoint.
+    #[test]
+    fn test_external_domain_with_scheme_prefix_matches() {
+        let config = Config {
+            external_domains: ["https://api.resend.com", "https://eu.posthog.com/"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            internal_domains: ["https://api.company.com"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            ..Default::default()
+        };
+        let normalizer = UrlNormalizer::new(&config);
+
+        let external = normalizer.normalize("https://api.resend.com/contacts");
+        assert!(
+            external.is_external,
+            "scheme-prefixed external domain should match"
+        );
+        assert!(!external.is_internal);
+
+        let internal = normalizer.normalize("https://api.company.com/v1/users");
+        assert!(
+            internal.is_internal,
+            "scheme-prefixed internal domain should match"
+        );
+        assert!(!internal.is_external);
+    }
+
+    /// Regression: a call whose URL is a single opaque variable (e.g.
+    /// `fetch(new Request(url))` surfacing as `${url}`) has no resolvable path.
+    /// It must be flagged unresolved so callers skip it instead of emitting a
+    /// bogus `GET ${url}` missing endpoint. A variable that only supplies the
+    /// host but is followed by a real path stays resolvable.
+    #[test]
+    fn test_whole_url_variable_is_unresolved() {
+        let config = create_test_config();
+        let normalizer = UrlNormalizer::new(&config);
+
+        assert!(normalizer.normalize("${url}").is_unresolved);
+        assert!(normalizer.normalize("${url}/").is_unresolved);
+        // An unknown base var followed by a real path is NOT unresolved — the
+        // path segment is still comparable.
+        assert!(!normalizer.normalize("${base}/users").is_unresolved);
+        // A configured internal base var is resolved, not unresolved.
+        assert!(!normalizer.normalize("${API_URL}/users").is_unresolved);
     }
 
     #[test]

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -278,11 +278,15 @@ impl UrlNormalizer {
         // The whole URL was a single opaque variable (e.g. `${url}` from
         // `fetch(new Request(url))`) when stripping the leading `${...}` left no
         // path behind and the variable wasn't a configured internal/external
-        // host. There's nothing to match, so flag it for callers to skip.
+        // host. There's nothing to match, so flag it for callers to skip. A
+        // query string or fragment alone (`${url}?x=1`, `${url}#h`) is not a
+        // path — strip it before the emptiness check, or it would slip through
+        // and `clean_path` would reduce it to `/` and falsely match root.
+        let result_path = result.split(['?', '#']).next().unwrap_or("");
         let is_unresolved = leading_var_stripped
             && !is_internal
             && !is_external
-            && result.trim_matches('/').is_empty();
+            && result_path.trim_matches('/').is_empty();
 
         // Convert remaining ${varName} to :varName for path parameter matching
         let path = self.convert_interpolations_to_params(&result);
@@ -397,13 +401,16 @@ impl UrlNormalizer {
     /// comparing. Without this, a `https://`-prefixed entry never matches and
     /// the call is misclassified as internal (reported as a missing endpoint).
     fn domain_host(domain: &str) -> String {
-        let without_scheme = domain
+        // Lowercase first so a mixed-case scheme (`HTTPS://`) still strips —
+        // URL schemes are case-insensitive.
+        let lower = domain.to_ascii_lowercase();
+        let without_scheme = lower
             .strip_prefix("https://")
-            .or_else(|| domain.strip_prefix("http://"))
-            .unwrap_or(domain);
+            .or_else(|| lower.strip_prefix("http://"))
+            .unwrap_or(&lower);
         // Drop anything from the first '/' (path) onward, then the port.
         let host = without_scheme.split('/').next().unwrap_or(without_scheme);
-        host.split(':').next().unwrap_or(host).to_ascii_lowercase()
+        host.split(':').next().unwrap_or(host).to_string()
     }
 
     /// Clean up a path by removing query strings, fragments, and normalizing slashes
@@ -578,6 +585,19 @@ mod tests {
             "scheme-prefixed internal domain should match"
         );
         assert!(!internal.is_external);
+
+        // Schemes are case-insensitive — a mixed-case config entry must still match.
+        let mixed = UrlNormalizer::new(&Config {
+            external_domains: ["HTTPS://api.resend.com"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            ..Default::default()
+        });
+        assert!(
+            mixed.normalize("https://api.resend.com/emails").is_external,
+            "mixed-case scheme in config should still match"
+        );
     }
 
     /// Regression: a call whose URL is a single opaque variable (e.g.
@@ -592,6 +612,9 @@ mod tests {
 
         assert!(normalizer.normalize("${url}").is_unresolved);
         assert!(normalizer.normalize("${url}/").is_unresolved);
+        // A query string or fragment alone is not a path.
+        assert!(normalizer.normalize("${url}?x=1").is_unresolved);
+        assert!(normalizer.normalize("${url}#section").is_unresolved);
         // An unknown base var followed by a real path is NOT unresolved — the
         // path segment is still comparable.
         assert!(!normalizer.normalize("${base}/users").is_unresolved);


### PR DESCRIPTION
## Why

Running the scanner against a repo with **multiple services** in `carrick.json` (e.g. `carrick-site` + a nested worker) dropped the root service entirely: the cloud index showed one mislabeled service with `endpoint_count: 0`, and the semantic/intent layer was empty. Investigation (code + live AWS data) traced three distinct issues, all surfacing here.

## What

- **Multi-service key collision (the big one).** The upload `LambdaRequest` never carried `service_name` at the top level, so the cloud derived the index key's service segment from the repo name for *every* service — collapsing them onto one `pk/sk`. The last upload (often an empty worker) clobbered the rest, dropping the root service's endpoints **and** its function intents. Now `service_name` is sent on every keyed action (including the bare existence check).
- **External-domain matching ignored the URL scheme.** `host_matches_domains` compared the bare call host against raw config entries, so URL-form `externalDomains`/`internalDomains` (e.g. `https://api.resend.com`) never matched and external calls were reported as missing endpoints. New `domain_host()` strips scheme/path/port before comparison — fixes internal matching too.
- **Unresolved whole-URL variables reported as calls.** `fetch(new Request(url))` surfaced as a bogus `GET ${url}` missing endpoint. `NormalizedUrl` now flags `is_unresolved` for single-variable URLs and the matcher skips them.

## Tests

- Added regression tests for scheme-prefixed domain matching and the unresolved-URL case.
- Full suite green via pre-commit hook (282 lib + integration + ts_check), `cargo fmt`/`clippy` clean.

## Companion

Pairs with carrick-cloud#<cloud-pr> (rollup fix, ingest fallback, extraction-prompt guard, gateway access logs). Deploy is independent; either order is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)