### PR TITLE
feat(evals): JSON output + Tier-A extraction-quality scorer (evals slice 1)

### DIFF
--- a/.github/workflows/eval-tier-a.yml
+++ b/.github/workflows/eval-tier-a.yml
@@ -1,0 +1,53 @@
+name: eval-tier-a
+
+# Evals plan, Slice 1: scores endpoint/call precision/recall/F1 for the Tier-A
+# framework fixtures against their expected.json, and prints a report.
+#
+# On-demand only (workflow_dispatch) — each run makes real LLM calls that cost a
+# few cents. Auth is GitHub Actions OIDC: the scanner is keyless, so this needs
+# `id-token: write` and no stored secret. The job's OIDC identity resolves
+# (repo -> App installation -> workspace) entirely on the cloud side, so it is
+# independent of any personal Carrick account.
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  eval-tier-a:
+    name: Tier-A extraction quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: |
+            src/sidecar/package-lock.json
+
+      - name: Build type sidecar
+        run: cd src/sidecar && npm ci && npm run build
+
+      - name: Install fixture dependencies
+        run: |
+          for f in koa-api fastify-api hapi-api nestjs-api; do
+            (cd "tests/fixtures/$f" && npm install)
+          done
+
+      - name: Build scanner (release)
+        env:
+          CARRICK_API_ENDPOINT: https://api.carrick.tools
+        run: cargo build --release
+
+      - name: Run Tier-A scorer
+        env:
+          CARRICK_API_ENDPOINT: https://api.carrick.tools
+        run: cargo test --release --test eval_tier_a -- --test-threads=1 --nocapture

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -371,6 +371,17 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     logging::finish_spinner(&sp, "Cross-repo analysis complete");
 
     let results = analyzer.get_results();
