### PR TITLE
Add an "In this PR" block listing endpoints this change added

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -272,16 +272,22 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         debug!("Skipping upload (PR/branch mode)");
     }
 
-    // Capture this repo's previously-indexed endpoint keys (its last uploaded
-    // state, i.e. main) before they're removed below. On a PR run, diffing the
-    // current scan against them yields what THIS change added. Empty on the
-    // first scan, in which case the "In this PR" block is suppressed.
-    let previous_self_keys: std::collections::HashSet<crate::operation::OperationKey> =
-        all_repo_data
-            .iter()
-            .filter(|repo| repo.repo_name == repo_name)
-            .flat_map(|repo| repo.endpoints.iter().map(|e| e.key.clone()))
-            .collect();
+    // Capture this repo's previously-indexed endpoints (its last uploaded state,
+    // i.e. main) before they're removed below. On a PR run, diffing the current
+    // scan against them yields what THIS change added. Keyed by (service, key)
+    // so that in a monorepo an endpoint newly added to one service still counts
+    // as new even if a sibling service already exposes the same route. Empty on
+    // the first scan, in which case the "In this PR" block is suppressed.
+    type ServiceEndpointKey = (Option<String>, crate::operation::OperationKey);
+    let previous_self_keys: std::collections::HashSet<ServiceEndpointKey> = all_repo_data
+        .iter()
+        .filter(|repo| repo.repo_name == repo_name)
+        .flat_map(|repo| {
+            repo.endpoints
+                .iter()
+                .map(|e| (repo.service_name.clone(), e.key.clone()))
+        })
+        .collect();
 
     // 6. Cross-repo analysis (reuse already-downloaded data).
     // Remove this repo's downloaded copies so the freshly-analyzed services
