### PR TITLE
fix(ts_check): treat unknown as unverifiable + land consumer type shape in bundle (#235)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1541,8 +1541,26 @@ impl Analyzer {
             })
             .collect::<Vec<_>>();
 
+        // Edges ts_check matched but could not verify — a side resolved to
+        // `any`/`unknown` (e.g. the type never reached the bundled .d.ts). These
+        // are NOT compatible; they are unverifiable, and the overlay must leave
+        // their verdict `None` rather than optimistically claiming `Some(true)`.
+        let unknown_pairs = result
+            .get("unknownPairs")
+            .and_then(|u| u.as_array())
+            .unwrap_or(&vec![])
+            .iter()
+            .map(|pair| {
+                serde_json::json!({
+                    "endpoint": pair.get("endpoint").unwrap_or(&serde_json::Value::Null),
+                    "reason": pair.get("reason").unwrap_or(&serde_json::Value::Null)
+                })
+            })
+            .collect::<Vec<_>>();
+
         Ok(serde_json::json!({
             "mismatches": mismatches,
+            "unknownPairs": unknown_pairs,
             "totalChecked": result.get("totalChecked").unwrap_or(&serde_json::Value::Number(serde_json::Number::from(0))),
             "compatiblePairs": result.get("compatibleCount").unwrap_or(&serde_json::Value::Number(serde_json::Number::from(0))),
             "incompatiblePairs": mismatches.len()
@@ -1642,8 +1660,11 @@ impl Analyzer {
     /// If `check_type_compatibility` returns `Err`, type checking did not run
     /// (or failed) for this scan: every edge keeps `type_compatible: None`
     /// (load-bearing — see [`CrossRepoMatch`]). On `Ok`, an edge whose producer
-    /// appears in the mismatch set gets `Some(false)` + the reason; otherwise
-    /// `Some(true)` (compat evaluated, no mismatch for that producer).
+    /// appears in the mismatch set gets `Some(false)` + the reason; an edge
+    /// whose producer ts_check matched but could NOT verify (a side resolved to
+    /// `any`/`unknown`, e.g. the type never reached the bundled `.d.ts`) keeps
+    /// `None` — unverifiable, not compatible; everything else (genuinely checked
+    /// and compatible) gets `Some(true)`.
     fn overlay_compat_verdicts(&self, matches: &mut [CrossRepoMatch]) {
         let result = match self.check_type_compatibility() {
             Ok(result) => result,
@@ -1675,20 +1696,36 @@ impl Analyzer {
             }
         }
 
+        // Producers ts_check matched but could not verify (a side resolved to
+        // `any`/`unknown`). The compat verdict is genuinely unknown for these
+        // edges — leaving the optimistic `Some(true)` default would assert a
+        // compatibility ts_check never established.
+        let mut unverifiable: HashSet<(String, String)> = HashSet::new();
+        if let Some(unknown_list) = result.get("unknownPairs").and_then(|u| u.as_array()) {
+            for pair in unknown_list {
+                let Some(endpoint) = pair.get("endpoint").and_then(|e| e.as_str()) else {
+                    continue;
+                };
+                if let Some(key) = parse_compat_endpoint(endpoint) {
+                    unverifiable.insert(key);
+                }
+            }
+        }
+
         for edge in matches.iter_mut() {
             // producer_key is `http|METHOD|path`; recover (METHOD, path).
             let Some((method, path)) = parse_producer_key(&edge.producer_key) else {
                 edge.type_compatible = Some(true);
                 continue;
             };
-            match incompatible.get(&(method, path)) {
-                Some(reason) => {
-                    edge.type_compatible = Some(false);
-                    edge.mismatch_reason = Some(reason.clone());
-                }
-                None => {
-                    edge.type_compatible = Some(true);
-                }
+            if let Some(reason) = incompatible.get(&(method.clone(), path.clone())) {
+                edge.type_compatible = Some(false);
+                edge.mismatch_reason = Some(reason.clone());
+            } else if unverifiable.contains(&(method, path)) {
+                // Matched but unverifiable — compat undetermined, NOT compatible.
+                edge.type_compatible = None;
+            } else {
+                edge.type_compatible = Some(true);
             }
         }
     }
@@ -2625,6 +2662,42 @@ mod tests {
         assert_eq!(
             matches[0].type_compatible, None,
             "no results file → compat not evaluated → verdict stays None (never fake true)"
+        );
+    }
+
+    /// An edge ts_check matched but could NOT verify (a side resolved to
+    /// `any`/`unknown`) lands in `unknownPairs`, not `mismatches`. Its verdict
+    /// must stay `None` (unverifiable) rather than the optimistic `Some(true)` —
+    /// asserting compatibility ts_check never established would mask a real
+    /// shape mismatch hidden behind an `= unknown` placeholder (#235).
+    #[test]
+    fn overlay_compat_verdicts_leaves_unverifiable_edge_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // GET /orders/:id is unverifiable (consumer resolved to `unknown`);
+        // POST /payments was genuinely checked and is compatible.
+        let results = r#"{
+            "mismatches": [],
+            "unknownPairs": [
+                { "endpoint": "GET /orders/:id (response)",
+                  "reason": "consumer type resolves to unknown (type missing from bundled types?)" }
+            ],
+            "totalChecked": 1,
+            "compatibleCount": 1
+        }"#;
+        let analyzer = analyzer_with_results(dir.path(), Some(results));
+
+        let mut matches = vec![edge("http|GET|/orders/:id"), edge("http|POST|/payments")];
+        analyzer.overlay_compat_verdicts(&mut matches);
+
+        assert_eq!(
+            matches[0].type_compatible, None,
+            "an unverifiable edge stays None, never a fake Some(true)"
+        );
+        assert!(matches[0].mismatch_reason.is_none());
+        assert_eq!(
+            matches[1].type_compatible,
+            Some(true),
+            "a genuinely-checked edge absent from both lists is compatible"
         );
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1756,15 +1756,35 @@ fn enrich_manifest_with_type_resolution(
         HashSet::new()
     };
 
+    // A type is genuinely unresolved when it resolves to `unknown`/`any`/empty,
+    // or when the bundled .d.ts only carries the trivial `= unknown` placeholder
+    // that append_missing_aliases injects for a missing alias. Either way the
+    // shape never reached the bundle, so the entry must read `Unknown` — never a
+    // promoted state that asserts a shape we don't actually have.
+    let dts_trivially_unknown = |alias: &str| {
+        bundled_dts
+            .map(|dts| dts_alias_is_trivially_unknown(dts, alias))
+            .unwrap_or(false)
+    };
+
     // Update manifest entries
     for entry in manifest.iter_mut() {
         if let Some((type_string, is_explicit)) = resolved_types.get(&entry.type_alias) {
             // Check if the type is actually resolved (not "unknown")
             let is_unknown_type = type_string.trim() == "unknown"
                 || type_string.trim() == "any"
-                || type_string.is_empty();
+                || type_string.is_empty()
+                || dts_trivially_unknown(&entry.type_alias);
 
-            if !is_unknown_type {
+            if is_unknown_type {
+                // Downgrade to Unknown so the `= unknown` placeholder gate
+                // (resolve_per_endpoint_definitions, ts_check) stays shut and the
+                // edge is reported unverifiable rather than falsely compatible.
+                entry.is_explicit = false;
+                entry.type_state = ManifestTypeState::Unknown;
+                entry.evidence.is_explicit = false;
+                entry.evidence.type_state = ManifestTypeState::Unknown;
+            } else {
                 entry.is_explicit = *is_explicit;
                 entry.type_state = if *is_explicit {
                     ManifestTypeState::Explicit
@@ -1779,6 +1799,12 @@ fn enrich_manifest_with_type_resolution(
             // This can happen for inline aliases or other edge cases
             entry.type_state = ManifestTypeState::Implicit;
             entry.evidence.type_state = ManifestTypeState::Implicit;
+        } else if dts_trivially_unknown(&entry.type_alias) {
+            // Only a `= unknown` placeholder reached the bundle — keep Unknown.
+            entry.is_explicit = false;
+            entry.type_state = ManifestTypeState::Unknown;
+            entry.evidence.is_explicit = false;
+            entry.evidence.type_state = ManifestTypeState::Unknown;
         }
     }
 
@@ -2250,6 +2276,8 @@ fn recreate_package_and_tsconfig(
 mod tests {
     use super::*;
     use crate::analyzer::ApiEndpointDetails;
+    use crate::cloud_storage::TypeEvidence;
+    use crate::services::type_sidecar::{InferredType, SourceLocation};
     use crate::visitor::{OwnerType, TypeReference};
     use std::path::PathBuf;
 
@@ -3269,6 +3297,128 @@ mod tests {
         assert!(
             err.to_string().contains("No JS/TS source files"),
             "expected empty-scan error, got: {err}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Type-state enrichment / placeholder handling (#235)
+    // -----------------------------------------------------------------------
+
+    fn consumer_entry(type_alias: &str) -> TypeManifestEntry {
+        let evidence = TypeEvidence {
+            file_path: "lib/api.ts".to_string(),
+            span_start: None,
+            span_end: None,
+            line_number: 5,
+            infer_kind: InferKind::CallResult,
+            is_explicit: false,
+            type_state: ManifestTypeState::Unknown,
+        };
+        TypeManifestEntry {
+            key: OperationKey::http("GET", "/orders/:id"),
+            role: ManifestRole::Consumer,
+            type_kind: ManifestTypeKind::Response,
+            type_alias: type_alias.to_string(),
+            file_path: "lib/api.ts".to_string(),
+            line_number: 5,
+            is_explicit: false,
+            type_state: ManifestTypeState::Unknown,
+            evidence,
+            resolved_definition: None,
+            expanded_definition: None,
+        }
+    }
+
+    fn empty_resolution() -> TypeResolutionResult {
+        TypeResolutionResult {
+            dts_content: None,
+            explicit_manifest: vec![],
+            inferred_types: vec![],
+            symbol_failures: vec![],
+            errors: vec![],
+        }
+    }
+
+    /// A genuine shape resolved by the sidecar promotes the entry to Implicit.
+    #[test]
+    fn enrich_promotes_resolved_consumer_shape() {
+        let mut manifest = vec![consumer_entry("OrderView")];
+        let mut resolution = empty_resolution();
+        resolution.inferred_types.push(InferredType {
+            alias: "OrderView".to_string(),
+            type_string: "{ id: string; currency: string }".to_string(),
+            is_explicit: false,
+            source_location: SourceLocation {
+                file_path: "lib/api.ts".to_string(),
+                start_line: 5,
+                end_line: 5,
+                start_column: None,
+                end_column: None,
+            },
+            infer_kind: InferKind::CallResult,
+        });
+
+        enrich_manifest_with_type_resolution(&mut manifest, &resolution, None);
+
+        assert_eq!(manifest[0].type_state, ManifestTypeState::Implicit);
+    }
+
+    /// A consumer alias that only resolves to `unknown` must stay `Unknown` so
+    /// the placeholder gate stays shut and the edge reads unverifiable, not
+    /// compatible (#235).
+    #[test]
+    fn enrich_keeps_unknown_resolution_unknown() {
+        let mut manifest = vec![consumer_entry("OrderView")];
+        let mut resolution = empty_resolution();
+        resolution.inferred_types.push(InferredType {
+            alias: "OrderView".to_string(),
+            type_string: "unknown".to_string(),
+            is_explicit: false,
+            source_location: SourceLocation {
+                file_path: "lib/api.ts".to_string(),
+                start_line: 5,
+                end_line: 5,
+                start_column: None,
+                end_column: None,
+            },
+            infer_kind: InferKind::CallResult,
+        });
+
+        enrich_manifest_with_type_resolution(&mut manifest, &resolution, None);
+
+        assert_eq!(manifest[0].type_state, ManifestTypeState::Unknown);
+    }
+
+    /// A `= unknown` placeholder in the bundled .d.ts must NOT promote the entry,
+    /// even if the bundle nominally "defines" the alias — it is downgraded to
+    /// `Unknown` (#235).
+    #[test]
+    fn enrich_downgrades_trivially_unknown_dts_alias() {
+        let mut manifest = vec![consumer_entry("OrderView")];
+        let resolution = empty_resolution();
+        let dts = "export type OrderView = unknown;\n";
+
+        enrich_manifest_with_type_resolution(&mut manifest, &resolution, Some(dts));
+
+        assert_eq!(manifest[0].type_state, ManifestTypeState::Unknown);
+    }
+
+    /// append_missing_aliases injects a `= unknown` placeholder for a manifest
+    /// alias absent from the bundle, and leaves an already-defined alias alone.
+    #[test]
+    fn append_missing_aliases_injects_unknown_placeholder() {
+        let manifest = vec![consumer_entry("OrderView"), consumer_entry("Payment")];
+        let dts = "export interface Payment { id: string }\n".to_string();
+
+        let out = append_missing_aliases(dts, Some(&manifest));
+
+        assert!(
+            out.contains("export type OrderView = unknown;"),
+            "missing alias should be injected as a placeholder, got: {out}"
+        );
+        assert!(
+            !out.contains("export type Payment = unknown;"),
+            "an already-defined alias must not be overwritten, got: {out}"
         );
     }
 }

--- a/ts_check/lib/type-checker.test.ts
+++ b/ts_check/lib/type-checker.test.ts
@@ -340,6 +340,131 @@ describe('TypeCompatibilityChecker', () => {
       assert.strictEqual(result.unknownPairs.length, 0);
     });
 
+    it('should treat an unknown-resolving side as unverifiable, not compatible', async () => {
+      // Regression for #235: when the consumer alias is missing from the bundle
+      // it is injected as `= unknown` by append_missing_aliases. Everything is
+      // assignable to `unknown`, so without an isUnknown() guard this edge read
+      // compatible and masked a real shape mismatch. It must be unverifiable.
+      const typesProject = new Project({
+        compilerOptions: {
+          strict: true,
+          skipLibCheck: true,
+        },
+      });
+
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type Order = { id: number; amountCents: number; currency: string };
+        export type OrderView = unknown;
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'orders-api',
+        commit_hash: 'abc',
+        entries: [
+          createManifestEntry(
+            'GET',
+            '/orders/:id',
+            'Order',
+            'producer',
+            'routes.ts',
+            10
+          ),
+        ],
+      };
+
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def',
+        entries: [
+          createManifestEntry(
+            'GET',
+            '/orders/:id',
+            'OrderView',
+            'consumer',
+            'api.ts',
+            5
+          ),
+        ],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.unknownPairs.length, 1);
+      assert.strictEqual(result.compatiblePairs, 0);
+      assert.strictEqual(result.incompatiblePairs, 0);
+      assert.ok(result.unknownPairs[0].reason.includes('unknown'));
+    });
+
+    it('should report a string-vs-number field mismatch as incompatible', async () => {
+      // The genuine orders→web defect (#235): producer Order.id is number,
+      // consumer OrderView.id is string. With the real shapes in the bundle the
+      // edge must read incompatible.
+      const typesProject = new Project({
+        compilerOptions: {
+          strict: true,
+          skipLibCheck: true,
+        },
+      });
+
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type Order = { id: number; amountCents: number; currency: string };
+        export type OrderView = { id: string; currency: string };
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'orders-api',
+        commit_hash: 'abc',
+        entries: [
+          createManifestEntry(
+            'GET',
+            '/orders/:id',
+            'Order',
+            'producer',
+            'routes.ts',
+            10
+          ),
+        ],
+      };
+
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def',
+        entries: [
+          createManifestEntry(
+            'GET',
+            '/orders/:id',
+            'OrderView',
+            'consumer',
+            'api.ts',
+            5
+          ),
+        ],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.incompatiblePairs, 1);
+      assert.strictEqual(result.compatiblePairs, 0);
+      assert.strictEqual(result.unknownPairs.length, 0);
+      assert.strictEqual(result.mismatches.length, 1);
+    });
+
     it('should match with path parameter normalization', async () => {
       const producers: TypeManifest = {
         repo_name: 'producer-api',

--- a/ts_check/lib/type-checker.ts
+++ b/ts_check/lib/type-checker.ts
@@ -296,13 +296,28 @@ export class TypeCompatibilityChecker {
       };
     }
 
-    if (producerType.isAny() || consumerType.isAny()) {
+    // `any` and `unknown` are both top-ish: everything is assignable to
+    // `unknown`, so a side that resolves to either makes `isAssignableTo`
+    // return true and the edge would read compatible without ever comparing
+    // the real shapes. These almost always mean the type never reached the
+    // bundle (a broken import, or an `= unknown` placeholder from
+    // append_missing_aliases). Classify the edge unverifiable, not compatible.
+    if (
+      producerType.isAny() ||
+      consumerType.isAny() ||
+      producerType.isUnknown() ||
+      consumerType.isUnknown()
+    ) {
       const reasonParts = [];
-      if (producerType.isAny()) {
-        reasonParts.push("producer type resolves to any (broken import in bundled types?)");
+      if (producerType.isAny() || producerType.isUnknown()) {
+        reasonParts.push(
+          `producer type resolves to ${producerType.isAny() ? "any" : "unknown"} (type missing from bundled types?)`
+        );
       }
-      if (consumerType.isAny()) {
-        reasonParts.push("consumer type resolves to any (broken import in bundled types?)");
+      if (consumerType.isAny() || consumerType.isUnknown()) {
+        reasonParts.push(
+          `consumer type resolves to ${consumerType.isAny() ? "any" : "unknown"} (type missing from bundled types?)`
+        );
       }
       return {
         kind: "unverifiable",


### PR DESCRIPTION
## Problem

The orders→web cross-repo edge read `type_compatible=Some(true)` though it is incompatible: the consumer's `OrderView.id: string` vs the producer's `Order.id: number`. The genuine `string`-vs-`number` mismatch was hidden behind an `= unknown` placeholder.

## Reproduction

Driving the real ts-morph checker over three cases:

| Case | consumer alias | `isAny` | `isUnknown` | `isAssignableTo` |
|------|----------------|---------|-------------|------------------|
| 1 — real shapes | `{ id: string; currency: string }` | false | false | **false** (correctly incompatible) |
| 2 — placeholder | `unknown` | false | **true** | **true** (read compatible — the bug) |
| 3 — broken import | `any` | true | false | true (already caught by `isAny` guard) |

**Case 2 (`= unknown`) is the live path.** `append_missing_aliases` injects `OrderView = unknown` when the real shape never reaches the bundle, and everything is assignable to `unknown`, so the edge read compatible. Case 1 proves that once the real shapes are in the bundle the edge already reads incompatible.

## Fix, per layer

1. **`compareTypes` (`ts_check/lib/type-checker.ts`)** — the guard covered `isAny()` but not `isUnknown()`. An `any`/`unknown` side is now classified **unverifiable**, not compatible.

2. **`enrich_manifest_with_type_resolution` (`src/engine/mod.rs`)** — it promoted entries but never **downgraded** `type_state` to `Unknown`. It now forces `Unknown` when the resolution is `unknown`/`any`/empty or the bundled `.d.ts` carries only a trivial `= unknown` placeholder, so the placeholder gate (`resolve_per_endpoint_definitions`, ts_check) stays shut.

3. **`overlay_compat_verdicts` (`src/analyzer/mod.rs`)** — it defaulted every non-`mismatches` edge to `Some(true)`. After layer 1 the orders→web edge is an unverifiable `unknownPair`, not a `mismatch`, so the optimistic default would still assert a compatibility ts_check never established. `transform_type_check_result` now surfaces `unknownPairs`, and the overlay leaves those edges **`None`** (compat undetermined). Only genuinely-checked-and-compatible edges read `Some(true)`. This change was load-bearing, not optional: without it, layer 1 alone would not have fixed the false `Some(true)`.

## Tests

- ts_check: `unknown` side → unverifiable; `string`-vs-`number` → incompatible. Existing 67 stay green (69 total).
- Rust: enrich downgrade (3 cases), `append_missing_aliases` placeholder injection, overlay `None` verdict for unverifiable edges. Full suite + cassette hard gate green.

Closes #235
Refs #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)