### PR TITLE
fix(extraction): deterministically extract route-descriptor endpoints (#234)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -36,7 +36,7 @@ use crate::{
         ExtractionConfig, InferKind, InferRequestItem, SymbolRequest, TypeResolutionResult,
         TypeSidecar,
     },
-    swc_scanner::{CandidateTarget, SwcScanner},
+    swc_scanner::{CandidateTarget, RouteDescriptorEndpoint, SwcScanner},
     type_manifest::{
         build_call_site_id, build_manifest_type_alias, build_manifest_type_alias_with_call_id,
         is_http_method, normalize_manifest_method, parse_file_location,
@@ -91,6 +91,10 @@ pub struct ProcessingStats {
     /// (Next.js app router, etc.) rather than from a call-site scan. A subset
     /// of `total_endpoints`.
     pub file_based_endpoints: usize,
+    /// Endpoints derived deterministically from route-descriptor data
+    /// (`{ method, path, handler }` in a registry array) rather than from the
+    /// file-analyzer LLM. A subset of `total_endpoints`. See #234.
+    pub route_descriptor_endpoints: usize,
     pub total_data_calls: usize,
     pub errors: Vec<String>,
 }
@@ -99,6 +103,15 @@ pub struct ProcessingStats {
 /// These routes have no mount chain — their derived path is already absolute —
 /// so the owner is a sentinel that matches no mount during path resolution.
 const FILE_BASED_ROUTE_OWNER: &str = "__file_based_route__";
+
+/// Sentinel owner for a route-descriptor endpoint whose handler is absent or not
+/// a bare identifier. Like `FILE_BASED_ROUTE_OWNER`, it matches no mount during
+/// path resolution, so the descriptor's already-absolute path is used as-is.
+const ROUTE_DESCRIPTOR_OWNER: &str = "__route_descriptor__";
+
+/// `pattern_matched` tag for endpoints emitted deterministically from
+/// route-descriptor data (#234).
+const ROUTE_DESCRIPTOR_PATTERN: &str = "route-descriptor";
 
 type EndpointLookup = HashMap<(String, u32), Vec<(String, String)>>;
 type DataCallLookup = HashMap<(String, u32), Vec<(String, String, String)>>;
@@ -190,6 +203,11 @@ impl FileOrchestrator {
             /// Endpoints derived from file-based routing conventions, merged in
             /// after the LLM pass. Empty for non-route files.
             route_endpoints: Vec<EndpointResult>,
+            /// Endpoints derived deterministically from route-descriptor data
+            /// (`{ method, path, handler }`), merged in after the LLM pass. The
+            /// LLM ignores route-as-data, so these are the authoritative source
+            /// for such endpoints. Empty for files with no route descriptors.
+            descriptor_endpoints: Vec<EndpointResult>,
         }
 
         // PHASE 1 (serial, CPU-bound): run the SWC gatekeeper on every file and build the
@@ -271,22 +289,51 @@ impl FileOrchestrator {
                 )
             };
 
+            // Route-descriptor routes: a route declared as data
+            // (`{ method, path, handler }` in a registry array) is fully
+            // structural — method, path, and handler owner are literals the
+            // file-analyzer prompt ignores (it only matches framework-call
+            // patterns). Emit it deterministically (#234) instead of relying on
+            // the LLM. The recall-boost candidate the scanner also raised for
+            // such an object is redundant once the route is owned here, so it is
+            // dropped from `http_candidates` below (matched by span): a file whose
+            // only candidates are deterministically-owned descriptors then skips
+            // the LLM entirely, like a file-based route.
+            let descriptor_endpoints =
+                Self::route_descriptor_endpoints(&self.swc_scanner, file_path, &content);
+            let descriptor_spans: HashSet<(u32, u32)> = descriptor_endpoints
+                .iter()
+                .filter_map(|e| Some((e.call_expression_span_start?, e.call_expression_span_end?)))
+                .collect();
+            let http_candidates: Vec<_> = http_candidates
+                .into_iter()
+                .filter(|c| !descriptor_spans.contains(&(c.span_start, c.span_end)))
+                .collect();
+
             // STEP 2: Check Relevance - if there are no candidates for a routed
-            // protocol, SKIP the (expensive) LLM call. File-based route endpoints
-            // are still recorded: they're derived structurally and need no LLM.
+            // protocol, SKIP the (expensive) LLM call. File-based route and
+            // route-descriptor endpoints are still recorded: they're derived
+            // structurally and need no LLM.
             if http_candidates.is_empty() {
-                if !route_endpoints.is_empty() {
+                let structural_endpoints: Vec<EndpointResult> = route_endpoints
+                    .iter()
+                    .cloned()
+                    .chain(descriptor_endpoints.iter().cloned())
+                    .collect();
+                if !structural_endpoints.is_empty() {
                     debug!(
-                        "File-based route (no call-site candidates): {} [{} endpoint(s)]",
+                        "Structural route(s) (no call-site candidates): {} [{} file-based, {} route-descriptor]",
                         path_str,
-                        route_endpoints.len()
+                        route_endpoints.len(),
+                        descriptor_endpoints.len()
                     );
-                    stats.total_endpoints += route_endpoints.len();
+                    stats.total_endpoints += structural_endpoints.len();
                     stats.file_based_endpoints += route_endpoints.len();
+                    stats.route_descriptor_endpoints += descriptor_endpoints.len();
                     file_results.insert(
                         path_str,
                         FileAnalysisResult {
-                            endpoints: route_endpoints,
+                            endpoints: structural_endpoints,
                             ..Default::default()
                         },
                     );
@@ -340,6 +387,7 @@ impl FileOrchestrator {
                 symbol_table,
                 env_alias_map,
                 route_endpoints,
+                descriptor_endpoints,
             });
         }
 
@@ -400,6 +448,13 @@ impl FileOrchestrator {
                     stats.file_based_endpoints +=
                         Self::merge_file_based_endpoints(&mut adjusted, pf.route_endpoints);
 
+                    // Merge route-descriptor endpoints (`{ method, path, handler }`
+                    // data) the LLM pass didn't produce — it ignores route-as-data,
+                    // so these are emitted deterministically and are authoritative
+                    // for such routes (#234).
+                    stats.route_descriptor_endpoints +=
+                        Self::merge_file_based_endpoints(&mut adjusted, pf.descriptor_endpoints);
+
                     stats.total_mounts += adjusted.mounts.len();
                     stats.total_endpoints += adjusted.endpoints.len();
                     stats.total_data_calls += adjusted.data_calls.len();
@@ -433,6 +488,10 @@ impl FileOrchestrator {
         debug!(
             "  - File-based route endpoints: {}",
             stats.file_based_endpoints
+        );
+        debug!(
+            "  - Route-descriptor endpoints: {}",
+            stats.route_descriptor_endpoints
         );
         debug!("  - Total data calls: {}", stats.total_data_calls);
 
@@ -1147,9 +1206,57 @@ impl FileOrchestrator {
         }
     }
 
-    /// Append file-based route endpoints the LLM pass didn't already produce
-    /// (matched by method + path), keeping the deterministic structural entries.
-    /// Returns the number actually added.
+    /// Build deterministic endpoints for routes declared as data
+    /// (`{ method: 'GET', path: '/health', handler: healthCheckHandler }` in a
+    /// registry array). The method, path, and handler owner are all structural
+    /// facts the file-analyzer prompt ignores (it only matches framework-call
+    /// patterns), so they are emitted directly instead of through the LLM (#234).
+    ///
+    /// The owner is the handler identifier (`healthCheckHandler`), never the
+    /// HTTP-method literal — the owner-fabrication trap (#227). The descriptor
+    /// path is already absolute and carries no mount chain, so (like file-based
+    /// routes) the owner resolves to no mount prefix and the path is used as-is.
+    /// Descriptors with no resolvable handler fall back to a sentinel owner.
+    fn route_descriptor_endpoints(
+        scanner: &SwcScanner,
+        file_path: &Path,
+        content: &str,
+    ) -> Vec<EndpointResult> {
+        scanner
+            .route_descriptor_endpoints(file_path, content)
+            .into_iter()
+            .filter(|d| is_http_method(&d.method))
+            .map(|d: RouteDescriptorEndpoint| {
+                let method = d.method.to_uppercase();
+                let handler = d
+                    .handler
+                    .unwrap_or_else(|| ROUTE_DESCRIPTOR_OWNER.to_string());
+                EndpointResult {
+                    candidate_id: format!("route-descriptor:{}:{}", method, d.span_start),
+                    line_number: d.line_number as i32,
+                    owner_node: handler.clone(),
+                    method,
+                    path: d.path,
+                    handler_name: handler,
+                    pattern_matched: ROUTE_DESCRIPTOR_PATTERN.to_string(),
+                    call_expression_span_start: Some(d.span_start),
+                    call_expression_span_end: Some(d.span_end),
+                    payload_expression_text: None,
+                    payload_expression_line: None,
+                    response_expression_text: None,
+                    response_expression_line: None,
+                    emission_style: None,
+                    primary_type_symbol: None,
+                    type_import_source: None,
+                }
+            })
+            .collect()
+    }
+
+    /// Append structurally derived endpoints (file-based routes and
+    /// route-descriptor data) the LLM pass didn't already produce (matched by
+    /// method + path), keeping the deterministic entries. Returns the number
+    /// actually added.
     fn merge_file_based_endpoints(
         result: &mut FileAnalysisResult,
         route_endpoints: Vec<EndpointResult>,
@@ -3008,6 +3115,55 @@ export const prerender = false;
             &builtin_conventions(&["express".to_string()]),
         );
         assert!(endpoints.is_empty());
+    }
+
+    #[test]
+    fn route_descriptor_endpoint_owner_is_handler_not_method() {
+        // #234: a route declared as data is emitted deterministically with the
+        // handler identifier as owner — never the HTTP-method literal "GET"
+        // (the owner-fabrication trap, #227). Drives the real fixture.
+        let scanner = SwcScanner::new();
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join(
+            "tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/health.handler.ts",
+        );
+        let content = std::fs::read_to_string(&fixture).expect("fixture must exist");
+
+        let endpoints = FileOrchestrator::route_descriptor_endpoints(&scanner, &fixture, &content);
+
+        assert_eq!(
+            endpoints.len(),
+            1,
+            "expected exactly one route-descriptor endpoint, got {endpoints:?}"
+        );
+        let ep = &endpoints[0];
+        assert_eq!(ep.method, "GET");
+        assert_eq!(ep.path, "/gateway/health");
+        assert_eq!(
+            ep.owner_node, "healthCheckHandler",
+            "owner must be the handler ident, not the method literal"
+        );
+        assert_ne!(ep.owner_node, "GET");
+        assert_eq!(ep.handler_name, "healthCheckHandler");
+        assert_eq!(ep.pattern_matched, ROUTE_DESCRIPTOR_PATTERN);
+        assert!(ep.call_expression_span_start.is_some());
+        assert!(ep.call_expression_span_end.is_some());
+    }
+
+    #[test]
+    fn route_descriptor_endpoint_missing_handler_uses_sentinel_owner() {
+        let scanner = SwcScanner::new();
+        let content = r#"
+const routes = [
+  { method: 'POST', path: '/widgets' },
+];
+export { routes };
+"#;
+        let endpoints =
+            FileOrchestrator::route_descriptor_endpoints(&scanner, Path::new("routes.ts"), content);
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].method, "POST");
+        assert_eq!(endpoints[0].path, "/widgets");
+        assert_eq!(endpoints[0].owner_node, ROUTE_DESCRIPTOR_OWNER);
     }
 
     fn synthetic_endpoint(method: &str, path: &str) -> EndpointResult {

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -112,6 +112,30 @@ pub struct ExportedHandler {
     pub span_end: u32,
 }
 
+/// A route declared as data in a registry array
+/// (`{ method: 'GET', path: '/health', handler: healthCheckHandler }`). The
+/// HTTP method, path, and handler owner are all structural facts — no call site
+/// the candidate scanner can see — so they are emitted as a deterministic
+/// endpoint instead of being routed through the LLM (#234). Only descriptors
+/// whose method *and* path are string literals are reported; dynamic-handler
+/// cases stay on the recall-boost candidate path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteDescriptorEndpoint {
+    /// The HTTP method literal (`GET`, `POST`, …), verbatim from the object.
+    pub method: String,
+    /// The route path literal (`/gateway/health`), verbatim from the object.
+    pub path: String,
+    /// The handler identifier (`healthCheckHandler`) — the route's real owner.
+    /// `None` when the handler is absent or not a bare identifier.
+    pub handler: Option<String>,
+    /// 1-based line number of the descriptor object literal.
+    pub line_number: usize,
+    /// Start byte offset of the descriptor object literal.
+    pub span_start: u32,
+    /// End byte offset of the descriptor object literal.
+    pub span_end: u32,
+}
+
 /// Lightweight SWC-based scanner for detecting potential API patterns.
 ///
 /// This scanner looks for method call expressions that match common
