### PR TITLE
feat(eval): surface cross_repo_matches + type manifest + deps in EvalProjection (S1)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1749,6 +1749,7 @@ impl FileOrchestrator {
                     client: data_call.pattern_matched.clone(),
                     file_location: format!("{}:{}", file_path, data_call.line_number),
                     call_kind: data_call.call_kind,
+                    repo_name: None,
                 });
             }
         }

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -33,12 +33,14 @@ static ARRAY_GENERIC_RE: LazyLock<regex::Regex> =
 // Type aliases to reduce complexity
 type RouteFieldMap = HashMap<OperationKey, Json>;
 /// Result of `analyze_matches_with_mount_graph`:
-///   `(call_issues, endpoint_issues, env_var_calls, verified_endpoints)`.
+///   `(call_issues, endpoint_issues, env_var_calls, verified_endpoints,
+///     cross_repo_matches)`.
 type MountGraphMatches = (
     Vec<String>,
     Vec<OrphanedEndpoint>,
     Vec<String>,
     Vec<(String, String)>,
+    Vec<CrossRepoMatch>,
 );
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -71,6 +73,33 @@ pub struct OrphanedEndpoint {
     pub method: String,
     pub path: String,
     pub service: Option<String>,
+}
+
+/// A structured producer→consumer edge captured at the matching site. This is
+/// the load-bearing cross-repo signal the eval scorer reads (contract §2): an
+/// endpoint in one repo matched by an outbound call in another (or the same)
+/// repo, with the type-compatibility verdict for that producer endpoint.
+///
+/// `type_compatible == None` is deliberate and load-bearing: it means compat
+/// was never evaluated for this edge (e.g. `ts_check_dir` was absent, so type
+/// checking did not run), as distinct from `Some(true)` "evaluated, compatible".
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct CrossRepoMatch {
+    /// Repo id of the producer endpoint (service_name ?? repo_name).
+    pub producer_repo: String,
+    /// `OperationKey::canonical()` of the producer endpoint (mount-resolved path).
+    pub producer_key: String,
+    /// Repo id of the consumer call.
+    pub consumer_repo: String,
+    /// `OperationKey::canonical()` of the consumer call (URL-normalized path).
+    pub consumer_key: String,
+    /// Matcher confidence in `[0, 1]`. `1.0` for an exact normalized-key match
+    /// (the only kind captured today; there is no finer score yet).
+    pub match_score: f64,
+    /// `None` = compat NOT evaluated for this edge; `Some(b)` = evaluated.
+    pub type_compatible: Option<bool>,
+    /// `Some(..)` iff `type_compatible == Some(false)`; human-readable reason.
+    pub mismatch_reason: Option<String>,
 }
 
 pub struct ApiIssues {
@@ -131,6 +160,10 @@ pub struct ApiAnalysisResult {
     /// Whether any GraphQL operations (schema fields or documents) made it
     /// into the index. Gates the "no GraphQL extracted" banner.
     pub graphql_operations_indexed: bool,
+    /// Structured producer→consumer edges captured at the matching site, with
+    /// per-edge type-compat verdicts. Populated by `get_results`; consumed by
+    /// the eval projection (it has no effect on the human Markdown report).
+    pub cross_repo_matches: Vec<CrossRepoMatch>,
 }
 
 /// Return the subset of `data_fetchers` that are GraphQL libraries.
@@ -154,6 +187,35 @@ pub fn filter_graphql_libraries(data_fetchers: &[String]) -> Vec<String> {
         })
         .cloned()
         .collect()
+}
+
+/// Parse a ts_check compat `endpoint` string back into `(METHOD, path)`. The
+/// string is built as `"<METHOD> <path> (<request|response>)"` by ts_check's
+/// type-checker, so split off the leading method and the trailing
+/// `" (type_kind)"` suffix. Returns `None` for an unrecognized shape.
+fn parse_compat_endpoint(endpoint: &str) -> Option<(String, String)> {
+    let (method, rest) = endpoint.split_once(' ')?;
+    // Drop the trailing " (request)" / " (response)" annotation if present.
+    let path = match rest.rfind(" (") {
+        Some(idx) if rest.ends_with(')') => &rest[..idx],
+        _ => rest,
+    };
+    if method.is_empty() || path.is_empty() {
+        return None;
+    }
+    Some((method.to_uppercase(), path.to_string()))
+}
+
+/// Recover `(METHOD, path)` from a canonical HTTP producer key
+/// (`"http|METHOD|path"`). Returns `None` for non-HTTP keys.
+fn parse_producer_key(key: &str) -> Option<(String, String)> {
+    let mut parts = key.splitn(3, '|');
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some("http"), Some(method), Some(path)) if !method.is_empty() && !path.is_empty() => {
+            Some((method.to_uppercase(), path.to_string()))
+        }
+        _ => None,
+    }
 }
 
 /// Accept only values whose *shape* is an extractable outgoing-call route, as
@@ -959,14 +1021,39 @@ impl Analyzer {
     }
 
     /// Framework-agnostic analysis using mount graph.
-    /// Returns `(call_issues, endpoint_issues, env_var_calls, verified_endpoints)`
-    /// — the fourth element captures (method, path) of every endpoint that
-    /// at least one consumer call successfully matched, so the formatter can
-    /// surface them as positive signal in the PR comment.
+    /// Returns `(call_issues, endpoint_issues, env_var_calls, verified_endpoints,
+    /// cross_repo_matches)` — the fourth element captures (method, path) of every
+    /// endpoint that at least one consumer call successfully matched (positive
+    /// signal for the PR comment), and the fifth captures the structured
+    /// producer→consumer edges (consumed only by the eval projection).
     fn analyze_matches_with_mount_graph(&self, mount_graph: &MountGraph) -> MountGraphMatches {
         let mut call_issues = Vec::new();
         let mut endpoint_issues = Vec::new();
         let mut env_var_calls = Vec::new();
+        // Structured producer→consumer edges for the eval projection.
+        let mut cross_repo_matches: Vec<CrossRepoMatch> = Vec::new();
+
+        // Consumer repo lookup: a call's `(METHOD, target_url, file_location)`
+        // → owning repo. `merge_from_repos` tags each merged data call with its
+        // repo; `self.calls` carry only `(key, file_path)`, so this re-attaches
+        // the repo identity at the matching site. Keyed on the full triple
+        // because two calls in one file can share a target.
+        let consumer_repo_by_call: HashMap<(String, String, String), String> = mount_graph
+            .get_data_calls()
+            .iter()
+            .filter_map(|c| {
+                c.repo_name.as_ref().map(|repo| {
+                    (
+                        (
+                            c.method.to_uppercase(),
+                            c.target_url.clone(),
+                            c.file_location.clone(),
+                        ),
+                        repo.clone(),
+                    )
+                })
+            })
+            .collect();
 
         // Track which endpoints have been matched
         let mut matched_endpoints: HashSet<String> = HashSet::new();
@@ -1035,6 +1122,16 @@ impl Analyzer {
                                 for endpoint in matching_endpoints {
                                     let key = format!("{}:{}", endpoint.method, endpoint.full_path);
                                     matched_endpoints.insert(key);
+                                    if let Some(edge) = Self::build_cross_repo_match(
+                                        call,
+                                        method,
+                                        target,
+                                        &normalized_path,
+                                        endpoint,
+                                        &consumer_repo_by_call,
+                                    ) {
+                                        cross_repo_matches.push(edge);
+                                    }
                                 }
                             }
                         }
