### PR TITLE
fix(action): stop 404 body poisoning the release download URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,12 @@ runs:
         ASSET="carrick-action-linux.tar.gz"
         JQ_ASSET_URL=".assets[] | select(.name==\"$ASSET\") | .browser_download_url"
 
+        # `gh api` prints the JSON error body to stdout on a 404 (e.g. a release
+        # tag that doesn't exist). Captured into DOWNLOAD_URL that blob is
+        # non-empty, so it slips past the `-z` fallback guards below and is
+        # handed to curl as a "URL". Only accept a value that is actually one.
+        valid_url() { case "$1" in https://*) return 0 ;; *) return 1 ;; esac; }
+
         # Pin the binary to the release matching this action checkout:
         # release-please bumps Cargo.toml in the same commit it tags, so the
         # version here identifies the release this ref shipped with. Without
@@ -44,19 +50,24 @@ runs:
         VERSION=$(grep -m1 '^version' "$GITHUB_ACTION_PATH/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
         echo "Resolving Carrick release for version $VERSION"
 
-        DOWNLOAD_URL=$(gh api "repos/daveymoores/carrick/releases/tags/v$VERSION" \
+        # release-please tags releases as carrick-v<version>.
+        DOWNLOAD_URL=$(gh api "repos/daveymoores/carrick/releases/tags/carrick-v$VERSION" \
           --jq "$JQ_ASSET_URL" 2>/dev/null || true)
+        valid_url "$DOWNLOAD_URL" || DOWNLOAD_URL=""
 
         if [ -z "$DOWNLOAD_URL" ]; then
-          # Tag naming may carry a prefix (e.g. carrick-v0.1.30); match by suffix.
+          # Fallback for any other tag scheme: match a release whose tag ends
+          # with this version.
           DOWNLOAD_URL=$(gh api repos/daveymoores/carrick/releases --paginate \
             --jq ".[] | select(.tag_name | endswith(\"$VERSION\")) | $JQ_ASSET_URL" \
             2>/dev/null | head -n 1 || true)
+          valid_url "$DOWNLOAD_URL" || DOWNLOAD_URL=""
         fi
 
         if [ -z "$DOWNLOAD_URL" ]; then
           echo "::warning::No release found matching version $VERSION (expected when running from an untagged ref); falling back to the latest release"
-          DOWNLOAD_URL=$(gh api repos/daveymoores/carrick/releases/latest --jq "$JQ_ASSET_URL")
+          DOWNLOAD_URL=$(gh api repos/daveymoores/carrick/releases/latest --jq "$JQ_ASSET_URL" 2>/dev/null || true)
+          valid_url "$DOWNLOAD_URL" || DOWNLOAD_URL=""
         fi
 
         if [ -z "$DOWNLOAD_URL" ]; then


### PR DESCRIPTION
## Problem

`@v1` (and `@main`) have failed to download the Carrick binary since **v0.1.30** (introduced in #152), with:

```
curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535
Downloading {"message":"Not Found",...,"status":"404"}
```

#152 changed the download step to pin the binary to the version in `Cargo.toml` (good: previously every run floated to latest regardless of the pinned action ref). It resolves the release via:

```bash
gh api "repos/daveymoores/carrick/releases/tags/v$VERSION" --jq "$JQ_ASSET_URL" 2>/dev/null || true
```

Two compounding issues:
1. release-please tags releases as **`carrick-v<version>`**, but this queries the unprefixed **`v<version>`** → always 404.
2. On a 404, `gh api` writes the JSON error body to **stdout**. `2>/dev/null` only hides stderr and `|| true` only fixes the exit code, so `DOWNLOAD_URL` becomes `{"message":"Not Found",...}` — **non-empty**. That slips past every `[ -z "$DOWNLOAD_URL" ]` guard, so the suffix-match and `releases/latest` fallbacks never run, and `curl` is handed the JSON blob as a "URL".

The suffix-match fallback (added in #152 precisely for the `carrick-` prefix) is correct — it just never executes because the variable is already poisoned.

## Fix

- Query the correctly-prefixed **`carrick-v$VERSION`** tag on the happy path.
- Add a `valid_url` guard (`https://*`) after each lookup so a non-URL (404 body) can never satisfy the `-z` checks or reach `curl`.
- Swallow stdout on the `releases/latest` fallback too (`2>/dev/null || true`).

The floating-`v1` model is unchanged: `release.yml` still force-moves `v1` to each stable release commit, and the action downloads the release matching that commit's `Cargo.toml`. Consumers keep using `@v1`.

## Validation

- `bash -n` on the extracted download script passes.
- Logic check: a 404 JSON body resolves to empty (falls through), a real `https://…` URL is accepted.
- Local pre-commit hook (clippy + full Rust + ts_check suites) green.

After merge, cut a release so `v1` advances to the fixed action; that unblocks the `carrick` check on daveymoores/carrick-cloud#128.