@@ -361,12 +385,103 @@ impl SwcScanner {
 
         out
     }
+
+    /// Extract route-descriptor endpoints declared as data in a registry array
+    /// (`{ method: 'GET', path: '/health', handler: healthCheckHandler }`).
+    ///
+    /// This powers deterministic route-descriptor extraction (#234): the method,
+    /// path, and handler owner are all structural facts with no call site the
+    /// candidate scanner can see, and the file-analyzer prompt only matches
+    /// framework-call patterns — so the orchestrator builds the endpoint from
+    /// these facts directly, bypassing the LLM. Only descriptors whose method
+    /// *and* path are string literals are returned; the rest stay on the
+    /// recall-boost candidate path.
+    pub fn route_descriptor_endpoints(
+        &self,
+        file_path: &Path,
+        content: &str,
+    ) -> Vec<RouteDescriptorEndpoint> {
+        use swc_common::FileName;
+        use swc_ecma_parser::{Parser, StringInput, Syntax, lexer::Lexer};
+
+        let syntax = match file_path.extension().and_then(|e| e.to_str()) {
+            Some("ts") => Syntax::Typescript(TsSyntax {
+                decorators: true,
+                ..Default::default()
+            }),
+            Some("tsx") => Syntax::Typescript(TsSyntax {
+                tsx: true,
+                decorators: true,
+                ..Default::default()
+            }),
+            Some("jsx") => Syntax::Es(EsSyntax {
+                jsx: true,
+                ..Default::default()
+            }),
+            _ => Syntax::Es(Default::default()),
+        };
+
+        let sm: Lrc<SourceMap> = Default::default();
+        let source_file = sm.new_source_file(
+            Lrc::new(FileName::Real(file_path.to_path_buf())),
+            content.to_string(),
+        );
+        let lexer = Lexer::new(
+            syntax,
+            Default::default(),
+            StringInput::from(&*source_file),
+            None,
+        );
+        let mut parser = Parser::new_from(lexer);
+        let module = match parser.parse_module() {
+            Ok(m) => m,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut visitor = RouteDescriptorVisitor {
+            source_map: sm,
+            endpoints: Vec::new(),
+        };
+        module.visit_with(&mut visitor);
+        visitor.endpoints
+    }
+}
+
+/// Walks every object literal collecting deterministic route descriptors
+/// (`{ method, path, handler }` with literal method + path). Shares the shape
+/// guard with the recall-boost candidate via [`CandidateVisitor::route_descriptor`].
+struct RouteDescriptorVisitor {
+    source_map: Lrc<SourceMap>,
+    endpoints: Vec<RouteDescriptorEndpoint>,
+}
+
+impl Visit for RouteDescriptorVisitor {
+    fn visit_object_lit(&mut self, node: &ObjectLit) {
+        if let Some(descriptor) = CandidateVisitor::route_descriptor(node) {
+            // The deterministic path requires literal method *and* path; a
+            // descriptor missing either keeps only its recall-boost candidate.
+            if let (Some(method), Some(path)) = (descriptor.method, descriptor.path) {
+                let span = node.span;
+                self.endpoints.push(RouteDescriptorEndpoint {
+                    method,
+                    path,
+                    handler: descriptor.handler,
+                    line_number: self.source_map.lookup_char_pos(span.lo).line,
+                    span_start: span.lo.0,
+                    span_end: span.hi.0,
+                });
+            }
+        }
+        node.visit_children_with(self);
+    }
 }
 
 /// The salient parts of a route-descriptor object literal