@@ -308,8 +314,8 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         let mut seen = std::collections::HashSet::new();
         for service_data in &current_services_data {
             for endpoint in &service_data.endpoints {
-                if !previous_self_keys.contains(&endpoint.key) && seen.insert(endpoint.key.clone())
-                {
+                let id = (service_data.service_name.clone(), endpoint.key.clone());
+                if !previous_self_keys.contains(&id) && seen.insert(id) {
                     let (method, path) = endpoint.key.display_labels();
                     new_endpoints.push(crate::formatter::NewEndpoint {
                         method,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -274,7 +274,8 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
 
     // On a PR run, capture this repo's previously-indexed endpoints (its last
     // uploaded state, i.e. main) before they're removed below, so the diff can
-    // surface what THIS change added. Keyed by (service, key) so that in a
+    // surface what this change added relative to that baseline. Keyed by
+    // (service, key) so that in a
     // monorepo an endpoint newly added to one service still counts as new even
     // if a sibling service already exposes the same route. `had_prior_index` is
     // tracked separately so a prior scan that indexed zero endpoints still
@@ -319,9 +320,12 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         peer_repo_count, local_service_count
     );
 
-    // On a PR run with a prior index, surface what this change added: endpoints
-    // in the freshly-analyzed services that the previous index didn't have.
-    // Computed before `current_services_data` is moved into the analyzer.
+    // On a PR run with a prior index, surface what this change added: operations
+    // in the freshly-analyzed services that the previous (last-uploaded) index
+    // didn't have. Because the baseline is the last uploaded index, this can
+    // include an operation that landed on main since its last scan rather than
+    // in this PR. Computed before `current_services_data` is moved into the
+    // analyzer.
     let pr_delta = if is_pr_run && had_prior_index {
         let mut new_endpoints = Vec::new();
         let mut seen = std::collections::HashSet::new();
@@ -329,20 +333,19 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
             for endpoint in &service_data.endpoints {
                 let id = (service_data.service_name.clone(), endpoint.key.clone());
                 if !previous_self_keys.contains(&id) && seen.insert(id) {
-                    let (method, path) = endpoint.key.display_labels();
+                    let (label, name) = endpoint.key.display_labels();
                     new_endpoints.push(crate::formatter::NewEndpoint {
-                        method,
-                        path,
+                        label,
+                        name,
                         service: service_data.service_name.clone(),
                     });
                 }
             }
         }
-        // Sort by (method, path, service) for deterministic output even when two
-        // services add the same route.
-        new_endpoints.sort_by(|a, b| {
-            (&a.method, &a.path, &a.service).cmp(&(&b.method, &b.path, &b.service))
-        });
+        // Sort by (label, name, service) for deterministic output even when two
+        // services add the same operation.
+        new_endpoints
+            .sort_by(|a, b| (&a.label, &a.name, &a.service).cmp(&(&b.label, &b.name, &b.service)));
         Some(crate::formatter::PrDelta { new_endpoints })
     } else {
         None

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -272,6 +272,17 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         debug!("Skipping upload (PR/branch mode)");
     }
 
+    // Capture this repo's previously-indexed endpoint keys (its last uploaded
+    // state, i.e. main) before they're removed below. On a PR run, diffing the
+    // current scan against them yields what THIS change added. Empty on the
+    // first scan, in which case the "In this PR" block is suppressed.
+    let previous_self_keys: std::collections::HashSet<crate::operation::OperationKey> =
+        all_repo_data
+            .iter()
+            .filter(|repo| repo.repo_name == repo_name)
+            .flat_map(|repo| repo.endpoints.iter().map(|e| e.key.clone()))
+            .collect();
+
     // 6. Cross-repo analysis (reuse already-downloaded data).
     // Remove this repo's downloaded copies so the freshly-analyzed services
     // are the ones used.
@@ -289,6 +300,31 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         peer_repo_count, local_service_count
     );
 
+    // On a PR run with a prior index, surface what this change added: endpoints
+    // in the freshly-analyzed services that the previous index didn't have.
+    // Computed before `current_services_data` is moved into the analyzer.
+    let pr_delta = if pr_number_from_env().is_some() && !previous_self_keys.is_empty() {
+        let mut new_endpoints = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for service_data in &current_services_data {
+            for endpoint in &service_data.endpoints {
+                if !previous_self_keys.contains(&endpoint.key) && seen.insert(endpoint.key.clone())
+                {
+                    let (method, path) = endpoint.key.display_labels();
+                    new_endpoints.push(crate::formatter::NewEndpoint {
+                        method,
+                        path,
+                        service: service_data.service_name.clone(),
+                    });
+                }
+            }
+        }
+        new_endpoints.sort_by(|a, b| (&a.method, &a.path).cmp(&(&b.method, &b.path)));
+        Some(crate::formatter::PrDelta { new_endpoints })
+    } else {
+        None
+    };
+
     let sp = logging::spinner("Running cross-repo analysis...");
     let analyzer =
         build_cross_repo_analyzer(all_repo_data, current_services_data, ts_check_dir).await?;
@@ -300,7 +336,7 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         local_service_count,
         peer_repo_count,
     };
-    let formatted = crate::formatter::FormattedOutput::new(results, topology);
+    let formatted = crate::formatter::FormattedOutput::new(results, topology, pr_delta);
     formatted.print();
 
     // On pull_request runs we deliberately skip the index upload (see

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -276,9 +276,13 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     // i.e. main) before they're removed below. On a PR run, diffing the current
     // scan against them yields what THIS change added. Keyed by (service, key)
     // so that in a monorepo an endpoint newly added to one service still counts
-    // as new even if a sibling service already exposes the same route. Empty on
-    // the first scan, in which case the "In this PR" block is suppressed.
+    // as new even if a sibling service already exposes the same route.
     type ServiceEndpointKey = (Option<String>, crate::operation::OperationKey);
+    // Whether this repo was indexed at all before. Tracked separately from the
+    // key set so that a prior scan which happened to index zero endpoints still
+    // counts as a baseline (its newly-added endpoints are genuinely new), rather
+    // than being conflated with a first-ever scan where "new" is meaningless.
+    let had_prior_index = all_repo_data.iter().any(|repo| repo.repo_name == repo_name);
     let previous_self_keys: std::collections::HashSet<ServiceEndpointKey> = all_repo_data
         .iter()
         .filter(|repo| repo.repo_name == repo_name)
@@ -309,7 +313,7 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     // On a PR run with a prior index, surface what this change added: endpoints
     // in the freshly-analyzed services that the previous index didn't have.
     // Computed before `current_services_data` is moved into the analyzer.
-    let pr_delta = if pr_number_from_env().is_some() && !previous_self_keys.is_empty() {
+    let pr_delta = if pr_number_from_env().is_some() && had_prior_index {
         let mut new_endpoints = Vec::new();
         let mut seen = std::collections::HashSet::new();
         for service_data in &current_services_data {
@@ -325,7 +329,11 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
                 }
             }
         }
-        new_endpoints.sort_by(|a, b| (&a.method, &a.path).cmp(&(&b.method, &b.path)));
+        // Sort by (method, path, service) for deterministic output even when two
+        // services add the same route.
+        new_endpoints.sort_by(|a, b| {
+            (&a.method, &a.path, &a.service).cmp(&(&b.method, &b.path, &b.service))
+        });
         Some(crate::formatter::PrDelta { new_endpoints })
     } else {
         None

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -272,26 +272,35 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         debug!("Skipping upload (PR/branch mode)");
     }
 
-    // Capture this repo's previously-indexed endpoints (its last uploaded state,
-    // i.e. main) before they're removed below. On a PR run, diffing the current
-    // scan against them yields what THIS change added. Keyed by (service, key)
-    // so that in a monorepo an endpoint newly added to one service still counts
-    // as new even if a sibling service already exposes the same route.
+    // On a PR run, capture this repo's previously-indexed endpoints (its last
+    // uploaded state, i.e. main) before they're removed below, so the diff can
+    // surface what THIS change added. Keyed by (service, key) so that in a
+    // monorepo an endpoint newly added to one service still counts as new even
+    // if a sibling service already exposes the same route. `had_prior_index` is
+    // tracked separately so a prior scan that indexed zero endpoints still
+    // counts as a baseline, rather than being conflated with a first-ever scan
+    // where "new" is meaningless. Skipped entirely off PR runs, where the block
+    // is suppressed anyway.
     type ServiceEndpointKey = (Option<String>, crate::operation::OperationKey);
-    // Whether this repo was indexed at all before. Tracked separately from the
-    // key set so that a prior scan which happened to index zero endpoints still
-    // counts as a baseline (its newly-added endpoints are genuinely new), rather
-    // than being conflated with a first-ever scan where "new" is meaningless.
-    let had_prior_index = all_repo_data.iter().any(|repo| repo.repo_name == repo_name);
-    let previous_self_keys: std::collections::HashSet<ServiceEndpointKey> = all_repo_data
-        .iter()
-        .filter(|repo| repo.repo_name == repo_name)
-        .flat_map(|repo| {
-            repo.endpoints
-                .iter()
-                .map(|e| (repo.service_name.clone(), e.key.clone()))
-        })
-        .collect();
+    let is_pr_run = pr_number_from_env().is_some();
+    let (had_prior_index, previous_self_keys): (
+        bool,
+        std::collections::HashSet<ServiceEndpointKey>,
+    ) = if is_pr_run {
+        let had = all_repo_data.iter().any(|repo| repo.repo_name == repo_name);
+        let keys = all_repo_data
+            .iter()
+            .filter(|repo| repo.repo_name == repo_name)
+            .flat_map(|repo| {
+                repo.endpoints
+                    .iter()
+                    .map(|e| (repo.service_name.clone(), e.key.clone()))
+            })
+            .collect();
+        (had, keys)
+    } else {
+        (false, std::collections::HashSet::new())
+    };
 
     // 6. Cross-repo analysis (reuse already-downloaded data).
     // Remove this repo's downloaded copies so the freshly-analyzed services
@@ -313,7 +322,7 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     // On a PR run with a prior index, surface what this change added: endpoints
     // in the freshly-analyzed services that the previous index didn't have.
     // Computed before `current_services_data` is moved into the analyzer.
-    let pr_delta = if pr_number_from_env().is_some() && had_prior_index {
+    let pr_delta = if is_pr_run && had_prior_index {
         let mut new_endpoints = Vec::new();
         let mut seen = std::collections::HashSet::new();
         for service_data in &current_services_data {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -279,8 +279,8 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     // if a sibling service already exposes the same route. `had_prior_index` is
     // tracked separately so a prior scan that indexed zero endpoints still
     // counts as a baseline, rather than being conflated with a first-ever scan
-    // where "new" is meaningless. Skipped entirely off PR runs, where the block
-    // is suppressed anyway.
+    // where "new" is meaningless. On non-PR runs the capture is skipped
+    // entirely, since the block is suppressed there anyway.
     type ServiceEndpointKey = (Option<String>, crate::operation::OperationKey);
     let is_pr_run = pr_number_from_env().is_some();
     let (had_prior_index, previous_self_keys): (

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -61,13 +61,35 @@ impl Topology {
     }
 }
 
+/// An endpoint added by the current PR (present now, absent from the repo's
+/// previously-indexed state).
+#[derive(Debug, Clone)]
+pub struct NewEndpoint {
+    pub method: String,
+    pub path: String,
+    pub service: Option<String>,
+}
+
+/// What changed in this PR relative to the repo's last-indexed (main) state.
+/// `None` outside a PR run or when there is no prior index to diff against.
+#[derive(Debug, Clone)]
+pub struct PrDelta {
+    pub new_endpoints: Vec<NewEndpoint>,
+}
+
+impl PrDelta {
+    fn is_empty(&self) -> bool {
+        self.new_endpoints.is_empty()
+    }
+}
+
 pub struct FormattedOutput {
     pub content: String,
 }
 
 impl FormattedOutput {
-    pub fn new(result: ApiAnalysisResult, topology: Topology) -> Self {
-        let content = format_analysis_results(result, &topology);
+    pub fn new(result: ApiAnalysisResult, topology: Topology, pr_delta: Option<PrDelta>) -> Self {
+        let content = format_analysis_results(result, &topology, pr_delta.as_ref());
         Self { content }
     }
 
@@ -95,9 +117,13 @@ impl FormattedOutput {
     }
 }
 
-pub fn format_analysis_results(result: ApiAnalysisResult, topology: &Topology) -> String {
+pub fn format_analysis_results(
+    result: ApiAnalysisResult,
+    topology: &Topology,
+    pr_delta: Option<&PrDelta>,
+) -> String {
     if result.issues.is_empty() {
-        return format_no_issues(&result, topology);
+        return format_no_issues(&result, topology, pr_delta);
     }
 
     let categorized_issues = categorize_issues(&result.issues);
@@ -134,6 +160,8 @@ pub fn format_analysis_results(result: ApiAnalysisResult, topology: &Topology) -
         topology,
     ));
     output.push_str("\n\n");
+
+    output.push_str(&format_pr_delta(pr_delta));
 
     output.push_str(&format!(
         "Indexed **{} endpoints** and **{} cross-service calls**.\n\n",
@@ -178,6 +206,34 @@ pub fn format_analysis_results(result: ApiAnalysisResult, topology: &Topology) -
 
     output.push_str(&dashboard_footer());
     output.push_str("\n<!-- CARRICK_OUTPUT_END -->\n");
+    output
+}
+
+/// The "In this PR" block: endpoints this change added relative to the repo's
+/// last-indexed state. Empty (renders nothing) outside a PR run, when there is
+/// no prior index to diff against, or when nothing new was added.
+fn format_pr_delta(pr_delta: Option<&PrDelta>) -> String {
+    let Some(delta) = pr_delta else {
+        return String::new();
+    };
+    if delta.is_empty() {
+        return String::new();
+    }
+    let mut output = String::from("**In this PR**\n\n");
+    for ep in &delta.new_endpoints {
+        let suffix = ep
+            .service
+            .as_deref()
+            .map(|s| format!(" ({})", s))
+            .unwrap_or_default();
+        output.push_str(&format!(
+            "- New endpoint `{} {}`{}\n",
+            code_cell(&ep.method),
+            code_cell(&ep.path),
+            suffix
+        ));
+    }
+    output.push('\n');
     output
 }
 
@@ -282,7 +338,11 @@ fn join_human(parts: &[String]) -> String {
     }
 }
 
-fn format_no_issues(result: &ApiAnalysisResult, topology: &Topology) -> String {
+fn format_no_issues(
+    result: &ApiAnalysisResult,
+    topology: &Topology,
+    pr_delta: Option<&PrDelta>,
+) -> String {
     let mut output = String::new();
     output.push_str("<!-- CARRICK_OUTPUT_START -->\n<!-- CARRICK_ISSUE_COUNT:0 -->\n");
     output.push_str(&format!("## 🪢 Carrick{}\n\n", topology.header_suffix()));
@@ -290,6 +350,7 @@ fn format_no_issues(result: &ApiAnalysisResult, topology: &Topology) -> String {
         "> [!TIP]\n> All cross-service calls match the indexed contracts across {}.\n\n",
         topology.scope_phrase()
     ));
+    output.push_str(&format_pr_delta(pr_delta));
     output.push_str(&format!(
         "Indexed **{} endpoints** and **{} cross-service calls**.\n\n",
         result.endpoints.len(),
@@ -952,7 +1013,7 @@ mod tests {
             graphql_operations_indexed: false,
         };
 
-        let output = format_analysis_results(result, &topology_baseline());
+        let output = format_analysis_results(result, &topology_baseline(), None);
 
         // The endpoints and the raw compiler error are surfaced as table rows.
         assert!(output.contains("GET /users/:param/comments"));
@@ -985,7 +1046,7 @@ mod tests {
             graphql_operations_indexed: false,
         };
 
-        let output = format_analysis_results(result, &topology_baseline());
+        let output = format_analysis_results(result, &topology_baseline(), None);
 
         // The endpoint, both type names, and the error are surfaced.
         assert!(output.contains("GET /api/users"));
@@ -1015,7 +1076,7 @@ mod tests {
             ],
             graphql_operations_indexed: false,
         };
-        let output = format_analysis_results(result, &topology_baseline());
+        let output = format_analysis_results(result, &topology_baseline(), None);
         assert!(output.contains("GraphQL detected"));
         assert!(output.contains("graphql-request"));
         assert!(output.contains("@apollo/client"));
@@ -1040,7 +1101,7 @@ mod tests {
             detected_graphql_libraries: vec!["@apollo/client".to_string()],
             graphql_operations_indexed: true,
         };
-        let output = format_analysis_results(result, &topology_baseline());
+        let output = format_analysis_results(result, &topology_baseline(), None);
         assert!(!output.contains("GraphQL detected"));
     }
 
@@ -1062,7 +1123,7 @@ mod tests {
             detected_graphql_libraries: vec![],
             graphql_operations_indexed: false,
         };
-        let output = format_analysis_results(result, &topology_baseline());
+        let output = format_analysis_results(result, &topology_baseline(), None);
         assert!(!output.contains("GraphQL detected"));
     }
 
@@ -1086,7 +1147,7 @@ mod tests {
             graphql_operations_indexed: false,
         };
 
-        let output = format_analysis_results(result, &topology_baseline());
+        let output = format_analysis_results(result, &topology_baseline(), None);
 
         // Check that no issues message is displayed
         assert!(output.contains("All cross-service calls match the indexed contracts"));
@@ -1112,7 +1173,7 @@ mod tests {
             graphql_operations_indexed: false,
         };
 
-        let formatted = FormattedOutput::new(result, topology_baseline());
+        let formatted = FormattedOutput::new(result, topology_baseline(), None);
         let body = formatted.pr_comment_body();
 
         // The marker lines the old Action stripped before posting must not
@@ -1148,7 +1209,7 @@ mod tests {
             graphql_operations_indexed: false,
         };
 
-        let output = format_analysis_results(result, &topology_baseline());
+        let output = format_analysis_results(result, &topology_baseline(), None);
 
         assert!(output.contains("Verified (2)"));
         assert!(output.contains("`GET` | `/api/users`"));
@@ -1174,7 +1235,7 @@ mod tests {
             graphql_operations_indexed: false,
         };
 
-        let output = format_analysis_results(result, &topology_baseline());
+        let output = format_analysis_results(result, &topology_baseline(), None);
 
         assert!(output.contains("Verified (1)"));
     }
@@ -1201,7 +1262,7 @@ mod tests {
             graphql_operations_indexed: false,
         };
 
-        let output = format_analysis_results(result, &topology_baseline());
+        let output = format_analysis_results(result, &topology_baseline(), None);
 
         assert!(output.contains("All cross-service calls match the indexed contracts"));
         assert!(output.contains("Verified (1)"));
@@ -1310,7 +1371,7 @@ mod tests {
             graphql_operations_indexed: false,
         };
 
-        let output = format_analysis_results(result, &topology_first_repo());
+        let output = format_analysis_results(result, &topology_first_repo(), None);
 
         // Headline count excludes the two connectivity findings → zero issues.
         assert!(
@@ -1383,7 +1444,7 @@ mod tests {
         issues.type_mismatches = vec![
             "Type mismatch on GET /api/users: Producer (UserResponse) incompatible with Consumer (User[]) - Property 'role' is missing".to_string(),
         ];
-        let output = format_analysis_results(result_with(issues), &topology);
+        let output = format_analysis_results(result_with(issues), &topology, None);
 
         assert!(output.contains("## 🪢 Carrick · monorepo (3 services)"));
         assert!(output.contains("> [!CAUTION]"));
@@ -1398,7 +1459,7 @@ mod tests {
             local_service_count: 1,
             peer_repo_count: 0,
         };
-        let output = format_analysis_results(result_with(empty_issues()), &topology);
+        let output = format_analysis_results(result_with(empty_issues()), &topology, None);
 
         assert!(output.contains("## 🪢 Carrick · api-server"));
         assert!(output.contains("> [!TIP]"));
@@ -1425,7 +1486,7 @@ mod tests {
             }],
             severity: ConflictSeverity::Warning,
         }];
-        let output = format_analysis_results(result_with(issues), &topology);
+        let output = format_analysis_results(result_with(issues), &topology, None);
 
         assert!(output.contains("## 🪢 Carrick · monorepo (3 services)"));
         assert!(output.contains("across 3 repos"));
@@ -1448,7 +1509,7 @@ mod tests {
             }],
             severity: ConflictSeverity::Warning,
         }];
