### PR TITLE
feat(extraction): call_kind classification field (groundwork, #129)

### DIFF
--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -84,6 +84,21 @@ where
         .and_then(EmissionStyle::parse_lenient))
 }
 
+fn deserialize_call_kind<'de, D>(
+    deserializer: D,
+) -> Result<Option<crate::operation::CallKind>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    // Absorb off-enum / non-string call_kind values to None instead of failing
+    // the whole file's parse (mirrors emission_style; supports fail-closed).
+    let raw: Option<serde_json::Value> = Option::deserialize(deserializer)?;
+    Ok(raw
+        .as_ref()
+        .and_then(serde_json::Value::as_str)
+        .and_then(crate::operation::CallKind::parse_lenient))
+}
+
 /// Result of analyzing a single endpoint definition
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EndpointResult {
@@ -132,9 +147,10 @@ pub struct DataCallResult {
     pub target: String,
     pub method: Option<String>,
     /// LLM classification of the call target (internal_http / external_http /
-    /// sdk / unresolved). `None` when the model omitted it; downstream gating
-    /// treats that as unclassified. See `crate::operation::CallKind`.
-    #[serde(default)]
+    /// sdk / unresolved). `None` when the model omitted it or emitted an off-enum
+    /// value (lenient, like emission_style); downstream gating treats that as
+    /// unclassified. See `crate::operation::CallKind`.
+    #[serde(default, deserialize_with = "deserialize_call_kind")]
     pub call_kind: Option<crate::operation::CallKind>,
     pub pattern_matched: String,
     /// Start byte offset of the data call expression (from SWC via apply_candidate_map)
@@ -738,6 +754,52 @@ mod tests {
             }}"#,
             extra_fields
         )