-/// (`{ method, path, handler }`): the path literal snippet (when present) and
-/// the handler identifier (when it is a bare identifier reference).
+/// (`{ method, path, handler }`): the HTTP method literal (when it is a string
+/// literal), the path literal snippet (when present) and the handler identifier
+/// (when it is a bare identifier reference).
 struct RouteDescriptor {
+    method: Option<String>,
     path: Option<String>,
     handler: Option<String>,
 }
@@ -689,6 +804,7 @@ impl CandidateVisitor {
 
         let mut has_method = false;
         let mut has_path = false;
+        let mut method = None;
         let mut path = None;
         let mut handler = None;
 
@@ -703,11 +819,20 @@ impl CandidateVisitor {
                 continue;
             };
             match name.as_str() {
-                "method" => has_method = true,
+                "method" => {
+                    has_method = true;
+                    // Keep the method literal so the route can be emitted
+                    // deterministically (#234). A non-literal method (computed
+                    // expr) still satisfies the shape guard but yields no
+                    // deterministic emission — only the recall-boost candidate.
+                    if let Expr::Lit(Lit::Str(s)) = &*kv.value {
+                        method = Some(s.value.to_string());
+                    }
+                }
                 "path" => {
                     has_path = true;
                     if let Expr::Lit(Lit::Str(s)) = &*kv.value {
-                        path = Some(format!("'{}'", s.value));
+                        path = Some(s.value.to_string());
                     }
                 }
                 "handler" => {
@@ -719,7 +844,11 @@ impl CandidateVisitor {
             }
         }
 
-        (has_method && has_path).then_some(RouteDescriptor { path, handler })
+        (has_method && has_path).then_some(RouteDescriptor {
+            method,
+            path,
+            handler,
+        })
     }
 
     /// Extract callee object name from expression
@@ -859,9 +988,16 @@ impl Visit for CandidateVisitor {
         // avoid flagging ordinary config objects. The candidate is keyed on the
         // `handler` identifier when present so the hint points the LLM at the
         // real owner (the handler fn), not the HTTP method string — the
-        // owner-fabrication trap. The LLM still classifies and extracts; this is
-        // a recall booster for the gate, not an authoritative route emission.
+        // owner-fabrication trap.
+        //
+        // When the method and path are both string literals the route is now
+        // emitted deterministically by the orchestrator (`route_descriptor_endpoints`,
+        // #234), bypassing the LLM. This candidate stays as a recall booster for
+        // the dynamic-handler cases the deterministic path can't own (e.g. a
+        // computed method/path, or a handler that isn't a bare identifier): the
+        // gate still keeps the file and the LLM classifies it.
         if let Some(descriptor) = Self::route_descriptor(node) {
+            let path_snippet = descriptor.path.map(|p| format!("'{}'", p));
             self.push_span_candidate(
                 node.span,
                 Protocol::Http,
@@ -869,7 +1005,7 @@ impl Visit for CandidateVisitor {
                     .handler
                     .unwrap_or_else(|| "<route-descriptor>".to_string()),
                 None,
-                descriptor.path,
+                path_snippet,
             );
         }
         node.visit_children_with(self);
@@ -1284,6 +1420,72 @@ export { routes };
         assert!(only_method.candidates.is_empty());
         assert!(only_path.candidates.is_empty());
         assert!(neither.candidates.is_empty());
+    }
+
+    #[test]
+    fn route_descriptor_endpoints_extracts_method_path_handler() {
+        // #234: the route declared as data carries the full method/path/handler
+        // structurally, so it is emitted deterministically (no LLM). The owner is
+        // the handler identifier `healthCheckHandler`, never the method literal
+        // "GET" (the owner-fabrication trap).
+        let content = r#"
+export const healthCheckHandler = async (_req: unknown, _res: unknown) => {
+  return { ok: true, ts: Date.now() };
+};
+
+const routeRegistry = [
+  { method: 'GET', path: '/gateway/health', handler: healthCheckHandler },
+];
+
+export { routeRegistry };
+"#;
+        let scanner = SwcScanner::new();
+        let endpoints =
+            scanner.route_descriptor_endpoints(&PathBuf::from("health.handler.ts"), content);
+        assert_eq!(endpoints.len(), 1, "expected one route descriptor endpoint");
+        let ep = &endpoints[0];
+        assert_eq!(ep.method, "GET");
+        assert_eq!(ep.path, "/gateway/health");
+        assert_eq!(ep.handler.as_deref(), Some("healthCheckHandler"));
+        assert_ne!(ep.handler.as_deref(), Some("GET"));
+        assert!(ep.span_end > ep.span_start);
+    }
+
+    #[test]
+    fn route_descriptor_endpoints_skips_dynamic_method_or_path() {
+        // A computed method/path can't be emitted deterministically — it stays on
+        // the recall-boost candidate path, so no deterministic endpoint is built.
+        let dynamic = r#"
+const verb = 'GET';
+const routes = [
+  { method: verb, path: '/widgets', handler: listWidgets },
+];
+export { routes };
+"#;
+        let scanner = SwcScanner::new();
+        let endpoints = scanner.route_descriptor_endpoints(&PathBuf::from("routes.ts"), dynamic);
+        assert!(
+            endpoints.is_empty(),
+            "non-literal method must not yield a deterministic endpoint, got {endpoints:?}"
+        );
+    }
+
+    #[test]
+    fn route_descriptor_endpoints_allows_missing_handler() {
+        // Literal method + path with no (or non-identifier) handler still emits a
+        // deterministic endpoint; the owner is left unresolved for the caller.
+        let content = r#"
+const routes = [
+  { method: 'POST', path: '/widgets' },
+];
+export { routes };
+"#;
+        let scanner = SwcScanner::new();
+        let endpoints = scanner.route_descriptor_endpoints(&PathBuf::from("routes.ts"), content);
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].method, "POST");
+        assert_eq!(endpoints[0].path, "/widgets");
+        assert_eq!(endpoints[0].handler, None);
     }
 
     #[test]

