### PR TITLE
fix(hooks): isolate git env in pre-commit + block on test failure

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -37,6 +37,13 @@ cat > "$HOOKS_DIR/pre-commit" << 'EOF'
 
 set -euo pipefail  # Exit on error and fail pipelines
 
+# Isolate child processes (notably Rust tests that `git init` throwaway repos in
+# tempdirs) from the ambient GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE that git
+# sets for this hook. Without this a test's `git add .` targets THIS repo's
+# index, and inside a linked worktree it corrupts the worktree index mid-commit
+# (it produced bogus "delete the whole repo" trees during the eval work).
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 echo "🪢 Carrick Pre-Commit Hook"
@@ -119,6 +126,7 @@ else
     # Clean up
     rm -f /tmp/carrick-test-output.txt
 
+    exit 1
 fi
 
 # Run ts_check tests


### PR DESCRIPTION
Two pre-commit hook bugs surfaced repeatedly by the cross-repo-eval agents working in git worktrees:

1. **Worktree index corruption.** The hook runs `cargo test`; tests that `git init`/`git add`/`git commit` in tempdirs inherited the hook's ambient `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`, so inside a linked worktree they wrote to the *worktree's* index instead of the tempdir — corrupting it mid-commit (one agent's `--no-verify` commit captured a "delete the whole repo" tree before it was caught on review). Fix: `unset` those vars at the top of the generated hook so all child git processes discover the repo from CWD. (Complements #210, which fixed the scanner-side `get_changed_files`/`get_current_commit_hash`.)
2. **Failing tests didn't block.** The test-failure branch printed "Commit blocked" but never `exit 1`. Added it.

Re-run `./scripts/install-hooks.sh` to pick up the fix (the live `.git/hooks/pre-commit` is regenerated from this template; worktrees share it).

Closes #213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)