### PR TITLE
fix: close scanner failure points — cloud resilience, fail-loud scans, degradation surfacing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,22 +28,60 @@ runs:
         node-version: "24"
 
     - name: Download Carrick
+      id: download
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        DOWNLOAD_URL=$(gh api repos/daveymoores/carrick/releases/latest --jq '.assets[] | select(.name=="carrick-action-linux.tar.gz") | .browser_download_url')
-        curl -L -o carrick-action.tar.gz "$DOWNLOAD_URL"
-        tar -xzf carrick-action.tar.gz
-        chmod +x carrick
+        ASSET="carrick-action-linux.tar.gz"
+        JQ_ASSET_URL=".assets[] | select(.name==\"$ASSET\") | .browser_download_url"
+
+        # Pin the binary to the release matching this action checkout:
+        # release-please bumps Cargo.toml in the same commit it tags, so the
+        # version here identifies the release this ref shipped with. Without
+        # this, every run floated to the latest release regardless of which
+        # action ref the workflow pinned.
+        VERSION=$(grep -m1 '^version' "$GITHUB_ACTION_PATH/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
+        echo "Resolving Carrick release for version $VERSION"
+
+        DOWNLOAD_URL=$(gh api "repos/daveymoores/carrick/releases/tags/v$VERSION" \
+          --jq "$JQ_ASSET_URL" 2>/dev/null || true)
+
+        if [ -z "$DOWNLOAD_URL" ]; then
+          # Tag naming may carry a prefix (e.g. carrick-v0.1.30); match by suffix.
+          DOWNLOAD_URL=$(gh api repos/daveymoores/carrick/releases --paginate \
+            --jq ".[] | select(.tag_name | endswith(\"$VERSION\")) | $JQ_ASSET_URL" \
+            2>/dev/null | head -n 1 || true)
+        fi
+
+        if [ -z "$DOWNLOAD_URL" ]; then
+          echo "::warning::No release found matching version $VERSION (expected when running from an untagged ref); falling back to the latest release"
+          DOWNLOAD_URL=$(gh api repos/daveymoores/carrick/releases/latest --jq "$JQ_ASSET_URL")
+        fi
+
+        if [ -z "$DOWNLOAD_URL" ]; then
+          echo "::error::Could not resolve a download URL for $ASSET from any release of daveymoores/carrick"
+          exit 1
+        fi
+
+        # Extract into a scratch directory: extracting into the workspace
+        # would clobber any carrick/ts_check/sidecar paths in the user's repo
+        # and pollute their scan root.
+        DIST_DIR="$RUNNER_TEMP/carrick-dist"
+        mkdir -p "$DIST_DIR"
+        echo "Downloading $DOWNLOAD_URL"
+        curl -fsSL --retry 3 --retry-delay 2 -o "$DIST_DIR/$ASSET" "$DOWNLOAD_URL"
+        tar -xzf "$DIST_DIR/$ASSET" -C "$DIST_DIR"
+        chmod +x "$DIST_DIR/carrick"
+        echo "dist-dir=$DIST_DIR" >> "$GITHUB_OUTPUT"
 
     - name: Install ts_check dependencies
       shell: bash
-      run: cd ts_check && npm ci
+      run: cd "${{ steps.download.outputs.dist-dir }}/ts_check" && npm ci
 
     - name: Install sidecar dependencies
       shell: bash
-      run: cd sidecar && npm ci
+      run: cd "${{ steps.download.outputs.dist-dir }}/sidecar" && npm ci
 
     - name: Run analysis
       id: analysis
@@ -56,7 +94,7 @@ runs:
         CI: "true"
       run: |
         set +e
-        ./carrick ${{ inputs.path }} > analysis.log 2>&1
+        "${{ steps.download.outputs.dist-dir }}/carrick" "${{ inputs.path }}" > analysis.log 2>&1
         EXIT_CODE=$?
         set -e
 

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -74,6 +74,10 @@ pub struct ProcessingStats {
     pub files_skipped: usize,
     /// Files skipped because SWC found no API candidates (zero-cost skips)
     pub files_skipped_no_candidates: usize,
+    /// Files excluded because they could not be parsed. Counted separately
+    /// from zero-cost skips: a parse failure silently removes the file's
+    /// endpoints from the index. A subset of `files_skipped`.
+    pub files_parse_failed: usize,
     pub total_mounts: usize,
     pub total_endpoints: usize,
     /// Endpoints derived structurally from file-based routing conventions
@@ -202,6 +206,23 @@ impl FileOrchestrator {
                 &framework_detection.data_fetchers,
             );
 
+            // A parse failure excludes the whole file (and any endpoints in
+            // it) from the index — surface it instead of letting it look like
+            // a healthy file with no API patterns.
+            if scan_result.parse_failed {
+                warn!(
+                    "Failed to parse {} — file excluded from analysis; any endpoints in it \
+                     will be missing from the index",
+                    path_str
+                );
+                stats.errors.push(format!("Parse failure: {}", path_str));
+                stats.files_skipped += 1;
+                stats.files_parse_failed += 1;
+                // Store empty result so incremental cache knows this file was processed
+                file_results.insert(path_str, FileAnalysisResult::default());
+                continue;
+            }
+
             // File-based routing: routes declared by file location (Next.js app
             // router, etc.) have no call-site candidate — the endpoint *is* the
             // exported handler declaration. The path comes from the layout and the
@@ -326,7 +347,7 @@ impl FileOrchestrator {
                     // using the compiler-based approach instead of position-based extraction.
 
                     let mut adjusted = result;
-                    Self::apply_candidate_map(&mut adjusted, &pf.candidate_map);
+                    Self::apply_candidate_map(&mut adjusted, &pf.candidate_map, &pf.path_str);
                     Self::validate_type_hints(&mut adjusted, &pf.symbol_table);
                     Self::normalize_unusable_types(&mut adjusted, &framework_detection.frameworks);
 
@@ -357,6 +378,12 @@ impl FileOrchestrator {
             "  - Zero-cost skips (no API patterns): {}",
             stats.files_skipped_no_candidates
         );
+        if stats.files_parse_failed > 0 {
+            warn!(
+                "{} file(s) failed to parse and are excluded from the index",
+                stats.files_parse_failed
+            );
+        }
         debug!("  - Total mounts: {}", stats.total_mounts);
         debug!("  - Total endpoints: {}", stats.total_endpoints);
         debug!(
@@ -1035,19 +1062,38 @@ impl FileOrchestrator {
     fn apply_candidate_map(
         result: &mut FileAnalysisResult,
         candidate_map: &HashMap<String, CandidateTarget>,
+        file_path: &str,
     ) {
-        // Endpoints: keep filter_map (endpoints without candidates are unreliable)
+        // Endpoints: keep filter_map (endpoints without candidates are unreliable),
+        // but a drop means an endpoint the LLM reported vanishes from the index —
+        // log which, so silent loss is at least diagnosable.
+        let mut dropped_endpoints: Vec<String> = Vec::new();
         result.endpoints = result
             .endpoints
             .drain(..)
             .filter_map(|mut endpoint| {
-                let candidate = candidate_map.get(&endpoint.candidate_id)?;
+                let Some(candidate) = candidate_map.get(&endpoint.candidate_id) else {
+                    dropped_endpoints.push(format!(
+                        "{} {} (candidate_id '{}')",
+                        endpoint.method, endpoint.path, endpoint.candidate_id
+                    ));
+                    return None;
+                };
                 endpoint.line_number = candidate.line_number as i32;
                 endpoint.call_expression_span_start = Some(candidate.span_start);
                 endpoint.call_expression_span_end = Some(candidate.span_end);
                 Some(endpoint)
             })
             .collect();
+
+        if !dropped_endpoints.is_empty() {
+            warn!(
+                "[FileOrchestrator] {} endpoint(s) in {} dropped — no matching SWC candidate: {}",
+                dropped_endpoints.len(),
+                file_path,
+                dropped_endpoints.join(", ")
+            );
+        }
 
         // Data calls: preserve even without candidate match (inline aliases still work)
         let mut dropped_count = 0;

--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -445,6 +445,7 @@ impl CloudStorage for AwsStorage {
                     cached_guidance: None,
                     package_json_hash: None,
                     cache_version: None,
+                    type_extraction_status: None,
                 };
                 repo_s3_urls.insert(adjacent.repo.clone(), adjacent.s3_url);
                 all_repo_data.push(repo_data);

--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -4,7 +4,30 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::time::Duration;
 use tracing::{debug, warn};
+
+/// Total per-request deadline. Generous because uploads can carry multi-MB
+/// payloads over slow CI links, but bounded so a hung connection can't stall
+/// the scan until the CI job timeout.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Retries after the first attempt for transient failures (network errors,
+/// 408/429/5xx). A scan's cloud calls bookend a long, expensive analysis, so
+/// one Lambda cold start or load-balancer blip must not discard the run.
+const MAX_TRANSIENT_RETRIES: u32 = 3;
+
+fn retry_backoff(retries_so_far: u32) -> Duration {
+    // 2s, 4s, 8s
+    Duration::from_secs(2u64 << retries_so_far)
+}
+
+fn is_transient_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::REQUEST_TIMEOUT
+        || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+}
 
 pub struct AwsStorage {
     lambda_url: String,
@@ -100,9 +123,17 @@ impl AwsStorage {
         // from the signed OIDC claims, so there is no other way to authenticate.
         OidcProvider::global().map_err(|e| StorageError::ConnectionError(e.to_string()))?;
 
+        let http_client = Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .build()
+            .map_err(|e| {
+                StorageError::ConnectionError(format!("Failed to build HTTP client: {}", e))
+            })?;
+
         Ok(Self {
             lambda_url,
-            http_client: Client::new(),
+            http_client,
             multi_service: std::sync::atomic::AtomicBool::new(false),
         })
     }
@@ -110,6 +141,8 @@ impl AwsStorage {
     /// POSTs a JSON body to the upload endpoint with the OIDC bearer header,
     /// returning the raw response body on success. OIDC tokens are short-lived,
     /// so on a 401 (token likely expired mid-run) we re-mint once and retry.
+    /// Transient failures (network errors, 408/429/5xx) are retried with
+    /// exponential backoff up to [`MAX_TRANSIENT_RETRIES`] times.
     async fn send_lambda<B>(&self, body: &B) -> Result<String, StorageError>
     where
         B: serde::Serialize + ?Sized,
@@ -122,41 +155,69 @@ impl AwsStorage {
             .map_err(|e| StorageError::ConnectionError(e.to_string()))?;
 
         let mut reminted = false;
+        let mut retries = 0u32;
         loop {
-            let response = self
+            let transient_error = match self
                 .http_client
                 .post(&self.lambda_url)
                 .header("X-Carrick-OIDC", &token)
                 .json(body)
                 .send()
                 .await
-                .map_err(|e| {
-                    StorageError::ConnectionError(format!("Lambda request failed: {}", e))
-                })?;
+            {
+                Ok(response) => {
+                    let status = response.status();
+                    match response.text().await {
+                        Ok(response_text) => {
+                            if status.as_u16() == 401 && !reminted {
+                                warn!(
+                                    "Upload returned 401; re-minting OIDC token and retrying once"
+                                );
+                                token = provider
+                                    .remint()
+                                    .await
+                                    .map_err(|e| StorageError::ConnectionError(e.to_string()))?;
+                                reminted = true;
+                                continue;
+                            }
 
-            let status = response.status();
-            let response_text = response.text().await.map_err(|e| {
-                StorageError::ConnectionError(format!("Failed to read response: {}", e))
-            })?;
+                            if status.is_success() {
+                                return Ok(response_text);
+                            }
 
-            if status.as_u16() == 401 && !reminted {
-                warn!("Upload returned 401; re-minting OIDC token and retrying once");
-                token = provider
-                    .remint()
-                    .await
-                    .map_err(|e| StorageError::ConnectionError(e.to_string()))?;
-                reminted = true;
-                continue;
-            }
+                            if !is_transient_status(status) {
+                                return Err(StorageError::ConnectionError(format!(
+                                    "Lambda returned error {}: {}",
+                                    status, response_text
+                                )));
+                            }
 
-            if !status.is_success() {
+                            format!("Lambda returned {}: {}", status, response_text)
+                        }
+                        Err(e) => format!("Failed to read response: {}", e),
+                    }
+                }
+                Err(e) => format!("Lambda request failed: {}", e),
+            };
+
+            if retries >= MAX_TRANSIENT_RETRIES {
                 return Err(StorageError::ConnectionError(format!(
-                    "Lambda returned error {}: {}",
-                    status, response_text
+                    "{} (after {} attempts)",
+                    transient_error,
+                    retries + 1
                 )));
             }
 
-            return Ok(response_text);
+            let backoff = retry_backoff(retries);
+            warn!(
+                "{}; retrying in {}s ({}/{})",
+                transient_error,
+                backoff.as_secs(),
+                retries + 1,
+                MAX_TRANSIENT_RETRIES
+            );
+            tokio::time::sleep(backoff).await;
+            retries += 1;
         }
     }
 
@@ -184,29 +245,57 @@ impl AwsStorage {
         })
     }
 
+    /// PUTs content to a pre-signed S3 URL. The PUT is idempotent, so
+    /// transient failures (network errors, 5xx) are retried with backoff.
     async fn upload_to_s3(&self, upload_url: &str, content: &str) -> Result<(), StorageError> {
-        let response = self
-            .http_client
-            .put(upload_url)
-            .header("Content-Type", "text/plain")
-            .body(content.to_string())
-            .send()
-            .await
-            .map_err(|e| StorageError::ConnectionError(format!("S3 upload failed: {}", e)))?;
+        let mut retries = 0u32;
+        loop {
+            let transient_error = match self
+                .http_client
+                .put(upload_url)
+                .header("Content-Type", "text/plain")
+                .body(content.to_string())
+                .send()
+                .await
+            {
+                Ok(response) if response.status().is_success() => return Ok(()),
+                Ok(response) => {
+                    // Always include the response body — S3 returns the actual
+                    // cause (AccessDenied, signature mismatch, missing header,
+                    // etc.) in the XML error document. A bare status code is
+                    // rarely actionable.
+                    let status = response.status();
+                    let body = response.text().await.unwrap_or_default();
+                    if !is_transient_status(status) {
+                        return Err(StorageError::ConnectionError(format!(
+                            "S3 upload returned {}: {}",
+                            status, body
+                        )));
+                    }
+                    format!("S3 upload returned {}: {}", status, body)
+                }
+                Err(e) => format!("S3 upload failed: {}", e),
+            };
 
-        if !response.status().is_success() {
-            // Always include the response body — S3 returns the actual cause
-            // (AccessDenied, signature mismatch, missing header, etc.) in the
-            // XML error document. A bare status code is rarely actionable.
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(StorageError::ConnectionError(format!(
-                "S3 upload returned {}: {}",
-                status, body
-            )));
+            if retries >= MAX_TRANSIENT_RETRIES {
+                return Err(StorageError::ConnectionError(format!(
+                    "{} (after {} attempts)",
+                    transient_error,
+                    retries + 1
+                )));
+            }
+
+            let backoff = retry_backoff(retries);
+            warn!(
+                "{}; retrying in {}s ({}/{})",
+                transient_error,
+                backoff.as_secs(),
+                retries + 1,
+                MAX_TRANSIENT_RETRIES
+            );
+            tokio::time::sleep(backoff).await;
+            retries += 1;
         }
-
-        Ok(())
     }
 
     async fn store_repo_metadata(
@@ -463,5 +552,37 @@ impl CloudStorage for AwsStorage {
     fn supports_multi_service(&self) -> bool {
         self.multi_service
             .load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::StatusCode;
+
+    #[test]
+    fn transient_statuses_are_retryable() {
+        assert!(is_transient_status(StatusCode::REQUEST_TIMEOUT));
+        assert!(is_transient_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_transient_status(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_transient_status(StatusCode::BAD_GATEWAY));
+        assert!(is_transient_status(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(is_transient_status(StatusCode::GATEWAY_TIMEOUT));
+    }
+
+    #[test]
+    fn permanent_statuses_are_not_retryable() {
+        assert!(!is_transient_status(StatusCode::BAD_REQUEST));
+        assert!(!is_transient_status(StatusCode::UNAUTHORIZED));
+        assert!(!is_transient_status(StatusCode::FORBIDDEN));
+        assert!(!is_transient_status(StatusCode::NOT_FOUND));
+        assert!(!is_transient_status(StatusCode::PAYLOAD_TOO_LARGE));
+    }
+
+    #[test]
+    fn backoff_grows_exponentially() {
+        assert_eq!(retry_backoff(0), Duration::from_secs(2));
+        assert_eq!(retry_backoff(1), Duration::from_secs(4));
+        assert_eq!(retry_backoff(2), Duration::from_secs(8));
     }
 }

--- a/src/cloud_storage/mock_storage.rs
+++ b/src/cloud_storage/mock_storage.rs
@@ -110,6 +110,7 @@ impl CloudStorage for MockStorage {
                     cached_guidance: None,
                     package_json_hash: None,
                     cache_version: None,
+                    type_extraction_status: None,
                 },
                 CloudRepoData {
                     repo_name: "repo-b".to_string(),
@@ -133,6 +134,7 @@ impl CloudStorage for MockStorage {
                     cached_guidance: None,
                     package_json_hash: None,
                     cache_version: None,
+                    type_extraction_status: None,
                 },
             ];
             result.extend(mock_repos);

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -137,6 +137,12 @@ pub struct CloudRepoData {
     /// Cache format version — discard cached data if mismatched
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_version: Option<u32>,
+    /// Why type extraction was skipped or failed for this service, if it was.
+    /// `None` means types were resolved normally. Set so the index records
+    /// that this service's data is degraded (endpoints without types) instead
+    /// of that being indistinguishable from "endpoints have no types".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_extraction_status: Option<String>,
 }
 
 impl CloudRepoData {
@@ -240,6 +246,7 @@ impl CloudRepoData {
             cached_guidance: None,
             package_json_hash: None,
             cache_version: None,
+            type_extraction_status: None,
         }
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -155,7 +155,7 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     // 3. Resolve the services declared for this repo (one for the common
     //    single-service case; one per directory for a monorepo carrick.json).
     let repo_name = get_repository_name(repo_path);
-    let services = resolve_services(repo_path);
+    let services = resolve_services(repo_path)?;
     let multi_service = services.len() > 1;
     if multi_service {
         info!(
@@ -173,7 +173,7 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     let sp = logging::spinner("Analyzing repository...");
     let mut current_services_data = Vec::with_capacity(services.len());
     for service in &services {
-        let packages = load_packages_for_service(repo_path, service);
+        let packages = load_packages_for_service(repo_path, service)?;
 
         // Scope the sidecar's type extraction to this service's directory/tsconfig.
         scope_sidecar_to_service(sidecar, repo_path, service);
@@ -995,6 +995,22 @@ fn discover_files_and_symbols(
     let ignore_patterns = service_ignore_patterns(service);
     let (files, _) = find_service_files(repo_path, service, &ignore_patterns);
 
+    // Zero files means the scan target is wrong (typo'd path, empty checkout):
+    // proceeding would upload an empty service and silently erase its
+    // coverage from the index.
+    if files.is_empty() {
+        let scope = match &service.directory {
+            Some(dir) => format!("service directory '{}'", dir),
+            None => "repository root".to_string(),
+        };
+        return Err(format!(
+            "No JS/TS source files found under {} in '{}'. Check the scan path \
+             and the directory/include entries in carrick.json.",
+            scope, repo_path
+        )
+        .into());
+    }
+
     debug!("Found {} files to analyze in {}", files.len(), repo_path);
 
     // Extract imported symbols and function definitions by parsing files
@@ -1037,7 +1053,11 @@ fn discover_files_and_symbols(
 /// No config, or a flat config, yields a single service rooted at the repo
 /// root (zero-config single-service mode). A `services` array yields one entry
 /// per declared service. Always returns at least one service.
-fn resolve_services(repo_path: &str) -> Vec<Config> {
+///
+/// A config that exists but cannot be parsed, or that declares paths that
+/// don't exist, is a hard error: silently falling back to defaults would
+/// ignore the user's declared service layout and upload a wrong index.
+fn resolve_services(repo_path: &str) -> Result<Vec<Config>, Box<dyn std::error::Error>> {
     // carrick.json belongs at the scan root. Read it there directly rather than
     // walking the tree (a tree walk would pick up nested example/fixture
     // configs in a repo that contains them).
@@ -1045,18 +1065,57 @@ fn resolve_services(repo_path: &str) -> Vec<Config> {
 
     let services = if config_path.is_file() {
         debug!("Found carrick.json: {}", config_path.display());
-        Config::load_services(vec![config_path]).unwrap_or_else(|e| {
-            warn!("Error parsing config file: {}", e);
-            Vec::new()
-        })
+        Config::load_services(vec![config_path.clone()]).map_err(|e| {
+            format!(
+                "Failed to parse {}: {}. Fix the config or delete it to scan \
+                 the repo as a single zero-config service.",
+                config_path.display(),
+                e
+            )
+        })?
     } else {
         Vec::new()
     };
 
+    // A typo'd directory would otherwise walk nothing and upload an empty
+    // service, silently erasing its coverage from the index.
+    let root = std::path::Path::new(repo_path);
+    for service in &services {
+        let label = service
+            .service_name
+            .as_deref()
+            .or(service.directory.as_deref())
+            .unwrap_or("<unnamed>");
+        if let Some(dir) = &service.directory
+            && !root.join(dir).is_dir()
+        {
+            return Err(format!(
+                "Service '{}' in {} declares directory '{}', which does not exist under '{}'",
+                label,
+                config_path.display(),
+                dir,
+                repo_path
+            )
+            .into());
+        }
+        for inc in &service.include {
+            if !root.join(inc).exists() {
+                return Err(format!(
+                    "Service '{}' in {} declares include path '{}', which does not exist under '{}'",
+                    label,
+                    config_path.display(),
+                    inc,
+                    repo_path
+                )
+                .into());
+            }
+        }
+    }
+
     if services.is_empty() {
-        vec![Config::default()]
+        Ok(vec![Config::default()])
     } else {
-        services
+        Ok(services)
     }
 }
 
@@ -1077,17 +1136,22 @@ fn service_ignore_patterns(service: &Config) -> Vec<&'static str> {
 
 /// Load the package data for a single service, scoped to its own
 /// `package.json` (within its directory), not an arbitrary one from the repo.
-fn load_packages_for_service(repo_path: &str, service: &Config) -> Packages {
+///
+/// A missing `package.json` is fine (empty dependency set); one that exists
+/// but cannot be parsed is a hard error — defaulting to zero dependencies
+/// would silently gut framework detection and endpoint extraction.
+fn load_packages_for_service(
+    repo_path: &str,
+    service: &Config,
+) -> Result<Packages, Box<dyn std::error::Error>> {
     let ignore_patterns = service_ignore_patterns(service);
     let (_, package_json_path) = find_service_files(repo_path, service, &ignore_patterns);
     if let Some(package_path) = package_json_path {
         debug!("Found package.json: {}", package_path.display());
-        Packages::new(vec![package_path]).unwrap_or_else(|e| {
-            warn!("Error parsing package.json: {}", e);
-            Packages::default()
-        })
+        Packages::new(vec![package_path.clone()])
+            .map_err(|e| format!("Failed to parse {}: {}", package_path.display(), e).into())
     } else {
-        Packages::default()
+        Ok(Packages::default())
     }
 }
 
@@ -2547,5 +2611,109 @@ mod tests {
         assert!(data.cached_guidance.is_none());
         assert!(data.package_json_hash.is_none());
         assert!(data.cache_version.is_none());
+    }
+
+    #[test]
+    fn resolve_services_without_config_defaults_to_single_service() {
+        let tmp = tempfile::tempdir().unwrap();
+        let services = resolve_services(tmp.path().to_str().unwrap()).unwrap();
+        assert_eq!(services.len(), 1);
+        assert!(services[0].directory.is_none());
+    }
+
+    #[test]
+    fn resolve_services_rejects_malformed_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("carrick.json"), "{ not valid json").unwrap();
+
+        let err = resolve_services(tmp.path().to_str().unwrap()).unwrap_err();
+        assert!(
+            err.to_string().contains("Failed to parse"),
+            "expected parse error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_services_rejects_missing_service_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("carrick.json"),
+            r#"{ "services": [{ "name": "api", "directory": "does-not-exist" }] }"#,
+        )
+        .unwrap();
+
+        let err = resolve_services(tmp.path().to_str().unwrap()).unwrap_err();
+        assert!(
+            err.to_string().contains("does-not-exist")
+                && err.to_string().contains("does not exist"),
+            "expected missing-directory error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_services_rejects_missing_include_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("svc")).unwrap();
+        std::fs::write(
+            tmp.path().join("carrick.json"),
+            r#"{ "services": [{ "name": "api", "directory": "svc", "include": ["shared"] }] }"#,
+        )
+        .unwrap();
+
+        let err = resolve_services(tmp.path().to_str().unwrap()).unwrap_err();
+        assert!(
+            err.to_string().contains("include path 'shared'"),
+            "expected missing-include error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_services_accepts_valid_service_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("svc")).unwrap();
+        std::fs::create_dir(tmp.path().join("shared")).unwrap();
+        std::fs::write(
+            tmp.path().join("carrick.json"),
+            r#"{ "services": [{ "name": "api", "directory": "svc", "include": ["shared"] }] }"#,
+        )
+        .unwrap();
+
+        let services = resolve_services(tmp.path().to_str().unwrap()).unwrap();
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].directory.as_deref(), Some("svc"));
+    }
+
+    #[test]
+    fn load_packages_rejects_malformed_package_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("package.json"), "{ trailing-comma: ,}").unwrap();
+
+        let err = load_packages_for_service(tmp.path().to_str().unwrap(), &Config::default())
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("Failed to parse"),
+            "expected parse error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn load_packages_missing_package_json_defaults_to_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let packages =
+            load_packages_for_service(tmp.path().to_str().unwrap(), &Config::default()).unwrap();
+        assert!(packages.merged_dependencies.is_empty());
+    }
+
+    #[test]
+    fn discovery_rejects_service_with_no_source_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cm: Lrc<SourceMap> = Default::default();
+
+        let err = discover_files_and_symbols(tmp.path().to_str().unwrap(), &Config::default(), cm)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("No JS/TS source files"),
+            "expected empty-scan error, got: {err}"
+        );
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -232,12 +232,35 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
             );
         } else {
             let sp = logging::spinner("Uploading results...");
-            for data in &current_services_data {
-                let cloud_data_serialized = strip_ast_nodes(data.clone());
-                storage
-                    .upload_repo_data(&cloud_data_serialized)
-                    .await
-                    .map_err(|e| format!("Failed to upload repo data: {}", e))?;
+            // Prepare every payload before uploading any, so a serialization
+            // problem can't surface halfway through a multi-service upload.
+            let payloads: Vec<CloudRepoData> = current_services_data
+                .iter()
+                .map(|data| strip_ast_nodes(data.clone()))
+                .collect();
+            for (i, payload) in payloads.iter().enumerate() {
+                if let Err(e) = storage.upload_repo_data(payload).await {
+                    // Uploads are keyed per (repo, service) and idempotent, so
+                    // a re-run restores consistency — but until then the index
+                    // holds this run's data for some services and the previous
+                    // run's for the rest. Make that state explicit.
+                    let uploaded: Vec<&str> = payloads[..i]
+                        .iter()
+                        .map(|d| d.service_name.as_deref().unwrap_or(&d.repo_name))
+                        .collect();
+                    let not_uploaded: Vec<&str> = payloads[i..]
+                        .iter()
+                        .map(|d| d.service_name.as_deref().unwrap_or(&d.repo_name))
+                        .collect();
+                    return Err(format!(
+                        "Failed to upload repo data: {}. Uploaded: [{}]; not uploaded: [{}]. \
+                         The index is mixed-generation for this repo until a successful re-run.",
+                        e,
+                        uploaded.join(", "),
+                        not_uploaded.join(", ")
+                    )
+                    .into());
+                }
             }
             logging::finish_spinner(&sp, "Uploaded results to Carrick Cloud");
         }
@@ -416,17 +439,34 @@ fn strip_ast_nodes(mut data: CloudRepoData) -> CloudRepoData {
     // Payload size guard: Lambda function URLs have a 6MB request payload limit.
     // If serialized data exceeds ~5MB, drop file_results to stay under the limit.
     const MAX_PAYLOAD_BYTES: usize = 5 * 1024 * 1024; // 5MB safety margin
+    const LAMBDA_HARD_LIMIT_BYTES: usize = 6 * 1024 * 1024;
     if let Ok(serialized) = serde_json::to_string(&data)
         && serialized.len() > MAX_PAYLOAD_BYTES
     {
         warn!(
-            "Payload size {}KB exceeds {}KB limit, dropping file_results cache for this upload",
+            "Payload size {}KB exceeds {}KB limit, dropping file_results cache for this \
+             upload — the next scan cannot run incrementally and will re-analyze every file",
             serialized.len() / 1024,
             MAX_PAYLOAD_BYTES / 1024
         );
         data.file_results = None;
         data.cached_detection = None;
         data.cached_guidance = None;
+
+        // Re-check: if the payload is still over Lambda's hard request limit
+        // even without the cache, say so up front — the upload will be
+        // rejected with an otherwise cryptic 413.
+        if let Ok(reserialized) = serde_json::to_string(&data)
+            && reserialized.len() > LAMBDA_HARD_LIMIT_BYTES
+        {
+            warn!(
+                "Payload is still {}KB after dropping caches, which exceeds the cloud's \
+                 {}KB request limit — the upload will likely be rejected. Consider splitting \
+                 the repo into services via carrick.json.",
+                reserialized.len() / 1024,
+                LAMBDA_HARD_LIMIT_BYTES / 1024
+            );
+        }
     }
 
     data
@@ -443,8 +483,29 @@ fn get_changed_files(repo_path: &str, base_commit: &str) -> Option<Vec<String>> 
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        debug!("git diff failed (shallow clone?): {}", stderr.trim());
-        debug!("Set fetch-depth: 0 in your workflow for incremental mode.");
+        // Surface this at warn level with the cause: a shallow clone
+        // (actions/checkout defaults to fetch-depth: 1) silently forces a
+        // full re-analysis — including its full LLM cost — on every run.
+        let is_shallow = std::process::Command::new("git")
+            .args(["rev-parse", "--is-shallow-repository"])
+            .current_dir(repo_path)
+            .output()
+            .ok()
+            .is_some_and(|o| String::from_utf8_lossy(&o.stdout).trim() == "true");
+        if is_shallow {
+            warn!(
+                "Incremental mode unavailable: this is a shallow clone, so the previous \
+                 scan's commit isn't reachable for diffing. Set `fetch-depth: 0` on \
+                 actions/checkout to avoid re-analyzing every file on each run."
+            );
+        } else {
+            warn!(
+                "Incremental mode unavailable: git diff against {} failed ({}). \
+                 Falling back to full analysis.",
+                base_commit,
+                stderr.trim()
+            );
+        }
         return None;
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -885,6 +885,7 @@ fn build_cloud_data_from_mount_graph(
         cached_guidance: None,
         package_json_hash: None,
         cache_version: None,
+        type_extraction_status: None,
     }
 }
 
@@ -938,7 +939,14 @@ fn resolve_types_if_available(
     config: &Config,
     cloud_data: &mut CloudRepoData,
 ) {
-    let Some(sidecar) = sidecar else { return };
+    let Some(sidecar) = sidecar else {
+        cloud_data.type_extraction_status = Some(
+            "type extraction skipped: sidecar unavailable (not found, failed to start, \
+             or failed to initialize)"
+                .to_string(),
+        );
+        return;
+    };
 
     debug!("Starting sidecar type resolution");
     match sidecar.wait_ready(Duration::from_secs(10)) {
@@ -972,12 +980,16 @@ fn resolve_types_if_available(
                 Err(e) => {
                     warn!("Type resolution failed: {}", e);
                     debug!("Continuing without bundled types");
+                    cloud_data.type_extraction_status =
+                        Some(format!("type resolution failed: {}", e));
                 }
             }
         }
         Err(e) => {
             warn!("Sidecar not ready: {}", e);
             debug!("Skipping type resolution");
+            cloud_data.type_extraction_status =
+                Some(format!("type extraction skipped: sidecar not ready: {}", e));
         }
     }
 }
@@ -1869,6 +1881,7 @@ mod tests {
             cached_guidance: None,
             package_json_hash: None,
             cache_version: None,
+            type_extraction_status: None,
         };
 
         // Verify strip_ast_nodes removes AST nodes
@@ -1907,6 +1920,7 @@ mod tests {
             cached_guidance: None,
             package_json_hash: None,
             cache_version: None,
+            type_extraction_status: None,
         }];
 
         // Test Config merging
@@ -1980,6 +1994,7 @@ mod tests {
             cached_guidance: None,
             package_json_hash: None,
             cache_version: None,
+            type_extraction_status: None,
         }];
 
         // Test that cross-repo builder doesn't fail with SourceMap issues
@@ -2329,6 +2344,7 @@ mod tests {
             cached_guidance: None,
             package_json_hash: None,
             cache_version: Some(CACHE_VERSION),
+            type_extraction_status: None,
         };
 
         let stripped = strip_ast_nodes(data);
@@ -2370,6 +2386,7 @@ mod tests {
             cached_guidance: None,
             package_json_hash: None,
             cache_version: Some(CACHE_VERSION),
+            type_extraction_status: None,
         };
 
         let stripped = strip_ast_nodes(data);
@@ -2502,6 +2519,7 @@ mod tests {
             cached_guidance: None,
             package_json_hash: Some("abc123hash".to_string()),
             cache_version: Some(CACHE_VERSION),
+            type_extraction_status: None,
         };
 
         let json = serde_json::to_string(&data).expect("should serialize");
@@ -2571,6 +2589,7 @@ mod tests {
             cached_guidance: None,
             package_json_hash: None,
             cache_version: Some(CACHE_VERSION),
+            type_extraction_status: None,
         };
 
         let json = serde_json::to_string(&data).expect("should serialize");

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,16 @@ async fn main() {
 }
 
 async fn run_analysis(args: CliArgs) -> Result<(), Box<dyn std::error::Error>> {
+    // Validate the scan target up front. A nonexistent path would otherwise
+    // walk zero files and "succeed" with an empty analysis.
+    if !Path::new(&args.repo_path).is_dir() {
+        return Err(format!(
+            "Repository path '{}' does not exist or is not a directory",
+            args.repo_path
+        )
+        .into());
+    }
+
     // =======================================================================
     // STEP 1: Discover and spawn sidecar (non-blocking)
     // The sidecar is bundled with the tool - auto-discover its location

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -14,10 +14,20 @@
 
 use std::env;
 use std::sync::OnceLock;
+use std::time::Duration;
 use tokio::sync::Mutex;
+use tracing::warn;
 
 /// Audience the cloud requires in the OIDC token's `aud` claim.
 const AUDIENCE: &str = "https://api.carrick.tools";
+
+/// Deadline for the token request — minting must be fast, and a hung GitHub
+/// endpoint must not stall the scan indefinitely.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Retries after the first attempt for transient mint failures (transport
+/// errors, 5xx from the GitHub token endpoint).
+const MAX_FETCH_RETRIES: u32 = 2;
 
 #[derive(Debug)]
 pub enum OidcError {
@@ -72,7 +82,10 @@ impl OidcProvider {
         let request_url = env::var("ACTIONS_ID_TOKEN_REQUEST_URL").ok()?;
         let request_token = env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN").ok()?;
         Some(OidcProvider {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(FETCH_TIMEOUT)
+                .build()
+                .expect("default reqwest client construction cannot fail"),
             request_url,
             request_token,
             cached: Mutex::new(None),
@@ -100,37 +113,64 @@ impl OidcProvider {
     }
 
     async fn fetch(&self) -> Result<String, OidcError> {
-        // `.query()` merges into the URL's existing query string (the request
-        // URL already carries `?api-version=...`) and percent-encodes the
-        // audience, matching the official @actions/core toolkit behaviour.
-        let response = self
-            .client
-            .get(&self.request_url)
-            .query(&[("audience", AUDIENCE)])
-            .header("Authorization", format!("Bearer {}", self.request_token))
-            .send()
-            .await
-            .map_err(|e| OidcError::Request(e.to_string()))?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            return Err(OidcError::BadResponse(format!(
-                "GitHub token endpoint returned {}: {}",
-                status, body
-            )));
-        }
-
         #[derive(serde::Deserialize)]
         struct TokenResponse {
             value: String,
         }
 
-        let parsed: TokenResponse = response.json().await.map_err(|e| {
-            OidcError::BadResponse(format!("failed to parse token response: {}", e))
-        })?;
+        let mut retries = 0u32;
+        loop {
+            // `.query()` merges into the URL's existing query string (the
+            // request URL already carries `?api-version=...`) and
+            // percent-encodes the audience, matching the official
+            // @actions/core toolkit behaviour.
+            let transient_error = match self
+                .client
+                .get(&self.request_url)
+                .query(&[("audience", AUDIENCE)])
+                .header("Authorization", format!("Bearer {}", self.request_token))
+                .send()
+                .await
+            {
+                Ok(response) => {
+                    let status = response.status();
+                    if status.is_success() {
+                        let parsed: TokenResponse = response.json().await.map_err(|e| {
+                            OidcError::BadResponse(format!("failed to parse token response: {}", e))
+                        })?;
+                        return Ok(parsed.value);
+                    }
 
-        Ok(parsed.value)
+                    let body = response.text().await.unwrap_or_default();
+                    let err = OidcError::BadResponse(format!(
+                        "GitHub token endpoint returned {}: {}",
+                        status, body
+                    ));
+                    // 4xx means the request itself is bad (missing permission,
+                    // bad token) — retrying can't fix it.
+                    if !status.is_server_error() {
+                        return Err(err);
+                    }
+                    err
+                }
+                Err(e) => OidcError::Request(e.to_string()),
+            };
+
+            if retries >= MAX_FETCH_RETRIES {
+                return Err(transient_error);
+            }
+
+            let backoff = Duration::from_secs(1u64 << retries);
+            warn!(
+                "{}; retrying OIDC token mint in {}s ({}/{})",
+                transient_error,
+                backoff.as_secs(),
+                retries + 1,
+                MAX_FETCH_RETRIES
+            );
+            tokio::time::sleep(backoff).await;
+            retries += 1;
+        }
     }
 }
 
@@ -206,5 +246,74 @@ mod tests {
                 .contains("authorization: bearer request-token-xyz"),
             "bearer auth header missing: {request}"
         );
+    }
+
+    /// A transient 5xx from the token endpoint is retried; the mint succeeds
+    /// on the second attempt instead of aborting the scan.
+    #[tokio::test]
+    async fn fetch_retries_transient_server_errors() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            let responses = [
+                "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .to_string(),
+                {
+                    let body = r#"{"value":"retried.token.ok"}"#;
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                         Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    )
+                },
+            ];
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buf = [0u8; 8192];
+                let _ = stream.read(&mut buf).unwrap();
+                stream.write_all(response.as_bytes()).unwrap();
+                stream.flush().unwrap();
+            }
+        });
+
+        let url = format!("http://{}/token?api-version=2.0", addr);
+        let provider = OidcProvider::for_test(url, "request-token-xyz".to_string());
+
+        let token = provider.fetch().await.unwrap();
+        assert_eq!(token, "retried.token.ok");
+        server.join().unwrap();
+    }
+
+    /// A 4xx from the token endpoint (bad permission/token) is permanent —
+    /// no retry, error returned immediately.
+    #[tokio::test]
+    async fn fetch_does_not_retry_client_errors() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 8192];
+            let _ = stream.read(&mut buf).unwrap();
+            let response =
+                "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.flush().unwrap();
+            // A second connection attempt would block here and fail the test
+            // via join timeout if fetch retried; instead the listener is
+            // dropped right after the first response.
+        });
+
+        let url = format!("http://{}/token?api-version=2.0", addr);
+        let provider = OidcProvider::for_test(url, "request-token-xyz".to_string());
+
+        let err = provider.fetch().await.unwrap_err();
+        assert!(
+            matches!(&err, OidcError::BadResponse(msg) if msg.contains("403")),
+            "expected permanent 403 error, got: {err}"
+        );
+        server.join().unwrap();
     }
 }

--- a/src/sidecar/src/index.ts
+++ b/src/sidecar/src/index.ts
@@ -563,7 +563,19 @@ function main(): void {
   });
 
   process.on('unhandledRejection', (reason) => {
-    logError(`Unhandled rejection (exiting): ${reason}`);
+    // This log is the last diagnostic before exit, so it must be actionable:
+    // a bare interpolation renders non-Error reasons as [object Object].
+    let detail: string;
+    if (reason instanceof Error) {
+      detail = reason.stack || reason.message;
+    } else {
+      try {
+        detail = JSON.stringify(reason) ?? String(reason);
+      } catch {
+        detail = String(reason);
+      }
+    }
+    logError(`Unhandled rejection (exiting): ${detail}`);
     process.exit(1);
   });
 }

--- a/src/sidecar/src/index.ts
+++ b/src/sidecar/src/index.ts
@@ -551,16 +551,20 @@ function main(): void {
     process.exit(0);
   });
 
-  // Handle uncaught errors
+  // Fail fast on uncaught errors. Continuing after one means serving later
+  // requests from a possibly corrupted state and returning garbage types
+  // with a success status; exiting surfaces as ProcessDied on the Rust side,
+  // which degrades cleanly (scan continues, type_extraction_status records
+  // the loss).
   process.on('uncaughtException', (err) => {
-    logError(`Uncaught exception: ${err.message}`);
+    logError(`Uncaught exception (exiting): ${err.message}`);
     logError(err.stack || '');
-    // Keep running, but log the error
+    process.exit(1);
   });
 
   process.on('unhandledRejection', (reason) => {
-    logError(`Unhandled rejection: ${reason}`);
-    // Keep running, but log the error
+    logError(`Unhandled rejection (exiting): ${reason}`);
+    process.exit(1);
   });
 }
 

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -85,6 +85,10 @@ pub struct ScanResult {
     pub candidates: Vec<CandidateTarget>,
     /// Whether the file should be analyzed (has candidates)
     pub should_analyze: bool,
+    /// True when the file could not be parsed at all. Callers must surface
+    /// this: a parse failure excludes the whole file from the index, which is
+    /// very different from a healthy file with no API candidates.
+    pub parse_failed: bool,
 }
 
 /// A value exported from a module. Used by file-based routing to recover the