+
+    // Eval harness output mode: emit a machine-readable projection of the
+    // results and skip the human Markdown report + PR-comment relay. Consumed
+    // by the offline scorer (Slice 1 of the evals plan). Deliberately terminal —
+    // an eval run wants only the JSON, no upload or comment side effects.
+    if std::env::var("CARRICK_OUTPUT_JSON").is_ok() {
+        let projection = crate::eval_output::EvalProjection::from_results(&results);
+        println!("{}", serde_json::to_string_pretty(&projection)?);
+        return Ok(());
+    }
+
     let topology = crate::formatter::Topology {
         repo_name: repo_name.clone(),
         local_service_count,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -63,6 +63,15 @@ type FileDiscoveryResult = Result<
 /// Determine if we should upload data based on GitHub context
 /// Only upload on main/master branch, not on PRs
 fn should_upload_data() -> bool {
+    // Eval runs (`CARRICK_OUTPUT_JSON`) are read-only benchmarks against throwaway
+    // fixtures. Never upload, or a dispatch on main would pollute the real cloud
+    // index with fixture "services". This is the upstream half of eval mode's
+    // no-side-effects guarantee; the JSON output branch skips the markdown
+    // report + PR comment downstream.
+    if env::var("CARRICK_OUTPUT_JSON").is_ok() {
+        return false;
+    }
+
     // Check if we're in a pull request
     if let Ok(event_name) = env::var("GITHUB_EVENT_NAME")
         && event_name == "pull_request"

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -1,0 +1,97 @@
+//! Machine-readable scanner output for the eval harness.
+//!
+//! When `CARRICK_OUTPUT_JSON` is set, the engine emits an [`EvalProjection`]
+//! instead of the human-readable Markdown report. This is a *dedicated* shape,
+//! deliberately decoupled from the internal analyzer types, so the eval scoring
+//! contract stays stable across refactors of `ApiEndpointDetails` and friends.
+//! Slice 1 of the evals plan scores endpoint/call set accuracy from this.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+use crate::analyzer::{ApiAnalysisResult, ApiEndpointDetails};
+use crate::operation::OperationKey;
+
+/// The full eval projection of a single scan: the producer endpoints and the
+/// consumer calls the scanner extracted.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EvalProjection {
+    pub endpoints: Vec<EvalOp>,
+    pub calls: Vec<EvalOp>,
+}
+
+/// One extracted operation (endpoint or call), flattened for scoring.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EvalOp {
+    /// Stable identity from `OperationKey::canonical()`, e.g. `http|GET|/users`.
+    pub key: String,
+    /// `"http" | "graphql" | "socket"`.
+    pub protocol: String,
+    /// HTTP method, when this is an HTTP operation.
+    pub method: Option<String>,
+    /// HTTP path, GraphQL field, or socket event.
+    pub path: Option<String>,
+    pub handler: Option<String>,
+    pub request_type: Option<String>,
+    pub response_type: Option<String>,
+    pub file: String,
+    pub line: u32,
+}
+
+impl EvalProjection {
+    pub fn from_results(result: &ApiAnalysisResult) -> Self {
+        Self {
+            endpoints: result.endpoints.iter().map(EvalOp::from_details).collect(),
+            calls: result.calls.iter().map(EvalOp::from_details).collect(),
+        }
+    }
+}
+
+impl EvalOp {
+    fn from_details(d: &ApiEndpointDetails) -> Self {
+        let (protocol, method, path) = project_key(&d.key);
+        let (file, line) = split_location(&d.file_path);
+        EvalOp {
+            key: d.key.canonical(),
+            protocol,
+            method,
+            path,
+            handler: d.handler_name.clone(),
+            request_type: d
+                .request_type
+                .as_ref()
+                .map(|t| t.composite_type_string.clone()),
+            response_type: d
+                .response_type
+                .as_ref()
+                .map(|t| t.composite_type_string.clone()),
+            file,
+            line,
+        }
+    }
+}
+
+/// `(protocol, method, path)` projected from the operation key. For non-HTTP
+/// protocols `method` is `None` and `path` carries the field / event name.
+fn project_key(key: &OperationKey) -> (String, Option<String>, Option<String>) {
+    match key {
+        OperationKey::Http { method, path } => {
+            ("http".to_string(), Some(method.clone()), Some(path.clone()))
+        }
+        OperationKey::Graphql { field, .. } => ("graphql".to_string(), None, Some(field.clone())),
+        OperationKey::Socket { event, .. } => ("socket".to_string(), None, Some(event.clone())),
+    }
+}
+
+/// `file_path` is stored as `"<file>:<line>"` for deterministic output. Split it
+/// back into a path and a best-effort line number (0 when absent/unparseable).
+/// `file`/`line` are informational only — scoring keys off method + path.
+fn split_location(p: &Path) -> (String, u32) {
+    let s = p.to_string_lossy();
+    match s.rsplit_once(':') {
+        Some((file, line)) if !line.is_empty() && line.bytes().all(|b| b.is_ascii_digit()) => {
+            (file.to_string(), line.parse().unwrap_or(0))
+        }
+        _ => (s.into_owned(), 0),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod call_site_extractor;
 pub mod cloud_storage;
 pub mod config;
 pub mod engine;
+pub mod eval_output;
 pub mod extractor;
 pub mod file_based_router;
 pub mod file_finder;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod call_site_extractor;
 mod cloud_storage;
 mod config;
 mod engine;
+mod eval_output;
 mod extractor;
 mod file_based_router;
 mod file_finder;

--- a/tests/eval_tier_a.rs
+++ b/tests/eval_tier_a.rs
@@ -1,0 +1,256 @@
+//! Tier-A extraction-quality scorer (evals plan, Slice 1).
+//!
+//! Runs the release scanner against each framework fixture with
+//! `CARRICK_OUTPUT_JSON=1`, scores endpoint & call precision/recall/F1 against
+//! the fixture's `expected.json`, and prints a report. **Report-only:** it
+//! asserts only a non-flaky floor (valid JSON + endpoint recall > 0), because the
+//! live LLM is nondeterministic and a strict assertion would flake.
+//!
+//! Auth is GitHub Actions OIDC — the scanner is keyless (no API-key path). The
+//! runner exposes `ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN` only when the job has
+//! `permissions: id-token: write`, and the scanner exchanges them for an
+//! `X-Carrick-OIDC` token. When OIDC is unavailable (e.g. local `cargo test`)
+//! this test skips cleanly. Runner: `.github/workflows/eval-tier-a.yml`.
+//!
+//! The API endpoint is compile-time (`build.rs`), so build with it set:
+//!   CARRICK_API_ENDPOINT="https://api.carrick.tools" cargo build --release
+//!   cargo test --release --test eval_tier_a -- --test-threads=1 --nocapture
+
+use carrick::eval_output::EvalProjection;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const FIXTURES: &[&str] = &["koa-api", "fastify-api", "hapi-api", "nestjs-api"];
+
+#[derive(Debug, Deserialize)]
+struct Expected {
+    #[serde(default)]
+    endpoints: Vec<ExpEndpoint>,
+    #[serde(default)]
+    calls: Vec<ExpCall>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpEndpoint {
+    method: String,
+    path: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpCall {
+    method: String,
+    host_contains: String,
+    path_contains: String,
+}
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Collapse `:x` / `{x}` / `[x]` param syntaxes to `:param` and strip a trailing
+/// slash, so the Hapi `{id}` vs Express-style `:id` split (issue #167) doesn't
+/// cause false mismatches.
+fn norm_path(p: &str) -> String {
+    let mut out = String::new();
+    for (i, seg) in p.split('/').enumerate() {
+        if i > 0 {
+            out.push('/');
+        }
+        let is_param = seg.starts_with(':')
+            || (seg.starts_with('{') && seg.ends_with('}'))
+            || (seg.starts_with('[') && seg.ends_with(']'));
+        out.push_str(if is_param { ":param" } else { seg });
+    }
+    if out.len() > 1 && out.ends_with('/') {
+        out.pop();
+    }
+    out
+}
+
+fn prf(tp: usize, found: usize, expected: usize) -> (f64, f64, f64) {
+    let precision = if found == 0 {
+        if expected == 0 { 1.0 } else { 0.0 }
+    } else {
+        tp as f64 / found as f64
+    };
+    let recall = if expected == 0 {
+        1.0
+    } else {
+        tp as f64 / expected as f64
+    };
+    let f1 = if precision + recall == 0.0 {
+        0.0
+    } else {
+        2.0 * precision * recall / (precision + recall)
+    };
+    (precision, recall, f1)
+}
+
+/// Run the scanner in JSON mode, retrying once on empty stdout (a known
+/// transient when the cloud/LLM hiccups). The OIDC env
+/// (`ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN`) is inherited from the runner; the
+/// API endpoint is compile-time (`build.rs`), not a runtime var.
+fn run_scanner(bin: &Path, fixture_dir: &Path) -> Option<String> {
+    for attempt in 1..=2 {
+        let output = Command::new(bin)
+            .arg(fixture_dir)
+            .env("CARRICK_OUTPUT_JSON", "1")
+            .output()
+            .expect("failed to spawn the carrick binary");
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        if !stdout.trim().is_empty() {
+            return Some(stdout);
+        }
+        eprintln!(
+            "[eval] empty stdout for {} (attempt {}/2)",
+            fixture_dir.display(),
+            attempt
+        );
+    }
+    None
+}
+
+/// Tolerate log noise around the JSON by slicing from the first `{` to the last `}`.
+fn parse_projection(stdout: &str) -> Option<EvalProjection> {
+    let start = stdout.find('{')?;
+    let end = stdout.rfind('}')?;
+    serde_json::from_str(stdout.get(start..=end)?).ok()
+}
+
+#[test]
+fn tier_a_extraction_quality() {
+    // The scanner authenticates only via GitHub Actions OIDC. Without a runner
+    // granting `id-token: write`, no real scan can run — skip cleanly.
+    if std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL").is_err() {
+        eprintln!(
+            "[eval] GitHub Actions OIDC unavailable — skipping Tier-A scorer \
+             (run in CI with `permissions: id-token: write`)."
+        );
+        return;
+    }
+
+    let bin = manifest_dir().join("target/release/carrick");
+    if !bin.exists() {
+        eprintln!(
+            "[eval] release binary missing at {} — build first: \
+             CARRICK_API_ENDPOINT=\"https://api.carrick.tools\" cargo build --release",
+            bin.display()
+        );
+        return;
+    }
+
+    println!("\n=== Tier-A extraction quality (evals Slice 1, N=1) ===");
+    println!(
+        "{:<16} {:>24} {:>24}",
+        "fixture", "endpoints P/R/F1", "calls P/R/F1"
+    );
+
+    let n = FIXTURES.len() as f64;
+    let (mut sep, mut scall) = ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0));
+
+    for name in FIXTURES {
+        let fixture_dir = manifest_dir().join("tests/fixtures").join(name);
+        let expected: Expected = serde_json::from_str(
+            &std::fs::read_to_string(fixture_dir.join("expected.json"))
+                .unwrap_or_else(|e| panic!("read expected.json for {name}: {e}")),
+        )
+        .unwrap_or_else(|e| panic!("parse expected.json for {name}: {e}"));
+
+        let stdout = run_scanner(&bin, &fixture_dir).unwrap_or_else(|| {
+            panic!("[eval] {name}: empty output after retry (cloud/LLM hiccup)")
+        });
+        let projection = parse_projection(&stdout).unwrap_or_else(|| {
+            panic!("[eval] {name}: stdout was not valid EvalProjection JSON:\n{stdout}")
+        });
+
+        // Endpoints: set comparison over (METHOD, normalised path), HTTP only.
+        let expected_eps: HashSet<(String, String)> = expected
+            .endpoints
+            .iter()
+            .map(|e| (e.method.to_uppercase(), norm_path(&e.path)))
+            .collect();
+        let found_eps: HashSet<(String, String)> = projection
+            .endpoints
+            .iter()
+            .filter(|o| o.protocol == "http")
+            .filter_map(|o| {
+                Some((
+                    o.method.clone()?.to_uppercase(),
+                    norm_path(o.path.as_deref()?),
+                ))
+            })
+            .collect();
+        let ep_tp = expected_eps.intersection(&found_eps).count();
+        let (ep_p, ep_r, ep_f1) = prf(ep_tp, found_eps.len(), expected_eps.len());
+
+        // Calls: fuzzy match on method + host_contains + path_contains, because a
+        // consumer's target is a raw URL/expression, not a normalised route.
+        let found_calls: Vec<(String, String)> = projection
+            .calls
+            .iter()
+            .filter_map(|o| {
+                Some((
+                    o.method.clone().unwrap_or_default().to_uppercase(),
+                    o.path.clone()?,
+                ))
+            })
+            .collect();
+        let matches = |e: &ExpCall, c: &(String, String)| {
+            c.0 == e.method.to_uppercase()
+                && c.1.contains(&e.host_contains)
+                && c.1.contains(&e.path_contains)
+        };
+        let matched_expected = expected
+            .calls
+            .iter()
+            .filter(|e| found_calls.iter().any(|c| matches(e, c)))
+            .count();
+        let matched_found = found_calls
+            .iter()
+            .filter(|c| expected.calls.iter().any(|e| matches(e, c)))
+            .count();
+        let call_p = if found_calls.is_empty() {
+            if expected.calls.is_empty() { 1.0 } else { 0.0 }
+        } else {
+            matched_found as f64 / found_calls.len() as f64
+        };
+        let call_r = if expected.calls.is_empty() {
+            1.0
+        } else {
+            matched_expected as f64 / expected.calls.len() as f64
+        };
+        let call_f1 = if call_p + call_r == 0.0 {
+            0.0
+        } else {
+            2.0 * call_p * call_r / (call_p + call_r)
+        };
+
+        println!(
+            "{:<16} {:>6.2}/{:>5.2}/{:>5.2} {:>8.2}/{:>5.2}/{:>5.2}",
+            name, ep_p, ep_r, ep_f1, call_p, call_r, call_f1
+        );
+
+        sep = (sep.0 + ep_p, sep.1 + ep_r, sep.2 + ep_f1);
+        scall = (scall.0 + call_p, scall.1 + call_r, scall.2 + call_f1);
+
+        // Non-flaky floor: parsed JSON + at least one correct endpoint.
+        assert!(
+            ep_r > 0.0,
+            "[eval] {name}: endpoint recall is 0 — found {found_eps:?}, expected {expected_eps:?}"
+        );
+    }
+
+    println!(
+        "{:<16} {:>6.2}/{:>5.2}/{:>5.2} {:>8.2}/{:>5.2}/{:>5.2}",
+        "MEAN",
+        sep.0 / n,
+        sep.1 / n,
+        sep.2 / n,
+        scall.0 / n,
+        scall.1 / n,
+        scall.2 / n
+    );
+    println!("=== end Tier-A ===\n");
+}

--- a/tests/eval_tier_a.rs
+++ b/tests/eval_tier_a.rs
@@ -103,10 +103,17 @@ fn run_scanner(bin: &Path, fixture_dir: &Path) -> Option<String> {
         if !stdout.trim().is_empty() {
             return Some(stdout);
         }
+        // Surface the exit status + tail of stderr so a CI failure is
+        // diagnosable rather than a bare "empty output" panic.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let lines: Vec<&str> = stderr.lines().collect();
+        let tail = lines[lines.len().saturating_sub(15)..].join("\n");
         eprintln!(
-            "[eval] empty stdout for {} (attempt {}/2)",
+            "[eval] empty stdout for {} (attempt {}/2): {}\n--- stderr (last 15 lines) ---\n{}",
             fixture_dir.display(),
-            attempt
+            attempt,
+            output.status,
+            tail
         );
     }
     None
@@ -190,6 +197,7 @@ fn tier_a_extraction_quality() {
         let found_calls: Vec<(String, String)> = projection
             .calls
             .iter()
+            .filter(|o| o.protocol == "http")
             .filter_map(|o| {
                 Some((
                     o.method.clone().unwrap_or_default().to_uppercase(),

--- a/tests/fixtures/fastify-api/expected.json
+++ b/tests/fixtures/fastify-api/expected.json
@@ -1,0 +1,11 @@
+{
+  "endpoints": [
+    { "method": "GET",  "path": "/users" },
+    { "method": "GET",  "path": "/users/:id" },
+    { "method": "POST", "path": "/orders" },
+    { "method": "GET",  "path": "/api/v1/status" }
+  ],
+  "calls": [
+    { "method": "GET", "host_contains": "comment-service", "path_contains": "/api/comments" }
+  ]
+}

--- a/tests/fixtures/hapi-api/expected.json
+++ b/tests/fixtures/hapi-api/expected.json
@@ -1,0 +1,11 @@
+{
+  "endpoints": [
+    { "method": "GET",  "path": "/users" },
+    { "method": "GET",  "path": "/users/{id}" },
+    { "method": "POST", "path": "/orders" },
+    { "method": "GET",  "path": "/api/v1/status" }
+  ],
+  "calls": [
+    { "method": "GET", "host_contains": "comment-service", "path_contains": "/api/comments" }
+  ]
+}

--- a/tests/fixtures/koa-api/expected.json
+++ b/tests/fixtures/koa-api/expected.json
@@ -1,0 +1,11 @@
+{
+  "endpoints": [
+    { "method": "GET",  "path": "/users" },
+    { "method": "GET",  "path": "/users/:id" },
+    { "method": "POST", "path": "/orders" },
+    { "method": "GET",  "path": "/api/v1/status" }
+  ],
+  "calls": [
+    { "method": "GET", "host_contains": "comment-service", "path_contains": "/api/comments" }
+  ]
+}

--- a/tests/fixtures/nestjs-api/expected.json
+++ b/tests/fixtures/nestjs-api/expected.json
@@ -1,0 +1,8 @@
+{
+  "endpoints": [
+    { "method": "GET",  "path": "/users" },
+    { "method": "GET",  "path": "/users/:id" },
+    { "method": "POST", "path": "/users" }
+  ],
+  "calls": []
+}


### PR DESCRIPTION
## Summary
Slice 1 of the evals/benchmarking plan: the first versioned, repeatable extraction-quality number (endpoint & call precision/recall/F1) for the framework fixtures.

- **`CARRICK_OUTPUT_JSON`** — env-gated output mode emitting a dedicated `EvalProjection` (`src/eval_output.rs`) of endpoints/calls keyed by `OperationKey::canonical()`. Terminal: skips the markdown report + upload/PR-comment side effects. Default behaviour unchanged.
- **Ground truth** — `expected.json` for the koa/fastify/hapi/nestjs fixtures.
- **Scorer** — `tests/eval_tier_a.rs`: runs the scanner per fixture, normalises path params (`:id`/`{id}`/`[id]`), scores endpoint (set) + call (fuzzy host/path) P/R/F1, prints a report. Report-only: asserts only a non-flaky floor (valid JSON + endpoint recall > 0).
- **Workflow** — `.github/workflows/eval-tier-a.yml`: `workflow_dispatch`, `id-token: write`. Authenticates via GitHub Actions OIDC.

## Rationale
Extraction is non-deterministic, so "did this change help?" can't be eyeballed. This is the smallest slice that yields a graded number; later slices add N-run variance/`pass^k`, a longitudinal store + `prompt_hash` attribution, and a deterministic cassette gate.

## Auth note
The scanner authenticates **only** via OIDC (`grep CARRICK_API_KEY src/` is empty); the older fixture-harness handoff's `CARRICK_API_KEY` invocation is stale. The eval runs in CI via OIDC and is independent of any personal Carrick account.

## How to run
`workflow_dispatch` becomes available once this lands on the default branch; then Actions -> `eval-tier-a` (or `gh workflow run eval-tier-a.yml`). Resolves via the carrick repo's App installation -> workspace.

## Tests run
- `cargo build --release` — ok
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --release --test eval_tier_a` — passes (skips without OIDC)
- mock JSON smoke (`CARRICK_OUTPUT_JSON=1 CARRICK_MOCK_ALL=1`) — valid EvalProjection (4 endpoints + 1 call)
- regression: `output_contract_test` + `framework_coverage_test` — pass
- pre-commit hook (full Rust + ts_check suites) — pass

No linked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)