### PR TITLE
fix(scanner): address Copilot review feedback from #163, #171, #145

### DIFF
--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -1201,4 +1201,69 @@ mod tests {
         assert_eq!(missing.len(), 1);
         assert!(orphaned.is_empty());
     }
+
+    #[test]
+    fn test_no_baseline_excludes_connectivity_from_headline_count() {
+        // First repo indexed (has_cross_repo_baseline = false): connectivity
+        // findings are inconclusive (no peers to match against) so they must be
+        // kept OUT of the headline CARRICK_ISSUE_COUNT, yet the section must
+        // still render — framed as informational "Observations". This covers
+        // the previously-untested `false` branch of `has_cross_repo_baseline`.
+        let issues = ApiIssues {
+            call_issues: vec![],
+            endpoint_issues: vec![
+                "Orphaned endpoint: GET /api/users in src/routes.ts:42".to_string(),
+                "Orphaned endpoint: PUT /api/sessions in src/sessions.ts:7".to_string(),
+            ],
+            env_var_calls: vec![],
+            mismatches: vec![],
+            type_mismatches: vec![],
+            dependency_conflicts: vec![],
+        };
+        let result = ApiAnalysisResult {
+            endpoints: vec![],
+            calls: vec![],
+            issues,
+            verified_endpoints: vec![],
+            detected_graphql_libraries: vec![],
+            graphql_operations_indexed: false,
+        };
+
+        let output = format_analysis_results(result, false);
+
+        // Headline count excludes the two connectivity findings → zero issues.
+        assert!(
+            output.contains("<!-- CARRICK_ISSUE_COUNT:0 -->"),
+            "first-run connectivity findings must not inflate the headline count, got:\n{}",
+            output
+        );
+        // But the connectivity section still renders, framed as observations.
+        assert!(
+            output.contains("Connectivity Observations"),
+            "connectivity section must still render as informational observations, got:\n{}",
+            output
+        );
+        assert!(
+            output.contains("first repo indexed"),
+            "first-run observations must carry the informational framing, got:\n{}",
+            output
+        );
+        // The orphaned endpoints are rendered as Method/Path table rows.
+        assert!(
+            output.contains("`/api/users`"),
+            "the orphaned endpoints must still be listed, got:\n{}",
+            output
+        );
+        assert!(
+            output.contains("`/api/sessions`"),
+            "the orphaned endpoints must still be listed, got:\n{}",
+            output
+        );
+        // Headline phrasing reflects the informational framing, not "gaps".
+        assert!(
+            output.contains("connectivity observations"),
+            "headline should frame first-run connectivity as observations, got:\n{}",
+            output
+        );
+    }
 }

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -557,7 +557,13 @@ export class TypeInferrer {
     // on an ancestor — wins over the call's raw `Promise<any>` / `any`. Only
     // recover when one is genuinely present; untyped `request.formData()`
     // stays `FormData` / `any`.
-    const explicitType = this.extractExplicitTypeFromAncestor(located);
+    //
+    // Use the unwrapped `node`, not `located`: when the locator lands ON the
+    // `(...) as T` cast itself, the cast is the located node (not an ancestor),
+    // so an ancestor walk from `located` would miss it. `node` is the inner
+    // expression whose ancestors include the `as T`, so the cast is recovered;
+    // the typed-binding and untyped-control cases are unaffected.
+    const explicitType = this.extractExplicitTypeFromAncestor(node);
     if (explicitType) {
       typeString = explicitType;
       isExplicit = true;

--- a/src/sidecar/test/request-body-cast.test.ts
+++ b/src/sidecar/test/request-body-cast.test.ts
@@ -105,6 +105,48 @@ describe('Request body cast/binding regressions (#133 A1)', () => {
     );
   });
 
+  it('recovers the cast type when the located node IS the `as T` cast itself', async () => {
+    // Regression for the #163 Copilot finding: when the locator resolves the
+    // span onto the `(await request.json()) as RegisterRequest` cast NODE
+    // (not the inner call), the cast is the located node — not an ancestor —
+    // so the old `extractExplicitTypeFromAncestor(located)` missed it and fell
+    // back to `Promise<any>` / `any`. The fix passes the unwrapped inner node,
+    // whose ancestors include the `as T`, so the cast type is recovered.
+    const cast = spanOf('(await request.json()) as RegisterRequest');
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'reqbody-cast-on-node',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: cast.line,
+          span_start: cast.start,
+          span_end: cast.end,
+          infer_kind: 'request_body',
+          alias: 'RegisterCastNodeBody',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'RegisterCastNodeBody'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.strictEqual(
+      inferred.type_string,
+      'RegisterRequest',
+      `expected the cast type to win when located ON the cast, got ${inferred.type_string}`
+    );
+    assert.strictEqual(
+      inferred.is_explicit,
+      true,
+      'a recovered declared type must be reported explicit'
+    );
+  });
+
   it('follows a typed variable binding on an awaited request.json()', async () => {
     // `const body: RegisterRequest = await request.json();` — the typed
     // binding annotation must win over the call's `Promise<any>`.

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -493,9 +493,11 @@ impl CandidateVisitor {
 
     /// Is this a `navigator.sendBeacon(url, ...)` call? This is a web-platform
     /// data-transmitting primitive (a fire-and-forget HTTP POST), the same
-    /// family as `fetch`/`XMLHttpRequest`. Matching the structural shape
+    /// family as `fetch`/`XMLHttpRequest`. Matching the syntactic shape
     /// `navigator.sendBeacon(...)` keeps the scanner free of any third-party
-    /// client allowlist: only the standard browser built-in is recognized.
+    /// client allowlist. This is shape-based, not resolution-based: it keys off
+    /// a receiver named `navigator`, which a local could shadow, so it does not
+    /// prove the actual browser built-in is being called.
     fn is_navigator_send_beacon(callee: &Callee) -> bool {
         let Callee::Expr(expr) = callee else {
             return false;
@@ -1012,10 +1014,9 @@ async function run() { return sdk.doThing(); }
         // dedicated shape signal keeps this file from being skipped by the gate.
         let content = r#"function track() { const ok = navigator.sendBeacon('/collect', payload); return ok; }"#;
         let result = scan_test_content(content);
-        let beacon = result
-            .candidates
-            .iter()
-            .find(|c| c.callee_object == "navigator");
+        let beacon = result.candidates.iter().find(|c| {
+            c.callee_object == "navigator" && c.callee_property.as_deref() == Some("sendBeacon")
+        });
         assert!(
             beacon.is_some(),
             "expected a navigator.sendBeacon candidate, got {:?}",
@@ -1057,7 +1058,8 @@ async function run() { return sdk.doThing(); }
             !result
                 .candidates
                 .iter()
-                .any(|c| c.callee_object == "navigator"),
+                .any(|c| c.callee_object == "navigator"
+                    && c.callee_property.as_deref() == Some("sendBeacon")),
             "non-navigator.sendBeacon must not be tagged as the navigator primitive"
         );
     }


### PR DESCRIPTION
Scoped follow-up addressing Copilot review feedback from three already-merged PRs (#163, #171, #145). One finding each.

## 1. (#163) `src/sidecar/src/type-inferrer.ts` — cast recovery misses a locator that lands ON the cast

`inferRequestBody` recovered an explicit request type by walking ancestors of the *located* node (`extractExplicitTypeFromAncestor(located)`). When the locator resolves the span onto the `(...) as T` cast node itself, the cast is the located node, not an ancestor, so the explicit type was missed and it fell back to `Promise<any>` / `any`.

Fix: pass the already-computed unwrapped inner `node` instead of `located`. `node` strips `await`/`as`/parens/`!`, so its ancestors include the `as T` cast → recovered. Strictly better: the typed-binding case and the untyped `request.formData()` control are unaffected.

TDD: added a regression test in `request-body-cast.test.ts` whose locator spans the full `(await request.json()) as RegisterRequest` cast node and asserts the recovered type is `RegisterRequest` (explicit). Confirmed red before the fix (`any`), green after. The three pre-existing request-body-cast tests still pass.

Relates to daveymoores/carrick-cloud#133.

## 2. (#171) `src/swc_scanner.rs` — three robustness nits (Copilot approved)

- Reworded the `is_navigator_send_beacon` doc comment: it no longer claims "only the standard browser built-in is recognized". It now describes shape-based (not resolution-based) matching — a receiver named `navigator` that a local could shadow.
- `detects_navigator_send_beacon_relative_url`: tightened the `find` predicate to match BOTH `callee_object == "navigator"` AND `callee_property == Some("sendBeacon")`.
- `ignores_unrelated_send_beacon_member`: now asserts absence of a `navigator.sendBeacon` candidate specifically (object AND property) rather than any `navigator.*`.

Relates to #131.

## 3. (#145) `src/formatter/mod.rs` — test the false-baseline path

`has_cross_repo_baseline` added a formatting mode but only the `true` path was tested. Added a test-only unit test for `has_cross_repo_baseline = false` asserting connectivity findings are excluded from the headline `CARRICK_ISSUE_COUNT` (count is 0) while the connectivity section still renders as informational "Connectivity Observations" with the endpoints listed. No formatter output behavior changed. Skipped the optional cosmetic first-run header wording nit to avoid disturbing output/snapshots.

Relates to #145.

## Verification

- Rust (repo root): `cargo fmt`, `cargo clippy --all-targets -- -D warnings` (exit 0), `CARRICK_MOCK_ALL=1 cargo test` — all suites green (345/352 lib+bin, all integration suites pass).
- Sidecar: `npm install && rm -rf dist && npm run build && npm test` — 65 pass, 0 fail, 1 pre-existing skip, exit 0.
- Pre-commit hook (fmt + clippy + rust + ts_check) passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)