@@ -144,6 +148,7 @@ impl SwcScanner {
                 return ScanResult {
                     candidates: Vec::new(),
                     should_analyze: false,
+                    parse_failed: true,
                 };
             }
         };
@@ -159,6 +164,7 @@ impl SwcScanner {
         ScanResult {
             candidates: visitor.candidates,
             should_analyze,
+            parse_failed: false,
         }
     }
 
@@ -235,6 +241,7 @@ impl SwcScanner {
                 return ScanResult {
                     candidates: Vec::new(),
                     should_analyze: false,
+                    parse_failed: true,
                 };
             }
         };
@@ -258,6 +265,7 @@ impl SwcScanner {
         ScanResult {
             candidates: visitor.candidates,
             should_analyze,
+            parse_failed: false,
         }
     }
 
@@ -883,6 +891,17 @@ mod tests {
             .collect();
         names.sort();
         names
+    }
+
+    #[test]
+    fn scan_content_flags_parse_failures() {
+        let result = scan_test_content("function broken( {{{");
+        assert!(result.parse_failed);
+        assert!(!result.should_analyze);
+
+        let healthy = scan_test_content("const x = 1;");
+        assert!(!healthy.parse_failed);
+        assert!(!healthy.should_analyze);
     }
 
     #[test]

--- a/tests/file_centric_analysis_test.rs
+++ b/tests/file_centric_analysis_test.rs
@@ -254,6 +254,7 @@ fn test_processing_stats_tracking() {
         files_processed: 5,
         files_skipped: 2,
         files_skipped_no_candidates: 1,
+        files_parse_failed: 1,
         total_mounts: 3,
         total_endpoints: 10,
         file_based_endpoints: 2,

--- a/tests/mock_storage_test.rs
+++ b/tests/mock_storage_test.rs
@@ -44,6 +44,7 @@ fn create_test_repo_data(repo_name: &str, commit_hash: &str) -> CloudRepoData {
         cached_guidance: None,
         package_json_hash: None,
         cache_version: None,
+        type_extraction_status: None,
     }
 }
 


