### PR TITLE
fix(scanner): extraction determinism + signature fidelity

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1169,9 +1169,11 @@ impl FileOrchestrator {
             if is_catch_all {
                 out.push_str("**");
             } else if seg.len() > 2 && seg.starts_with('[') && seg.ends_with(']') {
+                // trim() mirrors the router's sanitize_param so whitespace-jittered
+                // LLM output (`[ slug ]`) still dedupes against the router's `:slug`.
                 let inner = seg.trim_matches(|c| c == '[' || c == ']').replace('.', "");
                 out.push(':');
-                out.push_str(&inner);
+                out.push_str(inner.trim());
             } else {
                 out.push_str(seg);
             }
@@ -2983,6 +2985,16 @@ export const prerender = false;
         assert_eq!(
             FileOrchestrator::canonicalize_route_path("/blog/[[...slug]]"),
             "/blog/**"
+        );
+        // Whitespace-jittered brackets must still dedupe against the router's
+        // trimmed colon form (Copilot review).
+        assert_eq!(
+            FileOrchestrator::canonicalize_route_path("/w/[ slug ]/x"),
+            "/w/:slug/x"
+        );
+        assert_eq!(
+            FileOrchestrator::canonicalize_route_path("/w/[[ id ]]/x"),
+            "/w/:id/x"
         );
         assert_eq!(
             FileOrchestrator::canonicalize_route_path("/w/:slug/invite"),

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -379,6 +379,12 @@ impl FileOrchestrator {
                     Self::validate_type_hints(&mut adjusted, &pf.symbol_table);
                     Self::normalize_unusable_types(&mut adjusted, &framework_detection.frameworks);
 
+                    // Canonicalize LLM-emitted endpoint paths to colon-style params
+                    // (`/w/[slug]` -> `/w/:slug`) so they dedupe against the file-based
+                    // router's structural entries instead of both surviving and flipping
+                    // form between non-deterministic scans.
+                    Self::canonicalize_endpoint_paths(&mut adjusted);
+
                     // Merge file-based route endpoints the LLM pass didn't already
                     // produce. The structural (method, path) facts are authoritative.
                     stats.file_based_endpoints +=
@@ -1142,6 +1148,40 @@ impl FileOrchestrator {
             }
         }
         added
+    }
+
+    /// Canonicalize a route path to colon-style params so structurally identical
+    /// endpoints from the LLM pass (`/w/[slug]`) and the file-based router
+    /// (`/w/:slug`) dedupe to one entry instead of both surviving and flipping
+    /// form between non-deterministic scans. `[id]` -> `:id`, `[...rest]` -> `**`;
+    /// `:id`, `*`, and literal segments are left unchanged (idempotent).
+    fn canonicalize_route_path(path: &str) -> String {
+        let mut out = String::with_capacity(path.len());
+        for (i, seg) in path.split('/').enumerate() {
+            if i > 0 {
+                out.push('/');
+            }
+            if seg.starts_with("[...") && seg.ends_with(']') {
+                out.push_str("**");
+            } else if seg.len() > 2 && seg.starts_with('[') && seg.ends_with(']') {
+                out.push(':');
+                out.push_str(&seg[1..seg.len() - 1].replace('.', ""));
+            } else {
+                out.push_str(seg);
+            }
+        }
+        out
+    }
+
+    /// Rewrite every LLM-emitted endpoint path to the canonical colon form before
+    /// the file-based merge, so the structural router entries dedupe against them.
+    fn canonicalize_endpoint_paths(result: &mut FileAnalysisResult) {
+        for ep in &mut result.endpoints {
+            let canon = Self::canonicalize_route_path(&ep.path);
+            if canon != ep.path {
+                ep.path = canon;
+            }
+        }
     }
 
     fn apply_candidate_map(
@@ -2914,5 +2954,50 @@ export const prerender = false;
                 .iter()
                 .any(|e| e.method == "POST" && e.path == "/users")
         );
+    }
+
+    #[test]
+    fn test_canonicalize_route_path_brackets_to_colons() {
+        // Astro/Next bracket params -> colon form; catch-alls -> **; colon and
+        // literal segments are untouched (idempotent).
+        assert_eq!(
+            FileOrchestrator::canonicalize_route_path("/w/[slug]/projects/new"),
+            "/w/:slug/projects/new"
+        );
+        assert_eq!(
+            FileOrchestrator::canonicalize_route_path("/w/[slug]/p/[projSlug]/keys/new"),
+            "/w/:slug/p/:projSlug/keys/new"
+        );
+        assert_eq!(
+            FileOrchestrator::canonicalize_route_path("/files/[...path]"),
+            "/files/**"
+        );
+        assert_eq!(
+            FileOrchestrator::canonicalize_route_path("/w/:slug/invite"),
+            "/w/:slug/invite"
+        );
+    }
+
+    #[test]
+    fn test_canonicalize_collapses_bracket_and_colon_duplicate() {
+        // The LLM emitted the bracket form; the file-based router emits the colon
+        // form. After canonicalization they are the same path, so the structural
+        // entry dedupes instead of producing a second, form-flipped endpoint.
+        let mut result = FileAnalysisResult {
+            endpoints: vec![synthetic_endpoint("POST", "/w/[slug]/projects/new")],
+            ..Default::default()
+        };
+        FileOrchestrator::canonicalize_endpoint_paths(&mut result);
+        assert_eq!(result.endpoints[0].path, "/w/:slug/projects/new");
+
+        let added = FileOrchestrator::merge_file_based_endpoints(
+            &mut result,
+            vec![synthetic_endpoint("POST", "/w/:slug/projects/new")],
+        );
+        assert_eq!(
+            added, 0,
+            "colon-form route should dedupe against the canonicalized LLM path"
+        );
+        assert_eq!(result.endpoints.len(), 1);
     }
 }

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1161,11 +1161,17 @@ impl FileOrchestrator {
             if i > 0 {
                 out.push('/');
             }
-            if seg.starts_with("[...") && seg.ends_with(']') {
+            // Catch-all (`[...rest]`) and optional catch-all (`[[...rest]]`) both
+            // map to the router's `**`; ordinary dynamic segments (`[id]`, `[[id]]`)
+            // map to `:id`.
+            let is_catch_all = (seg.starts_with("[...") && seg.ends_with(']'))
+                || (seg.starts_with("[[...") && seg.ends_with("]]"));
+            if is_catch_all {
                 out.push_str("**");
             } else if seg.len() > 2 && seg.starts_with('[') && seg.ends_with(']') {
+                let inner = seg.trim_matches(|c| c == '[' || c == ']').replace('.', "");
                 out.push(':');
-                out.push_str(&seg[1..seg.len() - 1].replace('.', ""));
+                out.push_str(&inner);
             } else {
                 out.push_str(seg);
             }
@@ -2971,6 +2977,12 @@ export const prerender = false;
         assert_eq!(
             FileOrchestrator::canonicalize_route_path("/files/[...path]"),
             "/files/**"
+        );
+        // Next.js optional catch-all must also reach `**`, matching the router,
+        // not a malformed `:[slug]`.
+        assert_eq!(
+            FileOrchestrator::canonicalize_route_path("/blog/[[...slug]]"),
+            "/blog/**"
         );
         assert_eq!(
             FileOrchestrator::canonicalize_route_path("/w/:slug/invite"),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2469,8 +2469,11 @@ mod tests {
                 path
             );
         }
+        // F3c: the member expression `${order.userId}` now collapses to the clean
+        // segment `:userId` rather than the malformed `:order.userId`. Param names
+        // are matching-agnostic, so this is purely a well-formedness improvement.
         assert!(
-            consumer_paths.contains(&"/api/users/:order.userId"),
+            consumer_paths.contains(&"/api/users/:userId"),
             "expected normalized user-service path, got {:?}",
             consumer_paths
         );

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -301,7 +301,14 @@ impl UrlNormalizer {
         }
     }
 
-    /// Convert ${varName} interpolations to :varName path parameters
+    /// Convert ${varName} interpolations to :varName path parameters.
+    ///
+    /// Member/call/complex inner expressions are reduced to their final
+    /// identifier, so `${row.pr_number}` yields the valid segment `:pr_number`
+    /// rather than the malformed `:row.pr_number`. The param name is cosmetic for
+    /// matching (`:x` and `:y` are equivalent param segments — see
+    /// `is_param_segment` in mount_graph.rs), so collapsing to one clean token is
+    /// safe and keeps the path well-formed.
     fn convert_interpolations_to_params(&self, path: &str) -> String {
         let mut result = String::new();
         let mut chars = path.chars().peekable();
@@ -318,13 +325,38 @@ impl UrlNormalizer {
                 }
                 // Convert to path parameter format
                 result.push(':');
-                result.push_str(&var_name);
+                result.push_str(&Self::clean_param_name(&var_name));
             } else {
                 result.push(c);
             }
         }
 
         result