@@ -1075,9 +1172,20 @@ impl Analyzer {
                         ));
                     } else {
                         // Mark endpoints as matched
+                        let normalized_path = normalizer.normalize(target).path;
                         for endpoint in matching_endpoints {
                             let key = format!("{}:{}", endpoint.method, endpoint.full_path);
                             matched_endpoints.insert(key);
+                            if let Some(edge) = Self::build_cross_repo_match(
+                                call,
+                                method,
+                                target,
+                                &normalized_path,
+                                endpoint,
+                                &consumer_repo_by_call,
+                            ) {
+                                cross_repo_matches.push(edge);
+                            }
                         }
                     }
                 }
@@ -1107,7 +1215,79 @@ impl Analyzer {
         verified.sort();
         verified.dedup();
 
-        (call_issues, endpoint_issues, env_var_calls, verified)
+        // Deterministic order for the projection (mirrors verified.sort()): the
+        // matcher iterates calls/endpoints in a non-deterministic order, so sort
+        // and dedup the captured edges on their identity tuple.
+        cross_repo_matches.sort_by(|a, b| {
+            (
+                &a.producer_repo,
+                &a.producer_key,
+                &a.consumer_repo,
+                &a.consumer_key,
+            )
+                .cmp(&(
+                    &b.producer_repo,
+                    &b.producer_key,
+                    &b.consumer_repo,
+                    &b.consumer_key,
+                ))
+        });
+        cross_repo_matches.dedup_by(|a, b| {
+            a.producer_repo == b.producer_repo
+                && a.producer_key == b.producer_key
+                && a.consumer_repo == b.consumer_repo
+                && a.consumer_key == b.consumer_key
+        });
+
+        (
+            call_issues,
+            endpoint_issues,
+            env_var_calls,
+            verified,
+            cross_repo_matches,
+        )
+    }
+
+    /// Build a [`CrossRepoMatch`] from a matched consumer call + producer
+    /// endpoint. Returns `None` only when the consumer's repo cannot be
+    /// attributed (no `repo_name` tag in the merged graph for this call) — an
+    /// edge without both repo ids is not useful to the scorer.
+    ///
+    /// `match_score` is `1.0`: every edge captured here is an exact
+    /// normalized-key match (there is no finer scorer yet). `type_compatible`
+    /// is left `None` here; `get_results` overlays the per-endpoint compat
+    /// verdict after type checking has (or has not) run.
+    fn build_cross_repo_match(
+        call: &ApiEndpointDetails,
+        method: &str,
+        target: &str,
+        normalized_consumer_path: &str,
+        endpoint: &crate::mount_graph::ResolvedEndpoint,
+        consumer_repo_by_call: &HashMap<(String, String, String), String>,
+    ) -> Option<CrossRepoMatch> {
+        let producer_repo = endpoint
+            .service_name
+            .clone()
+            .or_else(|| endpoint.repo_name.clone())?;
+        let lookup_key = (
+            method.to_uppercase(),
+            target.to_string(),
+            call.file_path.display().to_string(),
+        );
+        let consumer_repo = consumer_repo_by_call.get(&lookup_key).cloned()?;
+
+        let producer_key = OperationKey::http(&endpoint.method, endpoint.full_path.clone());
+        let consumer_key = OperationKey::http(method, normalized_consumer_path.to_string());
+
+        Some(CrossRepoMatch {
+            producer_repo,
+            producer_key: producer_key.canonical(),
+            consumer_repo,
+            consumer_key: consumer_key.canonical(),
+            match_score: 1.0,
+            type_compatible: None,
+            mismatch_reason: None,
+        })
     }
 
     /// Match consumers against producers of a protocol whose operations have