+    }
+
+    fn data_call_json(extra_fields: &str) -> String {
+        format!(
+            r#"{{
+                "candidate_id": "span:1-2",
+                "line_number": 5,
+                "target": "/api/users",
+                "method": "GET",
+                "pattern_matched": "fetch(",
+                "payload_expression_text": null,
+                "payload_expression_line": null,
+                "primary_type_symbol": null,
+                "type_import_source": null{}
+            }}"#,
+            extra_fields
+        )
+    }
+
+    #[test]
+    fn call_kind_absorbs_model_junk_instead_of_failing_the_file() {
+        // An off-enum call_kind must degrade to None, not fail the whole file's
+        // parse (which would drop every data call in the file); this is the
+        // fail-closed behavior the field is meant to provide.
+        for junk in ["internal-http", "INTERNAL_HTTP", "datastore", "", "???"] {
+            let json = data_call_json(&format!(r#", "call_kind": "{}""#, junk));
+            let call: DataCallResult = serde_json::from_str(&json)
+                .unwrap_or_else(|e| panic!("junk {:?} failed the parse: {}", junk, e));
+            assert_eq!(
+                call.call_kind,
+                crate::operation::CallKind::parse_lenient(junk),
+                "junk {:?}",
+                junk
+            );
+        }
+        // Non-string JSON values degrade to None the same way.
+        for junk in ["0", "false", "{}", "[\"sdk\"]"] {
+            let json = data_call_json(&format!(r#", "call_kind": {}"#, junk));
+            let call: DataCallResult = serde_json::from_str(&json)
+                .unwrap_or_else(|e| panic!("non-string {:?} failed the parse: {}", junk, e));
+            assert_eq!(call.call_kind, None, "non-string {:?}", junk);
+        }
+        // Valid wire values still parse.
+        let json = data_call_json(r#", "call_kind": "sdk""#);
+        let call: DataCallResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(call.call_kind, Some(crate::operation::CallKind::Sdk));
     }
 
     #[test]

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -131,6 +131,11 @@ pub struct DataCallResult {
     pub line_number: i32,
     pub target: String,
     pub method: Option<String>,
+    /// LLM classification of the call target (internal_http / external_http /
+    /// sdk / unresolved). `None` when the model omitted it; downstream gating
+    /// treats that as unclassified. See `crate::operation::CallKind`.
+    #[serde(default)]
+    pub call_kind: Option<crate::operation::CallKind>,
     pub pattern_matched: String,
     /// Start byte offset of the data call expression (from SWC via apply_candidate_map)
     #[serde(default)]
@@ -928,6 +933,7 @@ mod tests {
     #[test]
     fn test_data_call_result_serialization() {
         let data_call = DataCallResult {
+            call_kind: None,
             candidate_id: "span:200-260".to_string(),
             line_number: 25,
             target: "https://api.example.com/data".to_string(),
@@ -975,6 +981,7 @@ mod tests {
                 type_import_source: Some(".repo-a_types.ts".to_string()),
             }],
             data_calls: vec![DataCallResult {
+                call_kind: None,
                 candidate_id: "span:60-120".to_string(),
                 line_number: 2,
                 target: "https://example.com".to_string(),
@@ -1077,6 +1084,7 @@ mod tests {
                 type_import_source: None,
             }],
             data_calls: vec![DataCallResult {
+                call_kind: None,
                 candidate_id: "span:190-240".to_string(),
                 line_number: 3,
                 target: "/users".to_string(),

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1748,6 +1748,7 @@ impl FileOrchestrator {
                     target_url: data_call.target.clone(),
                     client: data_call.pattern_matched.clone(),
                     file_location: format!("{}:{}", file_path, data_call.line_number),
+                    call_kind: data_call.call_kind,
                 });
             }
         }
@@ -2101,6 +2102,7 @@ mod tests {
                 mounts: vec![],
                 endpoints: vec![],
                 data_calls: vec![DataCallResult {
+                    call_kind: None,
                     candidate_id: "span:200-260".to_string(),
                     line_number: 15,
                     target: "https://api.example.com/data".to_string(),
@@ -2141,6 +2143,7 @@ mod tests {
                 endpoints: vec![],
                 data_calls: vec![
                     DataCallResult {
+                        call_kind: None,
                         candidate_id: "span:300-340".to_string(),
                         line_number: 12,
                         target: "ordersResp".to_string(),
@@ -2156,6 +2159,7 @@ mod tests {
                         type_import_source: None,
                     },
                     DataCallResult {
+                        call_kind: None,
                         candidate_id: "span:350-400".to_string(),
                         line_number: 15,
                         target: "https://api.example.com/data".to_string(),
@@ -2194,6 +2198,7 @@ mod tests {
                 mounts: vec![],
                 endpoints: vec![],
                 data_calls: vec![DataCallResult {
+                    call_kind: None,
                     candidate_id: "span:410-460".to_string(),
                     line_number: 12,
                     target: "https://api.example.com/data".to_string(),
@@ -2234,6 +2239,7 @@ mod tests {
                 endpoints: vec![],
                 data_calls: vec![
                     DataCallResult {
+                        call_kind: None,
                         candidate_id: "span:470-520".to_string(),
                         line_number: 10,
                         target: "https://api.example.com/orders".to_string(),
@@ -2249,6 +2255,7 @@ mod tests {
                         type_import_source: None,
                     },
                     DataCallResult {
+                        call_kind: None,
                         candidate_id: "span:530-580".to_string(),
                         line_number: 20,
                         target: "https://api.example.com/orders".to_string(),
@@ -2563,6 +2570,7 @@ mod tests {
                 },
             ],
             data_calls: vec![DataCallResult {
+                call_kind: None,
                 candidate_id: "span:660-700".to_string(),
                 line_number: 12,
                 target: "/users".to_string(),

--- a/src/agents/schemas.rs
+++ b/src/agents/schemas.rs
@@ -357,6 +357,12 @@ impl AgentSchemas {
                                 "nullable": true,
                                 "description": "HTTP method if detectable (GET, POST, etc.)"
                             },
+                            "call_kind": {
+                                "type": "STRING",
+                                "enum": ["internal_http", "external_http", "sdk", "unresolved"],
+                                "nullable": true,
+                                "description": "How the call target was classified: internal_http (a call to another service's HTTP API), external_http (a third-party or public HTTP API), sdk (a cloud-service or datastore client call), or unresolved (could not be classified)."
+                            },
                             "pattern_matched": {
                                 "type": "STRING",
                                 "description": "The specific pattern that triggered this result"
@@ -636,6 +642,48 @@ mod tests {
             .as_array()
             .unwrap();
         assert!(required.iter().any(|v| v == "emission_style"));
+    }
+
+    #[test]
+    fn call_kind_schema_enum_matches_serde_wire_values() {
+        // The data_calls call_kind enum and CallKind's serde output must stay in
+        // lockstep, or a value the schema advertises but the enum can't parse is
+        // silently absorbed to None and the classification is lost.
+        use crate::operation::CallKind;
+
+        let schema = AgentSchemas::file_analysis_schema();
+        let schema_values: Vec<String> = schema["properties"]["data_calls"]["items"]["properties"]
+            ["call_kind"]["enum"]
+            .as_array()
+            .expect("call_kind enum must exist")
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+
+        let serde_values: Vec<String> = [
+            CallKind::InternalHttp,
+            CallKind::ExternalHttp,
+            CallKind::Sdk,
+            CallKind::Unresolved,
+        ]
+        .iter()
+        .map(|k| {
+            serde_json::to_value(k)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+
+        assert_eq!(schema_values, serde_values);
+
+        // call_kind is optional (nullable, not required): a missing label is legal
+        // and defaults to unclassified rather than forcing the model to guess.
+        let required = schema["properties"]["data_calls"]["items"]["required"]
+            .as_array()
+            .unwrap();
+        assert!(!required.iter().any(|v| v == "call_kind"));
     }
 
     #[test]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2411,6 +2411,7 @@ mod tests {
             data_calls: data_calls
                 .into_iter()
                 .map(|target| DataCallResult {
+                    call_kind: None,
                     candidate_id: "cand_456".to_string(),
                     line_number: 20,
                     target: target.to_string(),
@@ -2444,12 +2445,14 @@ mod tests {
                 target_url: "`${USER_SERVICE_URL}/api/users/${order.userId}`".to_string(),
                 client: "fetch".to_string(),
                 file_location: "src/orders.ts:42".to_string(),
+                call_kind: None,
             },
             crate::mount_graph::DataFetchingCall {
                 method: "GET".to_string(),
                 target_url: "`${NOTIFICATION_SERVICE_URL}/api/notifications/status`".to_string(),
                 client: "fetch".to_string(),
                 file_location: "src/notify.ts:7".to_string(),
+                call_kind: None,
             },
         ];
 

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -91,7 +91,7 @@ pub struct DataFetchingCall {
     pub file_location: String,
     /// Semantic kind carried from extraction; `None` until the file-analyzer
     /// prompt emits it. Drives compat gating in a later stage.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub call_kind: Option<crate::operation::CallKind>,
 }
 

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -89,6 +89,10 @@ pub struct DataFetchingCall {
     pub target_url: String,
     pub client: String,
     pub file_location: String,
+    /// Semantic kind carried from extraction; `None` until the file-analyzer
+    /// prompt emits it. Drives compat gating in a later stage.
+    #[serde(default)]
+    pub call_kind: Option<crate::operation::CallKind>,
 }
 
 /// The complete mount and endpoint graph
@@ -311,6 +315,7 @@ impl MountGraph {
             target_url,
             client,
             file_location: site.call_site.location.clone(),
+            call_kind: None,
         })
     }
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -34,6 +34,21 @@ pub enum GraphqlOperationKind {
     Subscription,
 }
 
+/// Semantic classification of an outbound call, orthogonal to `Protocol` (the
+/// wire format). Assigned by the file-analyzer LLM. Only `InternalHttp` is meant
+/// to feed cross-service compatibility matching; `ExternalHttp` / `Sdk` are
+/// retained for a dependency view but excluded from compat; `Unresolved` (and an
+/// absent label) is excluded from matching. The gating that acts on this lands in
+/// a later stage; today the field is captured and carried only.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CallKind {
+    InternalHttp,
+    ExternalHttp,
+    Sdk,
+    Unresolved,
+}
+
 impl GraphqlOperationKind {
     pub fn as_str(&self) -> &'static str {
         match self {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -37,9 +37,12 @@ pub enum GraphqlOperationKind {
 /// Semantic classification of an outbound call, orthogonal to `Protocol` (the
 /// wire format). Assigned by the file-analyzer LLM. Only `InternalHttp` is meant
 /// to feed cross-service compatibility matching; `ExternalHttp` / `Sdk` are
-/// retained for a dependency view but excluded from compat; `Unresolved` (and an
-/// absent label) is excluded from matching. The gating that acts on this lands in
-/// a later stage; today the field is captured and carried only.
+/// excluded from compat and earmarked for a future dependency view — though today
+/// many SDK/external targets are still dropped upstream by
+/// `analyzer::is_valid_route_shape` (non-route shapes: `||`, parens, whitespace)
+/// before they reach the graph, so that retention is not yet complete. `Unresolved`
+/// (and an absent label) is excluded from matching. The gating that acts on this
+/// lands in a later stage; today the field is captured and carried only.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CallKind {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -49,6 +49,26 @@ pub enum CallKind {
     Unresolved,
 }
 
+impl CallKind {
+    /// Parse a model-emitted kind string leniently (case-insensitive; `-`/space
+    /// separators tolerated). Returns `None` for anything off-enum so one junk
+    /// value can't fail the whole file's deserialization (mirrors EmissionStyle).
+    pub fn parse_lenient(value: &str) -> Option<Self> {
+        match value
+            .trim()
+            .to_ascii_lowercase()
+            .replace(['-', ' '], "_")
+            .as_str()
+        {
+            "internal_http" => Some(CallKind::InternalHttp),
+            "external_http" => Some(CallKind::ExternalHttp),
+            "sdk" => Some(CallKind::Sdk),
+            "unresolved" => Some(CallKind::Unresolved),
+            _ => None,
+        }
+    }
+}
+
 impl GraphqlOperationKind {
     pub fn as_str(&self) -> &'static str {
         match self {

--- a/tests/file_centric_analysis_test.rs
+++ b/tests/file_centric_analysis_test.rs
@@ -130,6 +130,7 @@ fn test_file_analysis_result_structures() {
 
     // Test DataCallResult structure
     let data_call = DataCallResult {
+        call_kind: None,
         candidate_id: "span:200-260".to_string(),
         line_number: 25,
         target: "https://api.example.com/users".to_string(),
@@ -206,6 +207,7 @@ fn test_file_analysis_result_serialization() {
             },
         ],
         data_calls: vec![DataCallResult {
+            call_kind: None,
             candidate_id: "span:410-460".to_string(),
             line_number: 20,
             target: "https://external-api.com/data".to_string(),
@@ -490,6 +492,7 @@ fn test_data_call_extraction() {
         endpoints: vec![],
         data_calls: vec![
             DataCallResult {
+                call_kind: None,
                 candidate_id: "span:670-700".to_string(),
                 line_number: 10,
                 target: "https://api.example.com/users".to_string(),
@@ -505,6 +508,7 @@ fn test_data_call_extraction() {
                 type_import_source: None,
             },
             DataCallResult {
+                call_kind: None,
                 candidate_id: "span:750-780".to_string(),
                 line_number: 15,
                 target: "/api/posts".to_string(),
@@ -520,6 +524,7 @@ fn test_data_call_extraction() {
                 type_import_source: None,
             },
             DataCallResult {
+                call_kind: None,
                 candidate_id: "span:790-820".to_string(),
                 line_number: 20,
                 target: "${baseUrl}/data".to_string(),


### PR DESCRIPTION
## What

Stage 1 of #129, re-scoped to the **live file-analyzer path** (`/extract-calls` is dead). Pure, harmless groundwork: capture the LLM's `call_kind` label on each data call. **No gating, no prompt change** — with today's prompt the field is `None` and behavior is unchanged.

## Changes

- Schema: nullable `call_kind` enum (`internal_http | external_http | sdk | unresolved`) on `data_calls` items in `file_analysis_schema`.
- `CallKind` enum in `operation.rs`, orthogonal to `Protocol` (wire format vs semantic destination class).
- Thread `Option<CallKind>` through `DataCallResult` → `DataFetchingCall` (carried into the index).
- Schema/serde lockstep test pinning the enum to `CallKind`'s wire values and asserting `call_kind` stays optional.

## Decisions baked in (flag for review)

- **Fail-closed:** `call_kind` is optional; a missing label is treated as unclassified (later gating will exclude anything that isn't `internal_http`).
- **Tag-only:** does not change the prompt to emit currently-dropped SDK calls, nor build a dependency view — tracked as carrick-cloud#152.

## Next stages (separate PRs)

- carrick-cloud: file-analyzer prompt teaches the labelling (+ stop emitting MCP tools / event-lambda `POST /` as endpoints).
- carrick: flip the compat/manifest gating to consume `call_kind`, after a multi-run A/B confirms the tagging is reliable.

## Tests

374 lib tests pass; clippy clean.