+    }
+
+    /// Reduce an interpolation expression to a single clean param identifier.
+    /// `row.pr_number` -> `pr_number`, `userId` -> `userId`; an expression with no
+    /// usable leading-alpha identifier (empty, numeric, operators) -> `param`.
+    fn clean_param_name(expr: &str) -> String {
+        // Take the final run of identifier characters: for a member/bracket/call
+        // expression that is the accessed key, which is the meaningful name.
+        let mut last = String::new();
+        let mut cur = String::new();
+        for c in expr.chars() {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                cur.push(c);
+            } else if !cur.is_empty() {
+                last = std::mem::take(&mut cur);
+            }
+        }
+        if !cur.is_empty() {
+            last = cur;
+        }
+        if last.is_empty() || last.starts_with(|c: char| c.is_ascii_digit()) {
+            "param".to_string()
+        } else {
+            last
+        }
     }
 
     /// Normalize a full URL with protocol and host
@@ -667,6 +699,20 @@ mod tests {
         let result = normalizer.normalize("${SERVICE_URL}/orders/${orderId}/items/${itemId}");
 
         assert_eq!(result.path, "/orders/:orderId/items/:itemId");
+        assert!(result.is_internal);
+    }
+
+    /// Regression (F3c): a dotted/member interpolation must collapse to its final
+    /// identifier so the segment is a valid `:pr_number`, not the malformed
+    /// `:row.pr_number` that the verbatim copy used to produce.
+    #[test]
+    fn test_normalize_dotted_interpolation_param() {
+        let config = create_test_config();
+        let normalizer = UrlNormalizer::new(&config);
+
+        let result = normalizer.normalize("${API_URL}/pulls/${row.pr_number}/comments");
+
+        assert_eq!(result.path, "/pulls/:pr_number/comments");
         assert!(result.is_internal);
     }
 

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -306,9 +306,9 @@ impl UrlNormalizer {
     /// Member/call/complex inner expressions are reduced to their final
     /// identifier, so `${row.pr_number}` yields the valid segment `:pr_number`
     /// rather than the malformed `:row.pr_number`. The param name is cosmetic for
-    /// matching (`:x` and `:y` are equivalent param segments — see
+    /// matching (`:x` and `:y` are equivalent param segments; see
     /// `is_param_segment` in mount_graph.rs), so collapsing to one clean token is
-    /// safe and keeps the path well-formed.
+    /// safe and keeps each param a single well-formed segment.
     fn convert_interpolations_to_params(&self, path: &str) -> String {
         let mut result = String::new();
         let mut chars = path.chars().peekable();
@@ -343,7 +343,7 @@ impl UrlNormalizer {
         let mut last = String::new();
         let mut cur = String::new();
         for c in expr.chars() {
-            if c.is_ascii_alphanumeric() || c == '_' {
+            if c.is_alphanumeric() || c == '_' {
                 cur.push(c);
             } else if !cur.is_empty() {
                 last = std::mem::take(&mut cur);

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -349,11 +349,11 @@ impl FunctionDefinitionExtractor {
 
     /// Resolve a parameter `Pat` to its `(name, type annotation)`.
     ///
-    /// Handles plain identifiers, rest params, and defaulted params
-    /// (`role: "a" | "b" = "x"`), where the annotation lives on the inner
-    /// `left` pattern of the `AssignPat`. Destructuring patterns
-    /// (`Pat::Object` / `Pat::Array`) are not yet supported and fall through
-    /// to the unnamed placeholder.
+    /// Handles plain identifiers, rest params, defaulted params
+    /// (`role: "a" | "b" = "x"` — annotation on the inner `left`), and
+    /// object/array destructuring (`{ id }: { id: string }` — annotation on the
+    /// pattern's own `type_ann`). Anything else falls through to the unnamed
+    /// placeholder.
     fn pat_name_and_type(&self, pat: &Pat) -> (String, Option<TsTypeAnn>) {
         match pat {
             Pat::Ident(ident) => (
@@ -370,8 +370,59 @@ impl FunctionDefinitionExtractor {
             // A defaulted param (`role = "x"`); the annotation, if any, is on
             // the inner left pattern. Recurse so name and type are preserved.
             Pat::Assign(assign) => self.pat_name_and_type(&assign.left),
+            // Destructuring params carry their annotation on the pattern's own
+            // `type_ann`; recover it and reconstruct a readable binding name so the
+            // param is named and (when annotated) reported explicit.
+            Pat::Object(obj) => (
+                Self::object_pat_name(obj),
+                obj.type_ann.as_ref().map(|t| *t.clone()),
+            ),
+            Pat::Array(arr) => (
+                Self::array_pat_name(arr),
+                arr.type_ann.as_ref().map(|t| *t.clone()),
+            ),
             _ => ("param".to_string(), None),
         }
+    }
+
+    /// Reconstruct a readable name for an object-destructuring param, e.g.
+    /// `{ id, name }`. Nested value patterns collapse to their key.
+    fn object_pat_name(obj: &ObjectPat) -> String {
+        let keys: Vec<String> = obj
+            .props
+            .iter()
+            .map(|prop| match prop {
+                ObjectPatProp::Assign(a) => a.key.sym.to_string(),
+                ObjectPatProp::KeyValue(kv) => match &kv.key {
+                    PropName::Ident(i) => i.sym.to_string(),
+                    PropName::Str(s) => s.value.to_string(),
+                    _ => "_".to_string(),
+                },
+                ObjectPatProp::Rest(rest) => match &*rest.arg {
+                    Pat::Ident(i) => format!("...{}", i.id.sym),
+                    _ => "...rest".to_string(),
+                },
+            })
+            .collect();
+        format!("{{ {} }}", keys.join(", "))
+    }
+
+    /// Reconstruct a readable name for an array-destructuring param, e.g.
+    /// `[a, b]`. Elisions and nested patterns collapse to `_`.
+    fn array_pat_name(arr: &ArrayPat) -> String {
+        let elems: Vec<String> = arr
+            .elems
+            .iter()
+            .map(|elem| match elem {
+                Some(Pat::Ident(i)) => i.id.sym.to_string(),
+                Some(Pat::Rest(rest)) => match &*rest.arg {
+                    Pat::Ident(i) => format!("...{}", i.id.sym),
+                    _ => "...rest".to_string(),
+                },
+                _ => "_".to_string(),
+            })
+            .collect();
+        format!("[{}]", elems.join(", "))
     }
 
     /// Build a `FunctionArgument` from a resolved `(name, type annotation)`.
@@ -1074,6 +1125,47 @@ mod tests {
         assert_eq!(def.arguments[0].name, "role");
         assert!(def.arguments[0].type_string.is_none());
         assert!(!def.arguments[0].is_explicit);
+    }
+
+    #[test]
+    fn recovers_object_destructured_param_on_function_declaration() {
+        let defs = extract(r#"function f({ id }: { id: string }) { return id; }"#);
+        let def = defs.get("f").expect("should find f");
+        assert_eq!(def.arguments.len(), 1);
+        assert_eq!(def.arguments[0].name, "{ id }");
+        assert!(def.arguments[0].is_explicit);
+        assert!(
+            def.arguments[0]
+                .type_string
+                .as_deref()
+                .is_some_and(|t| t.contains("id") && t.contains("string")),
+            "object param should keep its annotation, got {:?}",
+            def.arguments[0].type_string
+        );
+    }
+
+    #[test]
+    fn recovers_object_destructured_param_on_arrow_function() {
+        let defs = extract(r#"const f = ({ id, name }: { id: string; name: string }) => id;"#);
+        let def = defs.get("f").expect("should find f");
+        assert_eq!(def.arguments[0].name, "{ id, name }");
+        assert!(def.arguments[0].is_explicit);
+    }
+
+    #[test]
+    fn recovers_array_destructured_param() {
+        let defs = extract(r#"function f([a, b]: [number, number]) { return a + b; }"#);
+        let def = defs.get("f").expect("should find f");
+        assert_eq!(def.arguments[0].name, "[a, b]");
+        assert!(def.arguments[0].is_explicit);
+        assert!(
+            def.arguments[0]
+                .type_string
+                .as_deref()
+                .is_some_and(|t| t.contains("number")),
+            "array param should keep its tuple annotation, got {:?}",
+            def.arguments[0].type_string
+        );
     }
 
     #[test]

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -350,8 +350,8 @@ impl FunctionDefinitionExtractor {
     /// Resolve a parameter `Pat` to its `(name, type annotation)`.
     ///
     /// Handles plain identifiers, rest params, defaulted params
-    /// (`role: "a" | "b" = "x"` — annotation on the inner `left`), and
-    /// object/array destructuring (`{ id }: { id: string }` — annotation on the
+    /// (`role: "a" | "b" = "x"`, annotation on the inner `left`), and
+    /// object/array destructuring (`{ id }: { id: string }`, annotation on the
     /// pattern's own `type_ann`). Anything else falls through to the unnamed
     /// placeholder.
     fn pat_name_and_type(&self, pat: &Pat) -> (String, Option<TsTypeAnn>) {


### PR DESCRIPTION
## What

Makes the scanner robust to LLM extraction jitter. We verified that
`temperature: 0` alone does not stabilize extraction (two identical-input
scans of carrick-cloud diverged: 22 vs 24 endpoints, with `[slug]`/`:slug`
flipping and endpoints vanishing), so the lever is scanner-side robustness,
not the sampling temperature.

## Changes

- **Canonicalize LLM endpoint paths** to colon-style params before the
  file-based merge, so `/w/[slug]` and `/w/:slug` dedupe to one entry instead
  of both surviving and flipping form between scans. Optional catch-all
  `[[...slug]]` maps to `**`.
- **Collapse member-expression interpolation params**: `${row.pr_number}`
  yields `:pr_number` instead of the malformed `:row.pr_number`.
- **Recover name + type of destructured params** (`{ id }: { id: string }`,
  `[a, b]: [number, number]`) for both function declarations and arrows (#170).

## Tests

373 lib tests pass; clippy clean. Each fix has a focused regression test
(verified fail-on-revert).

## Deferred (cloud-blocked)

- #155 (stop GET-fabrication) needs the file-analyzer to emit `method: null` (FAR-64).
- #157 (deterministic re-anchor) needs the cloud re-anchor task (FAR-66).
