### PR TITLE
test(fixtures): extend xrepo-corpus-1 with cross-repo GraphQL + WebSocket + richer types

### DIFF
--- a/tests/fixtures/xrepo-corpus-1/README.md
+++ b/tests/fixtures/xrepo-corpus-1/README.md
@@ -14,43 +14,112 @@ in a separate commit, reviewed against the spec — never to match scanner outpu
   renamed scoped-closure plugin param (owner-drift trap, #133/#167),
   `new Router({prefix})` mounted with no path, barrel re-export. `gateway`
   (NestJS): `@Controller('users')`+`@Get(':id')` prefix concat, an owner=method
-  fabrication trap (`/gateway/health`), and an MCP `server.tool()` decoy.
+  fabrication trap (`/gateway/health`), an MCP `server.tool()` decoy, an
+  **Implicit-return** `@Get('recent')` (no annotation → inferred shape, #222),
+  and a **schema-first GraphQL** producer (`src/schema.graphql` +
+  `src/orders.resolver.ts`, #220).
 - `payments-svc/` — Express producer + consumers: env-var-base `/orders/:param`
   (compatible edge), orphan `/billing/charge`, `sendBeacon('/metrics/ingest')`
   built-in (must emit, `import_source: null`), SDK-as-HTTP decoy (`audit.ts`),
-  Lambda-handler decoy (`settle.ts`).
-- `web-frontend/` — Next.js-style consumer: `/orders/[id]` (type-INCOMPATIBLE
-  with the producer) and `/payments` (compatible).
+  Lambda-handler decoy (`settle.ts`), and a **Socket.IO server emit** of
+  `payment:settled` (`realtime/server.ts`, #221).
+- `web-frontend/` — Next.js-style consumer: REST `/orders/[id]` (type-INCOMPATIBLE
+  with the producer) and `/payments` (compatible); a **GraphQL client**
+  (`lib/graphql.ts`: `query order` compatible, `subscription orderUpdated`
+  INCOMPATIBLE via optional-field widening, #220/#222); a **Socket.IO client
+  listener** for `payment:settled` (`lib/realtime.ts`, #221).
 
 ## Configuration
 The consumer repos carry a `carrick.json` declaring their env-var base URLs as
-`internalEnvVars`. Cross-repo matching of an `${ENV}`-based call to a producer
-only fires when the env var is classified internal (`Config::is_internal_call`,
-matcher at `src/analyzer/mod.rs`), so without this the edges never form (a fresh
-corpus scan showed cross-repo match F1 = 0). This is deliberate: the explicit
-internal/external classification is kept (internal-by-default was considered and
-rejected — see `carrick-cloud/docs/internal/cross-repo-call-classification-decision.md`).
+`internalEnvVars`. Cross-repo matching of an `${ENV}`-based **HTTP** call to a
+producer only fires when the env var is classified internal
+(`Config::is_internal_call`, matcher at `src/analyzer/mod.rs`), so without this
+the HTTP edges never form (a fresh corpus scan showed cross-repo match F1 = 0).
+This is deliberate: the explicit internal/external classification is kept
+(internal-by-default was considered and rejected — see
+`carrick-cloud/docs/internal/cross-repo-call-classification-decision.md`).
+
+**GraphQL and Socket.IO need no connection-classification config.** Their
+matchers (`Analyzer::analyze_exact_key_matches`, `src/analyzer/mod.rs`) key on
+the *operation identity*, not the URL: GraphQL on `OperationKey::Graphql { kind,
+field }` (e.g. `graphql|query|order`) and Socket.IO on `OperationKey::Socket {
+event, direction }` (e.g. `socket|SERVER->CLIENT|payment:settled`). A consumer
+document field meets a producer schema field by name; a socket emitter meets a
+listener on the same event+direction — regardless of which URL either side
+connects to. So the GraphQL/socket connection URLs
+(`NEXT_PUBLIC_GATEWAY_GQL_URL`, `NEXT_PUBLIC_PAYMENTS_WS_URL`) are left out of
+`internalEnvVars` on purpose; adding them would be inert for matching.
 
 ## Ground truth
-- Per-repo `<repo>/expected.json` — endpoints/calls + owner + type anchor +
-  resolved type + `_must_not_emit` negatives, every label tagged
-  `capability`/`roadmap` (all `capability` here).
-- Corpus `expected-output.json` — cross-repo `matches` (with compat verdict),
-  `orphans`, and `dependency_conflicts`.
+- Per-repo `<repo>/expected.json` — HTTP `endpoints`/`calls` + owner + type
+  anchor + resolved type + `_must_not_emit` negatives, plus the non-HTTP
+  `graphql_operations` and `socket_events` arrays (each with `role`/`service`/
+  `key`/`primary_type_symbol`/`resolved_type`/`type_state`). Every label tagged
+  `capability`/`roadmap` (all `capability` here). The current S4-thin-slice
+  scorer (`tests/eval_xrepo.rs`) reads only `endpoints[].{method,path}` and
+  ignores the new arrays via serde defaults; the full S4 scorer (#223) scores
+  them.
+- Corpus `expected-output.json` — cross-repo `matches` (now carrying a
+  `protocol` tag per edge + the compat verdict), `orphans`, and
+  `dependency_conflicts`.
 
 ## Cross-repo edges
-| Producer | Consumer | Compat |
-|---|---|---|
-| orders-monorepo `GET /orders/:param` | payments-svc | compatible |
-| orders-monorepo `GET /orders/:param` | web-frontend | **incompatible** (`id` string vs number) |
-| payments-svc `POST /payments` | web-frontend | compatible |
+| Protocol | Producer | Consumer | Key | Compat |
+|---|---|---|---|---|
+| http | orders-pkg `GET /orders/:param` | payments-svc | `http\|GET\|/orders/:param` | compatible |
+| http | orders-pkg `GET /orders/:param` | web-frontend | `http\|GET\|/orders/:param` | **incompatible** (`id` string vs number) |
+| http | payments-svc `POST /payments` | web-frontend | `http\|POST\|/payments` | compatible |
+| graphql | gateway `query order` | web-frontend | `graphql\|query\|order` | compatible |
+| graphql | gateway `subscription orderUpdated` | web-frontend | `graphql\|subscription\|orderUpdated` | **incompatible** (optional-field widening: consumer `note` required, producer optional) |
+| socket | web-frontend (listener) | payments-svc (emitter) | `socket\|SERVER->CLIENT\|payment:settled` | compatible |
+
+**Socket producer/consumer direction (read before "fixing" the labels).** In
+Carrick's socket model a *listener* (`socket.on`) is the **producer (endpoint)**
+of the key it receives and an *emitter* (`socket.emit`) is the **consumer
+(call)** of the key it sends (`src/socket_io.rs`, `src/engine/mod.rs`: "listeners
+as endpoints, emitters as calls"; unit test `test_socket_matching_is_direction_aware`).
+So for the `payment:settled` event flow (payments-svc server *emits* →
+web-frontend client *listens*), the structured `matches` edge has
+`producer_repo: web-frontend` (the listener) and `consumer_repo: payments-svc`
+(the emitter), both on `socket|SERVER->CLIENT|payment:settled`. The *event*
+flows payments-svc → web-frontend; the *contract producer* is the listener.
 
 Orphan producers: orders `GET /api/v1/status`, gateway `GET /users/:param`,
-`GET /gateway/health`, payments `GET /payments/:param`. Orphan consumers:
-payments `POST /billing/charge`, `POST /metrics/ingest`. Decoys (MCP tools,
-`audit.ts`, `settle.ts`) emit nothing.
+`GET /users/recent`, `GET /gateway/health`, gateway `graphql mutation
+refundOrder`; payments `GET /payments/:param`. Orphan consumers: payments
+`POST /billing/charge`, `POST /metrics/ingest`. Decoys (MCP tools, `audit.ts`,
+`settle.ts`) emit nothing.
 
 `dependency_conflicts` carries one deliberate cross-repo conflict (`zod` 3.x vs
 4.x). Its exact version-string and severity are deterministic scanner output,
 verified against a real scan when the scorer (S4) / cassette gate (S5) wire the
 corpus in.
+
+## Type-inference cases (#222)
+The corpus previously had `type_state` 9×Explicit / 2×Unknown / **0×Implicit**
+and only flat named interfaces. Threaded through the new edges:
+- **Implicit (inferred) return type** — gateway `GET /users/recent` has no
+  return annotation; the sidecar must infer `{ count: number; ids: string[] }`
+  (`type_state: Implicit`, the corpus's first and only one).
+- **Generic wrapper** — `ApiResponse<T>` wraps the GraphQL `order`/`refundOrder`
+  payloads (`src/orders.resolver.ts`).
+- **Nested object** — `Money` (`{ amountCents; currency }`) inside `Order.total`.
+- **Optional field** — `Order.note?` on the producer.
+- **Union field** — `OrderStatus` (`placed | refunded`), modelled as a GraphQL
+  `union OrderStatus` and a discriminated TS union.
+- **Subtler compat mismatch** — the `orderUpdated` subscription widens the
+  optional producer `note` into a required consumer `OrderUpdate.note`, a quieter
+  mismatch than the blunt `id: number` vs `string` REST trap.
+
+## Protocol detectability (what the scanner keys on)
+- **GraphQL producer**: `gateway/src/schema.graphql` (SDL). `scan_repo`
+  (`src/graphql.rs`) walks the repo for `.graphql`/`.gql` files and indexes
+  root-operation fields (`Query`/`Mutation`/`Subscription`) as producers.
+- **GraphQL consumer**: `gql\`…\`` tagged templates in `web-frontend/lib/graphql.ts`
+  (`extract_from_ts_file`); the top-level executable-document field is the
+  consumer key (alias-aware, `__typename`/introspection skipped).
+- **Socket producer/consumer**: `new Server()` from `socket.io` +
+  `io.on('connection', socket => socket.emit('payment:settled', …))`
+  (payments-svc emitter) and `io(url)` from `socket.io-client` +
+  `socket.on('payment:settled', …)` (web-frontend listener). String-literal
+  event names only; `connect`/`disconnect` reserved events are filtered.

--- a/tests/fixtures/xrepo-corpus-1/expected-output.json
+++ b/tests/fixtures/xrepo-corpus-1/expected-output.json
@@ -7,6 +7,7 @@
       "consumer_key": "http|GET|/orders/:param",
       "type_compatible": true,
       "mismatch_reason": null,
+      "protocol": "http",
       "tier": "capability"
     },
     {
@@ -16,6 +17,7 @@
       "consumer_key": "http|GET|/orders/:param",
       "type_compatible": false,
       "mismatch_reason": "consumer OrderView.id is string but producer Order.id is number",
+      "protocol": "http",
       "tier": "capability"
     },
     {
@@ -25,13 +27,46 @@
       "consumer_key": "http|POST|/payments",
       "type_compatible": true,
       "mismatch_reason": null,
+      "protocol": "http",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "gateway",
+      "producer_key": "graphql|query|order",
+      "consumer_repo": "web-frontend",
+      "consumer_key": "graphql|query|order",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "graphql",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "gateway",
+      "producer_key": "graphql|subscription|orderUpdated",
+      "consumer_repo": "web-frontend",
+      "consumer_key": "graphql|subscription|orderUpdated",
+      "type_compatible": false,
+      "mismatch_reason": "consumer OrderUpdate.note is required but producer Order.note is optional (optional-field widening)",
+      "protocol": "graphql",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "web-frontend",
+      "producer_key": "socket|SERVER->CLIENT|payment:settled",
+      "consumer_repo": "payments-svc",
+      "consumer_key": "socket|SERVER->CLIENT|payment:settled",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "socket",
       "tier": "capability"
     }
   ],
   "orphans": [
     { "repo": "orders-pkg", "side": "producer", "key": "http|GET|/api/v1/status", "tier": "capability" },
     { "repo": "gateway", "side": "producer", "key": "http|GET|/users/:param", "tier": "capability" },
+    { "repo": "gateway", "side": "producer", "key": "http|GET|/users/recent", "tier": "capability" },
     { "repo": "gateway", "side": "producer", "key": "http|GET|/gateway/health", "tier": "capability" },
+    { "repo": "gateway", "side": "producer", "key": "graphql|mutation|refundOrder", "tier": "capability" },
     { "repo": "payments-svc", "side": "producer", "key": "http|GET|/payments/:param", "tier": "capability" },
     { "repo": "payments-svc", "side": "consumer", "key": "http|POST|/billing/charge", "tier": "capability" },
     { "repo": "payments-svc", "side": "consumer", "key": "http|POST|/metrics/ingest", "tier": "capability" }
@@ -46,12 +81,13 @@
   ],
   "summary": {
     "total_repos": 3,
-    "producers": 6,
-    "consumers": 5,
-    "matched_edges": 3,
-    "incompatible_edges": 1,
-    "orphan_producers": 4,
+    "producers": 11,
+    "consumers": 8,
+    "matched_edges": 6,
+    "incompatible_edges": 2,
+    "orphan_producers": 5,
     "orphan_consumers": 2,
-    "decoys_must_not_emit": 4
+    "decoys_must_not_emit": 4,
+    "matched_edges_by_protocol": { "http": 3, "graphql": 2, "socket": 1 }
   }
 }

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/expected.json
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/expected.json
@@ -29,6 +29,15 @@
     },
     {
       "method": "GET",
+      "path": "/users/recent",
+      "owner": "recent",
+      "primary_type_symbol": null,
+      "resolved_type": "{ count: number; ids: string[]; }",
+      "type_state": "Implicit",
+      "tier": "capability"
+    },
+    {
+      "method": "GET",
       "path": "/gateway/health",
       "owner": "healthCheckHandler",
       "primary_type_symbol": "HealthResponse",
@@ -38,6 +47,44 @@
     }
   ],
   "calls": [],
+  "graphql_operations": [
+    {
+      "role": "producer",
+      "service": "gateway",
+      "key": "graphql|query|order",
+      "kind": "query",
+      "field": "order",
+      "source": "packages/gateway/src/schema.graphql",
+      "primary_type_symbol": "ApiResponse<Order>",
+      "resolved_type": "{ data: { id: string; total: { amountCents: number; currency: string; }; status: { kind: \"placed\"; placedAt: string; } | { kind: \"refunded\"; refundedAt: string; reason?: string; }; note?: string; }; errors: string[]; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "producer",
+      "service": "gateway",
+      "key": "graphql|mutation|refundOrder",
+      "kind": "mutation",
+      "field": "refundOrder",
+      "source": "packages/gateway/src/schema.graphql",
+      "primary_type_symbol": "ApiResponse<Order>",
+      "resolved_type": "{ data: { id: string; total: { amountCents: number; currency: string; }; status: { kind: \"placed\"; placedAt: string; } | { kind: \"refunded\"; refundedAt: string; reason?: string; }; note?: string; }; errors: string[]; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "producer",
+      "service": "gateway",
+      "key": "graphql|subscription|orderUpdated",
+      "kind": "subscription",
+      "field": "orderUpdated",
+      "source": "packages/gateway/src/schema.graphql",
+      "primary_type_symbol": "Order",
+      "resolved_type": "{ id: string; total: { amountCents: number; currency: string; }; status: { kind: \"placed\"; placedAt: string; } | { kind: \"refunded\"; refundedAt: string; reason?: string; }; note?: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
   "_must_not_emit": [
     {
       "kind": "endpoint",

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/package.json
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/package.json
@@ -5,6 +5,8 @@
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
+    "graphql": "^16.8.0",
+    "graphql-tag": "^2.12.6",
     "zod": "^3.22.0"
   },
   "scripts": {

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/index.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/index.ts
@@ -1,5 +1,11 @@
 export { UsersController } from './users.controller';
 export { healthCheckHandler, routeRegistry } from './health.handler';
 export { server as mcpServer } from './mcp-tools';
+export {
+  resolveOrder,
+  resolveRefundOrder,
+  resolveOrderUpdated,
+} from './orders.resolver';
 export type { UserSummary } from './users.controller';
 export type { HealthResponse } from './health.handler';
+export type { Order, Money, OrderStatus, ApiResponse } from './orders.resolver';

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/orders.resolver.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/orders.resolver.ts
@@ -1,0 +1,74 @@
+// GraphQL resolver shapes for the orders gateway (producer side of #220).
+//
+// The schema lives in src/schema.graphql (schema-first, scanner-detectable).
+// This module declares the TypeScript types behind those root fields so the
+// sidecar resolves the request/response shapes for the type-enrichment work
+// (#222): a generic wrapper (ApiResponse<T>), a nested object (Money), an
+// optional field (note), and a union field (status).
+
+// Nested object, reused inside Order.
+export interface Money {
+  amountCents: number;
+  currency: string;
+}
+
+// Union field — discriminated on `kind`.
+export type OrderStatus =
+  | { kind: "placed"; placedAt: string }
+  | { kind: "refunded"; refundedAt: string; reason?: string };
+
+// The GraphQL `Order` response shape. Mirrors src/schema.graphql `type Order`.
+//   - total: nested Money object
+//   - status: union field
+//   - note: optional field (present on producer; some consumers omit it)
+export interface Order {
+  id: string;
+  total: Money;
+  status: OrderStatus;
+  note?: string;
+}
+
+// Generic response wrapper threaded through the resolvers (#222 generics case).
+export interface ApiResponse<T> {
+  data: T;
+  errors: string[];
+}
+
+// query order(id): Order — producer for web-frontend `query order`.
+export async function resolveOrder(id: string): Promise<ApiResponse<Order>> {
+  return {
+    data: {
+      id,
+      total: { amountCents: 4999, currency: "EUR" },
+      status: { kind: "placed", placedAt: new Date().toISOString() },
+      note: "gift wrap",
+    },
+    errors: [],
+  };
+}
+
+// mutation refundOrder(id, reason): Order!
+export async function resolveRefundOrder(
+  id: string,
+  reason?: string
+): Promise<ApiResponse<Order>> {
+  return {
+    data: {
+      id,
+      total: { amountCents: 0, currency: "EUR" },
+      status: { kind: "refunded", refundedAt: new Date().toISOString(), reason },
+    },
+    errors: [],
+  };
+}
+
+// subscription orderUpdated: Order! — producer for web-frontend
+// `subscription orderUpdated`. Returns the full Order (with the optional `note`).
+export async function* resolveOrderUpdated(): AsyncGenerator<Order> {
+  yield {
+    id: "ord_1",
+    total: { amountCents: 4999, currency: "EUR" },
+    status: { kind: "placed", placedAt: new Date().toISOString() },
+    note: "gift wrap",
+  };
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/schema.graphql
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/schema.graphql
@@ -1,0 +1,53 @@
+# GraphQL schema (schema-first) for the orders gateway.
+#
+# This is the PRODUCER side of the cross-repo GraphQL edge (#220). The scanner
+# walks the repo for `.graphql`/`.gql` files (src/graphql.rs::scan_repo) and
+# indexes the root-operation fields below as producers, keyed by
+# OperationKey::Graphql { kind, field }:
+#   Query.order           -> graphql|query|order
+#   Mutation.refundOrder  -> graphql|mutation|refundOrder
+#   Subscription.orderUpdated -> graphql|subscription|orderUpdated
+#
+# The TS resolver shapes in src/orders.resolver.ts carry the corresponding
+# request/response types the sidecar resolves (richer-types work, #222):
+# a nested object (Money), an optional field (note), and a union field (status).
+
+type Money {
+  amountCents: Int!
+  currency: String!
+}
+
+# Discriminated-union-style status, modelled as a GraphQL union of object types.
+type OrderPlaced {
+  placedAt: String!
+}
+
+type OrderRefunded {
+  refundedAt: String!
+  reason: String
+}
+
+union OrderStatus = OrderPlaced | OrderRefunded
+
+type Order {
+  id: ID!
+  total: Money!
+  status: OrderStatus!
+  # Optional field — present on the producer, absent on some consumers.
+  note: String
+}
+
+type Query {
+  # Producer for the web-frontend `query order` consumer.
+  order(id: ID!): Order
+  orders: [Order!]!
+}
+
+type Mutation {
+  refundOrder(id: ID!, reason: String): Order!
+}
+
+type Subscription {
+  # Producer for the web-frontend `subscription orderUpdated` consumer.
+  orderUpdated: Order!
+}

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/users.controller.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/users.controller.ts
@@ -18,4 +18,14 @@ export class UsersController {
   findOne(@Param('id') id: string): UserSummary {
     return { id, displayName: 'placeholder' };
   }
+
+  // GET /users/recent — INFERRED (Implicit) return type (#222).
+  // No return annotation: the sidecar must infer the response shape from the
+  // returned object literal — { count: number; ids: string[] } — so this
+  // endpoint's type_state is Implicit, not Explicit. The only Implicit case in
+  // the corpus; it stresses type *inference*, not just resolution.
+  @Get('recent')
+  recent() {
+    return { count: 2, ids: ['u_1', 'u_2'] };
+  }
 }

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/expected.json
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/expected.json
@@ -54,6 +54,21 @@
       "tier": "capability"
     }
   ],
+  "socket_events": [
+    {
+      "role": "consumer",
+      "service": "payments-svc",
+      "key": "socket|SERVER->CLIENT|payment:settled",
+      "event": "payment:settled",
+      "direction": "SERVER->CLIENT",
+      "side": "emitter",
+      "source": "realtime/server.ts",
+      "primary_type_symbol": "Payment",
+      "resolved_type": "{ id: string; orderId: number; amountCents: number; status: \"pending\" | \"settled\"; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
   "_must_not_emit": [
     {
       "kind": "call",

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/package.json
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "axios": "^1.6.0",
+    "socket.io": "^4.7.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/realtime/server.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/realtime/server.ts
@@ -1,0 +1,43 @@
+// Socket.IO server emit (producer of the event flow, #221).
+//
+// Scanner-detectable via src/socket_io.rs: a `new Server(...)` from "socket.io"
+// makes `io` a server root; the `connection` handler's first param is a
+// per-connection server socket; `socket.emit("payment:settled", ...)` is an
+// EMITTER of the SERVER->CLIENT direction → keyed socket|SERVER->CLIENT|payment:settled.
+//
+// In Carrick's socket model an emitter is a CONSUMER (call) of the key it sends;
+// the matching producer (endpoint) is the listener on the other side — the
+// web-frontend client `socket.on("payment:settled", ...)`. So the structured
+// cross-repo edge is { producer_repo: web-frontend (listener),
+// consumer_repo: payments-svc (emitter) }, both on
+// socket|SERVER->CLIENT|payment:settled. This mirrors the unit test
+// `test_socket_matching_is_direction_aware` (client listener = endpoint).
+//
+// The emitted payload is the payments-svc `Payment` type (#222 carries it).
+
+import { Server } from "socket.io";
+import { createServer } from "http";
+import type { Payment } from "../src/types";
+
+const httpServer = createServer();
+const io = new Server(httpServer);
+
+io.on("connection", (socket) => {
+  // Emit a settled payment to connected clients (server -> client).
+  const settle = (payment: Payment) => {
+    socket.emit("payment:settled", payment);
+  };
+
+  // A reserved lifecycle event — never becomes a contract event.
+  socket.on("disconnect", () => {});
+
+  // Demonstrate the emit on a tick (statically analyzable, not run).
+  settle({
+    id: "pay_1",
+    orderId: 1,
+    amountCents: 4999,
+    status: "settled",
+  });
+});
+
+httpServer.listen(4100);

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/src/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/src/types/stubs.d.ts
@@ -53,3 +53,24 @@ declare module "@aws-sdk/client-dynamodb" {
     constructor(input: unknown);
   }
 }
+
+// Socket.IO server stub — referenced by realtime/server.ts (WebSocket producer).
+declare module "socket.io" {
+  export interface Socket {
+    id: string;
+    on(event: string, handler: (...args: unknown[]) => void): void;
+    emit(event: string, ...args: unknown[]): void;
+  }
+  export class Server {
+    constructor(httpServer?: unknown);
+    on(event: "connection", handler: (socket: Socket) => void): void;
+    emit(event: string, ...args: unknown[]): void;
+  }
+}
+
+declare module "http" {
+  export interface HttpServer {
+    listen(port: number, callback?: () => void): void;
+  }
+  export function createServer(): HttpServer;
+}

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/expected.json
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/expected.json
@@ -23,5 +23,46 @@
       "type_state": "Explicit",
       "tier": "capability"
     }
+  ],
+  "graphql_operations": [
+    {
+      "role": "consumer",
+      "service": "web-frontend",
+      "key": "graphql|query|order",
+      "kind": "query",
+      "field": "order",
+      "source": "lib/graphql.ts",
+      "primary_type_symbol": "OrderView",
+      "resolved_type": "{ id: string; total: { amountCents: number; currency: string; }; note?: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "consumer",
+      "service": "web-frontend",
+      "key": "graphql|subscription|orderUpdated",
+      "kind": "subscription",
+      "field": "orderUpdated",
+      "source": "lib/graphql.ts",
+      "primary_type_symbol": "OrderUpdate",
+      "resolved_type": "{ id: string; total: { amountCents: number; currency: string; }; note: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "socket_events": [
+    {
+      "role": "producer",
+      "service": "web-frontend",
+      "key": "socket|SERVER->CLIENT|payment:settled",
+      "event": "payment:settled",
+      "direction": "SERVER->CLIENT",
+      "side": "listener",
+      "source": "lib/realtime.ts",
+      "primary_type_symbol": "SettledPayment",
+      "resolved_type": "{ id: string; orderId: number; amountCents: number; status: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
   ]
 }

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/lib/graphql.ts
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/lib/graphql.ts
@@ -1,0 +1,85 @@
+// GraphQL consumer for the web frontend (consumer side of #220).
+//
+// `gql` tagged-template documents — scanner-detectable via
+// src/graphql.rs::extract_from_ts_file (tag must be `gql` or `graphql`). The
+// top-level field of each executable document is the consumer key:
+//   query GetOrder   -> order        -> graphql|query|order
+//   subscription ... -> orderUpdated -> graphql|subscription|orderUpdated
+// These match the gateway's schema-first producers (cross-repo edge).
+//
+// Type-enrichment (#222): the consumer shapes deliberately diverge from the
+// producer in a SUBTLE way on the subscription edge —
+//   producer Order.note is OPTIONAL (note: String)
+//   consumer OrderUpdate.note is REQUIRED (note: string)
+// an optional-field-widening mismatch (the consumer assumes a field the
+// producer may omit), distinct from the blunt `id: number` vs `string` REST
+// trap already in the corpus.
+
+import { gql } from "graphql-tag";
+import { GraphQLClient } from "graphql-request";
+
+const GATEWAY_URL = process.env.NEXT_PUBLIC_GATEWAY_GQL_URL ?? "";
+const client = new GraphQLClient(GATEWAY_URL);
+
+// Nested object on the consumer side (compatible with producer Money).
+export interface MoneyView {
+  amountCents: number;
+  currency: string;
+}
+
+// Consumer view of an order returned by `query order`. Compatible with the
+// producer Order: `note` is optional here too, so the query edge is compatible.
+export interface OrderView {
+  id: string;
+  total: MoneyView;
+  note?: string;
+}
+
+// Consumer view delivered by the `orderUpdated` subscription. INCOMPATIBLE with
+// the producer: `note` is REQUIRED here but optional on the producer
+// (optional-field widening). The render path below reads `update.note.length`,
+// assuming the field is always present.
+export interface OrderUpdate {
+  id: string;
+  total: MoneyView;
+  note: string;
+}
+
+export const GET_ORDER = gql`
+  query GetOrder($id: ID!) {
+    order(id: $id) {
+      id
+      total {
+        amountCents
+        currency
+      }
+      note
+    }
+  }
+`;
+
+export const ON_ORDER_UPDATED = gql`
+  subscription OnOrderUpdated {
+    orderUpdated {
+      id
+      total {
+        amountCents
+        currency
+      }
+      note
+    }
+  }
+`;
+
+// query order — fetch a single order from the gateway.
+export async function fetchOrderGraphql(id: string): Promise<OrderView> {
+  const res = await client.request<{ order: OrderView }>(GET_ORDER, { id });
+  return res.order;
+}
+
+// subscription orderUpdated — consumer assumes `note` is always present.
+export function renderOrderUpdate(update: OrderUpdate): string {
+  // Reads update.note directly: compiles because OrderUpdate.note is required,
+  // but the producer may omit `note`, so this edge is type-INCOMPATIBLE.
+  return `${update.id}: ${update.note.length} chars`;
+}

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/lib/realtime.ts
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/lib/realtime.ts
@@ -1,0 +1,38 @@
+// Socket.IO client listener (consumer side of the event flow, #221).
+//
+// Scanner-detectable via src/socket_io.rs: `io(...)` from "socket.io-client"
+// makes `socket` a client socket; `socket.on("payment:settled", ...)` is a
+// LISTENER of the SERVER->CLIENT direction → keyed
+// socket|SERVER->CLIENT|payment:settled.
+//
+// In Carrick's socket model a listener is a PRODUCER (endpoint) of the key it
+// receives. So web-frontend owns the producer side of this edge; the matching
+// consumer (call) is the payments-svc server emit. Both meet on
+// socket|SERVER->CLIENT|payment:settled.
+//
+// The payload shape (SettledPayment) is compatible with the payments-svc
+// Payment producer type.
+
+import { io } from "socket.io-client";
+
+const PAYMENTS_WS = process.env.NEXT_PUBLIC_PAYMENTS_WS_URL ?? "";
+const socket = io(PAYMENTS_WS);
+
+// Consumer view of the settled-payment payload. Compatible with payments-svc
+// `Payment` (id/orderId/amountCents/status).
+export interface SettledPayment {
+  id: string;
+  orderId: number;
+  amountCents: number;
+  status: string;
+}
+
+// Listen for server -> client `payment:settled` events.
+export function onPaymentSettled(handler: (p: SettledPayment) => void): void {
+  socket.on("payment:settled", (payload: SettledPayment) => {
+    handler(payload);
+  });
+}
+
+// Reserved lifecycle event — never a contract event.
+socket.on("connect", () => {});

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/package.json
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/package.json
@@ -3,9 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "graphql": "^16.8.0",
+    "graphql-request": "^6.1.0",
+    "graphql-tag": "^2.12.6",
     "next": "14.2.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
+    "socket.io-client": "^4.7.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/types/stubs.d.ts
@@ -1,0 +1,27 @@
+// Ambient stubs — keep the GraphQL + WebSocket consumer types resolvable
+// without npm install (mirrors the REST repos' *.d.ts stub convention).
+
+// graphql-tag: the `gql` tagged-template the scanner keys documents on.
+declare module "graphql-tag" {
+  export function gql(
+    literals: TemplateStringsArray,
+    ...placeholders: unknown[]
+  ): unknown;
+}
+
+// graphql-request: a minimal client used by lib/graphql.ts.
+declare module "graphql-request" {
+  export class GraphQLClient {
+    constructor(url: string);
+    request<T = unknown>(document: unknown, variables?: unknown): Promise<T>;
+  }
+}
+
+// socket.io-client: `io(url)` returns a client socket used by lib/realtime.ts.
+declare module "socket.io-client" {
+  export interface Socket {
+    on(event: string, handler: (...args: unknown[]) => void): void;
+    emit(event: string, ...args: unknown[]): void;
+  }
+  export function io(url?: string): Socket;
+}


### PR DESCRIPTION
Extends the authored cross-repo eval corpus (`xrepo-corpus-1`, epic #207) with the Tier-C flagship protocol breadth: cross-repo GraphQL (#220), WebSocket/Socket.IO (#221), and richer types to stress inference, not just resolution (#222). One coherent author across the existing three repos — no new repos. All labels are spec-of-record; code built to match scanner-detectable patterns.

## GraphQL (#220)
- **Producer** — `orders-monorepo/packages/gateway`: schema-first `src/schema.graphql` (`Query.order(id): Order`, `Mutation.refundOrder`, `Subscription.orderUpdated: Order`) + `src/orders.resolver.ts` carrying the TS shapes. Detected by `graphql::scan_repo` (the `.graphql` walk indexes root-operation fields as producers).
- **Consumer** — `web-frontend/lib/graphql.ts`: ``gql`...` `` documents `query GetOrder { order(...) }` and `subscription OnOrderUpdated { orderUpdated { ... } }`. Detected by `extract_from_ts_file` (top-level executable-document field = consumer key).
- **Edges** (`expected-output.json.matches`): gateway → web-frontend on `graphql|query|order` (compatible) and `graphql|subscription|orderUpdated` (**incompatible**).

## WebSocket (#221), Socket.IO
- **Server emit** — `payments-svc/realtime/server.ts`: `new Server()` + `io.on("connection", socket => socket.emit("payment:settled", payment))`. Detected by `socket_io::scan_files` as an emitter of `socket|SERVER->CLIENT|payment:settled`.
- **Client listen** — `web-frontend/lib/realtime.ts`: `io(url)` + `socket.on("payment:settled", ...)` → listener on the same key.
- **Edge**: in Carrick's socket model the **listener is the producer (endpoint)** and the **emitter is the consumer (call)** (`src/socket_io.rs`, `engine`: "listeners as endpoints, emitters as calls"). So the structured edge is `producer_repo: web-frontend` (listener) / `consumer_repo: payments-svc` (emitter), both on `socket|SERVER->CLIENT|payment:settled` (compatible). The event *flows* payments-svc → web-frontend; the contract producer is the listener. Documented in the README so it isn't mistaken for a labeling error.

## Detectable patterns used
Verified each end-to-end against the real extractors (`graphql::scan_repo`, `socket_io::scan_files`) before authoring labels: gateway → `query order`/`query orders`/`mutation refundOrder`/`subscription orderUpdated`; web-frontend gql → `query order`/`subscription orderUpdated`; payments emitter + web-frontend listener → `socket|SERVER->CLIENT|payment:settled`. Ambient `*.d.ts` stubs added for `socket.io` (payments-svc), and `socket.io-client`/`graphql-tag`/`graphql-request` (web-frontend), mirroring the existing REST stub convention — no `npm install` reliance.

## GraphQL/socket connection classification
**None needed.** GraphQL/socket cross-repo matching keys on the *operation identity* (field name / event name + direction) via `analyze_exact_key_matches`, not the URL — unlike HTTP, which needs `internalEnvVars` to classify `${ENV}`-base calls. The GraphQL/WS connection URLs (`NEXT_PUBLIC_GATEWAY_GQL_URL`, `NEXT_PUBLIC_PAYMENTS_WS_URL`) are deliberately left out of `carrick.json` — adding them would be inert for matching.

## Type inference cases (#222)
The corpus was 0×Implicit, all flat named interfaces. Added:
- **Implicit return** — gateway `GET /users/recent` has no annotation → sidecar infers `{ count: number; ids: string[] }` (the corpus's first `type_state: Implicit`).
- **Generic** `ApiResponse<T>` wrapping the GraphQL `order`/`refundOrder` payloads.
- **Nested** `Money` (`{ amountCents; currency }`) inside `Order.total`.
- **Optional** `Order.note?` on the producer.
- **Union** `OrderStatus` (`placed | refunded`) — GraphQL `union` + discriminated TS union.
- **Subtler compat mismatch** — `orderUpdated` widens the optional producer `note` into a required consumer `OrderUpdate.note` (optional-field widening), quieter than the blunt `id: number` vs `string` REST trap.

## Integrity
- Existing REST corpus, edges, orphans, and `dependency_conflicts` untouched.
- New `graphql_operations`/`socket_events` arrays in per-repo `expected.json` are ignored by the current S4-thin-slice scorer (serde defaults); the full S4 scorer (#223) will score them. `matches` edges gain a `protocol` tag.
- `cargo test` green, including `eval_xrepo` unit tests (`perfect_synthetic_projection_against_real_corpus`, `empty_projection_against_real_corpus_scores_zero_recall`), the GraphQL/socket extraction tests, the cassette hard gate, `output_contract`, and `xrepo_harness`. All touched JSON parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #220 #221 #222 #207