-        let output = format_analysis_results(result_with(issues), &topology_baseline());
+        let output = format_analysis_results(result_with(issues), &topology_baseline(), None);
 
         // No contract risks, but a counted issue → amber, not red.
         assert!(output.contains("> [!WARNING]"));
@@ -1464,7 +1525,7 @@ mod tests {
         issues.env_var_calls = vec![
             "Unclassified env var: GET /orders using [ORDER_SERVICE_URL] (from src/orders.ts) - add to internalEnvVars or externalEnvVars in carrick.json".to_string(),
         ];
-        let output = format_analysis_results(result_with(issues), &topology_first_repo());
+        let output = format_analysis_results(result_with(issues), &topology_first_repo(), None);
 
         assert!(output.contains("configuration suggestion"));
         assert!(
@@ -1487,7 +1548,7 @@ mod tests {
             path: "/legacy/ping".to_string(),
             service: Some("billing".to_string()),
         }];
-        let output = format_analysis_results(result_with(issues), &topology_baseline());
+        let output = format_analysis_results(result_with(issues), &topology_baseline(), None);
 
         for banned in ["✅", "ℹ️", "⚠️", "❌", "🔁"] {
             assert!(
@@ -1518,7 +1579,7 @@ mod tests {
                 service: Some("billing".to_string()),
             },
         ];
-        let output = format_analysis_results(result_with(issues), &topology_baseline());
+        let output = format_analysis_results(result_with(issues), &topology_baseline(), None);
 
         assert!(output.contains("| Method | Path | Service |"));
         assert!(output.contains("| `GET` | `/users` | `auth` |"));
@@ -1535,7 +1596,7 @@ mod tests {
             path: "/legacy/ping".to_string(),
             service: None,
         }];
-        let output = format_analysis_results(result_with(issues), &topology_first_repo());
+        let output = format_analysis_results(result_with(issues), &topology_first_repo(), None);
 
         assert!(!output.contains("Service |"));
         assert!(output.contains("| `GET` | `/legacy/ping` |"));
@@ -1569,10 +1630,77 @@ mod tests {
                 service: None,
             },
         ];