### PR DESCRIPTION
Implements the critical and high-priority fixes from the scanner failure-point audit. Six commits, one concern each.

## What changed

### Cloud resilience (`fix(cloud)`)
- Storage client now has a 120s request / 10s connect timeout instead of reqwest's unbounded default; a hung connection can no longer stall a scan until the CI job timeout.
- Transient failures (network errors, 408/429/5xx) retry up to 3 times with 2s/4s/8s backoff in `send_lambda` and the idempotent S3 PUT. 4xx stays permanent; the once-per-request 401 re-mint is preserved.
- OIDC token fetch gets a 30s deadline and 2 retries on 5xx; 4xx (missing `id-token: write`) still fails immediately with the actionable message.

### Fail loudly on misconfigured/empty scans (`fix(engine)`)
Previously all of these exited 0 and uploaded empty or wrong data, silently erasing service coverage from the index:
- Nonexistent repo path → rejected up front.
- Unparseable `carrick.json` → hard error instead of silent fallback to the zero-config default.
- Declared service `directory` / `include` paths must exist.
- Unparseable `package.json` → hard error (absent is still fine); defaulting to zero deps silently gutted framework detection.
- Service scope matching zero JS/TS files → hard error pointing at the scan path and config.

**Note:** repos that currently scan green with a latent misconfiguration will start failing — that is the fix working, but worth a line in release notes.

