### PR TITLE
Attribute orphaned endpoints to their owning service/repo

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1672,6 +1672,7 @@ impl FileOrchestrator {
                     file_location: format!("{}:{}", file_path, endpoint.line_number),
                     middleware_chain: Vec::new(),
                     repo_name: None,
+                    service_name: None,
                 });
             }
         }

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -34,7 +34,12 @@ static ARRAY_GENERIC_RE: LazyLock<regex::Regex> =
 type RouteFieldMap = HashMap<OperationKey, Json>;
 /// Result of `analyze_matches_with_mount_graph`:
 ///   `(call_issues, endpoint_issues, env_var_calls, verified_endpoints)`.
-type MountGraphMatches = (Vec<String>, Vec<String>, Vec<String>, Vec<(String, String)>);
+type MountGraphMatches = (
+    Vec<String>,
+    Vec<OrphanedEndpoint>,
+    Vec<String>,
+    Vec<(String, String)>,
+);
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum ConflictSeverity {
@@ -57,9 +62,20 @@ pub struct RepoPackageInfo {
     pub source_path: PathBuf,
 }
 
+/// A producer endpoint with no consumer in the indexed services. `service`
+/// names the owning service (monorepo `serviceName`) or repo (poly-repo) when
+/// known; it is `None` for protocols whose orphans are not repo-tagged
+/// (GraphQL/socket).
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct OrphanedEndpoint {
+    pub method: String,
+    pub path: String,
+    pub service: Option<String>,
+}
+
 pub struct ApiIssues {
     pub call_issues: Vec<String>,
-    pub endpoint_issues: Vec<String>,
+    pub endpoint_issues: Vec<OrphanedEndpoint>,
     pub env_var_calls: Vec<String>,
     pub mismatches: Vec<String>,
     pub type_mismatches: Vec<String>,
@@ -1076,10 +1092,16 @@ impl Analyzer {
             if matched_endpoints.contains(&key) {
                 verified.push((endpoint.method.clone(), endpoint.full_path.clone()));
             } else {
-                endpoint_issues.push(format!(
-                    "Orphaned endpoint: {} {} in {}",
-                    endpoint.method, endpoint.full_path, endpoint.file_location
-                ));
+                endpoint_issues.push(OrphanedEndpoint {
+                    method: endpoint.method.clone(),
+                    path: endpoint.full_path.clone(),
+                    // Prefer the monorepo service name, falling back to the repo
+                    // (matches the cloud's service_name ?? repo_name convention).
+                    service: endpoint
+                        .service_name
+                        .clone()
+                        .or_else(|| endpoint.repo_name.clone()),
+                });
             }
         }
         verified.sort();
@@ -1102,7 +1124,7 @@ impl Analyzer {
         &self,
         protocol: crate::operation::Protocol,
         protocol_label: &str,
-    ) -> (Vec<String>, Vec<String>, Vec<(String, String)>) {
+    ) -> (Vec<String>, Vec<OrphanedEndpoint>, Vec<(String, String)>) {
         let producer_keys: HashSet<&OperationKey> = self
             .endpoints
             .iter()
@@ -1152,12 +1174,13 @@ impl Analyzer {
             if matched.contains(&endpoint.key) {
                 verified.push((label, name));
             } else {
-                endpoint_issues.push(format!(
-                    "Orphaned endpoint: {} {} in {}",
-                    label,
-                    name,
-                    endpoint.file_path.display()
-                ));
+                // GraphQL/socket producers are not repo-tagged at this layer, so
+                // the owning service is unknown.
+                endpoint_issues.push(OrphanedEndpoint {
+                    method: label,
+                    path: name,
+                    service: None,
+                });
             }
         }
         verified.sort();
@@ -2018,11 +2041,10 @@ mod tests {
             call_issues[0]
         );
         assert_eq!(endpoint_issues.len(), 1);
-        assert!(
-            endpoint_issues[0].contains("Orphaned endpoint: MUTATION createUser"),
-            "got {}",
-            endpoint_issues[0]
-        );
+        assert_eq!(endpoint_issues[0].method, "MUTATION");
+        assert_eq!(endpoint_issues[0].path, "createUser");
+        // GraphQL orphans are not repo-tagged at this layer.
+        assert!(endpoint_issues[0].service.is_none());
     }
 
     #[test]

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -487,7 +487,7 @@ fn format_connectivity_section(
         output.push_str("| Method | Path |\n| :--- | :--- |\n");
         for issue in missing {
             let (method, path) = extract_method_path(issue);
-            output.push_str(&format!("| `{}` | `{}` |\n", method, path));
+            output.push_str(&format!("| `{}` | `{}` |\n", cell(&method), cell(&path)));
         }
         output.push('\n');
     }
@@ -499,20 +499,29 @@ fn format_connectivity_section(
         if orphaned.iter().any(|o| o.service.is_some()) {
             output.push_str("| Method | Path | Service |\n| :--- | :--- | :--- |\n");
             for o in orphaned {
+                // A row can be unattributed even when the column is shown (e.g.
+                // a GraphQL orphan alongside an attributed HTTP one); use a dash
+                // rather than an empty cell.
                 let service = o
                     .service
                     .as_deref()
-                    .map(|s| format!("`{}`", s))
-                    .unwrap_or_default();
+                    .map(|s| format!("`{}`", cell(s)))
+                    .unwrap_or_else(|| "-".to_string());
                 output.push_str(&format!(
                     "| `{}` | `{}` | {} |\n",
-                    o.method, o.path, service
+                    cell(&o.method),
+                    cell(&o.path),
+                    service
                 ));
             }
         } else {
             output.push_str("| Method | Path |\n| :--- | :--- |\n");
             for o in orphaned {
-                output.push_str(&format!("| `{}` | `{}` |\n", o.method, o.path));
+                output.push_str(&format!(
+                    "| `{}` | `{}` |\n",
+                    cell(&o.method),
+                    cell(&o.path)
+                ));
             }
         }
     }
@@ -1515,5 +1524,29 @@ mod tests {
 
         assert!(!output.contains("Service |"));
         assert!(output.contains("| `GET` | `/legacy/ping` |"));
+    }
+
+    #[test]
+    fn test_orphaned_mixed_attribution_uses_dash_and_escapes_cells() {
+        // When the Service column is shown, an unattributed row gets a dash, and
+        // any pipe in a value is escaped so it can't break the table.
+        let mut issues = empty_issues();
+        issues.endpoint_issues = vec![
+            OrphanedEndpoint {
+                method: "GET".to_string(),
+                path: "/users".to_string(),
+                service: Some("auth".to_string()),
+            },
+            OrphanedEndpoint {
+                method: "QUERY".to_string(),
+                path: "weird|field".to_string(),
+                service: None,
+            },
+        ];
+        let output = format_analysis_results(result_with(issues), &topology_baseline());
+
+        assert!(output.contains("| `GET` | `/users` | `auth` |"));
+        // Unattributed row → dash, and the pipe in the path is escaped.
+        assert!(output.contains("| `QUERY` | `weird\\|field` | - |"));
     }
 }

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -449,11 +449,13 @@ fn summarize_critical(issue: &str) -> (String, String) {
     }
 }
 
