### PR TITLE
fix(scanner): type-extraction fidelity quick wins — request-body cast unwrap + defaulted-union params (#133)

### DIFF
--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -520,14 +520,19 @@ export class TypeInferrer {
     request: InferRequestItem,
     extractionConfig?: ExtractionConfig
   ): InferredType | null {
-    const node = this.resolveTargetNode(sourceFile, request);
+    const located = this.resolveTargetNode(sourceFile, request);
 
-    if (!node) {
+    if (!located) {
       return null;
     }
 
+    // Mirror inferCallResult: strip `await`/`as`/parens/`!` so the inner
+    // expression's type (not the surrounding `Promise<any>`) is read.
+    const node = this.unwrapExpressionNode(located);
+
     const payloadType = node.getType();
     let typeString = typeText(payloadType, node);
+    let isExplicit = false;
 
     // Apply extraction config
     const unwrapResult = this.unwrapTypeWithConfig(
@@ -537,12 +542,25 @@ export class TypeInferrer {
     );
     if (unwrapResult.wasUnwrapped) {
       typeString = unwrapResult.typeString;
+      isExplicit = unwrapResult.isExplicit;
     }
+
+    // A declared type — an `as T` cast or a typed variable binding/annotation
+    // on an ancestor — wins over the call's raw `Promise<any>` / `any`. Only
+    // recover when one is genuinely present; untyped `request.formData()`
+    // stays `FormData` / `any`.
+    const explicitType = this.extractExplicitTypeFromAncestor(located);
+    if (explicitType) {
+      typeString = explicitType;
+      isExplicit = true;
+    }
+
+    typeString = this.unwrapPromise(typeString, payloadType);
 
     return this.createInferredType(
       request,
       typeString,
-      false,
+      isExplicit,
       this.getNodeLocation(node),
       unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined
     );

--- a/src/sidecar/test/fixtures/sample-repo/src/request-bodies.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/request-bodies.ts
@@ -19,3 +19,29 @@ export const createUser = async (req: Request) => {
 export async function sendUser(user: RequestBody) {
   return fetch('/api/users', { method: 'POST', body: user });
 }
+
+interface RegisterRequest {
+  username: string;
+  password: string;
+}
+
+// A1: `await request.json()` typed via an `as T` cast. The raw type of the
+// call node is `Promise<any>`; the declared cast must win.
+export async function registerViaCast(request: globalThis.Request) {
+  const body = (await request.json()) as RegisterRequest;
+  return body;
+}
+
+// A1: `await request.json()` typed via a variable annotation. Same recovery,
+// different syntax (typed binding instead of an `as` cast).
+export async function registerViaBinding(request: globalThis.Request) {
+  const body: RegisterRequest = await request.json();
+  return body;
+}
+
+// Control: an untyped `request.formData()` has no annotation, so it must stay
+// faithfully `FormData` / `any` and not be "recovered" into a declared type.
+export async function uploadUntyped(request: globalThis.Request) {
+  const form = await request.formData();
+  return form;
+}

--- a/src/sidecar/test/request-body-cast.test.ts
+++ b/src/sidecar/test/request-body-cast.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Targeted regression for issue #133 root cause A1.
+ *
+ * `inferRequestBody` used to read the raw type of the located node
+ * (`request.json()` / `await request.json()`), surfacing `Promise<any>` /
+ * `any` even when the caller declared the body type via an `as T` cast or a
+ * typed variable binding. The fix mirrors `inferCallResult`: unwrap the
+ * `await`/`as`/paren/`!` wrappers and let an explicit `as T` cast or typed
+ * binding/annotation on an ancestor win over the call's raw type.
+ *
+ * The control case proves the genuinely-untyped path is preserved: an
+ * untyped `await request.formData()` must stay `FormData`/`any` (faithful,
+ * not a bug — #133 lists it as NOT-a-bug), never "recovered" into a
+ * declared type that was never written.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const FIXTURE = path.join(FIXTURES_PATH, 'src/request-bodies.ts');
+const FIXTURE_SOURCE = fs.readFileSync(FIXTURE, 'utf-8');
+
+/** Byte span of `text` in the fixture (ASCII-only file, so byte == char offsets). */
+function spanOf(text: string): { start: number; end: number; line: number } {
+  const start = FIXTURE_SOURCE.indexOf(text);
+  assert.ok(start >= 0, `fixture must contain: ${text}`);
+  assert.strictEqual(
+    FIXTURE_SOURCE.indexOf(text, start + 1),
+    -1,
+    `fixture must contain exactly one occurrence of: ${text}`
+  );
+  const line = FIXTURE_SOURCE.slice(0, start).split('\n').length;
+  return { start, end: start + text.length, line };
+}
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    infer_kind: string;
+    is_explicit: boolean;
+  }>;
+  errors?: string[];
+}
+
+describe('Request body cast/binding regressions (#133 A1)', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'reqbody-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('follows an `as T` cast on an awaited request.json()', async () => {
+    // Locator covers the `request.json()` call inside
+    // `(await request.json()) as RegisterRequest`. The raw type is
+    // `Promise<any>`; the `as RegisterRequest` cast must win.
+    const call = spanOf('(await request.json()) as RegisterRequest');
+    const innerStart = call.start + '(await '.length;
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'reqbody-cast',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: call.line,
+          span_start: innerStart,
+          span_end: innerStart + 'request.json()'.length,
+          infer_kind: 'request_body',
+          alias: 'RegisterCastBody',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'RegisterCastBody'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.strictEqual(
+      inferred.type_string,
+      'RegisterRequest',
+      `expected the cast type to win, got ${inferred.type_string}`
+    );
+    assert.strictEqual(
+      inferred.is_explicit,
+      true,
+      'a recovered declared type must be reported explicit'
+    );
+  });
+
+  it('follows a typed variable binding on an awaited request.json()', async () => {
+    // `const body: RegisterRequest = await request.json();` — the typed
+    // binding annotation must win over the call's `Promise<any>`.
+    const stmt = spanOf('const body: RegisterRequest = await request.json();');
+    const callStart = stmt.start + 'const body: RegisterRequest = await '.length;
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'reqbody-binding',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: stmt.line,
+          span_start: callStart,
+          span_end: callStart + 'request.json()'.length,
+          infer_kind: 'request_body',
+          alias: 'RegisterBindingBody',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'RegisterBindingBody'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.strictEqual(
+      inferred.type_string,
+      'RegisterRequest',
+      `expected the typed binding to win, got ${inferred.type_string}`
+    );
+    assert.strictEqual(
+      inferred.is_explicit,
+      true,
+      'a recovered declared type must be reported explicit'
+    );
+  });
+
+  it('leaves an untyped request.formData() as FormData/any (NOT-a-bug control)', async () => {
+    // No cast, no typed binding → nothing to recover. Must stay faithful.
+    const stmt = spanOf('const form = await request.formData();');
+    const callStart = stmt.start + 'const form = await '.length;
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'reqbody-formdata',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: stmt.line,
+          span_start: callStart,
+          span_end: callStart + 'request.formData()'.length,
+          infer_kind: 'request_body',
+          alias: 'UntypedFormBody',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'UntypedFormBody'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.ok(
+      inferred.type_string === 'FormData' || inferred.type_string === 'any',
+      `expected untyped formData to stay FormData/any, got ${inferred.type_string}`
+    );
+    assert.notStrictEqual(
+      inferred.type_string,
+      'RegisterRequest',
+      'must not invent a declared type that was never written'
+    );
+  });
+});

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -347,33 +347,51 @@ impl FunctionDefinitionExtractor {
             .ok()
     }
 
+    /// Resolve a parameter `Pat` to its `(name, type annotation)`.
+    ///
+    /// Handles plain identifiers, rest params, and defaulted params
+    /// (`role: "a" | "b" = "x"`), where the annotation lives on the inner
+    /// `left` pattern of the `AssignPat`. Destructuring patterns
+    /// (`Pat::Object` / `Pat::Array`) are not yet supported and fall through
+    /// to the unnamed placeholder.
+    fn pat_name_and_type(&self, pat: &Pat) -> (String, Option<TsTypeAnn>) {
+        match pat {
+            Pat::Ident(ident) => (
+                ident.id.sym.to_string(),
+                ident.type_ann.as_ref().map(|t| *t.clone()),
+            ),
+            Pat::Rest(rest) => {
+                let rest_name = match &*rest.arg {
+                    Pat::Ident(ident) => format!("...{}", ident.id.sym),
+                    _ => "...rest".to_string(),
+                };
+                (rest_name, rest.type_ann.as_ref().map(|t| *t.clone()))
+            }
+            // A defaulted param (`role = "x"`); the annotation, if any, is on
+            // the inner left pattern. Recurse so name and type are preserved.
+            Pat::Assign(assign) => self.pat_name_and_type(&assign.left),
+            _ => ("param".to_string(), None),
+        }
+    }
+
+    /// Build a `FunctionArgument` from a resolved `(name, type annotation)`.
+    fn build_argument(&self, name: String, type_ann: Option<TsTypeAnn>) -> FunctionArgument {
+        let type_string = type_ann.as_ref().and_then(|t| self.type_ann_to_string(t));
+        FunctionArgument {
+            name,
+            type_ann,
+            is_explicit: type_string.is_some(),
+            type_string,
+        }
+    }
+
     /// Extract function arguments with their type annotations
     fn extract_arguments(&self, params: &[Param]) -> Vec<FunctionArgument> {
         params
             .iter()
             .map(|param| {
-                let (name, type_ann) = match &param.pat {
-                    Pat::Ident(ident) => (
-                        ident.id.sym.to_string(),
-                        ident.type_ann.as_ref().map(|t| *t.clone()),
-                    ),
-                    Pat::Rest(rest) => {
-                        let rest_name = match &*rest.arg {
-                            Pat::Ident(ident) => format!("...{}", ident.id.sym),
-                            _ => "...rest".to_string(),
-                        };
-                        (rest_name, rest.type_ann.as_ref().map(|t| *t.clone()))
-                    }
-                    _ => ("param".to_string(), None),
-                };
-                let type_string = type_ann.as_ref().and_then(|t| self.type_ann_to_string(t));
-
-                FunctionArgument {
-                    name,
-                    type_ann,
-                    is_explicit: type_string.is_some(),
-                    type_string,
-                }
+                let (name, type_ann) = self.pat_name_and_type(&param.pat);
+                self.build_argument(name, type_ann)
             })
             .collect()
     }
@@ -383,28 +401,8 @@ impl FunctionDefinitionExtractor {
         params
             .iter()
             .map(|pat| {
-                let (name, type_ann) = match pat {
-                    Pat::Ident(ident) => (
-                        ident.id.sym.to_string(),
-                        ident.type_ann.as_ref().map(|t| *t.clone()),
-                    ),
-                    Pat::Rest(rest) => {
-                        let rest_name = match &*rest.arg {
-                            Pat::Ident(ident) => format!("...{}", ident.id.sym),
-                            _ => "...rest".to_string(),
-                        };
-                        (rest_name, rest.type_ann.as_ref().map(|t| *t.clone()))
-                    }
-                    _ => ("param".to_string(), None),
-                };
-                let type_string = type_ann.as_ref().and_then(|t| self.type_ann_to_string(t));
-
-                FunctionArgument {
-                    name,
-                    type_ann,
-                    is_explicit: type_string.is_some(),
-                    type_string,
-                }
+                let (name, type_ann) = self.pat_name_and_type(pat);
+                self.build_argument(name, type_ann)
             })
             .collect()
     }
@@ -1031,6 +1029,51 @@ mod tests {
         let defs = extract("function bare(x) { return x; }");
         let def = defs.get("bare").expect("should find bare");
         assert!(def.arguments[0].type_string.is_none());
+    }
+
+    #[test]
+    fn recovers_defaulted_union_param_on_function_declaration() {
+        let defs = extract(
+            r#"function pick(role: "producer" | "consumer" = "producer") { return role; }"#,
+        );
+        let def = defs.get("pick").expect("should find pick");
+        assert_eq!(def.arguments.len(), 1);
+        assert_eq!(def.arguments[0].name, "role");
+        assert_eq!(
+            def.arguments[0].type_string.as_deref(),
+            Some(r#""producer" | "consumer""#)
+        );
+        assert!(
+            def.arguments[0].is_explicit,
+            "defaulted param with an annotation should be explicit"
+        );
+    }
+
+    #[test]
+    fn recovers_defaulted_union_param_on_arrow_function() {
+        let defs = extract(r#"const pick = (role: "producer" | "consumer" = "producer") => role;"#);
+        let def = defs.get("pick").expect("should find pick");
+        assert_eq!(def.arguments.len(), 1);
+        assert_eq!(def.arguments[0].name, "role");
+        assert_eq!(
+            def.arguments[0].type_string.as_deref(),
+            Some(r#""producer" | "consumer""#)
+        );
+        assert!(
+            def.arguments[0].is_explicit,
+            "defaulted param with an annotation should be explicit"
+        );
+    }
+
+    #[test]
+    fn recovers_defaulted_param_name_without_annotation() {
+        // A defaulted param with no annotation keeps its name but stays
+        // implicit (faithful: there is no declared type to recover).
+        let defs = extract(r#"function pick(role = "producer") { return role; }"#);
+        let def = defs.get("pick").expect("should find pick");
+        assert_eq!(def.arguments[0].name, "role");
+        assert!(def.arguments[0].type_string.is_none());
+        assert!(!def.arguments[0].is_explicit);
     }
 
     #[test]


### PR DESCRIPTION
Two self-contained type-extraction fidelity fixes from #133. Scoped to the quick wins only; the larger root causes stay as separate work.

## Fix A1 — request body: unwrap `await` and follow the `as T` cast / typed binding (TS sidecar)

`inferRequestBody` read the raw type of the located node, so both:

- `const body = (await request.json()) as RegisterRequest`
- `const body: RegisterRequest = await request.json()`

surfaced `Promise<any>` instead of `RegisterRequest`.

It now mirrors `inferCallResult`: apply `unwrapExpressionNode` (strips `await`/`as`/parens/`!`) and consult `extractExplicitTypeFromAncestor` so an `as T` cast or a typed variable binding/annotation wins over the call's raw `Promise<any>`/`any`. Both helpers already existed and are reused unchanged.

Genuinely-untyped cases are preserved: an untyped `request.formData()` with no annotation still resolves to `FormData`/`any` (#133 lists this as NOT-a-bug). Recovery only happens when an explicit cast or typed binding is actually present.

Maps to #133 root cause **A1**.

## Fix C-params — recover name + type of defaulted union params (Rust visitor)

`role: "producer" | "consumer" = "producer"` is a `Pat::Assign` whose annotation lives on the inner `left: Pat::Ident`. Both `extract_arguments` and `extract_arrow_arguments` only matched `Pat::Ident`/`Pat::Rest`, so defaulted params fell through to the unnamed `"param"` placeholder — losing name, type, and the explicit flag.

Factored a shared `pat_name_and_type` helper that recurses into `Pat::Assign` to recover the real name + annotation, plus a `build_argument` helper to keep both call sites DRY. A defaulted param now keeps its name, its union type, and is reported explicit.

Maps to #133 root cause **C-params**.

## Out of scope (noted for follow-up)

Destructured params (`Pat::Object` / `Pat::Array`) hit the same unnamed `"param"` placeholder in both extractors and have a related latent bug (name + type lost). They are intentionally NOT fixed here and should get their own issue. The new `pat_name_and_type` helper is the natural place to extend.

Per #133 scope, this PR also does NOT touch A2 (anchoring — overlaps #157), B (multi-branch Response union — separate issue), or C-methods (class-method visitor — separate issue).

## Tests

TDD: tests written first (confirmed red), then implemented to green.

- A1: `src/sidecar/test/request-body-cast.test.ts` (+ fixture cases in `request-bodies.ts`) — cast variant, typed-binding variant, and an untyped-`formData` control.
- C-params: three unit tests in `src/visitor.rs` — defaulted union param on a function declaration and on an arrow function (name + union type + explicit), plus a defaulted-no-annotation control (keeps name, stays implicit).

### Commands + results

```
# sidecar
cd src/sidecar && npm install && npm run build && npm test
# → tests 65, pass 64, fail 0, skipped 1 (pre-existing destructuring SKIP)

# rust (repo root)
cargo fmt --check        # OK
cargo clippy --all-targets -- -D warnings   # clean
CARRICK_MOCK_ALL=1 cargo test   # all suites pass (lib 339, integration suites, doctests)
```

Refs #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)