@@ -1374,8 +1554,13 @@ impl Analyzer {
         let mount_graph = self.mount_graph.as_ref()
             .expect("Mount graph must be set before calling get_results(). This is a framework-agnostic requirement.");
 
-        let (mut call_issues, mut endpoint_issues, env_var_calls, mut verified_endpoints) =
-            self.analyze_matches_with_mount_graph(mount_graph);
+        let (
+            mut call_issues,
+            mut endpoint_issues,
+            env_var_calls,
+            mut verified_endpoints,
+            mut cross_repo_matches,
+        ) = self.analyze_matches_with_mount_graph(mount_graph);
         for (protocol, label) in [
             (crate::operation::Protocol::Graphql, "GraphQL"),
             (crate::operation::Protocol::Websocket, "Socket.IO"),
@@ -1392,6 +1577,17 @@ impl Analyzer {
         let mismatches = Vec::new();
         let type_mismatches = self.get_type_mismatches();
         let dependency_conflicts = self.analyze_dependencies();
+
+        // Overlay the per-producer-endpoint type-compat verdict onto the captured
+        // edges. The verdict is keyed by the producer's (METHOD, full_path) — the
+        // ts_check output collapses all consumers of a producer into one verdict,
+        // so every edge into a given producer shares that producer's verdict.
+        //
+        // `type_compatible` stays `None` when compat was not evaluated
+        // (`check_type_compatibility` returns `Err`: ts_check_dir absent, results
+        // file missing, or type checking failed). This `None` is load-bearing:
+        // the scorer must never read absent compat data as "compatible".
+        self.overlay_compat_verdicts(&mut cross_repo_matches);
 
         let detected_graphql_libraries = filter_graphql_libraries(&self.detected_data_fetchers);
         let graphql_operations_indexed = self
@@ -1436,6 +1632,64 @@ impl Analyzer {
             verified_endpoints,
             detected_graphql_libraries,
             graphql_operations_indexed,
+            cross_repo_matches,
+        }
+    }
+
+    /// Overlay the type-compatibility verdict onto each captured cross-repo
+    /// edge, keyed by the producer's `(METHOD, full_path)`.
+    ///
+    /// If `check_type_compatibility` returns `Err`, type checking did not run
+    /// (or failed) for this scan: every edge keeps `type_compatible: None`
+    /// (load-bearing — see [`CrossRepoMatch`]). On `Ok`, an edge whose producer
+    /// appears in the mismatch set gets `Some(false)` + the reason; otherwise
+    /// `Some(true)` (compat evaluated, no mismatch for that producer).
+    fn overlay_compat_verdicts(&self, matches: &mut [CrossRepoMatch]) {
+        let result = match self.check_type_compatibility() {
+            Ok(result) => result,
+            // Compat was not evaluated for this run — leave every edge `None`.
+            Err(_) => return,
+        };
+
+        // Map producer `(METHOD, path)` → mismatch reason, parsed from each
+        // mismatch's `endpoint` string (`"<METHOD> <path> (<request|response>)"`,
+        // built by ts_check's type-checker). Multiple type_kinds per producer
+        // collapse to the first reason seen — the edge only records that the
+        // producer is incompatible.
+        let mut incompatible: HashMap<(String, String), String> = HashMap::new();
+        if let Some(mismatch_list) = result.get("mismatches").and_then(|m| m.as_array()) {
+            for mismatch in mismatch_list {
+                let Some(endpoint) = mismatch.get("endpoint").and_then(|e| e.as_str()) else {
+                    continue;
+                };
+                let Some((method, path)) = parse_compat_endpoint(endpoint) else {
+                    continue;
+                };
+                let reason = mismatch
+                    .get("error")
+                    .and_then(|e| e.as_str())
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("producer and consumer types are incompatible")
+                    .to_string();
+                incompatible.entry((method, path)).or_insert(reason);
+            }
+        }
+
+        for edge in matches.iter_mut() {
+            // producer_key is `http|METHOD|path`; recover (METHOD, path).
+            let Some((method, path)) = parse_producer_key(&edge.producer_key) else {
+                edge.type_compatible = Some(true);
+                continue;
+            };
+            match incompatible.get(&(method, path)) {
+                Some(reason) => {
+                    edge.type_compatible = Some(false);
+                    edge.mismatch_reason = Some(reason.clone());
+                }
+                None => {
+                    edge.type_compatible = Some(true);
+                }
+            }
         }
     }
 
@@ -2150,7 +2404,7 @@ mod tests {
         ));
 
         let mount_graph = MountGraph::new();
-        let (call_issues, endpoint_issues, env_var_calls, verified) =
+        let (call_issues, endpoint_issues, env_var_calls, verified, _cross_repo_matches) =
             analyzer.analyze_matches_with_mount_graph(&mount_graph);
         assert!(call_issues.is_empty());
         assert!(endpoint_issues.is_empty());
@@ -2227,7 +2481,7 @@ mod tests {
         let mount_graph = MountGraph::new(); // Empty graph
 
         // Run analysis
-        let (call_issues, _, env_var_calls, _verified) =
+        let (call_issues, _, env_var_calls, _verified, _cross_repo_matches) =
             analyzer.analyze_matches_with_mount_graph(&mount_graph);
 
         // Check results

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -374,6 +374,23 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         None
     };
 
+    // Collect the merged type manifest before `all_repo_data` /
+    // `current_services_data` are moved into the analyzer. The eval projection
+    // joins these to each op (keyed by OperationKey) for the type-resolution
+    // metrics; nothing else reads it. Cheap clone, only materialised for the
+    // eval path (it's just a flatten of each repo's already-built manifest).
+    let eval_type_manifest: Vec<TypeManifestEntry> = if std::env::var("CARRICK_OUTPUT_JSON").is_ok()
+    {
+        all_repo_data
+            .iter()
+            .chain(current_services_data.iter())
+            .filter_map(|repo| repo.type_manifest.as_ref())
+            .flat_map(|entries| entries.iter().cloned())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     let sp = logging::spinner("Running cross-repo analysis...");
     let analyzer =
         build_cross_repo_analyzer(all_repo_data, current_services_data, ts_check_dir).await?;
@@ -386,7 +403,8 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     // by the offline scorer (Slice 1 of the evals plan). Deliberately terminal —
     // an eval run wants only the JSON, no upload or comment side effects.
     if std::env::var("CARRICK_OUTPUT_JSON").is_ok() {
-        let projection = crate::eval_output::EvalProjection::from_results(&results);
+        let projection =
+            crate::eval_output::EvalProjection::from_results(&results, &eval_type_manifest);
         println!("{}", serde_json::to_string_pretty(&projection)?);
         return Ok(());
     }
@@ -2466,6 +2484,7 @@ mod tests {
                 client: "fetch".to_string(),
                 file_location: "src/orders.ts:42".to_string(),
                 call_kind: None,
+                repo_name: None,
             },
             crate::mount_graph::DataFetchingCall {
                 method: "GET".to_string(),
@@ -2473,6 +2492,7 @@ mod tests {
                 client: "fetch".to_string(),
                 file_location: "src/notify.ts:7".to_string(),
                 call_kind: None,
+                repo_name: None,
             },
         ];
 

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -4,20 +4,33 @@
 //! instead of the human-readable Markdown report. This is a *dedicated* shape,
 //! deliberately decoupled from the internal analyzer types, so the eval scoring
 //! contract stays stable across refactors of `ApiEndpointDetails` and friends.
-//! Slice 1 of the evals plan scores endpoint/call set accuracy from this.
+//! The cross-repo eval (slice S1) scores endpoint/call set accuracy, cross-repo
+//! producer→consumer matches, per-op type resolution, and dependency conflicts
+//! from this projection.
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::Path;
 
-use crate::analyzer::{ApiAnalysisResult, ApiEndpointDetails};
+use crate::analyzer::{
+    ApiAnalysisResult, ApiEndpointDetails, ConflictSeverity,
+    CrossRepoMatch as AnalyzerCrossRepoMatch, DependencyConflict,
+};
+use crate::cloud_storage::TypeManifestEntry;
 use crate::operation::OperationKey;
 
-/// The full eval projection of a single scan: the producer endpoints and the
-/// consumer calls the scanner extracted.
+/// The full eval projection of a single scan: the producer endpoints, the
+/// consumer calls, the cross-repo edges between them, and the dependency
+/// conflicts the scanner extracted.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EvalProjection {
     pub endpoints: Vec<EvalOp>,
     pub calls: Vec<EvalOp>,
+    /// Structured producer→consumer edges (contract §2). The scorer keys
+    /// cross-repo match P/R/F1 and the compat-verdict metric off these.
+    pub cross_repo_matches: Vec<CrossRepoMatch>,
+    /// Dependency version conflicts across the scanned repos (contract §4).
+    pub dependency_conflicts: Vec<EvalDependencyConflict>,
 }
 
 /// One extracted operation (endpoint or call), flattened for scoring.
@@ -36,23 +49,180 @@ pub struct EvalOp {
     pub response_type: Option<String>,
     pub file: String,
     pub line: u32,
+    // --- Type-manifest fields (contract §3), joined by OperationKey ---
+    /// The type alias used in the bundled `.d.ts` file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_alias: Option<String>,
+    /// `ManifestTypeState` in String form: `"Explicit"` / `"Implicit"` / `"Unknown"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_state: Option<String>,
+    /// Original declaration text as written (sidecar `resolved_definition`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_definition: Option<String>,
+    /// Compiler-expanded form with all types inlined (sidecar `expanded_definition`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expanded_definition: Option<String>,
+    /// Whether the type was explicitly annotated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_explicit: Option<bool>,
+    /// The LLM-emitted type anchor (contract §3, §5 row 5).
+    ///
+    /// The raw anchor (`primary_type_symbol` on the file-analyzer result) is not
+    /// keyed by `OperationKey` at projection time — it lives in the per-file LLM
+    /// results, not the type manifest. Per contract §3 ("if the join makes this
+    /// expensive, S1 may fall back to scoring the anchor metric against
+    /// `type_alias` and note the substitution"), this is populated from the
+    /// manifest `type_alias`. The scorer treats it as the anchor surrogate until
+    /// the raw anchor is threaded into the manifest (follow-up).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_type_symbol: Option<String>,
+}
+
+/// A structured producer→consumer edge (contract §2 FROZEN field set).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CrossRepoMatch {
+    pub producer_repo: String,
+    pub producer_key: String,
+    pub consumer_repo: String,
+    pub consumer_key: String,
+    pub match_score: f64,
+    /// `None` = compat NOT evaluated for this edge; `Some(b)` = evaluated.
+    /// Omitted from JSON when `None` so the scorer never reads absent compat
+    /// data as a verdict (the `ts_check_dir` trap, contract §7).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_compatible: Option<bool>,
+    /// `Some(..)` iff `type_compatible == Some(false)`; omitted otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mismatch_reason: Option<String>,
+}
+
+/// A dependency version conflict (contract §4). `versions` is sorted ascending
+/// for stable comparison against the answer key.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EvalDependencyConflict {
+    pub package: String,
+    pub versions: Vec<String>,
+    pub severity: String,
 }
 
 impl EvalProjection {
-    pub fn from_results(result: &ApiAnalysisResult) -> Self {
+    /// Build the projection from analyzer results plus the merged type manifest.
+    /// The manifest is joined per op by `OperationKey`; deps come straight from
+    /// `issues.dependency_conflicts`; matches from `result.cross_repo_matches`.
+    pub fn from_results(result: &ApiAnalysisResult, type_manifest: &[TypeManifestEntry]) -> Self {
+        let manifest_index = ManifestIndex::build(type_manifest);
+        // Canonical ordering so the projection is deterministic across runs:
+        // the matcher's edge order and analyze_dependencies' conflict order are
+        // both unstable, which would otherwise flake the cassette hard gate.
+        let mut cross_repo_matches: Vec<CrossRepoMatch> = result
+            .cross_repo_matches
+            .iter()
+            .map(CrossRepoMatch::from_analyzer)
+            .collect();
+        cross_repo_matches.sort_by(|a, b| {
+            (
+                &a.producer_repo,
+                &a.producer_key,
+                &a.consumer_repo,
+                &a.consumer_key,
+            )
+                .cmp(&(
+                    &b.producer_repo,
+                    &b.producer_key,
+                    &b.consumer_repo,
+                    &b.consumer_key,
+                ))
+        });
+        let mut dependency_conflicts: Vec<EvalDependencyConflict> = result
+            .issues
+            .dependency_conflicts
+            .iter()
+            .map(EvalDependencyConflict::from_conflict)
+            .collect();
+        dependency_conflicts.sort_by(|a, b| a.package.cmp(&b.package));
         Self {
-            endpoints: result.endpoints.iter().map(EvalOp::from_details).collect(),
-            calls: result.calls.iter().map(EvalOp::from_details).collect(),
+            endpoints: result
+                .endpoints
+                .iter()
+                .map(|d| EvalOp::from_details(d, &manifest_index))
+                .collect(),
+            calls: result
+                .calls
+                .iter()
+                .map(|d| EvalOp::from_details(d, &manifest_index))
+                .collect(),
+            cross_repo_matches,
+            dependency_conflicts,
         }
     }
 }
 
+/// The manifest fields an op carries, collapsed from the request/response
+/// manifest entries for a single operation key.
+#[derive(Default)]
+struct ManifestFields {
+    type_alias: Option<String>,
+    type_state: Option<String>,
+    resolved_definition: Option<String>,
+    expanded_definition: Option<String>,
+    is_explicit: Option<bool>,
+}
+
+/// Lookup from canonical operation key → manifest fields. The manifest carries
+/// up to two entries per op (request + response); we prefer the entry that has
+/// resolved-type detail so the projection surfaces the richest available type.
+struct ManifestIndex {
+    by_key: HashMap<String, ManifestFields>,
+}
+
+impl ManifestIndex {
+    fn build(entries: &[TypeManifestEntry]) -> Self {
+        let mut by_key: HashMap<String, ManifestFields> = HashMap::new();
+        for entry in entries {
+            let key = entry.key.canonical();
+            let slot = by_key.entry(key).or_default();
+            // Prefer an entry that resolved a concrete definition; otherwise
+            // keep the first-seen alias/state so the field is at least present.
+            let entry_has_definition =
+                entry.resolved_definition.is_some() || entry.expanded_definition.is_some();
+            let slot_has_definition =
+                slot.resolved_definition.is_some() || slot.expanded_definition.is_some();
+            if slot.type_alias.is_none() || (entry_has_definition && !slot_has_definition) {
+                slot.type_alias = Some(entry.type_alias.clone());
+                slot.type_state = Some(manifest_type_state_string(entry.type_state));
+                slot.resolved_definition = entry.resolved_definition.clone();
+                slot.expanded_definition = entry.expanded_definition.clone();
+                slot.is_explicit = Some(entry.is_explicit);
+            }
+        }
+        Self { by_key }
+    }
+
+    fn get(&self, key: &str) -> Option<&ManifestFields> {
+        self.by_key.get(key)
+    }
+}
+
+/// `ManifestTypeState` → its String form, matching the manifest's serde naming
+/// (`"Explicit"` / `"Implicit"` / `"Unknown"`).
+fn manifest_type_state_string(state: crate::cloud_storage::ManifestTypeState) -> String {
+    use crate::cloud_storage::ManifestTypeState::*;
+    match state {
+        Explicit => "Explicit",
+        Implicit => "Implicit",
+        Unknown => "Unknown",
+    }
+    .to_string()
+}
+
 impl EvalOp {
-    fn from_details(d: &ApiEndpointDetails) -> Self {
+    fn from_details(d: &ApiEndpointDetails, manifest: &ManifestIndex) -> Self {
         let (protocol, method, path) = project_key(&d.key);
         let (file, line) = split_location(&d.file_path);
+        let canonical = d.key.canonical();
+        let fields = manifest.get(&canonical);
         EvalOp {
-            key: d.key.canonical(),
+            key: canonical,
             protocol,
             method,
             path,
@@ -67,8 +237,54 @@ impl EvalOp {
                 .map(|t| t.composite_type_string.clone()),
             file,
             line,
+            type_alias: fields.and_then(|f| f.type_alias.clone()),
+            type_state: fields.and_then(|f| f.type_state.clone()),
+            resolved_definition: fields.and_then(|f| f.resolved_definition.clone()),
+            expanded_definition: fields.and_then(|f| f.expanded_definition.clone()),
+            is_explicit: fields.and_then(|f| f.is_explicit),
+            // Anchor surrogate: see field doc. Falls back to `type_alias`.
+            primary_type_symbol: fields.and_then(|f| f.type_alias.clone()),
         }
     }
+}
+
+impl CrossRepoMatch {
+    fn from_analyzer(m: &AnalyzerCrossRepoMatch) -> Self {
+        CrossRepoMatch {
+            producer_repo: m.producer_repo.clone(),
+            producer_key: m.producer_key.clone(),
+            consumer_repo: m.consumer_repo.clone(),
+            consumer_key: m.consumer_key.clone(),
+            match_score: m.match_score,
+            type_compatible: m.type_compatible,
+            mismatch_reason: m.mismatch_reason.clone(),
+        }
+    }
+}
+
+impl EvalDependencyConflict {
+    fn from_conflict(c: &DependencyConflict) -> Self {
+        let mut versions: Vec<String> = c.repos.iter().map(|r| r.version.clone()).collect();
+        versions.sort();
+        versions.dedup();
+        EvalDependencyConflict {
+            package: c.package_name.clone(),
+            versions,
+            severity: conflict_severity_string(&c.severity),
+        }
+    }
+}
+
+/// Render `ConflictSeverity` to a stable lowercase string. Mirrors the enum's
+/// variant identity (`critical` / `warning` / `info`) so the eval answer key
+/// compares against a stable token rather than display prose.
+fn conflict_severity_string(severity: &ConflictSeverity) -> String {
+    match severity {
+        ConflictSeverity::Critical => "critical",
+        ConflictSeverity::Warning => "warning",
+        ConflictSeverity::Info => "info",
+    }
+    .to_string()
 }
 
 /// `(protocol, method, path)` projected from the operation key. For non-HTTP
@@ -93,5 +309,246 @@ fn split_location(p: &Path) -> (String, u32) {
             (file.to_string(), line.parse().unwrap_or(0))
         }
         _ => (s.into_owned(), 0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analyzer::{
+        ApiIssues, ConflictSeverity, CrossRepoMatch as AnalyzerCrossRepoMatch, DependencyConflict,
+        RepoPackageInfo,
+    };
+    use crate::cloud_storage::{
+        ManifestRole, ManifestTypeKind, ManifestTypeState, TypeEvidence, TypeManifestEntry,
+    };
+    use crate::services::type_sidecar::InferKind;
+    use serde_json::Value;
+    use std::path::PathBuf;
+
+    fn manifest_entry(
+        key: OperationKey,
+        type_state: ManifestTypeState,
+        is_explicit: bool,
+        resolved: Option<&str>,
+    ) -> TypeManifestEntry {
+        TypeManifestEntry {
+            key,
+            role: ManifestRole::Producer,
+            type_kind: ManifestTypeKind::Response,
+            type_alias: "Endpoint_abc_Response".to_string(),
+            file_path: "src/orders.ts".to_string(),
+            line_number: 12,
+            is_explicit,
+            type_state,
+            evidence: TypeEvidence {
+                file_path: "src/orders.ts".to_string(),
+                span_start: None,
+                span_end: None,
+                line_number: 12,
+                infer_kind: InferKind::ResponseBody,
+                is_explicit,
+                type_state,
+            },
+            resolved_definition: resolved.map(String::from),
+            expanded_definition: None,
+        }
+    }
+
+    fn empty_issues_with_deps(dependency_conflicts: Vec<DependencyConflict>) -> ApiIssues {
+        ApiIssues {
+            call_issues: vec![],
+            endpoint_issues: vec![],
+            env_var_calls: vec![],
+            mismatches: vec![],
+            type_mismatches: vec![],
+            dependency_conflicts,
+        }
+    }
+
+    fn endpoint(method: &str, path: &str, file_line: &str) -> ApiEndpointDetails {
+        ApiEndpointDetails {
+            owner: None,
+            key: OperationKey::http(method, path.to_string()),
+            params: vec![],
+            request_body: None,
+            response_body: None,
+            handler_name: Some("getOrder".to_string()),
+            request_type: None,
+            response_type: None,
+            file_path: PathBuf::from(file_line),
+        }
+    }
+
+    /// Build a projection with a cross-repo match, manifest-joined op fields,
+    /// and a dependency conflict, then assert the serialized JSON shape.
+    #[test]
+    fn projection_serializes_full_cross_repo_shape() {
+        let producer_key = OperationKey::http("GET", "/orders/:param");
+        let endpoints = vec![endpoint("GET", "/orders/:param", "src/orders.ts:12")];
+
+        let matches = vec![
+            // Compat evaluated, compatible.
+            AnalyzerCrossRepoMatch {
+                producer_repo: "orders-monorepo".to_string(),
+                producer_key: producer_key.canonical(),
+                consumer_repo: "payments-svc".to_string(),
+                consumer_key: "http|GET|/orders/:param".to_string(),
+                match_score: 1.0,
+                type_compatible: Some(true),
+                mismatch_reason: None,
+            },
+            // Compat evaluated, incompatible.
+            AnalyzerCrossRepoMatch {
+                producer_repo: "orders-monorepo".to_string(),
+                producer_key: producer_key.canonical(),
+                consumer_repo: "web-frontend".to_string(),
+                consumer_key: "http|GET|/orders/:param".to_string(),
+                match_score: 1.0,
+                type_compatible: Some(false),
+                mismatch_reason: Some("id: number vs string".to_string()),
+            },
+            // Compat NOT evaluated (the load-bearing None).
+            AnalyzerCrossRepoMatch {
+                producer_repo: "orders-monorepo".to_string(),
+                producer_key: "http|POST|/payments".to_string(),
+                consumer_repo: "web-frontend".to_string(),
+                consumer_key: "http|POST|/payments".to_string(),
+                match_score: 1.0,
+                type_compatible: None,
+                mismatch_reason: None,
+            },
+        ];
+
+        let deps = vec![DependencyConflict {
+            package_name: "zod".to_string(),
+            // Deliberately out of order to prove the projection sorts versions.
+            repos: vec![
+                RepoPackageInfo {
+                    repo_name: "web-frontend".to_string(),
+                    version: "3.23.0".to_string(),
+                    source_path: PathBuf::from("web-frontend/package.json"),
+                },
+                RepoPackageInfo {
+                    repo_name: "payments-svc".to_string(),
+                    version: "3.22.0".to_string(),
+                    source_path: PathBuf::from("payments-svc/package.json"),
+                },
+            ],
+            severity: ConflictSeverity::Warning,
+        }];
+
+        let result = ApiAnalysisResult {
+            endpoints,
+            calls: vec![],
+            issues: empty_issues_with_deps(deps),
+            verified_endpoints: vec![],
+            detected_graphql_libraries: vec![],
+            graphql_operations_indexed: false,
+            cross_repo_matches: matches,
+        };
+
+        let manifest = vec![manifest_entry(
+            producer_key,
+            ManifestTypeState::Explicit,
+            true,
+            Some("{ id: number; amountCents: number }"),
+        )];
+
+        let projection = EvalProjection::from_results(&result, &manifest);
+        let json: Value =
+            serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
+
+        // --- top-level keys present, snake_case ---
+        assert!(json.get("cross_repo_matches").is_some());
+        assert!(json.get("dependency_conflicts").is_some());
+
+        // --- cross_repo_matches shape ---
+        let cms = json["cross_repo_matches"].as_array().unwrap();
+        assert_eq!(cms.len(), 3);
+
+        let compatible = &cms[0];
+        assert_eq!(compatible["producer_repo"], "orders-monorepo");
+        assert_eq!(compatible["producer_key"], "http|GET|/orders/:param");
+        assert_eq!(compatible["consumer_repo"], "payments-svc");
+        assert_eq!(compatible["match_score"], 1.0);
+        assert_eq!(compatible["type_compatible"], true);
+        // mismatch_reason omitted when None.
+        assert!(compatible.get("mismatch_reason").is_none());
+
+        let incompatible = &cms[1];
+        assert_eq!(incompatible["type_compatible"], false);
+        assert_eq!(incompatible["mismatch_reason"], "id: number vs string");
+
+        // type_compatible: None must be OMITTED, not serialized as null.
+        let not_evaluated = &cms[2];
+        assert!(
+            not_evaluated.get("type_compatible").is_none(),
+            "type_compatible: None must be omitted from JSON, got {:?}",
+            not_evaluated
+        );
+        assert!(not_evaluated.get("mismatch_reason").is_none());
+
+        // --- manifest-joined op fields ---
+        let op = &json["endpoints"].as_array().unwrap()[0];
+        assert_eq!(op["key"], "http|GET|/orders/:param");
+        assert_eq!(op["type_state"], "Explicit");
+        assert_eq!(op["is_explicit"], true);
+        assert_eq!(
+            op["resolved_definition"],
+            "{ id: number; amountCents: number }"
+        );
+        assert_eq!(op["type_alias"], "Endpoint_abc_Response");
+        // primary_type_symbol falls back to type_alias (documented substitution).
+        assert_eq!(op["primary_type_symbol"], "Endpoint_abc_Response");
+        // expanded_definition was None → omitted.
+        assert!(op.get("expanded_definition").is_none());
+
+        // --- dependency_conflicts shape: versions sorted ascending ---
+        let dc = &json["dependency_conflicts"].as_array().unwrap()[0];
+        assert_eq!(dc["package"], "zod");
+        assert_eq!(
+            dc["versions"].as_array().unwrap(),
+            &vec![Value::from("3.22.0"), Value::from("3.23.0")]
+        );
+        assert_eq!(dc["severity"], "warning");
+    }
+
+    /// An op with no manifest entry must omit every manifest field (omit-if-none).
+    #[test]
+    fn op_without_manifest_omits_type_fields() {
+        let result = ApiAnalysisResult {
+            endpoints: vec![endpoint("GET", "/api/v1/status", "src/status.ts:3")],
+            calls: vec![],
+            issues: empty_issues_with_deps(vec![]),
+            verified_endpoints: vec![],
+            detected_graphql_libraries: vec![],
+            graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
+        };
+
+        let projection = EvalProjection::from_results(&result, &[]);
+        let json: Value =
+            serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
+        let op = &json["endpoints"].as_array().unwrap()[0];
+
+        for field in [
+            "type_alias",
+            "type_state",
+            "resolved_definition",
+            "expanded_definition",
+            "is_explicit",
+            "primary_type_symbol",
+        ] {
+            assert!(
+                op.get(field).is_none(),
+                "{} must be omitted when there is no manifest entry, got {:?}",
+                field,
+                op
+            );
+        }
+        // Empty match/dep arrays still serialize as present empty arrays.
+        assert_eq!(json["cross_repo_matches"].as_array().unwrap().len(), 0);
+        assert_eq!(json["dependency_conflicts"].as_array().unwrap().len(), 0);
     }
 }

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -1075,6 +1075,7 @@ mod tests {
             verified_endpoints: vec![],
             detected_graphql_libraries: vec![],
             graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
         };
 
         let output = format_analysis_results(result, &topology_baseline(), None);
@@ -1108,6 +1109,7 @@ mod tests {
             verified_endpoints: vec![],
             detected_graphql_libraries: vec![],
             graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
         };
 
         let output = format_analysis_results(result, &topology_baseline(), None);
@@ -1139,6 +1141,7 @@ mod tests {
                 "@apollo/client".to_string(),
             ],
             graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
         };
         let output = format_analysis_results(result, &topology_baseline(), None);
         assert!(output.contains("GraphQL detected"));
@@ -1164,6 +1167,7 @@ mod tests {
             verified_endpoints: vec![],
             detected_graphql_libraries: vec!["@apollo/client".to_string()],
             graphql_operations_indexed: true,
+            cross_repo_matches: vec![],
         };
         let output = format_analysis_results(result, &topology_baseline(), None);
         assert!(!output.contains("GraphQL detected"));
@@ -1186,6 +1190,7 @@ mod tests {
             verified_endpoints: vec![],
             detected_graphql_libraries: vec![],
             graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
         };
         let output = format_analysis_results(result, &topology_baseline(), None);
         assert!(!output.contains("GraphQL detected"));
@@ -1209,6 +1214,7 @@ mod tests {
             verified_endpoints: vec![],
             detected_graphql_libraries: vec![],
             graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
         };
 
         let output = format_analysis_results(result, &topology_baseline(), None);
@@ -1235,6 +1241,7 @@ mod tests {
             verified_endpoints: vec![],
             detected_graphql_libraries: vec![],
             graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
         };
 
         let formatted = FormattedOutput::new(result, topology_baseline(), None);
@@ -1271,6 +1278,7 @@ mod tests {
             ],
             detected_graphql_libraries: vec![],
             graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
         };
 
         let output = format_analysis_results(result, &topology_baseline(), None);
@@ -1297,6 +1305,7 @@ mod tests {
             verified_endpoints: vec![("GET".to_string(), "/api/users".to_string())],
             detected_graphql_libraries: vec![],
             graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
         };
 
         let output = format_analysis_results(result, &topology_baseline(), None);
@@ -1324,6 +1333,7 @@ mod tests {
             verified_endpoints: vec![("GET".to_string(), "/api/users".to_string())],
             detected_graphql_libraries: vec![],
             graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
         };
 
         let output = format_analysis_results(result, &topology_baseline(), None);
@@ -1433,6 +1443,7 @@ mod tests {
             verified_endpoints: vec![],
             detected_graphql_libraries: vec![],
             graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
         };
 
         let output = format_analysis_results(result, &topology_first_repo(), None);
@@ -1492,6 +1503,7 @@ mod tests {
             verified_endpoints: vec![],
             detected_graphql_libraries: vec![],
             graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
         }
     }
 

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -93,6 +93,11 @@ pub struct DataFetchingCall {
     /// prompt emits it. Drives compat gating in a later stage.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub call_kind: Option<crate::operation::CallKind>,
+    /// Owning repo, tagged during cross-repo merge (`merge_from_repos`) so a
+    /// matched consumer can be attributed to its repo for cross-repo edges.
+    /// `None` until merge (single-repo graphs don't carry it).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_name: Option<String>,
 }
 
 /// The complete mount and endpoint graph