-        let output = format_analysis_results(result_with(issues), &topology_baseline());
+        let output = format_analysis_results(result_with(issues), &topology_baseline(), None);
 
         assert!(output.contains("| `GET` | `/users` | `auth` |"));
         // Unattributed row → dash, and the pipe in the path is escaped.
         assert!(output.contains("| `QUERY` | `weird\\|field` | - |"));
+    }
+
+    #[test]
+    fn test_pr_delta_strip_lists_new_endpoints() {
+        let delta = PrDelta {
+            new_endpoints: vec![
+                NewEndpoint {
+                    method: "POST".to_string(),
+                    path: "/v2/invoices".to_string(),
+                    service: Some("billing".to_string()),
+                },
+                NewEndpoint {
+                    method: "GET".to_string(),
+                    path: "/charges".to_string(),
+                    service: None,
+                },
+            ],
+        };
+        let mut issues = empty_issues();
+        issues.dependency_conflicts = vec![DependencyConflict {
+            package_name: "zod".to_string(),
+            repos: vec![crate::analyzer::RepoPackageInfo {
+                repo_name: "billing".to_string(),
+                version: "^3.22".to_string(),
+                source_path: std::path::PathBuf::from("package.json"),
+            }],
+            severity: ConflictSeverity::Warning,
+        }];
+        let output =
+            format_analysis_results(result_with(issues), &topology_baseline(), Some(&delta));
+
+        assert!(output.contains("**In this PR**"));
+        assert!(output.contains("- New endpoint `POST /v2/invoices` (billing)"));
+        assert!(output.contains("- New endpoint `GET /charges`"));
+        // The strip sits above the findings sections.
+        let strip_at = output.find("**In this PR**").unwrap();
+        let deps_at = output.find("Dependency conflicts").unwrap();
+        assert!(strip_at < deps_at, "the strip must precede the sections");
+    }
+
+    #[test]
+    fn test_pr_delta_absent_renders_no_strip() {
+        let output =
+            format_analysis_results(result_with(empty_issues()), &topology_baseline(), None);
+        assert!(!output.contains("In this PR"));
+    }
+
+    #[test]
+    fn test_pr_delta_strip_renders_on_clean_run() {
+        // A PR can add an endpoint without introducing any issue, so the strip
+        // must also appear on the clean (TIP) path.
+        let delta = PrDelta {
+            new_endpoints: vec![NewEndpoint {
+                method: "GET".to_string(),
+                path: "/health".to_string(),
+                service: None,
+            }],
+        };
+        let output = format_analysis_results(
+            result_with(empty_issues()),
+            &topology_baseline(),
+            Some(&delta),
+        );
+
+        assert!(output.contains("> [!TIP]"));
+        assert!(output.contains("**In this PR**"));
+        assert!(output.contains("- New endpoint `GET /health`"));
     }
 }

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -224,12 +224,12 @@ fn format_pr_delta(pr_delta: Option<&PrDelta>) -> String {
         let suffix = ep
             .service
             .as_deref()
-            .map(|s| format!(" ({})", s))
+            .map(|s| format!(" (`{}`)", code_span(s)))
             .unwrap_or_default();
         output.push_str(&format!(
             "- New endpoint `{} {}`{}\n",
-            code_cell(&ep.method),
-            code_cell(&ep.path),
+            code_span(&ep.method),
+            code_span(&ep.path),
             suffix
         ));
     }
