### PR TITLE
feat(scanner): recognize navigator.sendBeacon as an HTTP POST call (#131)

### DIFF
--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -491,6 +491,25 @@ impl CandidateVisitor {
         false
     }
 
+    /// Is this a `navigator.sendBeacon(url, ...)` call? This is a web-platform
+    /// data-transmitting primitive (a fire-and-forget HTTP POST), the same
+    /// family as `fetch`/`XMLHttpRequest`. Matching the structural shape
+    /// `navigator.sendBeacon(...)` keeps the scanner free of any third-party
+    /// client allowlist: only the standard browser built-in is recognized.
+    fn is_navigator_send_beacon(callee: &Callee) -> bool {
+        let Callee::Expr(expr) = callee else {
+            return false;
+        };
+        let Expr::Member(member) = &**expr else {
+            return false;
+        };
+        let MemberProp::Ident(prop) = &member.prop else {
+            return false;
+        };
+        prop.sym.as_ref() == "sendBeacon"
+            && matches!(&*member.obj, Expr::Ident(obj) if obj.sym.as_ref() == "navigator")
+    }
+
     /// Root identifier of a callee expression, e.g. `client` in
     /// `client.users.list()` or `client(...)`.
     fn callee_root_ident(expr: &Expr) -> Option<String> {
@@ -754,6 +773,19 @@ impl Visit for CandidateVisitor {
             self.push_candidate(call, "fetch".to_string(), None);
         }
 
+        // Signal 1b: `navigator.sendBeacon(url, ...)` — a web-platform HTTP POST
+        // primitive. Its first argument is the URL, so the existing
+        // `push_candidate` (which records the first-arg path snippet and tags
+        // Protocol::Http) routes it through the HTTP prompt, where the method is
+        // inferred as POST. Recognized by structural shape, no client allowlist.
+        if Self::is_navigator_send_beacon(&call.callee) {
+            self.push_candidate(
+                call,
+                "navigator".to_string(),
+                Some("sendBeacon".to_string()),
+            );
+        }
+
         // Signal 2: call rooted at an identifier imported from a known
         // network/data-fetching package (covers wrappers regardless of method
         // name), or direct invocation of such an import (`client(url)`).
@@ -970,6 +1002,64 @@ async function run() { return sdk.doThing(); }
         let content =
             r#"function run() { const ws = new WebSocket('wss://example.com'); return ws; }"#;
         assert!(!scan_test_content(content).candidates.is_empty());
+    }
+
+    #[test]
+    fn detects_navigator_send_beacon_relative_url() {
+        // `navigator.sendBeacon('/collect', payload)` is a web-platform HTTP
+        // POST primitive. None of the name heuristics match `navigator` or
+        // `sendBeacon`, and a relative `/collect` has no URL scheme, so only the
+        // dedicated shape signal keeps this file from being skipped by the gate.
+        let content = r#"function track() { const ok = navigator.sendBeacon('/collect', payload); return ok; }"#;
+        let result = scan_test_content(content);
+        let beacon = result
+            .candidates
+            .iter()
+            .find(|c| c.callee_object == "navigator");
+        assert!(
+            beacon.is_some(),
+            "expected a navigator.sendBeacon candidate, got {:?}",
+            result
+                .candidates
+                .iter()
+                .map(|c| (&c.callee_object, &c.callee_property))
+                .collect::<Vec<_>>()
+        );
+        let beacon = beacon.unwrap();
+        assert_eq!(beacon.callee_property.as_deref(), Some("sendBeacon"));
+        assert_eq!(beacon.protocol, Protocol::Http);
+        assert_eq!(beacon.path_snippet.as_deref(), Some("'/collect'"));
+    }
+
+    #[test]
+    fn detects_navigator_send_beacon_absolute_url() {
+        let content = r#"function track() {
+    navigator.sendBeacon('https://metrics.example.com/collect', JSON.stringify(data));
+}"#;
+        let result = scan_test_content(content);
+        assert!(
+            result
+                .candidates
+                .iter()
+                .any(|c| c.callee_object == "navigator"
+                    && c.callee_property.as_deref() == Some("sendBeacon")),
+            "expected a navigator.sendBeacon candidate for an absolute URL"
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_send_beacon_member() {
+        // A `sendBeacon` method on some other object is NOT the web-platform
+        // primitive; the shape guard requires the `navigator` receiver.
+        let content = r#"function f() { return tracker.sendBeacon('/x'); }"#;
+        let result = scan_test_content(content);
+        assert!(
+            !result
+                .candidates
+                .iter()
+                .any(|c| c.callee_object == "navigator"),
+            "non-navigator.sendBeacon must not be tagged as the navigator primitive"
+        );
     }
 
     #[test]

--- a/tests/fixtures/react-app/src/components/AnalyticsBeacon.tsx
+++ b/tests/fixtures/react-app/src/components/AnalyticsBeacon.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+interface PageViewPayload {
+  path: string;
+  referrer: string;
+}
+
+// A browser component that reports analytics with the web-platform
+// `navigator.sendBeacon` primitive (a fire-and-forget HTTP POST). There is no
+// import for it — it is a browser built-in — so only the scanner's structural
+// shape recognition keeps this file from being skipped before the LLM.
+export function AnalyticsBeacon({ path, referrer }: PageViewPayload) {
+  useEffect(() => {
+    const payload = JSON.stringify({ path, referrer });
+
+    // Relative URL.
+    navigator.sendBeacon('/collect', payload);
+
+    // Absolute URL.
+    navigator.sendBeacon('https://metrics.example.com/collect', payload);
+  }, [path, referrer]);
+
+  return null;
+}

--- a/tests/framework_coverage_test.rs
+++ b/tests/framework_coverage_test.rs
@@ -211,6 +211,30 @@ fn react_tsx_fixture_captures_fetch_calls() {
 }
 
 #[test]
+fn react_tsx_fixture_captures_send_beacon_calls() {
+    // `navigator.sendBeacon` is a web-platform HTTP POST primitive with no
+    // import. Without the scanner recognizing its shape, an analytics component
+    // that only beacons would produce zero candidates and be skipped before the
+    // LLM. Assert both the relative and absolute beacon calls surface.
+    let file = fixture_path("react-app/src/components/AnalyticsBeacon.tsx");
+    let result = scan(&file);
+
+    let beacons: Vec<_> = result
+        .candidates
+        .iter()
+        .filter(|c| {
+            c.callee_object == "navigator" && c.callee_property.as_deref() == Some("sendBeacon")
+        })
+        .collect();
+    assert!(
+        beacons.len() >= 2,
+        "expected >=2 navigator.sendBeacon candidates (relative + absolute), got {}: {:?}",
+        beacons.len(),
+        objects(&result.candidates)
+    );
+}
+
+#[test]
 fn react_jsx_fixture_captures_fetch_calls() {
     let file = fixture_path("react-app/src/legacy/LegacyWidget.jsx");
     let result = scan(&file);


### PR DESCRIPTION
## What

Teaches the SWC gatekeeper to recognize `navigator.sendBeacon(url, data)` as an HTTP call so files that beacon analytics actually reach the file-analyzer LLM.

Re-scoped implementation of daveymoores/carrick-cloud#131. **Paired with the cloud prompt change: daveymoores/carrick-cloud#137.** This scanner change is the half that makes the candidate visible; the prompt change is the half that makes the LLM emit it.

## The gatekeeper gap

The SWC scanner is an AST gate: a file with zero `http_candidates` is skipped before any LLM call (`src/agents/file_orchestrator.rs`). None of the existing candidate signals matched `navigator.sendBeacon`:

- **Signal 1** (`is_global_network_call`) matches only the bare `fetch` identifier.
- **Signal 2** (import-rooted) — sendBeacon has no import; it is a browser built-in.
- **Signal 3** (`first_arg_has_url_scheme`) matches `http(s)://` / `ws(s)://` / `//` literals, not a relative `/collect`.
- **Signal 4** (awaited + stringish) — sendBeacon is synchronous.
- **Signal 5** (name heuristics) — neither `navigator` nor `sendBeacon` is in the API-object/method allowlists.

So a browser component that only beacons produced no candidates and was invisible.

## The fix

`sendBeacon` is a standard web-platform data-transmitting primitive in the same family the scanner already recognizes — `fetch` (Signal 1), `XMLHttpRequest` and `new WebSocket`/`EventSource` (`visit_new_expr`). It is always an HTTP POST with the URL as its first argument, so it fits the existing `OperationKey::Http { method, path }` and routes through the existing HTTP prompt — no new `OperationKey` variant, no new protocol.

Added `is_navigator_send_beacon` and a dedicated "Signal 1b" in `visit_call_expr` (right after the `fetch` signal, since it's the same web-platform-primitive family). It matches on the structural shape `navigator.sendBeacon(...)` and emits a `Protocol::Http` candidate with `callee_object: "navigator"`, `callee_property: "sendBeacon"`, and the URL as the path snippet. The LLM infers method = POST via the paired prompt change.

**Kept principled:** recognition is by web-platform shape only. No third-party client allowlist was added; the existing "precision over recall, string-literal targets" guardrail is respected (a `sendBeacon` method on any non-`navigator` receiver is rejected — see `ignores_unrelated_send_beacon_member`).

## Out of scope

Raw WebSocket / EventSource remain tagged `Protocol::Websocket` but unrouted (no socket prompt is registered yet). They are not HTTP-shaped like sendBeacon, so routing them needs separate follow-up work and is intentionally not touched here.

## Tests (TDD)

- New fixture `tests/fixtures/react-app/src/components/AnalyticsBeacon.tsx` — a browser component beaconing both a relative (`/collect`) and an absolute URL.
- New scanner unit tests: `detects_navigator_send_beacon_relative_url`, `detects_navigator_send_beacon_absolute_url`, `ignores_unrelated_send_beacon_member`.
- New framework-coverage test `react_tsx_fixture_captures_send_beacon_calls`.

## Verification

- `cargo fmt` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `CARRICK_MOCK_ALL=1 cargo test` — all suites pass (lib 348, framework_coverage 7, etc.; 0 failures)
- pre-commit hook (fmt + clippy + `cargo test` + ts_check 67/67) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)