@@ -316,6 +321,7 @@ impl MountGraph {
             client,
             file_location: site.call_site.location.clone(),
             call_kind: None,
+            repo_name: None,
         })
     }
 
@@ -672,11 +678,16 @@ impl MountGraph {
                     }
                 }
 
-                // Merge data calls (deduplicate by method + target_url + file_location)
+                // Merge data calls (deduplicate by method + target_url + file_location).
+                // Tag each consumer with its owning repo (symmetric with the
+                // endpoint tagging above) so a matched call can be attributed to
+                // its repo for cross-repo edge capture.
                 for call in &mount_graph.data_calls {
                     let key = format!("{}:{}:{}", call.method, call.target_url, call.file_location);
                     if seen_data_calls.insert(key) {
-                        merged.data_calls.push(call.clone());
+                        let mut tagged_call = call.clone();
+                        tagged_call.repo_name = Some(repo_data.repo_name.clone());
+                        merged.data_calls.push(tagged_call);
                     }
                 }
 

--- a/tests/fixtures/llm-mocked-api/__golden__.json
+++ b/tests/fixtures/llm-mocked-api/__golden__.json
@@ -9,7 +9,13 @@
       "request_type": null,
       "response_type": null,
       "file": "tests/fixtures/llm-mocked-api/src/routes/users.ts",