@@ -528,6 +528,19 @@ fn cell(value: &str) -> String {
 /// out of the code span and could inject Markdown.
 fn code_cell(value: &str) -> String {
     cell(value).replace('`', "")
+}
+
+/// Sanitize a value wrapped in inline-code backticks in prose (not a table):
+/// collapse line breaks and drop backticks so the value can't break out of the
+/// span. Unlike `code_cell` it does not escape pipes, which are literal in a
+/// code span outside a table (escaping them would show a stray backslash).
+fn code_span(value: &str) -> String {
+    value
+        .replace("\r\n", " ")
+        .replace(['\r', '\n'], " ")
+        .replace('`', "")
+        .trim()
+        .to_string()
 }
 
 fn format_connectivity_section(
@@ -1667,7 +1680,7 @@ mod tests {
             format_analysis_results(result_with(issues), &topology_baseline(), Some(&delta));
 
         assert!(output.contains("**In this PR**"));
-        assert!(output.contains("- New endpoint `POST /v2/invoices` (billing)"));
+        assert!(output.contains("- New endpoint `POST /v2/invoices` (`billing`)"));
         assert!(output.contains("- New endpoint `GET /charges`"));
         // The strip sits above the findings sections.
         let strip_at = output.find("**In this PR**").unwrap();
@@ -1702,5 +1715,29 @@ mod tests {
         assert!(output.contains("> [!TIP]"));
         assert!(output.contains("**In this PR**"));
         assert!(output.contains("- New endpoint `GET /health`"));
+    }
+
+    #[test]
+    fn test_pr_delta_strip_inline_code_is_prose_safe() {
+        // In a prose code span a pipe is literal (must not be backslash-escaped
+        // the way a table cell would), and a backtick in the service is dropped.
+        let delta = PrDelta {
+            new_endpoints: vec![NewEndpoint {
+                method: "GET".to_string(),
+                path: "/a|b".to_string(),
+                service: Some("sv`c".to_string()),
+            }],
+        };
+        let output = format_analysis_results(
+            result_with(empty_issues()),
+            &topology_baseline(),
+            Some(&delta),
+        );
+
+        assert!(output.contains("- New endpoint `GET /a|b` (`svc`)"));
+        assert!(
+            !output.contains("\\|"),
+            "prose code span must not escape pipes"
+        );
     }
 }

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -224,7 +224,9 @@ fn format_pr_delta(pr_delta: Option<&PrDelta>) -> String {
         let suffix = ep
             .service
             .as_deref()
-            .map(|s| format!(" (`{}`)", code_span(s)))
+            .map(code_span)
+            .filter(|s| !s.is_empty())
+            .map(|s| format!(" (`{}`)", s))
             .unwrap_or_default();
         output.push_str(&format!(
             "- New endpoint `{} {}`{}\n",
@@ -1739,5 +1741,26 @@ mod tests {
             !output.contains("\\|"),
             "prose code span must not escape pipes"
         );
+    }
+
+    #[test]
+    fn test_pr_delta_strip_omits_empty_service_suffix() {
+        // A service name that sanitizes to empty (e.g. only backticks) must not
+        // render an empty " (``)" suffix.
+        let delta = PrDelta {
+            new_endpoints: vec![NewEndpoint {
+                method: "GET".to_string(),
+                path: "/x".to_string(),
+                service: Some("``".to_string()),
+            }],
+        };
+        let output = format_analysis_results(
+            result_with(empty_issues()),
+            &topology_baseline(),
+            Some(&delta),
+        );
+
+        assert!(output.contains("- New endpoint `GET /x`\n"));
+        assert!(!output.contains("(`"), "empty service must omit the suffix");
     }
 }

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -61,17 +61,21 @@ impl Topology {
     }
 }
 
-/// An endpoint added by the current PR (present now, absent from the repo's
-/// previously-indexed state).
+/// An endpoint present in the current scan but absent from the repo's
+/// previously-indexed state. `label`/`name` are protocol-agnostic
+/// (`OperationKey::display_labels`): for HTTP they are method + path, for
+/// GraphQL the operation kind + field, for sockets the direction + event.
 #[derive(Debug, Clone)]
 pub struct NewEndpoint {
-    pub method: String,
-    pub path: String,
+    pub label: String,
+    pub name: String,
     pub service: Option<String>,
 }
 
-/// What changed in this PR relative to the repo's last-indexed (main) state.
-/// `None` outside a PR run or when there is no prior index to diff against.
+/// What this PR added relative to the repo's last-indexed (main) state. Because
+/// the baseline is the last *uploaded* index, this can include an endpoint that
+/// landed on main since its last scan rather than in this PR. `None` outside a
+/// PR run or when there is no prior index to diff against.
 #[derive(Debug, Clone)]
 pub struct PrDelta {
     pub new_endpoints: Vec<NewEndpoint>,
@@ -230,8 +234,8 @@ fn format_pr_delta(pr_delta: Option<&PrDelta>) -> String {
             .unwrap_or_default();
         output.push_str(&format!(
             "- New endpoint `{} {}`{}\n",
-            code_span(&ep.method),
-            code_span(&ep.path),
+            code_span(&ep.label),
+            code_span(&ep.name),
             suffix
         ));
     }
@@ -1657,13 +1661,13 @@ mod tests {
         let delta = PrDelta {
             new_endpoints: vec![
                 NewEndpoint {
-                    method: "POST".to_string(),
-                    path: "/v2/invoices".to_string(),
+                    label: "POST".to_string(),
+                    name: "/v2/invoices".to_string(),
                     service: Some("billing".to_string()),
                 },
                 NewEndpoint {
-                    method: "GET".to_string(),
-                    path: "/charges".to_string(),
+                    label: "GET".to_string(),
+                    name: "/charges".to_string(),
                     service: None,
                 },
             ],
@@ -1703,8 +1707,8 @@ mod tests {
         // must also appear on the clean (TIP) path.
         let delta = PrDelta {
             new_endpoints: vec![NewEndpoint {
-                method: "GET".to_string(),
-                path: "/health".to_string(),
+                label: "GET".to_string(),
+                name: "/health".to_string(),
                 service: None,
             }],
         };
@@ -1725,8 +1729,8 @@ mod tests {
         // the way a table cell would), and a backtick in the service is dropped.
         let delta = PrDelta {
             new_endpoints: vec![NewEndpoint {
-                method: "GET".to_string(),
-                path: "/a|b".to_string(),
+                label: "GET".to_string(),
+                name: "/a|b".to_string(),
                 service: Some("sv`c".to_string()),
             }],
         };
@@ -1749,8 +1753,8 @@ mod tests {
         // render an empty " (``)" suffix.
         let delta = PrDelta {
             new_endpoints: vec![NewEndpoint {
-                method: "GET".to_string(),
-                path: "/x".to_string(),
+                label: "GET".to_string(),
+                name: "/x".to_string(),
                 service: Some("``".to_string()),
             }],
         };


### PR DESCRIPTION
## What

Third increment of the PR-comment redesign (follows #173, #174). Leads the comment with an **"In this PR"** block listing the endpoints this change added — so the comment tells the story of the PR, not just the whole-project snapshot.

## How

On a PR run, the scanner already downloads the repo's previously-uploaded (main) index. Before that data is dropped from the cross-repo set, we capture its endpoint keys, then diff the freshly-analyzed services against them. Endpoints present now but absent from the prior index are "new in this PR", attributed to their service.

Rendered as a plain list above the findings sections:

```
**In this PR**

- New endpoint `POST /v2/invoices` (billing)
- New endpoint `GET /charges`
```

## Gating

The block is suppressed when:
- it isn't a PR run (`pr_number` absent) — there's no "this PR" on a push to main;
- there's no prior index to diff against (first-ever scan);
- nothing new was added.

It renders on both the issues path and the clean (TIP) path — a PR can add an endpoint without introducing any problem.

## Notes / follow-up

This diffs against the last *uploaded* (main) index, so if main has advanced since its last scan the set can include a few endpoints not strictly from this PR. That's the best available signal without base-ref diffing and matches the approved design. "Changed" (not just new) endpoints and the reimplements signal are later increments (the latter depends on carrick#162).

## Tests

All targets green (`cargo test`). Added strip tests: lists new endpoints with service attribution, ordering above sections, absence when no delta, and rendering on the clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
