### PR TITLE
fix(engine): scope git invocations to repo_path (ignore ambient GIT_DIR)

### DIFF
--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -325,6 +325,13 @@ pub fn get_current_commit_hash(repo_path: &str) -> String {
     std::process::Command::new("git")
         .args(["rev-parse", "HEAD"])
         .current_dir(repo_path)
+        // Clear inherited git env so the repo is discovered from repo_path, not
+        // an ambient GIT_DIR / GIT_WORK_TREE (e.g. a pre-commit hook or the eval
+        // harness subprocess running inside a worktree) — otherwise this records
+        // the wrong repo's commit hash. Mirrors get_changed_files in the engine.
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
         .output()
         .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
         .unwrap_or_else(|_| "unknown".to_string())

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -589,6 +589,12 @@ fn get_changed_files(repo_path: &str, base_commit: &str) -> Option<Vec<String>> 
     let output = std::process::Command::new("git")
         .args(["diff", "--name-only", base_commit, "HEAD"])
         .current_dir(repo_path)
+        // Clear git env vars so git uses repo_path for repo discovery, not an
+        // ambient GIT_DIR / GIT_WORK_TREE inherited from a parent process (e.g.
+        // when invoked from a pre-commit hook inside a git worktree).
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
         .output()
         .ok()?;
 
@@ -600,6 +606,9 @@ fn get_changed_files(repo_path: &str, base_commit: &str) -> Option<Vec<String>> 
         let is_shallow = std::process::Command::new("git")
             .args(["rev-parse", "--is-shallow-repository"])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .ok()
             .is_some_and(|o| String::from_utf8_lossy(&o.stdout).trim() == "true");
@@ -2628,20 +2637,31 @@ mod tests {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let repo_path = temp_dir.path().to_str().unwrap();
 
-        // Init a git repo
+        // Init a git repo. Clear git env vars so the commands are scoped to
+        // repo_path rather than any ambient GIT_DIR set by a parent process
+        // (e.g. a pre-commit hook running inside a git worktree).
         Command::new("git")
             .args(["init"])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
         Command::new("git")
             .args(["config", "user.email", "test@test.com"])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
         Command::new("git")
             .args(["config", "user.name", "Test"])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
 
@@ -2651,11 +2671,17 @@ mod tests {
         Command::new("git")
             .args(["add", "."])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
         Command::new("git")
             .args(["commit", "-m", "initial"])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
 
@@ -2664,6 +2690,9 @@ mod tests {
             Command::new("git")
                 .args(["rev-parse", "HEAD"])
                 .current_dir(repo_path)
+                .env_remove("GIT_DIR")
+                .env_remove("GIT_WORK_TREE")
+                .env_remove("GIT_INDEX_FILE")
                 .output()
                 .unwrap()
                 .stdout,
@@ -2683,11 +2712,17 @@ mod tests {
         Command::new("git")
             .args(["add", "."])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
         Command::new("git")
             .args(["commit", "-m", "changes"])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
 
@@ -2712,27 +2747,42 @@ mod tests {
         Command::new("git")
             .args(["init"])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
         Command::new("git")
             .args(["config", "user.email", "test@test.com"])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
         Command::new("git")
             .args(["config", "user.name", "Test"])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
         std::fs::write(temp_dir.path().join("app.ts"), "x").unwrap();
         Command::new("git")
             .args(["add", "."])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
         Command::new("git")
             .args(["commit", "-m", "init"])
             .current_dir(repo_path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
 


### PR DESCRIPTION
`get_changed_files` runs `git diff` / `git rev-parse` with `.current_dir(repo_path)` but inherits an ambient `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` from the parent process. When the scanner runs from a pre-commit hook inside a git worktree — or as a **subprocess from the S2 cross-repo eval harness (#201)** — git resolves the inherited env's repo instead of `repo_path`, breaking change detection and (in the in-module tests) writing to the wrong git index.

Fix: `.env_remove(...)` those three vars on every git invocation so the repo is discovered from `repo_path` alone. Also applied to the in-module test helpers.

This was surfaced independently by three cross-repo-eval agents (corpus authoring + S1) while running `cargo test` inside git worktrees — extracting it here as a standalone fix keeps the corpus PR pure-fixtures and de-risks S2's subprocess phases.

## Checks
- `cargo build` clean
- `cargo test --lib get_changed_files` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)