### PR TITLE
fix(extraction): deterministic noise-reduction sweep (SDK / pass-through / owner / nested closures)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1707,9 +1707,17 @@ impl FileOrchestrator {
                     continue; // Skip non-HTTP methods (e.g., "use", empty)
                 }
 
-                // Try to resolve the owner using import information
-                let resolved_owner =
-                    self.resolve_endpoint_owner(&graph, &endpoint.owner_node, file_path);
+                // Guard against a fabricated owner: when the model bleeds the
+                // HTTP verb into `owner_node` (e.g. Astro `export const POST`,
+                // where the handler export name is the method), the owner reads
+                // as `POST`/`GET`. A verb never matches a mount child, so
+                // overriding it is safe; attribute the route to its file module
+                // instead (carrick-cloud#148, FAR-64).
+                let resolved_owner = if is_http_method(&endpoint.owner_node.trim().to_uppercase()) {
+                    Self::derive_file_owner(file_path)
+                } else {
+                    self.resolve_endpoint_owner(&graph, &endpoint.owner_node, file_path)
+                };
 
                 graph.endpoints.push(ResolvedEndpoint {
                     method,
@@ -1783,6 +1791,25 @@ impl FileOrchestrator {
             .trim_end_matches(".js")
             .trim_end_matches(".tsx")
             .trim_end_matches(".jsx")
+            .to_string()
+    }
+
+    /// Deterministic owner for a file-based route whose `owner_node` was a
+    /// fabricated HTTP verb (e.g. Astro `export const POST`, where the export
+    /// name is the verb). Falls back to the file module (basename without
+    /// extension) so the verb never surfaces as the owner. A verb owner never
+    /// matches a mount child, so this can't change mount resolution
+    /// (carrick-cloud#148, FAR-64).
+    fn derive_file_owner(file_path: &str) -> String {
+        file_path
+            .rsplit('/')
+            .next()
+            .unwrap_or(file_path)
+            .trim_end_matches(".astro")
+            .trim_end_matches(".tsx")
+            .trim_end_matches(".jsx")
+            .trim_end_matches(".ts")
+            .trim_end_matches(".js")
             .to_string()
     }
 
@@ -1882,6 +1909,21 @@ impl FileOrchestrator {
 mod tests {
     use super::*;
     use crate::agents::file_analyzer_agent::{DataCallResult, EndpointResult, MountResult};
+
+    #[test]
+    fn test_derive_file_owner_strips_path_and_extension() {
+        // owner=verb fabrication guard falls back to the file module, never a verb.
+        assert_eq!(
+            FileOrchestrator::derive_file_owner("app/src/pages/oauth/token.ts"),
+            "token"
+        );
+        assert_eq!(
+            FileOrchestrator::derive_file_owner("src/pages/index.astro"),
+            "index"
+        );
+        assert_eq!(FileOrchestrator::derive_file_owner("new.tsx"), "new");
+        assert_eq!(FileOrchestrator::derive_file_owner("handler.js"), "handler");
+    }
 
     /// Regression: `tsconfig.json` with `"baseUrl": "."` makes
     /// `import { X } from "types/user"` resolve to `<repo>/types/user.ts`.

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1732,6 +1732,22 @@ impl FileOrchestrator {
                 else {
                     continue;
                 };
+                // Drop AWS-SDK-style command dispatches (`client.send(new
+                // XCommand(...))`) — service-SDK calls (DynamoDB/S3/Lambda), not
+                // addressable HTTP. The file-analyzer prompt asks the model to
+                // skip these but does so unreliably (verified leaking into the
+                // index); enforce it deterministically here by call shape
+                // (carrick-cloud#148, #129).
+                if crate::analyzer::is_sdk_command_dispatch(
+                    data_call.call_expression_text.as_deref(),
+                ) || crate::analyzer::is_sdk_command_dispatch(Some(&data_call.pattern_matched))
+                {
+                    debug!(
+                        "Skipping SDK command-dispatch data call: {} ({})",
+                        data_call.target, file_path
+                    );
+                    continue;
+                }
                 // Drop calls whose target is not a real outgoing-call route
                 // (SDK ops, bare identifiers, member expressions). Filtering at
                 // the producer keeps the uploaded cross-repo index clean, not

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -200,6 +200,14 @@ pub fn is_valid_route_shape(route: &str) -> bool {
     }
     // Env-var base form: `${VAR}/path`, `${process.env.VAR}/…`, bare `${VAR}`.
     if let Some(rest) = route.strip_prefix("${") {
+        // Reject fully-dynamic pass-through concatenations like
+        // `${host}${url.pathname}` — two or more interpolations with no literal
+        // path segment outside the braces. These are dynamic proxies, not
+        // addressable routes, and surface as bogus missing endpoints
+        // (carrick-cloud#115).
+        if is_fully_dynamic_concat(route) {
+            return false;
+        }
         return rest.contains('}') && is_clean(route);
     }
     // Full URL.
@@ -212,6 +220,65 @@ pub fn is_valid_route_shape(route: &str) -> bool {
     }
     // Bare identifier, member/call expression, `Service:Op`, `#…`, literal.
     false
+}
+
+/// True when a target is two or more `${...}` interpolations concatenated with
+/// no literal path segment outside the braces (e.g. `${host}${url.pathname}`),
+/// i.e. a fully-dynamic pass-through proxy rather than an addressable route
+/// (carrick-cloud#115). `${VAR}/path` (one interpolation + literal) and
+/// `${A}/${B}` (literal `/` between) are kept.
+fn is_fully_dynamic_concat(route: &str) -> bool {
+    let mut skeleton = String::new();
+    let mut chars = route.chars().peekable();
+    let mut interp_count = 0u32;
+    while let Some(c) = chars.next() {
+        if c == '$' && chars.peek() == Some(&'{') {
+            chars.next(); // consume '{'
+            let mut depth = 1u32;
+            for d in chars.by_ref() {
+                match d {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            interp_count += 1;
+        } else {
+            skeleton.push(c);
+        }
+    }
+    interp_count >= 2 && !skeleton.contains('/')
+}
+
+/// True when a data-call expression is an AWS-SDK-style command dispatch
+/// (`client.send(new SomethingCommand(...))`) — a service-SDK call (cloud SDK,
+/// datastore/object-store client), not an addressable HTTP request. This is a
+/// deterministic mirror of the file-analyzer prompt's command-dispatch rule,
+/// enforced in the scanner so the model's (unreliable) adherence can't leak
+/// DynamoDB/S3/Lambda dispatches into the HTTP call graph
+/// (carrick-cloud#148, #129). Matched by call SHAPE, never by client name.
+pub fn is_sdk_command_dispatch(expr: Option<&str>) -> bool {
+    let Some(expr) = expr else {
+        return false;
+    };
+    // `.send(` followed (ignoring whitespace) by `new <Ident>Command(`.
+    let Some(after_send) = expr.split(".send(").nth(1) else {
+        return false;
+    };
+    let Some(after_new) = after_send.trim_start().strip_prefix("new ") else {
+        return false;
+    };
+    let ident: String = after_new
+        .trim_start()
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+    !ident.is_empty() && ident.ends_with("Command")
 }
 
 pub struct Analyzer {
@@ -1993,6 +2060,48 @@ mod tests {
         assert!(!Analyzer::is_env_var_base_url("${camelCase}/path")); // camelCase, not env var
         assert!(Analyzer::is_env_var_base_url("${API_V2}/users")); // UPPER_CASE with digit
     }
+
+    #[test]
+    fn test_is_valid_route_shape_rejects_dynamic_passthrough() {
+        // carrick-cloud#115: a fully-dynamic proxy concat is not an addressable
+        // route and must not surface as a missing endpoint.
+        assert!(!super::is_valid_route_shape("${host}${url.pathname}"));
+        assert!(!super::is_valid_route_shape("${proto}${rest}"));
+        // Real env-var routes with a literal path are kept.
+        assert!(super::is_valid_route_shape("${SERVICE_URL}/api/users"));
+        assert!(super::is_valid_route_shape("${API_BASE}/orders/${id}"));
+        // A literal slash between two interpolations keeps structure.
+        assert!(super::is_valid_route_shape("${base}/${id}"));
+        // A single bare env var is left to the SDK/shape filters, not dropped here.
+        assert!(super::is_valid_route_shape("${TABLE_NAME}"));
+    }
+
+    #[test]
+    fn test_is_sdk_command_dispatch() {
+        // AWS SDK v3 command dispatches across services (carrick-cloud#148/#129).
+        assert!(super::is_sdk_command_dispatch(Some(
+            "docClient.send(new QueryCommand(queryParams))"
+        )));
+        assert!(super::is_sdk_command_dispatch(Some(
+            "s3Client.send(new GetObjectCommand({ Bucket, Key }))"
+        )));
+        assert!(super::is_sdk_command_dispatch(Some(
+            "lambdaClient.send(new InvokeCommand(params))"
+        )));
+        assert!(super::is_sdk_command_dispatch(Some(
+            "client.send( new  UpdateItemCommand(x) )"
+        )));
+        // Not SDK dispatches — must not be suppressed.
+        assert!(!super::is_sdk_command_dispatch(Some(
+            "fetch(\"/api/users\")"
+        )));
+        assert!(!super::is_sdk_command_dispatch(Some("reply.send(users)")));
+        assert!(!super::is_sdk_command_dispatch(Some(
+            "axios.post(url, body)"
+        )));
+        assert!(!super::is_sdk_command_dispatch(None));
+    }
+
     fn graphql_details(key: OperationKey, file: &str) -> ApiEndpointDetails {
         ApiEndpointDetails {
             owner: None,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -298,6 +298,11 @@ pub struct FunctionDefinitionExtractor {
     source_map: swc_common::sync::Lrc<swc_common::SourceMap>,
     /// Names of functions that are exported (populated by visit_export_decl / visit_named_export)
     exported_names: HashSet<String>,
+    /// Nesting depth inside function/arrow bodies. Anonymous closures passed to
+    /// method calls (`.every`, `.map`, `.filter`, …) are only captured at depth
+    /// 0; closures nested inside an already-captured function body duplicate the
+    /// parent's intent and only clutter the function index (carrick#58).
+    fn_body_depth: usize,
 }
 
 impl FunctionDefinitionExtractor {
@@ -310,6 +315,7 @@ impl FunctionDefinitionExtractor {
             current_file_path: file_path,
             source_map,
             exported_names: HashSet::new(),
+            fn_body_depth: 0,
         }
     }
 
@@ -682,10 +688,30 @@ impl Visit for FunctionDefinitionExtractor {
     }
 
     /// Capture anonymous closures passed as arguments to method calls.
+    /// Track nesting inside function/arrow bodies so `visit_call_expr` can
+    /// capture top-level handler closures while skipping nested method-callback
+    /// closures (carrick#58).
+    fn visit_function(&mut self, func: &Function) {
+        self.fn_body_depth += 1;
+        func.visit_children_with(self);
+        self.fn_body_depth -= 1;
+    }
+
+    fn visit_arrow_expr(&mut self, arrow: &ArrowExpr) {
+        self.fn_body_depth += 1;
+        arrow.visit_children_with(self);
+        self.fn_body_depth -= 1;
+    }
+
     /// e.g. `app.get("/users", async (req, res) => { ... })` → name: "GET_users_handler"
     /// e.g. `emitter.on("data", (chunk) => { ... })` → name: "on_data_handler"
     fn visit_call_expr(&mut self, call: &CallExpr) {
-        if let Some((method_name, first_str_arg)) = extract_call_context(call) {
+        // Only capture anonymous closures at the top level; a closure nested
+        // inside an already-captured function body (e.g. `.every(...)` inside a
+        // validator) duplicates the parent's intent (carrick#58).
+        if self.fn_body_depth == 0
+            && let Some((method_name, first_str_arg)) = extract_call_context(call)
+        {
             // Look for function/arrow arguments (skip the first string arg)
             for arg in &call.args {
                 match &*arg.expr {
@@ -869,6 +895,31 @@ mod tests {
         module.visit_with(&mut extractor);
         extractor.finalize_exports();
         extractor.function_definitions
+    }
+
+    #[test]
+    fn skips_closures_nested_inside_a_captured_function_body() {
+        // carrick#58: the `.every(...)` callback duplicates isCommentArray's
+        // intent and must not be captured as its own `every_handler`.
+        let defs =
+            extract("function isCommentArray(arr) { return arr.every((c) => c.id && c.author); }");
+        assert!(defs.contains_key("isCommentArray"), "parent is captured");
+        assert!(
+            !defs.keys().any(|k| k.contains("every")),
+            "nested .every() closure must not be captured, got: {:?}",
+            defs.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn still_captures_top_level_handler_closures() {
+        // The depth gate must not regress real top-level handler capture.
+        let defs = extract("app.get(\"/users\", (req, res) => { res.json([]); });");
+        assert!(
+            defs.contains_key("get_users_handler"),
+            "top-level handler still captured, got: {:?}",
+            defs.keys().collect::<Vec<_>>()
+        );
     }
 
     #[test]


### PR DESCRIPTION
A single PR rolling up the scanner-resident, **deterministic** false-positive/clutter fixes surfaced by the 2026-06-21 carrick-cloud dashboard. None of these rely on LLM prompt adherence — they're enforced in Rust and verified by `cargo test` + a local scanner run, so no paid cloud scan is needed to validate (only to refresh the live index later).

Context: this is the deterministic complement to the **paused** call_kind line (carrick-cloud#129). The dashboard showed the file-analyzer prompt does *not* reliably suppress SDK calls, so these move that classification to deterministic AST shape detection.

## Fixes

1. **SDK-as-HTTP drop** — `client.send(new XCommand(...))` dispatches (DynamoDB/S3/Lambda) are service-SDK calls, not addressable HTTP. `is_sdk_command_dispatch` drops them by call shape in the graph-build pass. *(carrick-cloud#148, #129)*
2. **Dynamic pass-through drop** — `${host}${url.pathname}` and other multi-interpolation concatenations with no literal path segment are dynamic proxies, not routes; `is_valid_route_shape` now rejects them. *(carrick-cloud#115)*
3. **owner=HTTP-verb fabrication guard** — when the model bleeds the verb into `owner_node` (Astro `export const POST`), the endpoint owner read as `POST`/`GET`. A verb never matches a mount child, so this can't change mount resolution; the route is attributed to its file module instead. *(carrick-cloud#148, FAR-64)*
4. **Nested-closure capture** — closures passed to method calls (`.every`, `.map`, `.filter`) nested inside an already-captured function body were captured as standalone `every_handler`/`filter_handler` functions, duplicating the parent's intent. Now gated on function-body depth 0; named/assigned function capture is unchanged. *(carrick#58)*

## Already done (close the issue)
- **carrick#170** (recover destructured `Pat::Object`/`Pat::Array` param name+type) is already implemented + tested on `main` (landed in #183 / 0.1.36, `pat_name_and_type` + `recovers_*_destructured_param` tests). The issue is stale and can be closed.

## Tests
- New: `is_sdk_command_dispatch`, `is_valid_route_shape_rejects_dynamic_passthrough`, `derive_file_owner_strips_path_and_extension`, `skips_closures_nested_inside_a_captured_function_body`, `still_captures_top_level_handler_closures`.
- Full suite + clippy green via pre-commit.

## Not in scope (deferred, own PRs)
- carrick#121 host/service-scoped matching (kills the remaining *external-URL* compat false positives).
- Determinism/fidelity cluster (carrick#157/#167/#166).