### PR TITLE
perf(file-analyzer): front-load stable guidance for implicit prompt caching

### DIFF
--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -1334,17 +1334,20 @@ const data = await fetch('/api/users').then(resp => resp.json());
         // request prefix can extend across them. A regression here silently
         // strands triage hints / parsing notes after per-file content, killing
         // the within-scan prefix cache. See the format! comment.
+        // Key off the structural `### ` headers, not bare phrases: a phrase like
+        // "IMPORT TABLE" can occur inside guidance text or file source, which would
+        // make `find` match the wrong offset as the guidance evolves.
         let pos = |needle: &str| {
             message
                 .find(needle)
                 .unwrap_or_else(|| panic!("section `{needle}` missing from message:\n{message}"))
         };
-        let last_stable = pos("FRAMEWORK-SPECIFIC PARSING NOTES");
+        let last_stable = pos("### FRAMEWORK-SPECIFIC PARSING NOTES");
         for per_file in [
-            "CANDIDATE TARGETS",
-            "CANDIDATE CONTEXT",
-            "IMPORT TABLE",
-            "FILE CONTENT",
+            "### CANDIDATE TARGETS",
+            "### CANDIDATE CONTEXT",
+            "### IMPORT TABLE",
+            "### FILE CONTENT",
         ] {
             assert!(
                 last_stable < pos(per_file),

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -610,6 +610,13 @@ impl FileAnalyzerAgent {
   ]
 }}
 
+### FRAMEWORK-SPECIFIC HINTS
+{}
+
+### FRAMEWORK-SPECIFIC PARSING NOTES
+These notes are generated per-scan by the framework guidance layer and describe how to correctly extract endpoints, mounts, owners, and prefixes for the exact framework(s) detected in this repo. Read them carefully — they override any generic rule in the system prompt when they conflict.
+{}
+
 ### CANDIDATE TARGETS (AST-Detected Hints)
 {}
 
@@ -617,13 +624,6 @@ impl FileAnalyzerAgent {
 {}  // Use these JSON blobs to decide method/path/consumer vs non-consumer. If missing path/method, set them to null.
 
 ### IMPORT TABLE (Do not hallucinate sources)
-{}
-
-### FRAMEWORK-SPECIFIC HINTS
-{}
-
-### FRAMEWORK-SPECIFIC PARSING NOTES
-These notes are generated per-scan by the framework guidance layer and describe how to correctly extract endpoints, mounts, owners, and prefixes for the exact framework(s) detected in this repo. Read them carefully — they override any generic rule in the system prompt when they conflict.
 {}
 
 ### FILE CONTENT (Path: {})
@@ -658,14 +658,22 @@ primary_type_symbol, type_import_source
   - For payload_expression_line: read the line number from the prefix
 
 Return ONLY the JSON object, no explanations."#,
+            // Section order is load-bearing for Vertex implicit prompt caching.
+            // The guidance blocks (patterns + triage hints + parsing notes) are
+            // byte-identical across every file in a scan (one FrameworkGuidance is
+            // fetched once and reused), so keeping them as a contiguous front block
+            // — before any per-file content (candidates, imports, source) — lets the
+            // cacheable request prefix extend past the systemInstruction to cover
+            // them too. Per-file content stays last so it never breaks the prefix.
+            // Do not interleave stable and per-file sections.
             mount_patterns,
             endpoint_patterns,
             data_patterns,
+            guidance.triage_hints,
+            guidance.parsing_notes,
             candidates_section,
             candidate_contexts_section,
             imports_section,
-            guidance.triage_hints,
-            guidance.parsing_notes,
             file_path,
             numbered_content
         )
@@ -1320,6 +1328,29 @@ const data = await fetch('/api/users').then(resp => resp.json());
         assert!(message.contains("Line 3"));
         assert!(message.contains("CANDIDATE CONTEXT"));
         assert!(message.contains("/api/users"));
+
+        // Cache-prefix invariant (Vertex implicit caching): the per-scan-stable
+        // guidance blocks must precede every per-file block, so the cacheable
+        // request prefix can extend across them. A regression here silently
+        // strands triage hints / parsing notes after per-file content, killing
+        // the within-scan prefix cache. See the format! comment.
+        let pos = |needle: &str| {
+            message
+                .find(needle)
+                .unwrap_or_else(|| panic!("section `{needle}` missing from message:\n{message}"))
+        };
+        let last_stable = pos("FRAMEWORK-SPECIFIC PARSING NOTES");
+        for per_file in [
+            "CANDIDATE TARGETS",
+            "CANDIDATE CONTEXT",
+            "IMPORT TABLE",
+            "FILE CONTENT",
+        ] {
+            assert!(
+                last_stable < pos(per_file),
+                "stable guidance must precede per-file `{per_file}` for prefix caching"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Moves the per-scan-stable guidance blocks (`FRAMEWORK-SPECIFIC HINTS` + `PARSING NOTES`) up to sit directly after `ACTIVE PATTERNS` in the file-analyzer `user_message`, ahead of every per-file block (`CANDIDATE TARGETS` / `CANDIDATE CONTEXT` / `IMPORT TABLE` / `FILE CONTENT`). Only the two guidance blocks move; per-file blocks keep their relative order.

## Why

One `FrameworkGuidance` is fetched once per scan (`file_orchestrator.rs:159`) and reused for every file, so those blocks are byte-identical across every file-analyzer call in a scan. Keeping them contiguous at the front lets Vertex's implicit prompt cache extend the cacheable request prefix past the already-cached ~20KB `systemInstruction` to cover the guidance too. This is the documented rule: "put large, common content at the beginning of the prompt." Previously the guidance was stranded after the per-file content, so the cacheable prefix died early and the guidance re-sent uncached on every file.

This is lever 1 of the Gemini-caching work (evals handoff section C, the prereq for an affordable Tier B). Implicit-only, input-token side. Explicit `CachedContent` is the separate follow-up in carrick-cloud#158.

## Validation

Tier-A eval, N=5, run `28048900484` on this branch:

| fixture | endpoints F1 | endpoints pass^5 | calls F1 | calls pass^5 |
|---|---|---|---|---|
| koa-api | 1.00 +/- 0.00 | 1.00 | 1.00 +/- 0.00 | 1.00 |
| fastify-api | 1.00 +/- 0.00 | 1.00 | 1.00 +/- 0.00 | 1.00 |
| hapi-api | 1.00 +/- 0.00 | 1.00 | 1.00 +/- 0.00 | 1.00 |
| nestjs-api | 1.00 +/- 0.00 | 1.00 | 1.00 +/- 0.00 | 1.00 |

Every delta vs baseline is +0.00 ("no metric regressed beyond the noise band"). The reorder changes what the model reads and in what order, so this gate confirms determinism held.

Tier-A cannot measure the cache win (single-file fixtures have no repeated guidance prefix within a scan), so its role here is a determinism-regression guard only. The savings surface on the first multi-file scan via the #141 `cached_tokens` logging. Recorded before-baseline from CloudWatch: real multi-file scans on 0.1.37 already serve ~5% of prompt tokens from the implicit cache (systemInstruction only); this PR should push that higher because each hit now also discounts the guidance.

Adds an ordering-invariant unit test so a future section reshuffle cannot silently strand the guidance after per-file content and kill the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)