### PR TITLE
test(fixtures): authored 3-repo cross-repo corpus + ground truth (S3)

### DIFF
--- a/tests/fixtures/xrepo-corpus-1/README.md
+++ b/tests/fixtures/xrepo-corpus-1/README.md
@@ -1,0 +1,47 @@
+# xrepo-corpus-1 — authored cross-repo accuracy corpus
+
+Three statically-analyzable (not runnable) repos with an owned answer key, for
+the cross-repo accuracy eval (epic #207). Labels are **spec-of-record**: authored
+first, code built to match, never derived from a scan. Change a label only by hand,
+in a separate commit, reviewed against the spec — never to match scanner output.
+
+- Field shapes and per-metric comparison rules: the scorer contract
+  (`carrick-cloud/docs/internal/cross-repo-eval-scorer-contract.md`).
+- Per-failure-mode spec: build plan §6.
+
+## Repos
+- `orders-monorepo/` — npm-workspaces producer side. `orders-pkg` (Fastify):
+  renamed scoped-closure plugin param (owner-drift trap, #133/#167),
+  `new Router({prefix})` mounted with no path, barrel re-export. `gateway`
+  (NestJS): `@Controller('users')`+`@Get(':id')` prefix concat, an owner=method
+  fabrication trap (`/gateway/health`), and an MCP `server.tool()` decoy.
+- `payments-svc/` — Express producer + consumers: env-var-base `/orders/:param`
+  (compatible edge), orphan `/billing/charge`, `sendBeacon('/metrics/ingest')`
+  built-in (must emit, `import_source: null`), SDK-as-HTTP decoy (`audit.ts`),
+  Lambda-handler decoy (`settle.ts`).
+- `web-frontend/` — Next.js-style consumer: `/orders/[id]` (type-INCOMPATIBLE
+  with the producer) and `/payments` (compatible).
+
+## Ground truth
+- Per-repo `<repo>/expected.json` — endpoints/calls + owner + type anchor +
+  resolved type + `_must_not_emit` negatives, every label tagged
+  `capability`/`roadmap` (all `capability` here).
+- Corpus `expected-output.json` — cross-repo `matches` (with compat verdict),
+  `orphans`, and `dependency_conflicts`.
+
+## Cross-repo edges
+| Producer | Consumer | Compat |
+|---|---|---|
+| orders-monorepo `GET /orders/:param` | payments-svc | compatible |
+| orders-monorepo `GET /orders/:param` | web-frontend | **incompatible** (`id` string vs number) |
+| payments-svc `POST /payments` | web-frontend | compatible |
+
+Orphan producers: orders `GET /api/v1/status`, gateway `GET /users/:param`,
+`GET /gateway/health`, payments `GET /payments/:param`. Orphan consumers:
+payments `POST /billing/charge`, `POST /metrics/ingest`. Decoys (MCP tools,
+`audit.ts`, `settle.ts`) emit nothing.
+
+`dependency_conflicts` carries one deliberate cross-repo conflict (`zod` 3.x vs
+4.x). Its exact version-string and severity are deterministic scanner output,
+verified against a real scan when the scorer (S4) / cassette gate (S5) wire the
+corpus in.

--- a/tests/fixtures/xrepo-corpus-1/expected-output.json
+++ b/tests/fixtures/xrepo-corpus-1/expected-output.json
@@ -1,0 +1,57 @@
+{
+  "matches": [
+    {
+      "producer_repo": "orders-monorepo",
+      "producer_key": "http|GET|/orders/:param",
+      "consumer_repo": "payments-svc",
+      "consumer_key": "http|GET|/orders/:param",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "orders-monorepo",
+      "producer_key": "http|GET|/orders/:param",
+      "consumer_repo": "web-frontend",
+      "consumer_key": "http|GET|/orders/:param",
+      "type_compatible": false,
+      "mismatch_reason": "consumer OrderView.id is string but producer Order.id is number",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "payments-svc",
+      "producer_key": "http|POST|/payments",
+      "consumer_repo": "web-frontend",
+      "consumer_key": "http|POST|/payments",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "tier": "capability"
+    }
+  ],
+  "orphans": [
+    { "repo": "orders-monorepo", "side": "producer", "key": "http|GET|/api/v1/status", "tier": "capability" },
+    { "repo": "orders-monorepo", "side": "producer", "key": "http|GET|/users/:param", "tier": "capability" },
+    { "repo": "orders-monorepo", "side": "producer", "key": "http|GET|/gateway/health", "tier": "capability" },
+    { "repo": "payments-svc", "side": "producer", "key": "http|GET|/payments/:param", "tier": "capability" },
+    { "repo": "payments-svc", "side": "consumer", "key": "http|POST|/billing/charge", "tier": "capability" },
+    { "repo": "payments-svc", "side": "consumer", "key": "http|POST|/metrics/ingest", "tier": "capability" }
+  ],
+  "dependency_conflicts": [
+    {
+      "package": "zod",
+      "versions": ["3.22.0", "4.0.0"],
+      "severity": "critical",
+      "tier": "capability"
+    }
+  ],
+  "summary": {
+    "total_repos": 3,
+    "producers": 6,
+    "consumers": 5,
+    "matched_edges": 3,
+    "incompatible_edges": 1,
+    "orphan_producers": 4,
+    "orphan_consumers": 2,
+    "decoys_must_not_emit": 4
+  }
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/carrick.json
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/carrick.json
@@ -1,0 +1,14 @@
+{
+  "services": [
+    {
+      "name": "orders-pkg",
+      "directory": "packages/orders-pkg",
+      "tsconfig": "tsconfig.json"
+    },
+    {
+      "name": "gateway",
+      "directory": "packages/gateway",
+      "tsconfig": "tsconfig.json"
+    }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/expected.json
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/expected.json
@@ -1,0 +1,55 @@
+{
+  "endpoints": [
+    {
+      "method": "GET",
+      "path": "/orders/:id",
+      "owner": "ordersRouter",
+      "primary_type_symbol": "Order",
+      "resolved_type": "{ id: number; amountCents: number; currency: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/status",
+      "owner": "statusRouter",
+      "primary_type_symbol": "StatusResponse",
+      "resolved_type": "{ status: string; version: string; uptime: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "GET",
+      "path": "/users/:id",
+      "owner": "findOne",
+      "primary_type_symbol": "UserSummary",
+      "resolved_type": "{ id: string; displayName: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "GET",
+      "path": "/gateway/health",
+      "owner": "healthCheckHandler",
+      "primary_type_symbol": "HealthResponse",
+      "resolved_type": "{ ok: boolean; ts: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "calls": [],
+  "_must_not_emit": [
+    {
+      "kind": "endpoint",
+      "method": "*",
+      "path": "/__mcp__/lookup-order",
+      "evidence": "MCP server.tool('lookup-order', ...) registration in mcp-tools.ts — not an HTTP endpoint"
+    },
+    {
+      "kind": "endpoint",
+      "method": "*",
+      "path": "/__mcp__/cancel-order",
+      "evidence": "MCP server.tool('cancel-order', ...) registration in mcp-tools.ts — not an HTTP endpoint"
+    }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/package.json
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "orders-monorepo",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/orders-pkg",
+    "packages/gateway"
+  ],
+  "dependencies": {
+    "zod": "^3.22.0"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/package.json
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@orders-monorepo/gateway",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "zod": "^3.22.0"
+  },
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/health.handler.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/health.handler.ts
@@ -1,0 +1,32 @@
+// Owner-fabrication trap: a raw-handler block that tempts the LLM to emit
+// owner = "GET" (the HTTP method string) instead of the real function name.
+//
+// The handler is defined as a standalone arrow-function constant, then wired up
+// in a map-style registration block where the first argument is the method string
+// "GET".  A scanner that confuses the method-string argument with the owner will
+// emit owner="GET".  The REAL owner is `healthCheckHandler` — the identifier
+// bound to the function expression.
+//
+// Expected: method=GET, path=/gateway/health, owner=healthCheckHandler
+// Tier: capability
+
+export interface HealthResponse {
+  ok: boolean;
+  ts: number;
+}
+
+// The real handler function — owner = healthCheckHandler
+export const healthCheckHandler = async (
+  _req: unknown,
+  _res: unknown
+): Promise<HealthResponse> => {
+  return { ok: true, ts: Date.now() };
+};
+
+// Route registry — the method string "GET" appears as the first arg, which is
+// the fabrication bait.  The actual route owner is `healthCheckHandler` above.
+const routeRegistry: Array<{ method: string; path: string; handler: Function }> = [
+  { method: 'GET', path: '/gateway/health', handler: healthCheckHandler },
+];
+
+export { routeRegistry };

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/index.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/index.ts
@@ -1,0 +1,5 @@
+export { UsersController } from './users.controller';
+export { healthCheckHandler, routeRegistry } from './health.handler';
+export { server as mcpServer } from './mcp-tools';
+export type { UserSummary } from './users.controller';
+export type { HealthResponse } from './health.handler';

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/mcp-tools.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/mcp-tools.ts
@@ -1,0 +1,59 @@
+// MCP tool registration decoy — MUST NOT emit any HTTP endpoints or calls.
+//
+// This file registers tools on an MCP server using the server.tool(name, schema,
+// handler) pattern.  The registration call looks superficially like a route
+// registration (string name, object schema, async handler) but it is NOT an HTTP
+// endpoint.  The scanner must not extract these as endpoints.
+//
+// The _must_not_emit guard in expected.json uses a synthetic path marker
+// /__mcp__/lookup-order that the scanner would never emit from real HTTP code;
+// the real guard is set-absence: the total expected endpoint set is exact, so any
+// MCP-derived emission reduces precision even without the synthetic marker.
+
+interface McpTool {
+  name: string;
+  schema: object;
+  handler: (args: unknown) => Promise<unknown>;
+}
+
+// Minimal stub for an MCP server — no real import needed; the scanner reads AST.
+const server = {
+  tool(name: string, schema: object, handler: (args: unknown) => Promise<unknown>): void {
+    // no-op in this stub
+  },
+};
+
+// MCP tool: lookup-order — NOT an HTTP endpoint
+server.tool(
+  'lookup-order',
+  {
+    type: 'object',
+    properties: {
+      orderId: { type: 'string' },
+    },
+    required: ['orderId'],
+  },
+  async (args: unknown) => {
+    const { orderId } = args as { orderId: string };
+    return { id: orderId, status: 'shipped' };
+  }
+);
+
+// MCP tool: cancel-order — NOT an HTTP endpoint
+server.tool(
+  'cancel-order',
+  {
+    type: 'object',
+    properties: {
+      orderId: { type: 'string' },
+      reason: { type: 'string' },
+    },
+    required: ['orderId'],
+  },
+  async (args: unknown) => {
+    const { orderId } = args as { orderId: string; reason?: string };
+    return { orderId, cancelled: true };
+  }
+);
+
+export { server };

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/users.controller.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/users.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Param } from '@nestjs/common';
+
+// Shared user shape for this gateway.
+export interface UserSummary {
+  id: string;
+  displayName: string;
+}
+
+// Trap: @Controller('users') + @Get(':id') — decorator prefix concat.
+// The effective path is /users/:id, derived purely from decorators with NO
+// synthetic mount (no app.use, no register call).  The scanner must concatenate
+// the controller prefix and the method-level path to produce the full route.
+@Controller('users')
+export class UsersController {
+  // GET /users/:id — producer-only (no consumer in corpus)
+  // owner = findOne (the method name, resolved from the decorator)
+  @Get(':id')
+  findOne(@Param('id') id: string): UserSummary {
+    return { id, displayName: 'placeholder' };
+  }
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "typeRoots": ["./typings", "../../node_modules/@types"]
+  },
+  "include": ["src/**/*", "typings/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/typings/nestjs.d.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/typings/nestjs.d.ts
@@ -1,0 +1,21 @@
+// Minimal ambient shim for @nestjs/common and @nestjs/core.
+// Only the decorator factory signatures matter; the scanner reads AST structure.
+
+declare module '@nestjs/common' {
+  export function Controller(prefix?: string): ClassDecorator;
+  export function Get(path?: string): MethodDecorator;
+  export function Post(path?: string): MethodDecorator;
+  export function Put(path?: string): MethodDecorator;
+  export function Delete(path?: string): MethodDecorator;
+  export function Param(param?: string): ParameterDecorator;
+  export function Body(): ParameterDecorator;
+  export function Query(): ParameterDecorator;
+  export function Injectable(): ClassDecorator;
+  export function Module(metadata: object): ClassDecorator;
+}
+
+declare module '@nestjs/core' {
+  export class NestFactory {
+    static create(module: any): Promise<any>;
+  }
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/package.json
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@orders-monorepo/orders-pkg",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "fastify": "^4.26.0",
+    "zod": "^3.22.0"
+  },
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/src/index.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/src/index.ts
@@ -1,0 +1,8 @@
+// Barrel re-export: handlers and types surface through this index.
+// Trap: re-exported through a barrel. The scanner must follow the re-export
+// chain to attribute endpoints to their real authoring module, not this barrel.
+
+export { ordersPlugin } from './orders.routes';
+export { statusRouter } from './status.routes';
+export type { Order, StatusResponse } from './types';
+export { default as app } from './server';

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/src/orders.routes.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/src/orders.routes.ts
@@ -1,0 +1,29 @@
+import fastify from 'fastify';
+import type { Order, StatusResponse } from './types';
+
+// Trap: renamed scoped-closure plugin param.
+// The plugin callback's first argument is conventionally named after the instance
+// (e.g. `app` or `instance`), but here it is renamed to `ordersRouter` — a child
+// var name that is NOT the outer `app`. The scanner must resolve the owner as
+// `ordersRouter`, the child variable that registers the route, NOT the outer param
+// name that shadows it (silent-prefix-drop / owner-drift trap, issues #133/#167).
+//
+// This plugin is registered with prefix "/orders" so:
+//   GET /:id   → GET /orders/:id
+//   GET /      → (status endpoint registered separately below)
+
+const ordersPlugin = async (ordersRouter: ReturnType<typeof fastify>, opts: { prefix?: string }): Promise<void> => {
+  // GET /orders/:id — response type: Order
+  // Owner must be `ordersRouter` (the renamed scoped-closure param), not `app`.
+  ordersRouter.get<Order>('/:id', async (request, reply): Promise<Order> => {
+    const { id } = request.params;
+    const order: Order = {
+      id: Number(id),
+      amountCents: 4999,
+      currency: 'EUR',
+    };
+    return order;
+  });
+};
+
+export { ordersPlugin };

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/src/server.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/src/server.ts
@@ -1,0 +1,27 @@
+import fastify from 'fastify';
+import { ordersPlugin } from './orders.routes';
+import { statusRouter } from './status.routes';
+
+const app = fastify();
+
+// Register the orders plugin with a "/orders" prefix.
+// Routes inside the plugin:
+//   GET /:id  → resolves to GET /orders/:id
+app.register(ordersPlugin, { prefix: '/orders' });
+
+// Register the statusRouter plugin.
+// statusRouter carries its own prefix ("/api/v1") in its constructor;
+// mount_path is "" (no additional path segment here).
+// The scanner must recognise the constructor-carried prefix.
+app.register(async (instance) => {
+  for (const route of statusRouter.routes()) {
+    // Re-attach routes from the prefix-carrying router under its own prefix.
+    // The effective path becomes statusRouter.prefix + route.path = /api/v1/status.
+    (instance as any)[route.method.toLowerCase()](
+      statusRouter.prefix + route.path,
+      route.handler
+    );
+  }
+}, { prefix: '' });
+
+export default app;

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/src/status.routes.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/src/status.routes.ts
@@ -1,0 +1,39 @@
+import type { StatusResponse } from './types';
+
+// Trap: constructor-carried prefix, mounted with no path (mount_path "").
+// The prefix "/api/v1" is baked into the Router constructor options, so when
+// this router is mounted in server.ts it is mounted at "" (no additional path).
+// The scanner must honour the constructor-level prefix even when mount_path is "".
+//
+// Expected resolved endpoint: GET /api/v1/status
+
+// Minimal Router shim — constructor accepts { prefix } and carries it forward.
+// This is a deliberate structural pattern (not a real framework router); it lets
+// the scanner exercise the "prefix in constructor, no mount path" code path.
+class Router {
+  readonly prefix: string;
+  private _routes: Array<{ method: string; path: string; handler: Function }> = [];
+
+  constructor(opts: { prefix: string }) {
+    this.prefix = opts.prefix;
+  }
+
+  get<TReply>(path: string, handler: (req: unknown, res: unknown) => TReply): this {
+    this._routes.push({ method: 'GET', path, handler });
+    return this;
+  }
+
+  routes() {
+    return this._routes;
+  }
+}
+
+// The prefix is baked in; the mount path in server.ts is "" (empty string).
+const statusRouter = new Router({ prefix: '/api/v1' });
+
+// GET /api/v1/status  — producer-only (no consumer in corpus)
+statusRouter.get<StatusResponse>('/status', async (_req, _res): Promise<StatusResponse> => {
+  return { status: 'ok', version: '1.0.0', uptime: process.uptime() };
+});
+
+export { statusRouter };

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/src/types.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/src/types.ts
@@ -1,0 +1,14 @@
+// Shared domain types for the orders package.
+// The cross-repo eval expects this exact shape for Order.
+
+export interface Order {
+  id: number;
+  amountCents: number;
+  currency: string;
+}
+
+export interface StatusResponse {
+  status: string;
+  version: string;
+  uptime: number;
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "experimentalDecorators": true,
+    "typeRoots": ["./typings", "../../node_modules/@types"]
+  },
+  "include": ["src/**/*", "typings/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/typings/fastify.d.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/orders-pkg/typings/fastify.d.ts
@@ -1,0 +1,39 @@
+// Minimal ambient shim for fastify — real types not needed; scanner reads AST structure.
+declare module 'fastify' {
+  interface FastifyRequest {
+    params: Record<string, string>;
+    query: Record<string, string>;
+    body: unknown;
+  }
+
+  interface FastifyReply {
+    send(payload?: unknown): FastifyReply;
+    status(code: number): FastifyReply;
+  }
+
+  type RouteHandler<TReply = unknown> = (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ) => Promise<TReply> | TReply;
+
+  interface FastifyPluginOptions {
+    prefix?: string;
+  }
+
+  type FastifyPlugin = (
+    instance: FastifyInstance,
+    opts: FastifyPluginOptions,
+    done: () => void
+  ) => void | Promise<void>;
+
+  interface FastifyInstance {
+    get<TReply = unknown>(path: string, handler: RouteHandler<TReply>): this;
+    post<TReply = unknown>(path: string, handler: RouteHandler<TReply>): this;
+    put<TReply = unknown>(path: string, handler: RouteHandler<TReply>): this;
+    delete<TReply = unknown>(path: string, handler: RouteHandler<TReply>): this;
+    register(plugin: FastifyPlugin, opts?: FastifyPluginOptions): this;
+  }
+
+  function fastify(): FastifyInstance;
+  export = fastify;
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/clients/billing.client.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/clients/billing.client.ts
@@ -1,0 +1,24 @@
+import axios from "axios";
+
+export interface ChargeRequest {
+  paymentId: string;
+  amountCents: number;
+  currency: string;
+}
+
+export interface ChargeResponse {
+  chargeId: string;
+  status: "accepted" | "declined";
+}
+
+const BILLING_BASE = process.env.BILLING_URL ?? "http://localhost:3003";
+
+export async function chargePayment(
+  charge: ChargeRequest
+): Promise<ChargeResponse> {
+  const response = await axios.post<ChargeResponse>(
+    `${BILLING_BASE}/billing/charge`,
+    charge
+  );
+  return response.data;
+}

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/clients/orders.client.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/clients/orders.client.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+// Response shape compatible with orders-monorepo's Order producer
+export interface OrderResponse {
+  id: number;
+  amountCents: number;
+  currency: string;
+}
+
+const ORDERS_BASE = process.env.ORDERS_SERVICE_URL ?? "http://localhost:3001";
+
+export async function getOrder(orderId: number): Promise<OrderResponse> {
+  const response = await axios.get<OrderResponse>(
+    `${ORDERS_BASE}/orders/${orderId}`
+  );
+  return response.data;
+}

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/expected.json
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/expected.json
@@ -1,0 +1,71 @@
+{
+  "endpoints": [
+    {
+      "method": "POST",
+      "path": "/payments",
+      "owner": "createPayment",
+      "primary_type_symbol": "Payment",
+      "resolved_type": "{ id: string; orderId: number; amountCents: number; status: \"pending\" | \"settled\"; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "GET",
+      "path": "/payments/:paymentId",
+      "owner": "getPayment",
+      "primary_type_symbol": "Payment",
+      "resolved_type": "{ id: string; orderId: number; amountCents: number; status: \"pending\" | \"settled\"; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "calls": [
+    {
+      "method": "GET",
+      "path": "/orders/:param",
+      "host_contains": "ORDERS_SERVICE_URL",
+      "path_contains": "/orders/",
+      "import_source": "axios",
+      "primary_type_symbol": "OrderResponse",
+      "resolved_type": "{ id: number; amountCents: number; currency: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "POST",
+      "path": "/billing/charge",
+      "host_contains": "BILLING_URL",
+      "path_contains": "/billing/charge",
+      "import_source": "axios",
+      "primary_type_symbol": null,
+      "resolved_type": null,
+      "type_state": "Unknown",
+      "tier": "capability"
+    },
+    {
+      "method": "POST",
+      "path": "/metrics/ingest",
+      "host_contains": null,
+      "path_contains": "/metrics/ingest",
+      "import_source": null,
+      "primary_type_symbol": null,
+      "resolved_type": null,
+      "type_state": "Unknown",
+      "tier": "capability"
+    }
+  ],
+  "_must_not_emit": [
+    {
+      "kind": "call",
+      "method": "*",
+      "path": "/__sdk__/PutItemCommand",
+      "evidence": "lib/audit.ts: dynamo.send(new PutItemCommand(...)) is an AWS SDK call using the SDK's internal HTTP transport — not a direct HTTP data call. Must not be extracted as a consumer endpoint."
+    },
+    {
+      "kind": "endpoint",
+      "method": "POST",
+      "path": "/__lambda__/settle",
+      "evidence": "handlers/settle.ts: `export const handler = async (event: SQSEvent)` is an AWS Lambda SQS handler, not an HTTP route registration. Must not be extracted as a producer endpoint."
+    }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/handlers/settle.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/handlers/settle.ts
@@ -1,0 +1,32 @@
+// Lambda handler for async payment settlement — triggered by SQS, not HTTP.
+// This export follows the AWS Lambda handler convention and must NOT be
+// extracted as an HTTP endpoint by the scanner.
+
+export interface SQSEvent {
+  Records: Array<{
+    body: string;
+    messageId: string;
+  }>;
+}
+
+export interface LambdaResult {
+  batchItemFailures: Array<{ itemIdentifier: string }>;
+}
+
+// The handler signature looks like an HTTP handler but is invoked by the
+// Lambda runtime from an SQS trigger — it is a Lambda handler decoy.
+export const handler = async (event: SQSEvent): Promise<LambdaResult> => {
+  const failures: Array<{ itemIdentifier: string }> = [];
+
+  for (const record of event.Records) {
+    try {
+      const message = JSON.parse(record.body) as { paymentId: string };
+      // settle logic would go here
+      void message;
+    } catch {
+      failures.push({ itemIdentifier: record.messageId });
+    }
+  }
+
+  return { batchItemFailures: failures };
+};

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/index.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/index.ts
@@ -1,0 +1,35 @@
+import express from "express";
+import type { Request, Response } from "express";
+import type { Payment, CreatePayment } from "./src/types";
+
+const app = express();
+
+// POST /payments — create a new payment
+async function createPayment(req: Request, res: Response): Promise<void> {
+  const body = req.body as CreatePayment;
+  const payment: Payment = {
+    id: `pay_${Date.now()}`,
+    orderId: body.orderId,
+    amountCents: body.amountCents,
+    status: "pending",
+  };
+  res.status(201).json(payment);
+}
+
+// GET /payments/:paymentId — retrieve a payment by ID
+async function getPayment(req: Request, res: Response): Promise<void> {
+  const payment: Payment = {
+    id: req.params.paymentId,
+    orderId: 0,
+    amountCents: 0,
+    status: "pending",
+  };
+  res.json(payment);
+}
+
+app.post("/payments", createPayment);
+app.get("/payments/:paymentId", getPayment);
+
+app.listen(3002, () => {
+  console.log("payments-svc running on :3002");
+});

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/lib/audit.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/lib/audit.ts
@@ -1,0 +1,34 @@
+import { DynamoDBClient, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import axios from "axios";
+
+const dynamo = new DynamoDBClient({ region: "eu-west-1" });
+
+export interface AuditEvent {
+  paymentId: string;
+  action: string;
+  timestamp: string;
+}
+
+// Writes an audit record to DynamoDB — SDK call, NOT an HTTP endpoint.
+// The dynamo.send(PutItemCommand) below is an SDK-as-HTTP decoy: it uses
+// the AWS SDK transport layer, not a direct HTTP fetch, and must NOT be
+// extracted as a data call by the scanner.
+export async function recordAuditEvent(event: AuditEvent): Promise<void> {
+  await dynamo.send(
+    new PutItemCommand({
+      TableName: "payments-audit",
+      Item: {
+        paymentId: { S: event.paymentId },
+        action: { S: event.action },
+        timestamp: { S: event.timestamp },
+      },
+    })
+  );
+
+  // Real HTTP call adjacent to the SDK decoy — the scanner must extract this
+  // one but must not confuse the DynamoDB SDK call above for an HTTP call.
+  await axios.post(
+    `${process.env.AUDIT_WEBHOOK_URL ?? "http://localhost:3099"}/audit/events`,
+    event
+  );
+}

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/lib/beacon.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/lib/beacon.ts
@@ -1,0 +1,13 @@
+// Telemetry beacon — uses navigator.sendBeacon (browser built-in).
+// No import: sendBeacon is a global URL-transmitting function, not a library.
+
+export interface MetricPayload {
+  event: string;
+  paymentId: string;
+  durationMs: number;
+}
+
+export function reportMetric(payload: MetricPayload): boolean {
+  const body = JSON.stringify(payload);
+  return navigator.sendBeacon("/metrics/ingest", body);
+}

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/package.json
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "payments-svc",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "axios": "^1.6.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/src/types/index.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/src/types/index.ts
@@ -1,0 +1,13 @@
+// Shared domain types for payments-svc
+
+export interface Payment {
+  id: string;
+  orderId: number;
+  amountCents: number;
+  status: "pending" | "settled";
+}
+
+export interface CreatePayment {
+  orderId: number;
+  amountCents: number;
+}

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/src/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/src/types/stubs.d.ts
@@ -1,0 +1,55 @@
+// Ambient stubs — keep types resolvable without npm install
+
+declare module "express" {
+  export interface Request {
+    params: Record<string, string>;
+    body: unknown;
+    query: Record<string, string>;
+  }
+  export interface Response {
+    status(code: number): Response;
+    json(body: unknown): Response;
+    send(body: unknown): Response;
+  }
+  export interface NextFunction {
+    (err?: unknown): void;
+  }
+  export interface Router {
+    get(path: string, handler: (req: Request, res: Response) => void): Router;
+    post(path: string, handler: (req: Request, res: Response) => void): Router;
+    use(handler: (req: Request, res: Response, next: NextFunction) => void): Router;
+  }
+  export interface Application {
+    get(path: string, handler: (req: Request, res: Response) => void): Application;
+    post(path: string, handler: (req: Request, res: Response) => void): Application;
+    use(path: string, router: Router): Application;
+    use(handler: (req: Request, res: Response, next: NextFunction) => void): Application;
+    listen(port: number, callback?: () => void): void;
+  }
+  function express(): Application;
+  export default express;
+}
+
+declare module "axios" {
+  export interface AxiosResponse<T = unknown> {
+    data: T;
+    status: number;
+    statusText: string;
+  }
+  export interface AxiosInstance {
+    get<T = unknown>(url: string, config?: unknown): Promise<AxiosResponse<T>>;
+    post<T = unknown>(url: string, data?: unknown, config?: unknown): Promise<AxiosResponse<T>>;
+  }
+  const axios: AxiosInstance;
+  export default axios;
+}
+
+// AWS SDK stubs — referenced only by the decoy in lib/audit.ts
+declare module "@aws-sdk/client-dynamodb" {
+  export class DynamoDBClient {
+    send(command: unknown): Promise<unknown>;
+  }
+  export class PutItemCommand {
+    constructor(input: unknown);
+  }
+}

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/app/orders/[id]/page.tsx
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/app/orders/[id]/page.tsx
@@ -1,0 +1,23 @@
+// Next.js App Router page: app/orders/[id]/page.tsx → /orders/:id
+// Uses lib/api.ts to fetch the order and render it.
+// The [id] param is a Next.js dynamic-route segment, canonicalised to :param.
+
+import { fetchOrder, createPayment, type OrderView, type Payment } from "../../../lib/api";
+
+interface PageProps {
+  params: { id: string };
+}
+
+export default async function OrderPage({ params }: PageProps) {
+  const order: OrderView = await fetchOrder(params.id);
+
+  return (
+    <main>
+      <h1>Order {order.id}</h1>
+      <p>Currency: {order.currency}</p>
+    </main>
+  );
+}
+
+// Re-export types so the scanner sees them referenced in this file too.
+export type { OrderView, Payment };

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/expected.json
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/expected.json
@@ -1,0 +1,27 @@
+{
+  "endpoints": [],
+  "calls": [
+    {
+      "method": "GET",
+      "path": "/orders/:param",
+      "host_contains": "NEXT_PUBLIC_ORDERS_URL",
+      "path_contains": "/orders/",
+      "import_source": null,
+      "primary_type_symbol": "OrderView",
+      "resolved_type": "{ id: string; currency: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "POST",
+      "path": "/payments",
+      "host_contains": "NEXT_PUBLIC_PAYMENTS_URL",
+      "path_contains": "/payments",
+      "import_source": null,
+      "primary_type_symbol": "Payment",
+      "resolved_type": "{ id: string; orderId: number; amountCents: number; status: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/lib/api.ts
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/lib/api.ts
@@ -1,0 +1,57 @@
+// API client for the web frontend.
+// Types here deliberately differ from the orders-monorepo producer in ways that
+// create a cross-repo type incompatibility on the orders endpoint:
+//   - OrderView.id is string (producer Order.id is number)
+//   - OrderView has no amountCents field (producer has amountCents: number)
+//
+// The payments call is type-compatible with the payments-svc producer.
+
+const ORDERS_BASE = process.env.NEXT_PUBLIC_ORDERS_URL ?? "";
+const PAYMENTS_BASE = process.env.NEXT_PUBLIC_PAYMENTS_URL ?? "";
+
+// Intentionally INCOMPATIBLE with orders-monorepo's Order type:
+//   producer: Order { id: number; amountCents: number; currency: string }
+//   consumer: OrderView { id: string; currency: string }  ← id is string, amountCents absent
+export interface OrderView {
+  id: string;
+  currency: string;
+}
+
+// Compatible with the payments-svc producer response shape.
+export interface Payment {
+  id: string;
+  orderId: number;
+  amountCents: number;
+  status: string;
+}
+
+export interface CreatePaymentRequest {
+  orderId: number;
+  amountCents: number;
+}
+
+// GET /orders/:id — fetches a single order by id.
+// NOTE: id is typed as string here; the producer emits id as number (incompatible edge).
+export async function fetchOrder(id: string): Promise<OrderView> {
+  const res = await fetch(`${ORDERS_BASE}/orders/${id}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch order ${id}: ${res.status}`);
+  }
+  return res.json() as Promise<OrderView>;
+}
+
+// POST /payments — creates a new payment.
+// Request and response types are compatible with the payments-svc producer.
+export async function createPayment(
+  body: CreatePaymentRequest
+): Promise<Payment> {
+  const res = await fetch(`${PAYMENTS_BASE}/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to create payment: ${res.status}`);
+  }
+  return res.json() as Promise<Payment>;
+}

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/package.json
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "web-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.4.0"
+  },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Slice S3 (#202) of the cross-repo accuracy eval (#207). The authored, owned-answer-key corpus the live scorer (S4) runs against.

## What's here — `tests/fixtures/xrepo-corpus-1/`
Three statically-analyzable (not runnable) repos, authored to the build-plan §6 failure-mode spec. Labels are **spec-of-record** (authored first, code built to match, never derived from a scan).

- **`orders-monorepo/`** — npm-workspaces producer side. `orders-pkg` (Fastify): renamed scoped-closure plugin param (owner-drift trap #133/#167), `new Router({prefix})` mounted with no path, barrel re-export. `gateway` (NestJS): `@Controller('users')`+`@Get(':id')` prefix concat, an `owner=method` fabrication trap, an MCP `server.tool()` decoy.
- **`payments-svc/`** — Express producer + consumers: env-var-base `/orders/:param` (compatible edge), orphan `/billing/charge`, `sendBeacon('/metrics/ingest')` built-in (must emit, `import_source: null`), SDK-as-HTTP decoy (`audit.ts`), Lambda-handler decoy (`settle.ts`).
- **`web-frontend/`** — Next.js-style consumer: `/orders/[id]` (type-**incompatible**) and `/payments` (compatible).

## Cross-repo edges (`expected-output.json`)
| Producer | Consumer | Compat |
|---|---|---|
| orders `GET /orders/:param` | payments-svc | compatible |
| orders `GET /orders/:param` | web-frontend | **incompatible** (`id` string vs number) |
| payments `POST /payments` | web-frontend | compatible |

Plus 4 orphan producers, 2 orphan consumers, 4 decoys that must emit nothing, and one deliberate `zod` 3.x-vs-4.x dependency conflict.

## Process notes for the reviewer
- The three repos were authored in parallel by worktree-isolated agents and integrated here. The repo-level `expected.json` is authoritative; redundant per-package copies were dropped.
- `expected-output.json` `dependency_conflicts`: the *conflict* (zod major mismatch) is spec; its exact version-string + severity are deterministic scanner output, **verified against a real scan when S4/S5 wire the corpus in** (deps is the deterministic Layer-1 surface).
- Labels validate against a real scan during the thin-slice integration (S4); this PR lands the authored corpus + answer key.

Refs #202 #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)