### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",


### PR DESCRIPTION
## Summary
Bumps the transitive dependency **quinn-proto 0.11.14 → 0.11.15** (via reqwest's HTTP/3 support) to clear **RUSTSEC-2026-0185** — remote memory exhaustion from unbounded out-of-order stream reassembly. Lockfile-only patch bump.

## Why now
The advisory was published after the last `main` Security Audit run, so it began failing `Security Audit` on every PR (e.g. #190) even though those PRs don't touch dependencies. This unblocks all future PRs.

## Tests run
- pre-commit hook (full Rust + ts_check suites) — pass

No linked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)