-      "line": 6
+      "line": 6,
+      "type_alias": "Endpoint_a9cce7d0d8d0d9e6_Response",
+      "type_state": "Explicit",
+      "resolved_definition": "export interface Endpoint_a9cce7d0d8d0d9e6_Response {\n  id: number;\n  name: string;\n  email: string;\n}",
+      "expanded_definition": "Endpoint_a9cce7d0d8d0d9e6_Response",
+      "is_explicit": true,
+      "primary_type_symbol": "Endpoint_a9cce7d0d8d0d9e6_Response"
     },
     {
       "key": "http|GET|/export",
@@ -20,7 +26,11 @@
       "request_type": null,
       "response_type": null,
       "file": "tests/fixtures/llm-mocked-api/src/reports.ts",
-      "line": 9
+      "line": 9,
+      "type_alias": "Endpoint_1732d2237f37ec97_Response",
+      "type_state": "Unknown",
+      "is_explicit": false,
+      "primary_type_symbol": "Endpoint_1732d2237f37ec97_Response"
     },
     {
       "key": "http|GET|/health",
@@ -31,7 +41,13 @@
       "request_type": null,
       "response_type": null,
       "file": "tests/fixtures/llm-mocked-api/src/index.ts",
-      "line": 8
+      "line": 8,
+      "type_alias": "Endpoint_2a10f0dfd8c3cde7_Response",
+      "type_state": "Implicit",
+      "resolved_definition": "export type Endpoint_2a10f0dfd8c3cde7_Response = { status: string; };",
+      "expanded_definition": "{ status: string; }",
+      "is_explicit": false,
+      "primary_type_symbol": "Endpoint_2a10f0dfd8c3cde7_Response"
     },
     {
       "key": "http|GET|/summary",
@@ -42,7 +58,13 @@
       "request_type": null,
       "response_type": null,
       "file": "tests/fixtures/llm-mocked-api/src/reports.ts",
-      "line": 5
+      "line": 5,
+      "type_alias": "Endpoint_97b757a2c4112fad_Response",
+      "type_state": "Implicit",
+      "resolved_definition": "export type Endpoint_97b757a2c4112fad_Response = { total: number; };",
+      "expanded_definition": "{ total: number; }",
+      "is_explicit": false,
+      "primary_type_symbol": "Endpoint_97b757a2c4112fad_Response"
     },
     {
       "key": "http|POST|/api/users",
@@ -53,7 +75,13 @@
       "request_type": null,
       "response_type": null,
       "file": "tests/fixtures/llm-mocked-api/src/routes/users.ts",
-      "line": 11
+      "line": 11,
+      "type_alias": "Endpoint_7624e36e7268b452_Request",
+      "type_state": "Implicit",
+      "resolved_definition": "export type Endpoint_7624e36e7268b452_Request = { name: string; email: string; };",
+      "expanded_definition": "{ name: string; email: string; }",
+      "is_explicit": false,
+      "primary_type_symbol": "Endpoint_7624e36e7268b452_Request"
     }
   ],
   "calls": [
@@ -67,6 +95,33 @@
       "response_type": null,
       "file": "tests/fixtures/llm-mocked-api/src/client.ts",
       "line": 4
+    }
+  ],
+  "cross_repo_matches": [],
+  "dependency_conflicts": [
+    {
+      "package": "express",
+      "versions": [
+        "4.18.0",
+        "5.0.0"
+      ],
+      "severity": "critical"
+    },
+    {
+      "package": "lodash",
+      "versions": [
+        "4.17.21",
+        "4.17.22"
+      ],
+      "severity": "info"
+    },
+    {
+      "package": "react",
+      "versions": [
+        "18.2.0",
+        "18.3.0"
+      ],
+      "severity": "warning"
     }
   ]
 }


