### PR TITLE
fix(extraction): resolve env-var base URLs aliased through a local const (#218)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     cloud_storage::{ManifestRole, ManifestTypeKind},
     config::Config,
+    env_alias::{EnvAliasExtractor, EnvAliasMap, resolve_target_env_alias},
     file_based_router::{MethodSource, RoutingConvention, builtin_conventions, derive_route},
     framework_detector::DetectionResult,
     mount_graph::{DataFetchingCall, GraphNode, MountEdge, MountGraph, NodeType, ResolvedEndpoint},
@@ -180,6 +181,12 @@ impl FileOrchestrator {
             candidate_contexts: Vec<String>,
             candidate_map: HashMap<String, CandidateTarget>,
             symbol_table: SymbolTable,
+            /// `local const -> process.env name` bindings (e.g.
+            /// `ORDERS_BASE -> ORDERS_SERVICE_URL`). Used after the LLM pass to
+            /// rewrite call targets that interpolate an env-var base URL aliased
+            /// through a local const, so the real env-var name reaches
+            /// classification and cross-repo matching. See `crate::env_alias`.
+            env_alias_map: EnvAliasMap,
             /// Endpoints derived from file-based routing conventions, merged in
             /// after the LLM pass. Empty for non-route files.
             route_endpoints: Vec<EndpointResult>,
@@ -321,7 +328,8 @@ impl FileOrchestrator {
                 .map(|candidate| (candidate.candidate_id.clone(), candidate.clone()))
                 .collect();
 
-            let symbol_table = Self::extract_symbol_table(file_path, &cm, &handler);
+            let (symbol_table, env_alias_map) =
+                Self::extract_symbol_table(file_path, &cm, &handler);
 
             pending.push(PendingFile {
                 path_str,
@@ -330,6 +338,7 @@ impl FileOrchestrator {
                 candidate_contexts,
                 candidate_map,
                 symbol_table,
+                env_alias_map,
                 route_endpoints,
             });
         }
@@ -376,6 +385,7 @@ impl FileOrchestrator {
 
                     let mut adjusted = result;
                     Self::apply_candidate_map(&mut adjusted, &pf.candidate_map, &pf.path_str);
+                    Self::resolve_env_var_aliases(&mut adjusted, &pf.env_alias_map);
                     Self::validate_type_hints(&mut adjusted, &pf.symbol_table);
                     Self::normalize_unusable_types(&mut adjusted, &framework_detection.frameworks);
 
@@ -955,13 +965,16 @@ impl FileOrchestrator {
         (explicit_requests, infer_requests, inline_aliases)
     }
 
+    /// Parse a file once and extract both the symbol table and the env-var
+    /// alias map (`local const -> process.env name`). Sharing the parse keeps
+    /// the per-file CPU cost flat — both passes are cheap AST walks.
     fn extract_symbol_table(
         file_path: &Path,
         cm: &Lrc<SourceMap>,
         handler: &Handler,
-    ) -> SymbolTable {
+    ) -> (SymbolTable, EnvAliasMap) {
         let Some(module) = parse_file(file_path, cm, handler) else {
-            return SymbolTable::default();
+            return (SymbolTable::default(), EnvAliasMap::default());
         };
 
         let mut import_extractor = ImportSymbolExtractor::new();
@@ -970,10 +983,15 @@ impl FileOrchestrator {
         let mut type_extractor = TypeSymbolExtractor::new();
         module.visit_with(&mut type_extractor);
 
-        SymbolTable {
-            local_types: type_extractor.type_symbols,
-            imported_symbols: import_extractor.imported_symbols,
-        }
+        let env_alias_map = EnvAliasExtractor::build(&module);
+
+        (
+            SymbolTable {
+                local_types: type_extractor.type_symbols,
+                imported_symbols: import_extractor.imported_symbols,
+            },
+            env_alias_map,
+        )
     }
 
     fn validate_type_hints(result: &mut FileAnalysisResult, symbol_table: &SymbolTable) {
@@ -1250,6 +1268,29 @@ impl FileOrchestrator {
                 "[FileOrchestrator] {} data call(s) had no matching SWC candidate (spans unavailable)",
                 dropped_count
             );
+        }
+    }
+
+    /// Rewrite data-call targets that interpolate an env-var base URL aliased
+    /// through a local const so the real `process.env` name reaches downstream
+    /// classification and cross-repo matching (#218).
+    ///
+    /// The file analyzer emits the target verbatim — e.g.
+    /// `${ORDERS_BASE}/orders/${id}` for
+    /// `const ORDERS_BASE = process.env.ORDERS_SERVICE_URL ?? "...";`. Without
+    /// this pass, `Config::is_internal_call` and the cross-repo matcher key on
+    /// the local const `ORDERS_BASE` rather than `ORDERS_SERVICE_URL`, so the
+    /// edge never forms. Rewriting the leading `${ALIAS}` to
+    /// `${process.env.NAME}` funnels the call back through the existing
+    /// direct-`process.env` handling instead of duplicating env-var parsing.
+    fn resolve_env_var_aliases(result: &mut FileAnalysisResult, env_alias_map: &EnvAliasMap) {
+        if env_alias_map.is_empty() {
+            return;
+        }
+        for data_call in &mut result.data_calls {
+            if let Some(resolved) = resolve_target_env_alias(&data_call.target, env_alias_map) {
+                data_call.target = resolved;
+            }
         }
     }
 

--- a/src/env_alias.rs
+++ b/src/env_alias.rs
@@ -1,0 +1,298 @@
+//! Env-var alias resolution.
+//!
+//! A very common real pattern aliases an environment variable through a local
+//! const before interpolating it into a request URL:
+//!
+//! ```ts
+//! const ORDERS_BASE = process.env.ORDERS_SERVICE_URL ?? "http://localhost:3001";
+//! await fetch(`${ORDERS_BASE}/orders/${orderId}`);
+//! ```
+//!
+//! The file analyzer extracts the call target verbatim as
+//! `${ORDERS_BASE}/orders/${orderId}`, so every downstream consumer that keys
+//! on the env-var *name* (`Config::is_internal_call`, the cross-repo matcher)
+//! sees the local const `ORDERS_BASE` rather than the real env var
+//! `ORDERS_SERVICE_URL`. Internal/external classification and cross-repo
+//! matching then silently fail.
+//!
+//! This module builds a per-file map of `local const -> process.env name` for
+//! the direct-alias case and rewrites a target URL's leading `${ALIAS}` to
+//! `${process.env.NAME}`. That funnels the call back through the existing
+//! direct-`process.env` handling in [`crate::url_normalizer`] and
+//! [`crate::analyzer`], rather than duplicating env-var parsing.
+//!
+//! Scope is deliberately tight: only bindings initialized *directly* from
+//! `process.env` (optionally with a `??`/`||` default) are tracked. Anything
+//! beyond the direct alias — reassignment, string concatenation building the
+//! base URL, cross-file/imported bases, deep data flow — is intentionally not
+//! resolved. See the TODO in [`EnvAliasExtractor`].
+
+use std::collections::HashMap;
+use swc_ecma_ast::*;
+use swc_ecma_visit::{Visit, VisitWith};
+
+/// Maps a local binding name (e.g. `ORDERS_BASE`) to the `process.env` variable
+/// it was initialized from (e.g. `ORDERS_SERVICE_URL`).
+pub type EnvAliasMap = HashMap<String, String>;
+
+/// Visitor that collects `const/let/var X = process.env.NAME [?? default]`
+/// bindings into an [`EnvAliasMap`].
+///
+/// TODO(#218 follow-up): only direct `process.env` aliases are tracked. We do
+/// not follow reassignments, concatenated/templated bases
+/// (`const b = process.env.X + "/v1"`), or aliases imported from another
+/// module. Those need real data-flow / cross-file analysis and are out of
+/// scope for the deterministic direct-alias fix.
+#[derive(Default)]
+pub struct EnvAliasExtractor {
+    pub aliases: EnvAliasMap,
+}
+
+impl EnvAliasExtractor {
+    /// Build the alias map for a parsed module.
+    pub fn build(module: &Module) -> EnvAliasMap {
+        let mut extractor = EnvAliasExtractor::default();
+        module.visit_with(&mut extractor);
+        extractor.aliases
+    }
+}
+
+impl Visit for EnvAliasExtractor {
+    fn visit_var_decl(&mut self, var_decl: &VarDecl) {
+        for decl in &var_decl.decls {
+            // Only simple identifier bindings: `const X = ...`. Destructuring
+            // (`const { X } = process.env`) is a different, rarer pattern.
+            let Pat::Ident(binding) = &decl.name else {
+                continue;
+            };
+            let Some(init) = &decl.init else {
+                continue;
+            };
+
+            if let Some(env_name) = process_env_name(init) {
+                // SWC resolver gives each binding a unique SyntaxContext, but the
+                // call target the LLM emits is just the bare symbol text. Key on
+                // the symbol so `${ORDERS_BASE}` resolves. A name shadowed in a
+                // nested scope would collide here, but that is vanishingly rare
+                // for a base-URL const and far better than not resolving at all.
+                self.aliases.insert(binding.id.sym.to_string(), env_name);
+            }
+        }
+
+        var_decl.visit_children_with(self);
+    }
+}
+
+/// If `expr` reads a single `process.env` variable (optionally with a `??`/`||`
+/// default), return that variable's name.
+///
+/// Handles:
+/// - `process.env.NAME`
+/// - `process.env["NAME"]`
+/// - `process.env.NAME ?? <default>` / `process.env.NAME || <default>`
+fn process_env_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Member(member) => process_env_member_name(member),
+        // `process.env.NAME ?? "default"` / `... || "default"`: the env read is
+        // the left operand. The default literal is discarded — the env-var name
+        // is all the classifier needs.
+        Expr::Bin(bin) if matches!(bin.op, BinaryOp::NullishCoalescing | BinaryOp::LogicalOr) => {
+            process_env_name(&bin.left)
+        }
+        // Unwrap transparent wrappers so `(process.env.X)`, `process.env.X!`,
+        // and `process.env.X as string` still resolve.
+        Expr::Paren(paren) => process_env_name(&paren.expr),
+        Expr::TsNonNull(non_null) => process_env_name(&non_null.expr),
+        Expr::TsAs(ts_as) => process_env_name(&ts_as.expr),
+        _ => None,
+    }
+}
+
+/// If `member` is `process.env.NAME` or `process.env["NAME"]`, return `NAME`.
+fn process_env_member_name(member: &MemberExpr) -> Option<String> {
+    // The object must be exactly `process.env`.
+    let Expr::Member(obj) = &*member.obj else {
+        return None;
+    };
+    if !is_ident(&obj.obj, "process") || !is_ident_prop(&obj.prop, "env") {
+        return None;
+    }
+
+    match &member.prop {
+        MemberProp::Ident(ident) => Some(ident.sym.to_string()),
+        MemberProp::Computed(computed) => match &*computed.expr {
+            Expr::Lit(Lit::Str(s)) => Some(s.value.to_string()),
+            _ => None,
+        },
+        MemberProp::PrivateName(_) => None,
+    }
+}
+
+fn is_ident(expr: &Expr, name: &str) -> bool {
+    matches!(expr, Expr::Ident(ident) if ident.sym.as_ref() == name)
+}
+
+fn is_ident_prop(prop: &MemberProp, name: &str) -> bool {
+    matches!(prop, MemberProp::Ident(ident) if ident.sym.as_ref() == name)
+}
+
+/// Rewrite a leading `${ALIAS}` in a call target to `${process.env.NAME}` when
+/// `ALIAS` is a known env-var alias, so the existing direct-`process.env`
+/// handling resolves the real env-var name.
+///
+/// Only the *leading* interpolation is considered: that is the base-URL slot.
+/// A mid-path `${id}` is a path parameter, never an env alias, so it is left
+/// untouched. Returns `None` when nothing was rewritten.
+pub fn resolve_target_env_alias(target: &str, aliases: &EnvAliasMap) -> Option<String> {
+    if aliases.is_empty() {
+        return None;
+    }
+
+    // The analyzer/normalizer trim wrapper backticks/quotes themselves, but the
+    // alias sits at the very front, so peek past any leading wrapper char.
+    let trimmed = target.trim_start_matches(['`', '"', '\'']);
+    let rest = trimmed.strip_prefix("${")?;
+    let end = rest.find('}')?;
+    let alias = &rest[..end];
+
+    let env_name = aliases.get(alias)?;
+
+    // Splice `process.env.NAME` in for the bare alias, preserving everything the
+    // wrapper-trim skipped and the rest of the path verbatim.
+    let prefix_len = target.len() - trimmed.len();
+    let after_brace = &rest[end + 1..];
+    Some(format!(
+        "{}${{process.env.{}}}{}",
+        &target[..prefix_len],
+        env_name,
+        after_brace
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse_file;
+    use swc_common::{
+        SourceMap,
+        errors::{ColorConfig, Handler},
+        sync::Lrc,
+    };
+
+    fn build_map(source: &str) -> EnvAliasMap {
+        let tmp_dir = tempfile::tempdir().expect("tempdir");
+        let file_path = tmp_dir.path().join("input.ts");
+        std::fs::write(&file_path, source).expect("write file");
+
+        let cm: Lrc<SourceMap> = Default::default();
+        let handler = Handler::with_tty_emitter(ColorConfig::Never, true, false, Some(cm.clone()));
+        let module = parse_file(&file_path, &cm, &handler).expect("parsed module");
+
+        EnvAliasExtractor::build(&module)
+    }
+
+    #[test]
+    fn extracts_direct_process_env_alias() {
+        let map = build_map(r#"const ORDERS_BASE = process.env.ORDERS_SERVICE_URL;"#);
+        assert_eq!(
+            map.get("ORDERS_BASE").map(String::as_str),
+            Some("ORDERS_SERVICE_URL")
+        );
+    }
+
+    #[test]
+    fn extracts_nullish_coalescing_default_form() {
+        // The exact pattern from issue #218.
+        let map = build_map(
+            r#"const ORDERS_BASE = process.env.ORDERS_SERVICE_URL ?? "http://localhost:3001";"#,
+        );
+        assert_eq!(
+            map.get("ORDERS_BASE").map(String::as_str),
+            Some("ORDERS_SERVICE_URL")
+        );
+    }
+
+    #[test]
+    fn extracts_logical_or_default_form() {
+        let map = build_map(r#"const BASE = process.env.SERVICE_URL || "http://localhost:3001";"#);
+        assert_eq!(map.get("BASE").map(String::as_str), Some("SERVICE_URL"));
+    }
+
+    #[test]
+    fn extracts_bracket_access_form() {
+        let map = build_map(r#"const BASE = process.env["SERVICE_URL"];"#);
+        assert_eq!(map.get("BASE").map(String::as_str), Some("SERVICE_URL"));
+    }
+
+    #[test]
+    fn extracts_let_and_var_forms() {
+        let map = build_map(
+            r#"let A = process.env.A_URL;
+var B = process.env.B_URL ?? "";"#,
+        );
+        assert_eq!(map.get("A").map(String::as_str), Some("A_URL"));
+        assert_eq!(map.get("B").map(String::as_str), Some("B_URL"));
+    }
+
+    #[test]
+    fn unwraps_paren_nonnull_and_as_casts() {
+        let map = build_map(
+            r#"const A = (process.env.A_URL);
+const B = process.env.B_URL!;
+const C = process.env.C_URL as string;"#,
+        );
+        assert_eq!(map.get("A").map(String::as_str), Some("A_URL"));
+        assert_eq!(map.get("B").map(String::as_str), Some("B_URL"));
+        assert_eq!(map.get("C").map(String::as_str), Some("C_URL"));
+    }
+
+    #[test]
+    fn ignores_non_env_bindings() {
+        // Not process.env, a concatenated base, and a destructure — all out of scope.
+        let map = build_map(
+            r#"const HOST = config.host;
+const BASE = process.env.X_URL + "/v1";
+const { Y_URL } = process.env;"#,
+        );
+        assert!(!map.contains_key("HOST"));
+        // Concatenation is intentionally not resolved (TODO scope), so BASE must
+        // NOT map to a partial env name.
+        assert!(!map.contains_key("BASE"));
+        assert!(!map.contains_key("Y_URL"));
+    }
+
+    #[test]
+    fn resolves_leading_alias_in_target() {
+        let mut aliases = EnvAliasMap::new();
+        aliases.insert("ORDERS_BASE".to_string(), "ORDERS_SERVICE_URL".to_string());
+
+        assert_eq!(
+            resolve_target_env_alias("${ORDERS_BASE}/orders/${orderId}", &aliases).as_deref(),
+            Some("${process.env.ORDERS_SERVICE_URL}/orders/${orderId}")
+        );
+    }
+
+    #[test]
+    fn resolves_leading_alias_past_wrapper_backtick() {
+        let mut aliases = EnvAliasMap::new();
+        aliases.insert("ORDERS_BASE".to_string(), "ORDERS_SERVICE_URL".to_string());
+
+        assert_eq!(
+            resolve_target_env_alias("`${ORDERS_BASE}/orders/${id}`", &aliases).as_deref(),
+            Some("`${process.env.ORDERS_SERVICE_URL}/orders/${id}`")
+        );
+    }
+
+    #[test]
+    fn leaves_unknown_and_mid_path_interpolations_untouched() {
+        let mut aliases = EnvAliasMap::new();
+        aliases.insert("ORDERS_BASE".to_string(), "ORDERS_SERVICE_URL".to_string());
+
+        // Unknown leading var: not an alias.
+        assert!(resolve_target_env_alias("${API_URL}/users", &aliases).is_none());
+        // A path parameter mid-URL must never be treated as a base-URL alias.
+        assert!(resolve_target_env_alias("/orders/${ORDERS_BASE}", &aliases).is_none());
+        // Empty alias map short-circuits.
+        assert!(resolve_target_env_alias("${ORDERS_BASE}/x", &EnvAliasMap::new()).is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod call_site_extractor;
 pub mod cloud_storage;
 pub mod config;
 pub mod engine;
+pub mod env_alias;
 pub mod eval_output;
 pub mod extractor;
 pub mod file_based_router;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod call_site_extractor;
 mod cloud_storage;
 mod config;
 mod engine;
+mod env_alias;
 mod eval_output;
 mod extractor;
 mod file_based_router;

--- a/tests/url_alias_matching_test.rs
+++ b/tests/url_alias_matching_test.rs
@@ -324,6 +324,82 @@ fn test_expected_alias_format_for_type_checker() {
     );
 }
 
+/// Issue #218 end-to-end: a call whose URL base is an env var aliased through a
+/// local const must resolve to the *real* `process.env` name so internal/external
+/// classification (and cross-repo matching, which keys on the same name) works.
+///
+/// Drives the full chain the orchestrator runs: build the per-file alias map →
+/// rewrite the call target → normalize against a config that declares the real
+/// env var. Before the fix, the target carried the local const `ORDERS_BASE` and
+/// `is_internal` was false; after, it carries `ORDERS_SERVICE_URL` and matches.
+#[test]
+fn test_const_aliased_env_var_resolves_to_real_name() {
+    use carrick::config::Config;
+    use carrick::env_alias::{EnvAliasExtractor, resolve_target_env_alias};
+    use carrick::parser::parse_file;
+    use carrick::url_normalizer::UrlNormalizer;
+
+    // The exact pattern from issue #218 (payments-svc/clients/orders.client.ts).
+    let source = r#"
+const ORDERS_BASE = process.env.ORDERS_SERVICE_URL ?? "http://localhost:3001";
+
+export async function getOrder(orderId: number) {
+  return fetch(`${ORDERS_BASE}/orders/${orderId}`);
+}
+"#;
+
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let file_path = temp_dir.path().join("orders.client.ts");
+    let mut file = fs::File::create(&file_path).expect("Failed to create temp file");
+    file.write_all(source.as_bytes()).expect("write temp file");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let handler = Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(cm.clone()));
+    let module = parse_file(&file_path, &cm, &handler).expect("parsed module");
+
+    // 1. The per-file alias map links the local const to the real env var.
+    let aliases = EnvAliasExtractor::build(&module);
+    assert_eq!(
+        aliases.get("ORDERS_BASE").map(String::as_str),
+        Some("ORDERS_SERVICE_URL"),
+        "alias map should resolve the const to the process.env name"
+    );
+
+    // 2. The call target the LLM emits, rewritten through the alias map.
+    let target = "${ORDERS_BASE}/orders/${orderId}";
+    let rewritten = resolve_target_env_alias(target, &aliases)
+        .expect("leading const alias should be rewritten");
+    assert_eq!(
+        rewritten,
+        "${process.env.ORDERS_SERVICE_URL}/orders/${orderId}"
+    );
+
+    // 3. With ORDERS_SERVICE_URL declared internal, the rewritten target now
+    //    classifies as internal and yields the producer-matchable path. The
+    //    original (unaliased) target does NOT — that is the bug.
+    let config = Config {
+        internal_env_vars: ["ORDERS_SERVICE_URL"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        ..Default::default()
+    };
+    let normalizer = UrlNormalizer::new(&config);
+
+    let resolved = normalizer.normalize(&rewritten);
+    assert_eq!(resolved.path, "/orders/:orderId");
+    assert!(
+        resolved.is_internal,
+        "rewritten target must classify as internal via the real env var"
+    );
+
+    let unresolved = normalizer.normalize(target);
+    assert!(
+        !unresolved.is_internal,
+        "the un-rewritten const-aliased target should NOT classify as internal (this is #218)"
+    );
+}
+
 /// Test edge case: empty path
 #[test]
 fn test_empty_path_alias() {


### PR DESCRIPTION
## What

Resolves env-var base URLs that are aliased through a local const before being interpolated into a request URL — the pattern that zeroed cross-repo match F1 on the first live `eval-xrepo` run.

```ts
const ORDERS_BASE = process.env.ORDERS_SERVICE_URL ?? "http://localhost:3001";
await fetch(`${ORDERS_BASE}/orders/${orderId}`);
```

Before this change the file analyzer emitted the target verbatim as `${ORDERS_BASE}/orders/:param`, so `Config::is_internal_call` (`src/config.rs`) and the cross-repo matcher (`src/analyzer/mod.rs`) keyed on the local const `ORDERS_BASE` instead of the real env var `ORDERS_SERVICE_URL`. Internal/external classification and cross-repo edge formation silently failed for every consumer that aliases its base URL through a const.

## Where the alias map is built + applied

- **Built:** new module `src/env_alias.rs`. `EnvAliasExtractor::build(module)` walks `VarDecl`s and produces a per-file `local const -> process.env name` map. It is built in `FileOrchestrator::extract_symbol_table` (PHASE 1 of `analyze_files`), reusing the same SWC parse already done for the symbol table — no extra parse cost. Stored on `PendingFile.env_alias_map`.
- **Applied:** `FileOrchestrator::resolve_env_var_aliases` (PHASE 3 of `analyze_files`, immediately after `apply_candidate_map`). For each data call it calls `env_alias::resolve_target_env_alias`, which rewrites a leading `${ALIAS}` to `${process.env.NAME}`. That funnels the call back through the **existing** direct-`process.env` handling in `url_normalizer.rs` and `analyzer::extract_env_var_name` rather than duplicating env-var parsing.

## Cases handled vs deferred

Handled (direct alias):
- `const X = process.env.NAME`
- `const X = process.env.NAME ?? <default>` and `... || <default>`
- `const X = process.env["NAME"]`
- `let` / `var` equivalents
- transparent wrappers: `(process.env.X)`, `process.env.X!`, `process.env.X as string`
- only the **leading** `${ALIAS}` (the base-URL slot) is rewritten; a mid-path `${id}` is a path parameter and is left untouched.

Deferred (TODO in the module, out of scope per the issue):
- reassignment, concatenated/templated bases (`const b = process.env.X + "/v1"`), and cross-file / imported aliases — these need real data-flow / cross-file analysis.

## Tests

- `cargo test --lib env_alias` — 10 new unit tests (extraction of all the forms above + non-env rejection; target rewrite incl. wrapper backtick, unknown leading var, mid-path param, empty map).
- `tests/url_alias_matching_test.rs::test_const_aliased_env_var_resolves_to_real_name` — end-to-end: builds the alias map from the issue's exact source, rewrites the target, and asserts via the public `UrlNormalizer` that the rewritten target classifies as **internal** via `ORDERS_SERVICE_URL` and normalizes to `/orders/:orderId`, while the un-rewritten target does **not** (the bug).
- Full suite green: `cargo test` passes everywhere **except** `llm_cassette_hard_gate_test`, which fails identically on the clean base branch (verified by stashing this change). Its diff is entirely in TypeSidecar fields (`type_state`/`resolved_definition`/`expanded_definition`) — the ts-morph sidecar does not resolve types in this local environment. The `calls` and `cross_repo_matches` arrays are byte-identical to the golden, so **the cassette golden does not change** as a result of this fix (the `llm-mocked-api` fixture has no const-aliased env-var data calls; the pass is a no-op there). No re-record needed.
- `cargo fmt --all --check` clean; `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Integration acceptance (lead)

The cross-repo eval corpus + `carrick.json` already declare the real env vars (`ORDERS_SERVICE_URL` / `NEXT_PUBLIC_ORDERS_URL` / `NEXT_PUBLIC_PAYMENTS_URL`). The end-to-end acceptance is the lead re-running `eval-xrepo` (live, in CI): the `[diag]` dump should now show the resolved `process.env` names and cross-repo match F1 should rise off 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #218