### Surface degradation instead of hiding it (`feat(engine)`)
- `CloudRepoData.type_extraction_status` records why types are missing (sidecar unavailable / not ready / resolution failed), so degraded data is distinguishable from genuinely untyped endpoints. Follow-up for `carrick-cloud`: read and expose this over MCP.
- SWC parse failures get their own counter (`files_parse_failed`) and per-file warning instead of hiding inside zero-cost skips.
- `apply_candidate_map` logs exactly which endpoints it drops on a candidate-ID mismatch instead of deleting them silently.

### GitHub Action hardening (`fix(action)`)
- Binary is pinned to the release matching the checked-out action's `Cargo.toml` version (release-please bumps it in the tagged commit), with explicit warning/error paths before falling back to latest. Previously every run floated to the latest release regardless of the pinned action ref.
- `curl -fsSL --retry 3` (a 404 HTML page previously "downloaded" fine and died cryptically at `tar`).
- Tarball extracts into `$RUNNER_TEMP/carrick-dist` instead of the user's workspace root; exe-relative discovery finds `ts_check/` and `sidecar/` unchanged. Path input is quoted.

### Upload consistency + cost diagnostics (`fix(engine)`)
- All service payloads are serialized before any upload starts; a mid-loop failure now names which services uploaded and which didn't (the index is mixed-generation until a re-run).
- Payload guard re-checks against Lambda's 6MB hard limit after the cache drop and pre-explains the 413; both warnings state the incremental-mode consequences.
- Shallow clones (the `actions/checkout` default) now warn with the `fetch-depth: 0` fix instead of silently forcing full re-analysis — with full LLM cost — on every run.