### PR DESCRIPTION
## What

Slice **S1 (#200)** of the cross-repo accuracy eval. Extends the machine-readable `EvalProjection` (emitted under `CARRICK_OUTPUT_JSON`) so the downstream scorer (S4) can score cross-repo matching, per-op type resolution, and dependency conflicts. Previously matches lived only as `verified_endpoints: Vec<(String,String)>` + string-formatted issues + a `serde_json::Value` compat blob — none of it structured or repo-attributed.

Data-shape contract: `carrick-cloud/docs/internal/cross-repo-eval-scorer-contract.md` §2/§3/§4/§7.

## Changes

- **`CrossRepoMatch`** (`src/analyzer/mod.rs` + `src/eval_output.rs`) with the §2 FROZEN field set: `producer_repo`, `producer_key`, `consumer_repo`, `consumer_key`, `match_score: f64`, `type_compatible: Option<bool>`, `mismatch_reason: Option<String>`. Serialized as `cross_repo_matches: Vec<CrossRepoMatch>` on `EvalProjection`.
- **Structured edge capture** at the HTTP matching site (`analyze_matches_with_mount_graph`):
  - **Producer repo** from the matched `ResolvedEndpoint` (`service_name ?? repo_name`).
  - **Consumer repo** by tagging the merged `DataFetchingCall`s with `repo_name` in `MountGraph::merge_from_repos` (symmetric with the existing endpoint tagging at the same site), then re-attaching it at the matcher via a `(METHOD, target, file_location)` lookup — `ApiEndpointDetails` carries no repo field, so the identity is re-joined from the merged graph.
  - `match_score = 1.0` for exact normalized-key matches (no finer scorer exists yet).
- **Compat verdict overlay** in `get_results`: maps the per-producer-endpoint verdict from `check_type_compatibility()` onto each edge, keyed by the producer's `(METHOD, full_path)`. `Err` (type checking never ran / `ts_check_dir` absent) leaves **every edge `type_compatible: None`** — load-bearing per §7, and omitted from JSON so the scorer can never read absent compat as "compatible".
- **Manifest fields on `EvalOp`** (§3): `type_alias`, `type_state` (String form of `ManifestTypeState`), `resolved_definition`, `expanded_definition`, `is_explicit`, `primary_type_symbol` — all `Option`, `#[serde(default, skip_serializing_if = "Option::is_none")]`, joined by `OperationKey` from the merged type manifest (threaded into `from_results` from the engine emission site before `all_repo_data` is moved).
- **`dependency_conflicts`** (§4): `Vec<EvalDependencyConflict { package, versions (sorted), severity }>` projected from `issues.dependency_conflicts`.
- Human-facing Markdown report unchanged.

## Compromises (noted per task brief)

1. **`primary_type_symbol` falls back to `type_alias`** (contract §3 explicitly permits this). The raw LLM anchor lives on per-file `FileAnalysisResult`s, not keyed by `OperationKey` at projection time; threading it into the manifest is deeper than S1's scope. Documented inline in `eval_output.rs`. Follow-up: surface the raw anchor.
2. **Compat verdict is per-producer-endpoint, not per-edge.** ts_check collapses all consumers of a producer into one verdict keyed by `(method, path, type_kind)`, so every edge into a given producer shares that producer's verdict. This matches how the type checker actually works today; a per-consumer-repo verdict would require ts_check changes (out of scope).

## Checks

- `cargo build` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --lib` — 378 passed (incl. 2 new `eval_output` shape tests asserting field presence, snake_case, omit-if-none, and `type_compatible: None` omitted)
- `cargo test --test output_contract_test` — 4 passed
- `cargo test --test llm_cassette_hard_gate_test` — passed (golden re-recorded for the new projection shape; intentional output change per the test's documented re-record procedure)

Refs #200 #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)