### PR TITLE
chore(intent): bump INTENT_CACHE_VERSION for the Vertex AI model switch

### DIFF
--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -20,7 +20,10 @@ use tracing::{debug, warn};
 /// intents cached by content hash are regenerated rather than reused. The model
 /// and prompt live in the lambda (carrick-cloud), invisible to this crate, so
 /// this constant is the manual invalidation lever.
-const INTENT_CACHE_VERSION: u32 = 1;
+// v2: the /generate-intent lambda moved from the AI Studio gemini-3-flash-preview
+// model to Vertex AI gemini-3.1-flash-lite (carrick-cloud#140). Bumping forces a
+// one-time regeneration of every cached intent on the first post-switch scan.
+const INTENT_CACHE_VERSION: u32 = 2;
 
 /// Content hash of the exact inputs that determine a function's generated
 /// intent: the cache version, the function body, and its callees' intents.


### PR DESCRIPTION
## What

Bump `INTENT_CACHE_VERSION` 1 → 2 in `src/intent_generator.rs`.

## Why

Companion to **carrick-cloud#140** (carrick-cloud#144), which migrates the `/generate-intent` lambda from the AI Studio `gemini-3-flash-preview` model to Vertex AI **`gemini-3.1-flash-lite`**. Generated intents are cached by a content hash that mixes in `INTENT_CACHE_VERSION` (the prompt + model live in the lambda, invisible to this crate, so this constant is the manual invalidation lever). Without the bump, the first post-switch scan would reuse intents produced by the old model; bumping forces a one-time regeneration.

## Verification

`cargo build`, `cargo clippy`, and `cargo test` all pass; the pre-commit hook (fmt + clippy + full Rust suite + ts_check) ran green on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