### Sidecar fail-fast (`fix(sidecar)`)
Uncaught exceptions/rejections exit the sidecar instead of serving later requests from a corrupted state. Rust sees `ProcessDied` and degrades cleanly; `type_extraction_status` records the loss. Trade-off: wrong types are worse than absent-and-flagged types for a type index.

## Verification
- `cargo fmt --check` and `cargo clippy --all-targets` clean.
- Full Rust suite passes; the only 3 failures are pre-existing git-in-sandbox tests that fail identically on unmodified `main`.
- New tests: OIDC retry/no-retry against a local mock server, transient-status classification, 9 config/discovery hard-error tests, parse-failure flag regression test.
- Sidecar: `npm run build` + `npm test` green (54 pass, 0 fail) after the change.
- End-to-end smoke: `CARRICK_MOCK_ALL=1 cargo run -- examples/express-single` completes with normal findings output.

## Known caveats
- The action's exact-tag pinning path relies on release tags matching `v<version>` (or any tag suffixed with the version); if neither matches it warns and falls back to latest — safe, but check the step log on the next real release.
- The multi-service upload gate (`supports_multi_service`) still has no real-storage-shaped test (mock answers `true`); tracked as follow-up.

https://claude.ai/code/session_01Ck5GzmVKQo8hKQXY67DHK1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ck5GzmVKQo8hKQXY67DHK1)_