-/// Escape a value for a Markdown table cell: no pipes, no newlines.
+/// Escape a value for a Markdown table cell: no pipes, and no line breaks
+/// (CRLF, lone CR, or LF) that would otherwise split the row.
 fn cell(value: &str) -> String {
     value
         .replace('|', "\\|")
-        .replace('\n', " ")
+        .replace("\r\n", " ")
+        .replace(['\r', '\n'], " ")
         .trim()
         .to_string()
 }
@@ -1537,6 +1539,16 @@ mod tests {
 
         assert!(!output.contains("Service |"));
         assert!(output.contains("| `GET` | `/legacy/ping` |"));
+    }
+
+    #[test]
+    fn test_cell_escapes_pipes_and_collapses_line_breaks() {
+        assert_eq!(cell("a|b"), "a\\|b");
+        assert_eq!(cell("a\r\nb"), "a b");
+        assert_eq!(cell("a\rb"), "a b");
+        assert_eq!(cell("a\nb"), "a b");
+        // code_cell additionally drops backticks for inline-code cells.
+        assert_eq!(code_cell("x`y|z"), "xy\\|z");
     }
 
     #[test]

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -1,4 +1,6 @@
-use crate::analyzer::{ApiAnalysisResult, ApiIssues, ConflictSeverity, DependencyConflict};
+use crate::analyzer::{
+    ApiAnalysisResult, ApiIssues, ConflictSeverity, DependencyConflict, OrphanedEndpoint,
+};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Shape of the project being analyzed, threaded from the engine so the PR
@@ -106,7 +108,7 @@ pub fn format_analysis_results(result: ApiAnalysisResult, topology: &Topology) -
     // informational. Configuration suggestions are advisory and never gate CI,
     // so they are excluded from the count as well.
     let connectivity_in_headline = if has_baseline {
-        categorized_issues.connectivity.len()
+        categorized_issues.connectivity_len()
     } else {
         0
     };