--- a/tests/file_centric_analysis_test.rs
+++ b/tests/file_centric_analysis_test.rs
@@ -271,6 +271,7 @@ fn test_processing_stats_tracking() {
         total_mounts: 3,
         total_endpoints: 10,
         file_based_endpoints: 2,
+        route_descriptor_endpoints: 1,
         total_data_calls: 4,
         errors: vec!["Test error".to_string()],
     };


### PR DESCRIPTION
## What

Routes declared as data (`{ method, path, handler }` in a registry array) were never extracted. No call-site signal fires on such a file, and the file-analyzer prompt only matches framework-call patterns, so it ignores route-as-data. The scanner already flagged the shape as a recall-boost candidate (#230) but dropped the `method` literal, leaving the LLM to recover the route — which it doesn't, leaving `/gateway/health` a MISS (#227).

This makes the extraction **deterministic** instead of relying on the LLM, since the data is fully structural.

## How

- `RouteDescriptor` now keeps the `method` literal alongside path/handler.
- New `SwcScanner::route_descriptor_endpoints` collects descriptors whose method **and** path are string literals (method + path + handler ident + span).
- `FileOrchestrator` builds an `EndpointResult` from each. Owner is the **handler identifier** (e.g. `healthCheckHandler`), never the `"GET"` method literal — the owner-fabrication trap (#227). The descriptor path is already absolute and carries no mount chain, so (like file-based routes) the owner resolves to no mount prefix and the path is used as-is.
- Emitted via the same merge path as file-based routes, **bypassing the file-analyzer LLM**. A file whose only candidates are deterministically-owned descriptors now skips the LLM entirely. The existing object-literal recall-boost candidate survives only for the dynamic-handler cases the deterministic path can't own (computed method/path, or a handler that isn't a bare identifier).

## Tests

- Scanner: `route_descriptor_endpoints_extracts_method_path_handler`, `_skips_dynamic_method_or_path`, `_allows_missing_handler`.
- Orchestrator: `route_descriptor_endpoint_owner_is_handler_not_method` drives the real `health.handler.ts` fixture and asserts `GET /gateway/health` extracts with owner `healthCheckHandler` (never `GET`); `_missing_handler_uses_sentinel_owner`.
- All existing scanner/orchestrator tests stay green. `cargo fmt --all` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

Closes #234
Refs #167 #227 #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)