@@ -151,9 +153,10 @@ pub fn format_analysis_results(result: ApiAnalysisResult, topology: &Topology) -
         output.push_str(&format_critical_section(&categorized_issues.critical));
         output.push_str("\n\n");
     }
-    if !categorized_issues.connectivity.is_empty() {
+    if !categorized_issues.connectivity_is_empty() {
         output.push_str(&format_connectivity_section(
-            &categorized_issues.connectivity,
+            &categorized_issues.missing,
+            &categorized_issues.orphaned,
             has_baseline,
         ));
         output.push_str("\n\n");
@@ -203,7 +206,7 @@ fn format_verdict(
             plural(categorized.critical.len())
         ));
     }
-    if !categorized.connectivity.is_empty() {
+    if !categorized.connectivity_is_empty() {
         let noun = if has_baseline {
             "connectivity gap"
         } else {
@@ -211,9 +214,9 @@ fn format_verdict(
         };
         parts.push(format!(
             "{} {}{}",
-            categorized.connectivity.len(),
+            categorized.connectivity_len(),
             noun,
-            plural(categorized.connectivity.len())
+            plural(categorized.connectivity_len())
         ));
     }
     if !categorized.dependencies.is_empty() {
@@ -240,7 +243,7 @@ fn format_verdict(
     // Only explain the informational framing when there are connectivity
     // findings to frame; otherwise the note would reference connectivity that
     // isn't present (e.g. a lone repo with only configuration suggestions).
-    let baseline_note = if !has_baseline && !categorized.connectivity.is_empty() {
+    let baseline_note = if !has_baseline && !categorized.connectivity_is_empty() {
         " First repo indexed, so connectivity findings are informational.".to_string()
     } else {
         String::new()
@@ -360,14 +363,28 @@ struct EnvVarSuggestionGroup {
 
 struct CategorizedIssues {
     critical: Vec<String>,
-    connectivity: Vec<String>,
+    /// Consumer calls with no producer (still string-based; consumer-repo
+    /// attribution is a follow-up).
+    missing: Vec<String>,
+    /// Producers with no consumer, carrying their owning service/repo.
+    orphaned: Vec<OrphanedEndpoint>,
     configuration: Vec<EnvVarSuggestionGroup>,
     dependencies: Vec<DependencyConflict>,
 }
 
+impl CategorizedIssues {
+    fn connectivity_len(&self) -> usize {
+        self.missing.len() + self.orphaned.len()
+    }
+
+    fn connectivity_is_empty(&self) -> bool {
+        self.missing.is_empty() && self.orphaned.is_empty()
+    }
+}
+
 fn categorize_issues(issues: &ApiIssues) -> CategorizedIssues {
     let mut critical = Vec::new();
-    let mut connectivity = Vec::new();
+    let mut missing = Vec::new();
 
     critical.extend(issues.mismatches.clone());
     critical.extend(issues.type_mismatches.clone());
@@ -376,18 +393,15 @@ fn categorize_issues(issues: &ApiIssues) -> CategorizedIssues {
         if issue.contains("Method mismatch") {
             critical.push(issue.clone());
         } else {
-            connectivity.push(issue.clone());
+            missing.push(issue.clone());
         }
     }
 
-    connectivity.extend(issues.endpoint_issues.clone());
-
-    let configuration = group_env_var_suggestions(&issues.env_var_calls);
-
     CategorizedIssues {
         critical,
-        connectivity,
-        configuration,
+        missing,
+        orphaned: issues.endpoint_issues.clone(),
+        configuration: group_env_var_suggestions(&issues.env_var_calls),
         dependencies: issues.dependency_conflicts.clone(),
     }
 }
@@ -444,28 +458,11 @@ fn cell(value: &str) -> String {
         .to_string()
 }
 
-/// Separates endpoint issues into missing and orphaned categories
-fn separate_missing_orphaned(issues: &[String]) -> (Vec<&String>, Vec<&String>) {
-    let mut missing = Vec::new();
-    let mut orphaned = Vec::new();
-
-    // Prefixes must match what `analyzer::mod` emits:
-    //   "Missing endpoint for {METHOD} {PATH} ..." (no colon)
-    //   "Orphaned endpoint: {METHOD} {PATH} ..."   (has colon)
-    // Pre-2026-05 the missing-side check used a colon and silently dropped
-    // every entry. Tests below pin both literals.
-    for issue in issues {
-        if issue.starts_with("Missing endpoint for") {
-            missing.push(issue);
-        } else if issue.starts_with("Orphaned endpoint:") {
-            orphaned.push(issue);
-        }
-    }
-
-    (missing, orphaned)
-}
-
-fn format_connectivity_section(issues: &[String], has_baseline: bool) -> String {
+fn format_connectivity_section(
+    missing: &[String],
+    orphaned: &[OrphanedEndpoint],
+    has_baseline: bool,
+) -> String {
     let mut output = String::new();
 
     let heading = if has_baseline {
@@ -476,7 +473,7 @@ fn format_connectivity_section(issues: &[String], has_baseline: bool) -> String 
     output.push_str(&format!(
         "<details>\n<summary><strong>{} ({})</strong></summary>\n\n",
         heading,
-        issues.len()
+        missing.len() + orphaned.len()
     ));
 
     output.push_str("> Orphaned endpoints have no consumer in the indexed services. Missing endpoints have a consumer call but no producer.\n\n");
@@ -485,13 +482,11 @@ fn format_connectivity_section(issues: &[String], has_baseline: bool) -> String 
         output.push_str("> **First repo indexed for this project.** With nothing else to match against, every endpoint without a same-repo consumer is listed below; most resolve once you connect the repos that call them.\n\n");
     }
 
-    let (missing, orphaned) = separate_missing_orphaned(issues);
-
     if !missing.is_empty() {
         output.push_str(&format!("**Missing ({})**\n\n", missing.len()));
         output.push_str("| Method | Path |\n| :--- | :--- |\n");
-        for endpoint in missing {
-            let (method, path) = extract_method_path(endpoint);
+        for issue in missing {
+            let (method, path) = extract_method_path(issue);
             output.push_str(&format!("| `{}` | `{}` |\n", method, path));
         }
         output.push('\n');
@@ -499,10 +494,26 @@ fn format_connectivity_section(issues: &[String], has_baseline: bool) -> String 
 
     if !orphaned.is_empty() {
         output.push_str(&format!("**Orphaned ({})**\n\n", orphaned.len()));
-        output.push_str("| Method | Path |\n| :--- | :--- |\n");
-        for endpoint in orphaned {
-            let (method, path) = extract_method_path(endpoint);
-            output.push_str(&format!("| `{}` | `{}` |\n", method, path));
+        // Show the owning-service column only when at least one orphan is
+        // attributed (single-repo runs have none, so the column is dropped).
+        if orphaned.iter().any(|o| o.service.is_some()) {
+            output.push_str("| Method | Path | Service |\n| :--- | :--- | :--- |\n");
+            for o in orphaned {
+                let service = o
+                    .service
+                    .as_deref()
+                    .map(|s| format!("`{}`", s))
+                    .unwrap_or_default();
+                output.push_str(&format!(
+                    "| `{}` | `{}` | {} |\n",
+                    o.method, o.path, service
+                ));
+            }
+        } else {
+            output.push_str("| Method | Path |\n| :--- | :--- |\n");
+            for o in orphaned {
+                output.push_str(&format!("| `{}` | `{}` |\n", o.method, o.path));
+            }
         }
     }
 
@@ -1241,48 +1252,6 @@ mod tests {
     }
 
     #[test]
-    fn test_separate_missing_orphaned_routes_both_kinds() {
-        // Regression test: pre-fix, the "Missing endpoint for ..." prefix
-        // was checked as "Missing endpoint:" (with colon) which never matched
-        // the analyzer's actual output, so every missing-endpoint entry was
-        // silently filtered out before rendering.
-        let issues = vec![
-            "Missing endpoint for POST /api/orders (normalized: /api/orders) (called from src/client.ts)".to_string(),
-            "Orphaned endpoint: GET /api/users in src/routes.ts:42".to_string(),
-            "Missing endpoint for DELETE /items/:id (normalized: /items/:id) (called from src/items.ts)".to_string(),
-            "Orphaned endpoint: PUT /api/sessions in src/sessions.ts:7".to_string(),
-        ];
-
-        let (missing, orphaned) = separate_missing_orphaned(&issues);
-
-        assert_eq!(
-            missing.len(),
-            2,
-            "both missing-endpoint entries must route to the missing bucket"
-        );
-        assert_eq!(
-            orphaned.len(),
-            2,
-            "both orphaned-endpoint entries must route to the orphaned bucket"
-        );
-        assert!(missing[0].contains("POST /api/orders"));
-        assert!(missing[1].contains("DELETE /items/:id"));
-        assert!(orphaned[0].contains("GET /api/users"));
-        assert!(orphaned[1].contains("PUT /api/sessions"));
-    }
-
-    #[test]
-    fn test_separate_missing_orphaned_ignores_unrelated() {
-        let issues = vec![
-            "Some other diagnostic about types".to_string(),
-            "Missing endpoint for GET /a (normalized: /a) (called from src/x.ts)".to_string(),
-        ];
-        let (missing, orphaned) = separate_missing_orphaned(&issues);
-        assert_eq!(missing.len(), 1);
-        assert!(orphaned.is_empty());
-    }
-
-    #[test]
     fn test_no_baseline_excludes_connectivity_from_headline_count() {
         // First repo indexed (has_cross_repo_baseline = false): connectivity
         // findings are inconclusive (no peers to match against) so they must be
@@ -1292,8 +1261,16 @@ mod tests {
         let issues = ApiIssues {
             call_issues: vec![],
             endpoint_issues: vec![
-                "Orphaned endpoint: GET /api/users in src/routes.ts:42".to_string(),
-                "Orphaned endpoint: PUT /api/sessions in src/sessions.ts:7".to_string(),
+                OrphanedEndpoint {
+                    method: "GET".to_string(),
+                    path: "/api/users".to_string(),
+                    service: None,
+                },
+                OrphanedEndpoint {
+                    method: "PUT".to_string(),
+                    path: "/api/sessions".to_string(),
+                    service: None,
+                },
             ],
             env_var_calls: vec![],
             mismatches: vec![],
@@ -1481,8 +1458,11 @@ mod tests {
         issues.type_mismatches = vec![
             "Type mismatch on GET /api/users: Producer (UserResponse) incompatible with Consumer (User[]) - Property 'role' is missing".to_string(),
         ];
-        issues.endpoint_issues =
-            vec!["Orphaned endpoint: GET /legacy/ping in src/legacy.ts:3".to_string()];
+        issues.endpoint_issues = vec![OrphanedEndpoint {
+            method: "GET".to_string(),
+            path: "/legacy/ping".to_string(),
+            service: Some("billing".to_string()),
+        }];
         let output = format_analysis_results(result_with(issues), &topology_baseline());
 
         for banned in ["✅", "ℹ️", "⚠️", "❌", "🔁"] {
@@ -1495,5 +1475,45 @@ mod tests {
         }
         // The brand mark is intentionally retained.
         assert!(output.contains("🪢"));
+    }
+
+    #[test]
+    fn test_orphaned_endpoints_show_service_when_attributed() {
+        // When orphans carry an owning service, the connectivity table gains a
+        // Service column naming where each lives.
+        let mut issues = empty_issues();
+        issues.endpoint_issues = vec![
+            OrphanedEndpoint {
+                method: "GET".to_string(),
+                path: "/users".to_string(),
+                service: Some("auth".to_string()),
+            },
+            OrphanedEndpoint {
+                method: "POST".to_string(),
+                path: "/charges".to_string(),
+                service: Some("billing".to_string()),
+            },
+        ];
+        let output = format_analysis_results(result_with(issues), &topology_baseline());
+
+        assert!(output.contains("| Method | Path | Service |"));
+        assert!(output.contains("| `GET` | `/users` | `auth` |"));
+        assert!(output.contains("| `POST` | `/charges` | `billing` |"));
+    }
+
+    #[test]
+    fn test_orphaned_endpoints_omit_service_column_when_unattributed() {
+        // A lone repo has no service attribution, so the column is dropped
+        // rather than rendering an empty cell per row.
+        let mut issues = empty_issues();
+        issues.endpoint_issues = vec![OrphanedEndpoint {
+            method: "GET".to_string(),
+            path: "/legacy/ping".to_string(),
+            service: None,
+        }];
+        let output = format_analysis_results(result_with(issues), &topology_first_repo());
+
+        assert!(!output.contains("Service |"));
+        assert!(output.contains("| `GET` | `/legacy/ping` |"));
     }
 }

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -458,6 +458,15 @@ fn cell(value: &str) -> String {
         .to_string()
 }
 
+/// Sanitize a value that will be wrapped in inline-code backticks inside a
+/// table cell. Beyond `cell()`'s pipe/newline escaping, drop backticks: an
+/// HTTP method, route, or service name should never contain one, and a stray
+/// backtick (e.g. from a hand-written carrick.json `serviceName`) would break
+/// out of the code span and could inject Markdown.
+fn code_cell(value: &str) -> String {
+    cell(value).replace('`', "")
+}
+
 fn format_connectivity_section(
     missing: &[String],
     orphaned: &[OrphanedEndpoint],
@@ -487,7 +496,11 @@ fn format_connectivity_section(
         output.push_str("| Method | Path |\n| :--- | :--- |\n");
         for issue in missing {
             let (method, path) = extract_method_path(issue);
-            output.push_str(&format!("| `{}` | `{}` |\n", cell(&method), cell(&path)));
+            output.push_str(&format!(
+                "| `{}` | `{}` |\n",
+                code_cell(&method),
+                code_cell(&path)
+            ));
         }
         output.push('\n');
     }
@@ -505,12 +518,12 @@ fn format_connectivity_section(
                 let service = o
                     .service
                     .as_deref()
-                    .map(|s| format!("`{}`", cell(s)))
+                    .map(|s| format!("`{}`", code_cell(s)))
                     .unwrap_or_else(|| "-".to_string());
                 output.push_str(&format!(
                     "| `{}` | `{}` | {} |\n",
-                    cell(&o.method),
-                    cell(&o.path),
+                    code_cell(&o.method),
+                    code_cell(&o.path),
                     service
                 ));
             }
@@ -519,8 +532,8 @@ fn format_connectivity_section(
             for o in orphaned {
                 output.push_str(&format!(
                     "| `{}` | `{}` |\n",
-                    cell(&o.method),
-                    cell(&o.path)
+                    code_cell(&o.method),
+                    code_cell(&o.path)
                 ));
             }
         }
@@ -1535,7 +1548,8 @@ mod tests {
             OrphanedEndpoint {
                 method: "GET".to_string(),
                 path: "/users".to_string(),
-                service: Some("auth".to_string()),
+                // Backtick must be stripped so it can't break the code span.
+                service: Some("au`th".to_string()),
             },
             OrphanedEndpoint {
                 method: "QUERY".to_string(),

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -76,6 +76,10 @@ pub struct ResolvedEndpoint {
     /// Optional repo identifier for cross-repo matching
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo_name: Option<String>,
+    /// Optional service identifier (monorepo carrick.json serviceName), tagged
+    /// during cross-repo merge so findings can name the owning service.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_name: Option<String>,
 }
 
 /// Represents a data-fetching call with its target
@@ -265,6 +269,7 @@ impl MountGraph {
             file_location: site.call_site.location.clone(),
             middleware_chain: Vec::new(), // TODO: Could extract from handler_args if needed
             repo_name: None,              // Will be set during cross-repo merge
+            service_name: None,
         })
     }
 
@@ -634,8 +639,10 @@ impl MountGraph {
                     );
                     if seen_endpoints.insert(key) {
                         let mut tagged_endpoint = endpoint.clone();
-                        // Tag endpoint with repo name for service resolution
+                        // Tag endpoint with its owning repo and (monorepo) service
+                        // so cross-repo findings can name where it lives.
                         tagged_endpoint.repo_name = Some(repo_data.repo_name.clone());
+                        tagged_endpoint.service_name = repo_data.service_name.clone();
                         merged.endpoints.push(tagged_endpoint);
                     }
                 }
@@ -841,6 +848,7 @@ mod tests {
             file_location: "routes/users.js:10:1".to_string(),
             middleware_chain: vec![],
             repo_name: None,
+            service_name: None,
         });
 
         // Create config with internal domain
@@ -1114,6 +1122,7 @@ mod tests {
             file_location: "routes/orders.js:15:1".to_string(),
             middleware_chain: vec![],
             repo_name: None,
+            service_name: None,
         });
 
         let config = Config {
@@ -1154,6 +1163,7 @@ mod tests {
             file_location: "routes/orders.js:20:1".to_string(),
             middleware_chain: vec![],
             repo_name: None,
+            service_name: None,
         });
 
         let config = Config {
@@ -1185,6 +1195,7 @@ mod tests {
             file_location: "routes/users.js:5:1".to_string(),
             middleware_chain: vec![],
             repo_name: None,
+            service_name: None,
         });
 
         let config = Config::default();

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -630,13 +630,17 @@ impl MountGraph {
                         .or_insert_with(|| node.clone());
                 }
 
-                // Merge endpoints (deduplicate by method + full_path)
-                // Tag each endpoint with its source repo for cross-repo matching
+                // Merge endpoints, deduplicating by service identity + method +
+                // full_path. The service discriminator (service_name ?? repo_name,
+                // matching the cloud's convention) keeps two monorepo services
+                // that expose the same route (e.g. a shared `/health`) from
+                // collapsing into one endpoint and losing an orphan finding.
+                let service_id = repo_data
+                    .service_name
+                    .as_deref()
+                    .unwrap_or(&repo_data.repo_name);
                 for endpoint in &mount_graph.endpoints {
-                    let key = format!(
-                        "{}:{}:{}",
-                        repo_data.repo_name, endpoint.method, endpoint.full_path
-                    );
+                    let key = format!("{}:{}:{}", service_id, endpoint.method, endpoint.full_path);
                     if seen_endpoints.insert(key) {
                         let mut tagged_endpoint = endpoint.clone();
                         // Tag endpoint with its owning repo and (monorepo) service
@@ -1312,5 +1316,72 @@ mod tests {
             graph.nodes.get("userRouter").unwrap().node_type,
             NodeType::Mountable
         );
+    }
+
+    fn cloud_repo_with_health(
+        repo: &str,
+        service: Option<&str>,
+    ) -> crate::cloud_storage::CloudRepoData {
+        let mut mg = MountGraph::new();
+        mg.endpoints.push(ResolvedEndpoint {
+            method: "GET".to_string(),
+            path: "/health".to_string(),
+            full_path: "/health".to_string(),
+            handler: None,
+            owner: repo.to_string(),
+            file_location: format!("{}/health.ts:1", repo),
+            middleware_chain: vec![],
+            repo_name: None,
+            service_name: None,
+        });
+        crate::cloud_storage::CloudRepoData {
+            repo_name: repo.to_string(),
+            service_name: service.map(|s| s.to_string()),
+            endpoints: vec![],
+            calls: vec![],
+            mounts: vec![],
+            apps: std::collections::HashMap::new(),
+            imported_handlers: vec![],
+            function_definitions: std::collections::HashMap::new(),
+            config_json: None,
+            package_json: None,
+            packages: None,
+            last_updated: chrono::Utc::now(),
+            commit_hash: "test".to_string(),
+            mount_graph: Some(mg),
+            bundled_types: None,
+            type_manifest: None,
+            file_results: None,
+            cached_detection: None,
+            cached_guidance: None,
+            cached_extraction_config: None,
+            package_json_hash: None,
+            cache_version: None,
+            type_extraction_status: None,
+        }
+    }
+
+    #[test]
+    fn test_merge_keeps_same_route_across_monorepo_services() {
+        // Two services in the same repo both exposing GET /health must survive
+        // the merge as distinct, service-tagged endpoints rather than collapse
+        // into one (which would hide an orphan finding).
+        let repos = vec![
+            cloud_repo_with_health("platform", Some("auth")),
+            cloud_repo_with_health("platform", Some("billing")),
+        ];
+        let merged = MountGraph::merge_from_repos(&repos);
+        let health: Vec<_> = merged
+            .endpoints
+            .iter()
+            .filter(|e| e.full_path == "/health")
+            .collect();
+        assert_eq!(health.len(), 2, "both services' /health must be kept");
+        let services: std::collections::HashSet<_> = health
+            .iter()
+            .filter_map(|e| e.service_name.as_deref())
+            .collect();
+        assert!(services.contains("auth"));
+        assert!(services.contains("billing"));
     }
 }

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -630,17 +630,19 @@ impl MountGraph {
                         .or_insert_with(|| node.clone());
                 }
 
-                // Merge endpoints, deduplicating by service identity + method +
-                // full_path. The service discriminator (service_name ?? repo_name,
-                // matching the cloud's convention) keeps two monorepo services
-                // that expose the same route (e.g. a shared `/health`) from
-                // collapsing into one endpoint and losing an orphan finding.
-                let service_id = repo_data
-                    .service_name
-                    .as_deref()
-                    .unwrap_or(&repo_data.repo_name);
+                // Merge endpoints, deduplicating by repo + service + method +
+                // full_path. Keying on BOTH repo and service means neither two
+                // monorepo services that share a route (e.g. a common `/health`),
+                // nor two repos that happen to declare the same `serviceName`,
+                // collapse into one endpoint and lose an orphan finding.
                 for endpoint in &mount_graph.endpoints {
-                    let key = format!("{}:{}:{}", service_id, endpoint.method, endpoint.full_path);
+                    let key = format!(
+                        "{}:{}:{}:{}",
+                        repo_data.repo_name,
+                        repo_data.service_name.as_deref().unwrap_or(""),
+                        endpoint.method,
+                        endpoint.full_path
+                    );
                     if seen_endpoints.insert(key) {
                         let mut tagged_endpoint = endpoint.clone();
                         // Tag endpoint with its owning repo and (monorepo) service
@@ -1383,5 +1385,22 @@ mod tests {
             .collect();
         assert!(services.contains("auth"));
         assert!(services.contains("billing"));
+    }
+
+    #[test]
+    fn test_merge_keeps_same_route_across_repos_with_shared_service_name() {
+        // Two distinct repos that happen to declare the same serviceName must
+        // not collapse — repo identity is part of the dedup key.
+        let repos = vec![
+            cloud_repo_with_health("repo-a", Some("api")),
+            cloud_repo_with_health("repo-b", Some("api")),
+        ];
+        let merged = MountGraph::merge_from_repos(&repos);
+        let health = merged
+            .endpoints
+            .iter()
+            .filter(|e| e.full_path == "/health")
+            .count();
+        assert_eq!(health, 2, "endpoints from different repos must be kept");
     }
 }


### PR DESCRIPTION
## What

Second increment of the PR-comment redesign (follows #173). Names the **owning service/repo** of orphaned endpoints in the comment — the attribution that actually matters in a monorepo or poly-repo, which was previously thrown away when findings were flattened to strings.

## Changes

- `ResolvedEndpoint` gains an optional `service_name`, tagged during the cross-repo merge from the repo's `carrick.json` (`service_name ?? repo_name`, matching the cloud's convention). Serde-defaulted so cached graphs deserialize fine.
- `ApiIssues.endpoint_issues` becomes a structured `Vec<OrphanedEndpoint> { method, path, service }` instead of `Vec<String>`, populated at both the HTTP and exact-key (GraphQL/socket) emission sites.
- The connectivity section renders an owning-service column **only when at least one orphan is attributed** (a lone repo has none, so the column is dropped rather than showing empty cells). Deletes the now-dead `separate_missing_orphaned` string parser and its tests.

## Scope / follow-up

Consumer-side (missing-endpoint) attribution needs repo tagging on the call structures (`ApiEndpointDetails` / `DataFetchingCall` carry no repo identity today) — deliberately deferred to a follow-up to keep this PR off the core matching path. GraphQL/socket orphans are not repo-tagged at their layer, so their `service` is `None` (column omitted).

## Sample (poly-repo orphaned table)

```
**Orphaned (2)**

| Method | Path | Service |
| :--- | :--- | :--- |
| `GET` | `/users` | `auth` |
| `POST` | `/charges` | `billing` |
```

## Tests

All targets green (`cargo test`). Added tests for the attributed Service column and its omission when unattributed; updated the GraphQL-orphan analyzer test to assert struct fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
