### PR TITLE
fix(eval): GraphQL/socket cross-repo edges + real type-anchor & resolution metrics (#232, #233)

### DIFF
--- a/src/analyzer/builder.rs
+++ b/src/analyzer/builder.rs
@@ -36,8 +36,27 @@ impl AnalyzerBuilder {
 
         // Populate analyzer with data from all repos
         for repo_data in all_repo_data {
-            analyzer.endpoints.extend(repo_data.endpoints);
-            analyzer.calls.extend(repo_data.calls);
+            // Stamp repo identity onto every endpoint/call so the non-HTTP
+            // matcher (`analyze_exact_key_matches`) can attribute a matched
+            // GraphQL/socket producer↔consumer pair to its repos. HTTP ops also
+            // resolve identity from the repo-tagged mount graph, so stamping is
+            // redundant-but-harmless there; the non-HTTP path has no other source.
+            let repo_name = repo_data.repo_name.clone();
+            let service_name = repo_data.service_name.clone();
+            analyzer
+                .endpoints
+                .extend(repo_data.endpoints.into_iter().map(|mut e| {
+                    e.repo_name = Some(repo_name.clone());
+                    e.service_name = service_name.clone();
+                    e
+                }));
+            analyzer
+                .calls
+                .extend(repo_data.calls.into_iter().map(|mut c| {
+                    c.repo_name = Some(repo_name.clone());
+                    c.service_name = service_name.clone();
+                    c
+                }));
             analyzer.mounts.extend(repo_data.mounts);
             analyzer.apps.extend(repo_data.apps);
             analyzer

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1353,11 +1353,17 @@ impl Analyzer {
             return (Vec::new(), Vec::new(), Vec::new(), Vec::new());
         }
 
-        // Producer repo id (service_name ?? repo_name) per canonical key, so a
-        // matched consumer can be attributed to the producer's repo for a
-        // `CrossRepoMatch`. First producer for a key wins; a key with no repo
-        // identity simply yields no edge (the same guard the HTTP path applies).
-        let mut producer_repo_by_key: HashMap<String, String> = HashMap::new();
+        // Producer repo ids (service_name ?? repo_name) per canonical key, so a
+        // matched consumer can be attributed for a `CrossRepoMatch`. A key with
+        // no repo identity yields no edge (the same guard the HTTP path applies).
+        // Multiple producers can legitimately share one exact key — two services
+        // exposing the same GraphQL field, or several listeners for one socket
+        // event — and exact-key matching has no URL to disambiguate them. So
+        // collect ALL distinct producer repos (a `BTreeSet` for deterministic
+        // order) and emit one edge per producer↔consumer pair, rather than
+        // arbitrarily keeping the first by iteration order.
+        let mut producer_repos_by_key: HashMap<String, std::collections::BTreeSet<String>> =
+            HashMap::new();
         for endpoint in &self.endpoints {
             if endpoint.key.protocol() != protocol {
                 continue;
@@ -1367,9 +1373,10 @@ impl Analyzer {
                 .clone()
                 .or_else(|| endpoint.repo_name.clone())
             {
-                producer_repo_by_key
+                producer_repos_by_key
                     .entry(endpoint.key.canonical())
-                    .or_insert(repo);
+                    .or_default()
+                    .insert(repo);
             }
         }
 
@@ -1395,18 +1402,20 @@ impl Analyzer {
                 // `overlay_compat_verdicts` fills it in if compat ran.
                 let consumer_repo = call.service_name.clone().or_else(|| call.repo_name.clone());
                 let canonical = call.key.canonical();
-                if let (Some(producer_repo), Some(consumer_repo)) =
-                    (producer_repo_by_key.get(&canonical).cloned(), consumer_repo)
+                if let (Some(producer_repos), Some(consumer_repo)) =
+                    (producer_repos_by_key.get(&canonical), consumer_repo)
                 {
-                    cross_repo_matches.push(CrossRepoMatch {
-                        producer_repo,
-                        producer_key: canonical.clone(),
-                        consumer_repo,
-                        consumer_key: canonical,
-                        match_score: 1.0,
-                        type_compatible: None,
-                        mismatch_reason: None,
-                    });
+                    for producer_repo in producer_repos {
+                        cross_repo_matches.push(CrossRepoMatch {
+                            producer_repo: producer_repo.clone(),
+                            producer_key: canonical.clone(),
+                            consumer_repo: consumer_repo.clone(),
+                            consumer_key: canonical.clone(),
+                            match_score: 1.0,
+                            type_compatible: None,
+                            mismatch_reason: None,
+                        });
+                    }
                 }
             } else {
                 let (label, name) = call.key.display_labels();
@@ -2602,6 +2611,42 @@ mod tests {
         assert_eq!(s.consumer_repo, "payments-svc");
         assert_eq!(s.producer_key, "socket|SERVER->CLIENT|payment:settled");
         assert_eq!(s.consumer_key, "socket|SERVER->CLIENT|payment:settled");
+    }
+
+    #[test]
+    fn test_exact_key_matches_emit_edge_per_producer_repo() {
+        use crate::operation::GraphqlOperationKind;
+        let cm = Lrc::new(SourceMap::default());
+        let mut analyzer = Analyzer::new(Config::default(), cm);
+
+        // Two services expose the same GraphQL field; exact-key matching cannot
+        // disambiguate by URL, so a consumer of `order` gets an edge to each.
+        analyzer.endpoints.push(graphql_details_in_repo(
+            OperationKey::graphql(GraphqlOperationKind::Query, "order"),
+            "gateway/schema.graphql:3",
+            "gateway",
+        ));
+        analyzer.endpoints.push(graphql_details_in_repo(
+            OperationKey::graphql(GraphqlOperationKind::Query, "order"),
+            "legacy/schema.graphql:3",
+            "legacy-gateway",
+        ));
+        analyzer.calls.push(graphql_details_in_repo(
+            OperationKey::graphql(GraphqlOperationKind::Query, "order"),
+            "web/lib/graphql.ts:5",
+            "web-frontend",
+        ));
+
+        let (_, _, _, edges) =
+            analyzer.analyze_exact_key_matches(crate::operation::Protocol::Graphql, "GraphQL");
+        assert_eq!(edges.len(), 2, "one edge per producer repo expected");
+        let producer_repos: std::collections::BTreeSet<&str> =
+            edges.iter().map(|e| e.producer_repo.as_str()).collect();
+        assert_eq!(
+            producer_repos,
+            ["gateway", "legacy-gateway"].into_iter().collect()
+        );
+        assert!(edges.iter().all(|e| e.consumer_repo == "web-frontend"));
     }
 
     #[test]

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -42,6 +42,16 @@ type MountGraphMatches = (
     Vec<(String, String)>,
     Vec<CrossRepoMatch>,
 );
+/// Result of `analyze_exact_key_matches` (the non-HTTP, exact-operation-key
+/// matcher): `(call_issues, endpoint_issues, verified_endpoints,
+/// cross_repo_matches)`. No `env_var_calls` slot — GraphQL/socket keys carry no
+/// URL to classify.
+type ExactKeyMatches = (
+    Vec<String>,
+    Vec<OrphanedEndpoint>,
+    Vec<(String, String)>,
+    Vec<CrossRepoMatch>,
+);
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum ConflictSeverity {
@@ -140,6 +150,20 @@ pub struct ApiEndpointDetails {
     pub request_type: Option<TypeReference>,
     pub response_type: Option<TypeReference>,
     pub file_path: PathBuf,
+    /// Owning repo, stamped during the cross-repo merge from
+    /// `CloudRepoData::repo_name`. `None` outside cross-repo mode (single-repo
+    /// data is not repo-tagged). Non-HTTP (GraphQL/socket) matching reads this to
+    /// attribute a matched producer/consumer pair to its repos for a
+    /// `CrossRepoMatch` edge — HTTP ops get repo identity from the repo-tagged
+    /// mount graph instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_name: Option<String>,
+    /// Owning service (monorepo `serviceName`), stamped during the cross-repo
+    /// merge. Preferred over `repo_name` for the edge repo id (matches the
+    /// cloud's `service_name ?? repo_name` convention). `None` when no
+    /// `serviceName`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_name: Option<String>,
 }
 
 pub struct ApiAnalysisResult {
@@ -216,6 +240,35 @@ fn parse_producer_key(key: &str) -> Option<(String, String)> {
         }
         _ => None,
     }
+}
+
+/// Sort cross-repo edges into a deterministic order and drop exact duplicates,
+/// keyed on the `(producer_repo, producer_key, consumer_repo, consumer_key)`
+/// identity tuple. The HTTP matcher and the non-HTTP matcher capture edges in
+/// non-deterministic iteration order, and `get_results` re-runs this over the
+/// combined set so every consumer (PR comment, dashboard, eval projection,
+/// cassette gate) sees a stable order.
+fn sort_dedup_cross_repo_matches(matches: &mut Vec<CrossRepoMatch>) {
+    matches.sort_by(|a, b| {
+        (
+            &a.producer_repo,
+            &a.producer_key,
+            &a.consumer_repo,
+            &a.consumer_key,
+        )
+            .cmp(&(
+                &b.producer_repo,
+                &b.producer_key,
+                &b.consumer_repo,
+                &b.consumer_key,
+            ))
+    });
+    matches.dedup_by(|a, b| {
+        a.producer_repo == b.producer_repo
+            && a.producer_key == b.producer_key
+            && a.consumer_repo == b.consumer_repo
+            && a.consumer_key == b.consumer_key
+    });
 }
 
 /// Accept only values whose *shape* is an extractable outgoing-call route, as
@@ -474,6 +527,8 @@ impl Analyzer {
                 request_type: call.request_type.clone(),
                 response_type: call.response_type.clone(),
                 file_path: call.call_file.clone(),
+                repo_name: None,
+                service_name: None,
             });
         }
     }
@@ -1217,27 +1272,10 @@ impl Analyzer {
 
         // Deterministic order for the projection (mirrors verified.sort()): the
         // matcher iterates calls/endpoints in a non-deterministic order, so sort
-        // and dedup the captured edges on their identity tuple.
-        cross_repo_matches.sort_by(|a, b| {
-            (
-                &a.producer_repo,
-                &a.producer_key,
-                &a.consumer_repo,
-                &a.consumer_key,
-            )
-                .cmp(&(
-                    &b.producer_repo,
-                    &b.producer_key,
-                    &b.consumer_repo,
-                    &b.consumer_key,
-                ))
-        });
-        cross_repo_matches.dedup_by(|a, b| {
-            a.producer_repo == b.producer_repo
-                && a.producer_key == b.producer_key
-                && a.consumer_repo == b.consumer_repo
-                && a.consumer_key == b.consumer_key
-        });
+        // and dedup the captured edges on their identity tuple. The non-HTTP
+        // edges added later in `get_results` are re-sorted there over the
+        // combined set, so this is the HTTP-only first pass.
+        sort_dedup_cross_repo_matches(&mut cross_repo_matches);
 
         (
             call_issues,
@@ -1304,7 +1342,7 @@ impl Analyzer {
         &self,
         protocol: crate::operation::Protocol,
         protocol_label: &str,
-    ) -> (Vec<String>, Vec<OrphanedEndpoint>, Vec<(String, String)>) {
+    ) -> ExactKeyMatches {
         let producer_keys: HashSet<&OperationKey> = self
             .endpoints
             .iter()
@@ -1312,10 +1350,31 @@ impl Analyzer {
             .map(|endpoint| &endpoint.key)
             .collect();
         if producer_keys.is_empty() {
-            return (Vec::new(), Vec::new(), Vec::new());
+            return (Vec::new(), Vec::new(), Vec::new(), Vec::new());
+        }
+
+        // Producer repo id (service_name ?? repo_name) per canonical key, so a
+        // matched consumer can be attributed to the producer's repo for a
+        // `CrossRepoMatch`. First producer for a key wins; a key with no repo
+        // identity simply yields no edge (the same guard the HTTP path applies).
+        let mut producer_repo_by_key: HashMap<String, String> = HashMap::new();
+        for endpoint in &self.endpoints {
+            if endpoint.key.protocol() != protocol {
+                continue;
+            }
+            if let Some(repo) = endpoint
+                .service_name
+                .clone()
+                .or_else(|| endpoint.repo_name.clone())
+            {
+                producer_repo_by_key
+                    .entry(endpoint.key.canonical())
+                    .or_insert(repo);
+            }
         }
 
         let mut call_issues = Vec::new();
+        let mut cross_repo_matches: Vec<CrossRepoMatch> = Vec::new();
         let mut matched: HashSet<&OperationKey> = HashSet::new();
         let mut seen_calls = HashSet::new();
         for call in &self.calls {
@@ -1328,6 +1387,27 @@ impl Analyzer {
             }
             if producer_keys.contains(&call.key) {
                 matched.insert(&call.key);
+                // Emit the cross-repo edge. Exact-key protocols share one key on
+                // both sides, so producer_key == consumer_key. For sockets the
+                // producer is the listener (an endpoint) and the consumer is the
+                // emitter (a call); this attribution follows directly from which
+                // side the op sits on. `type_compatible` is left `None` —
+                // `overlay_compat_verdicts` fills it in if compat ran.
+                let consumer_repo = call.service_name.clone().or_else(|| call.repo_name.clone());
+                let canonical = call.key.canonical();
+                if let (Some(producer_repo), Some(consumer_repo)) =
+                    (producer_repo_by_key.get(&canonical).cloned(), consumer_repo)
+                {
+                    cross_repo_matches.push(CrossRepoMatch {
+                        producer_repo,
+                        producer_key: canonical.clone(),
+                        consumer_repo,
+                        consumer_key: canonical,
+                        match_score: 1.0,
+                        type_compatible: None,
+                        mismatch_reason: None,
+                    });
+                }
             } else {
                 let (label, name) = call.key.display_labels();
                 call_issues.push(format!(
@@ -1366,7 +1446,7 @@ impl Analyzer {
         verified.sort();
         verified.dedup();
 
-        (call_issues, endpoint_issues, verified)
+        (call_issues, endpoint_issues, verified, cross_repo_matches)
     }
 
     pub fn compute_full_paths_for_endpoint(
@@ -1583,14 +1663,22 @@ impl Analyzer {
             (crate::operation::Protocol::Graphql, "GraphQL"),
             (crate::operation::Protocol::Websocket, "Socket.IO"),
         ] {
-            let (protocol_call_issues, protocol_endpoint_issues, protocol_verified) =
-                self.analyze_exact_key_matches(protocol, label);
+            let (
+                protocol_call_issues,
+                protocol_endpoint_issues,
+                protocol_verified,
+                protocol_cross_repo_matches,
+            ) = self.analyze_exact_key_matches(protocol, label);
             call_issues.extend(protocol_call_issues);
             endpoint_issues.extend(protocol_endpoint_issues);
             verified_endpoints.extend(protocol_verified);
+            cross_repo_matches.extend(protocol_cross_repo_matches);
         }
         verified_endpoints.sort();
         verified_endpoints.dedup();
+        // Re-sort/dedup over the combined HTTP + non-HTTP edge set so the final
+        // ordering is stable regardless of which matcher produced an edge.
+        sort_dedup_cross_repo_matches(&mut cross_repo_matches);
         // Note: JSON body comparison removed - type checking is done via TypeScript (ts_check/)
         let mismatches = Vec::new();
         let type_mismatches = self.get_type_mismatches();
@@ -2337,6 +2425,17 @@ mod tests {
             request_type: None,
             response_type: None,
             file_path: PathBuf::from(file),
+            repo_name: None,
+            service_name: None,
+        }
+    }
+
+    /// Like [`graphql_details`] but stamps repo identity (as the cross-repo
+    /// merge does), so the exact-key matcher can attribute an edge to repos.
+    fn graphql_details_in_repo(key: OperationKey, file: &str, repo: &str) -> ApiEndpointDetails {
+        ApiEndpointDetails {
+            repo_name: Some(repo.to_string()),
+            ..graphql_details(key, file)
         }
     }
 
@@ -2363,7 +2462,7 @@ mod tests {
             "client.ts:20",
         ));
 
-        let (call_issues, endpoint_issues, verified) =
+        let (call_issues, endpoint_issues, verified, _edges) =
             analyzer.analyze_exact_key_matches(crate::operation::Protocol::Graphql, "GraphQL");
 
         assert_eq!(verified, vec![("QUERY".to_string(), "user".to_string())]);
@@ -2393,11 +2492,12 @@ mod tests {
             "client.ts:12",
         ));
 
-        let (call_issues, endpoint_issues, verified) =
+        let (call_issues, endpoint_issues, verified, edges) =
             analyzer.analyze_exact_key_matches(crate::operation::Protocol::Graphql, "GraphQL");
         assert!(call_issues.is_empty());
         assert!(endpoint_issues.is_empty());
         assert!(verified.is_empty());
+        assert!(edges.is_empty());
     }
 
     #[test]
@@ -2430,7 +2530,7 @@ mod tests {
             "client.ts:9",
         ));
 
-        let (call_issues, endpoint_issues, verified) =
+        let (call_issues, endpoint_issues, verified, _edges) =
             analyzer.analyze_exact_key_matches(crate::operation::Protocol::Websocket, "Socket.IO");
 
         assert_eq!(
@@ -2447,6 +2547,61 @@ mod tests {
             call_issues[0]
         );
         assert!(endpoint_issues.is_empty());
+    }
+
+    #[test]
+    fn test_exact_key_matches_emit_cross_repo_edges() {
+        use crate::operation::{GraphqlOperationKind, SocketDirection};
+        let cm = Lrc::new(SourceMap::default());
+        let mut analyzer = Analyzer::new(Config::default(), cm);
+
+        // GraphQL: producer schema field in `gateway`, consumer document field
+        // in `web-frontend`. Same operation key on both sides.
+        analyzer.endpoints.push(graphql_details_in_repo(
+            OperationKey::graphql(GraphqlOperationKind::Query, "order"),
+            "schema.graphql:3",
+            "gateway",
+        ));
+        analyzer.calls.push(graphql_details_in_repo(
+            OperationKey::graphql(GraphqlOperationKind::Query, "order"),
+            "web/lib/graphql.ts:5",
+            "web-frontend",
+        ));
+        // Socket: the producer is the LISTENER (an endpoint) in `web-frontend`;
+        // the consumer is the EMITTER (a call) in `payments-svc`. The event flows
+        // payments-svc → web-frontend, but the contract producer is the listener.
+        analyzer.endpoints.push(graphql_details_in_repo(
+            OperationKey::socket("payment:settled", SocketDirection::ServerToClient),
+            "web/lib/realtime.ts:8",
+            "web-frontend",
+        ));
+        analyzer.calls.push(graphql_details_in_repo(
+            OperationKey::socket("payment:settled", SocketDirection::ServerToClient),
+            "payments/realtime/server.ts:9",
+            "payments-svc",
+        ));
+
+        let (_, _, _, gql_edges) =
+            analyzer.analyze_exact_key_matches(crate::operation::Protocol::Graphql, "GraphQL");
+        assert_eq!(gql_edges.len(), 1, "one graphql edge expected");
+        let e = &gql_edges[0];
+        assert_eq!(e.producer_repo, "gateway");
+        assert_eq!(e.consumer_repo, "web-frontend");
+        assert_eq!(e.producer_key, "graphql|query|order");
+        assert_eq!(e.consumer_key, "graphql|query|order");
+        assert_eq!(e.match_score, 1.0);
+        // Compat is filled in later by overlay_compat_verdicts, not here.
+        assert_eq!(e.type_compatible, None);
+
+        let (_, _, _, socket_edges) =
+            analyzer.analyze_exact_key_matches(crate::operation::Protocol::Websocket, "Socket.IO");
+        assert_eq!(socket_edges.len(), 1, "one socket edge expected");
+        let s = &socket_edges[0];
+        // Direction-aware: listener repo is the producer, emitter repo the consumer.
+        assert_eq!(s.producer_repo, "web-frontend");
+        assert_eq!(s.consumer_repo, "payments-svc");
+        assert_eq!(s.producer_key, "socket|SERVER->CLIENT|payment:settled");
+        assert_eq!(s.consumer_key, "socket|SERVER->CLIENT|payment:settled");
     }
 
     #[test]
@@ -2493,6 +2648,8 @@ mod tests {
             request_type: None,
             response_type: None,
             file_path: PathBuf::from("test.ts"),
+            repo_name: None,
+            service_name: None,
         });
 
         // 2. Unclassified env var (not in internal/external list)
@@ -2506,6 +2663,8 @@ mod tests {
             request_type: None,
             response_type: None,
             file_path: PathBuf::from("test.ts"),
+            repo_name: None,
+            service_name: None,
         });
 
         // 3. Process.env pattern (should be detected as env var)
@@ -2519,6 +2678,8 @@ mod tests {
             request_type: None,
             response_type: None,
             file_path: PathBuf::from("test.ts"),
+            repo_name: None,
+            service_name: None,
         });
 
         // 4. Raw code pattern with UPPERCASE var (common in legacy code)
@@ -2533,6 +2694,8 @@ mod tests {
             request_type: None,
             response_type: None,
             file_path: PathBuf::from("test.ts"),
+            repo_name: None,
+            service_name: None,
         });
 
         let mount_graph = MountGraph::new(); // Empty graph

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -97,6 +97,13 @@ pub struct TypeManifestEntry {
     /// Generated at CI time via ts-morph's type.getText() with NoTruncation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expanded_definition: Option<String>,
+    /// The LLM-emitted type-anchor symbol for this op (e.g. `StatusResponse`),
+    /// joined from the file-analyzer result by `(file_path, line_number)`. Unlike
+    /// `type_alias` (the synthetic `Endpoint_<hash>_Response` name), this is the
+    /// real source symbol the eval anchor metric scores against. `None` when the
+    /// model emitted no anchor for this op.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_type_symbol: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -189,6 +196,8 @@ impl CloudRepoData {
                 request_type: None,
                 response_type: None,
                 file_path: PathBuf::from(&endpoint.file_location),
+                repo_name: None,
+                service_name: None,
             })
             .collect();
 
@@ -206,6 +215,8 @@ impl CloudRepoData {
                 request_type: None,
                 response_type: None,
                 file_path: PathBuf::from(&call.file_location),
+                repo_name: None,
+                service_name: None,
             })
             .collect();
 
@@ -370,6 +381,7 @@ mod tests {
             },
             resolved_definition: None,
             expanded_definition: None,
+            primary_type_symbol: None,
         };
 
         let json: serde_json::Value = serde_json::to_value(&entry).unwrap();

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1671,24 +1671,32 @@ fn build_type_manifest_entries(
 /// `line_number`. Stamp the symbol onto every manifest entry for that op
 /// (request + response) so the eval projection surfaces the real anchor instead
 /// of the hash. The first non-None symbol per `(file, line)` wins.
+///
+/// The symbol-side line is normalized exactly as the manifest side
+/// (`parse_file_location`): a non-positive/missing line collapses to `1`. Keying
+/// a line-0 anchor at `0` would never join a manifest entry (always `>= 1`), so
+/// the anchor would silently fall back to the hashed `type_alias`.
 fn stamp_manifest_anchor_symbols(
     manifest: &mut [TypeManifestEntry],
     file_results: &HashMap<String, crate::agents::file_analyzer_agent::FileAnalysisResult>,
 ) {
+    // Mirror `parse_file_location`'s `Some(0) | None => 1` normalization so the
+    // join keys line up on both sides.
+    let normalize_line = |line: i32| -> u32 { if line <= 0 { 1 } else { line as u32 } };
     // (file_path, line_number) -> primary_type_symbol, from endpoints and calls.
     let mut symbols: HashMap<(String, u32), String> = HashMap::new();
     for (file_path, result) in file_results {
         for endpoint in &result.endpoints {
             if let Some(symbol) = endpoint.primary_type_symbol.as_ref() {
                 symbols
-                    .entry((file_path.clone(), endpoint.line_number.max(0) as u32))
+                    .entry((file_path.clone(), normalize_line(endpoint.line_number)))
                     .or_insert_with(|| symbol.clone());
             }
         }
         for call in &result.data_calls {
             if let Some(symbol) = call.primary_type_symbol.as_ref() {
                 symbols
-                    .entry((file_path.clone(), call.line_number.max(0) as u32))
+                    .entry((file_path.clone(), normalize_line(call.line_number)))
                     .or_insert_with(|| symbol.clone());
             }
         }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -991,7 +991,8 @@ async fn analyze_current_repo_incremental(
             cloud_data.cache_version = Some(CACHE_VERSION);
 
             // Build type manifest
-            let manifest_entries = build_type_manifest_entries(&mount_graph, config);
+            let mut manifest_entries = build_type_manifest_entries(&mount_graph, config);
+            stamp_manifest_anchor_symbols(&mut manifest_entries, &merged_results);
             if !manifest_entries.is_empty() {
                 cloud_data.type_manifest = Some(manifest_entries);
             }
@@ -1117,6 +1118,8 @@ fn append_deterministic_protocol_operations(
         request_type: None,
         response_type: None,
         file_path: PathBuf::from(format!("{}:{}", file_path.display(), line)),
+        repo_name: None,
+        service_name: None,
     };
 
     let graphql = crate::graphql::scan_repo(Path::new(repo_path), files);
@@ -1195,6 +1198,8 @@ fn build_cloud_data_from_mount_graph(
             request_type: None,
             response_type: None,
             file_path: PathBuf::from(&endpoint.file_location),
+            repo_name: None,
+            service_name: None,
         })
         .collect();
 
@@ -1211,6 +1216,8 @@ fn build_cloud_data_from_mount_graph(
             request_type: None,
             response_type: None,
             file_path: PathBuf::from(&call.file_location),
+            repo_name: None,
+            service_name: None,
         })
         .collect();
 
@@ -1654,6 +1661,48 @@ fn build_type_manifest_entries(
     entries
 }
 
+/// Thread the LLM's real type-anchor symbol onto the manifest entries (#233).
+///
+/// The manifest's `type_alias` is a synthetic hashed name (`Endpoint_<hash>_…`);
+/// the real source symbol (`StatusResponse`) lives on the file-analyzer result.
+/// Join by `(file_path, line_number)`: the mount-graph `file_location` the
+/// manifest is built from is `"{file_path}:{line}"`, where `file_path` is the
+/// same key `file_results` is keyed by and `line` is the same LLM-emitted
+/// `line_number`. Stamp the symbol onto every manifest entry for that op
+/// (request + response) so the eval projection surfaces the real anchor instead
+/// of the hash. The first non-None symbol per `(file, line)` wins.
+fn stamp_manifest_anchor_symbols(
+    manifest: &mut [TypeManifestEntry],
+    file_results: &HashMap<String, crate::agents::file_analyzer_agent::FileAnalysisResult>,
+) {
+    // (file_path, line_number) -> primary_type_symbol, from endpoints and calls.
+    let mut symbols: HashMap<(String, u32), String> = HashMap::new();
+    for (file_path, result) in file_results {
+        for endpoint in &result.endpoints {
+            if let Some(symbol) = endpoint.primary_type_symbol.as_ref() {
+                symbols
+                    .entry((file_path.clone(), endpoint.line_number.max(0) as u32))
+                    .or_insert_with(|| symbol.clone());
+            }
+        }
+        for call in &result.data_calls {
+            if let Some(symbol) = call.primary_type_symbol.as_ref() {
+                symbols
+                    .entry((file_path.clone(), call.line_number.max(0) as u32))
+                    .or_insert_with(|| symbol.clone());
+            }
+        }
+    }
+    if symbols.is_empty() {
+        return;
+    }
+    for entry in manifest.iter_mut() {
+        if let Some(symbol) = symbols.get(&(entry.file_path.clone(), entry.line_number)) {
+            entry.primary_type_symbol = Some(symbol.clone());
+        }
+    }
+}
+
 fn add_manifest_pair(
     entries: &mut Vec<TypeManifestEntry>,
     key: OperationKey,
@@ -1696,6 +1745,9 @@ fn add_manifest_pair(
             evidence,
             resolved_definition: None,
             expanded_definition: None,
+            // Threaded on after the fact by `stamp_manifest_anchor_symbols`,
+            // which joins the LLM's real anchor symbol by `(file_path, line)`.
+            primary_type_symbol: None,
         });
     }
 }
@@ -1899,7 +1951,8 @@ async fn analyze_current_repo(
     );
     append_deterministic_protocol_operations(&mut cloud_data, repo_path, &files);
 
-    let manifest_entries = build_type_manifest_entries(&analysis_result.mount_graph, config);
+    let mut manifest_entries = build_type_manifest_entries(&analysis_result.mount_graph, config);
+    stamp_manifest_anchor_symbols(&mut manifest_entries, &analysis_result.file_results);
     if !manifest_entries.is_empty() {
         cloud_data.type_manifest = Some(manifest_entries);
     }
@@ -2306,6 +2359,8 @@ mod tests {
                 alias: "ResponseType".to_string(),
             }),
             handler_name: Some("testHandler".to_string()),
+            repo_name: None,
+            service_name: None,
         };
 
         let test_data = CloudRepoData {
@@ -2420,6 +2475,8 @@ mod tests {
                 alias: "ResponseType".to_string(),
             }),
             handler_name: Some("testHandler".to_string()),
+            repo_name: None,
+            service_name: None,
         };
 
         let test_data = vec![CloudRepoData {
@@ -3326,6 +3383,7 @@ mod tests {
             evidence,
             resolved_definition: None,
             expanded_definition: None,
+            primary_type_symbol: None,
         }
     }
 

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -67,13 +67,11 @@ pub struct EvalOp {
     pub is_explicit: Option<bool>,
     /// The LLM-emitted type anchor (contract §3, §5 row 5).
     ///
-    /// The raw anchor (`primary_type_symbol` on the file-analyzer result) is not
-    /// keyed by `OperationKey` at projection time — it lives in the per-file LLM
-    /// results, not the type manifest. Per contract §3 ("if the join makes this
-    /// expensive, S1 may fall back to scoring the anchor metric against
-    /// `type_alias` and note the substitution"), this is populated from the
-    /// manifest `type_alias`. The scorer treats it as the anchor surrogate until
-    /// the raw anchor is threaded into the manifest (follow-up).
+    /// The real anchor (`primary_type_symbol` on the file-analyzer result) is
+    /// threaded onto the type manifest at build time, joined by `(file_path,
+    /// line_number)`, so this carries the real source symbol (`StatusResponse`)
+    /// rather than the hashed `type_alias`. Falls back to `type_alias` only when
+    /// no real anchor was extracted for the op.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub primary_type_symbol: Option<String>,
 }
@@ -166,6 +164,10 @@ struct ManifestFields {
     resolved_definition: Option<String>,
     expanded_definition: Option<String>,
     is_explicit: Option<bool>,
+    /// Real LLM type-anchor symbol, threaded onto the manifest entry at build
+    /// time. Distinct from `type_alias` (the synthetic hashed
+    /// `Endpoint_<hash>_Response` name); the anchor metric scores against this.
+    primary_type_symbol: Option<String>,
 }
 
 /// Lookup from canonical operation key → manifest fields. The manifest carries
@@ -193,6 +195,13 @@ impl ManifestIndex {
                 slot.resolved_definition = entry.resolved_definition.clone();
                 slot.expanded_definition = entry.expanded_definition.clone();
                 slot.is_explicit = Some(entry.is_explicit);
+            }
+            // The anchor symbol is independent of the definition-richness race
+            // above: keep the first non-None symbol seen for this op so a
+            // response entry that wins on definition but carries no symbol does
+            // not erase a request entry's symbol.
+            if slot.primary_type_symbol.is_none() {
+                slot.primary_type_symbol = entry.primary_type_symbol.clone();
             }
         }
         Self { by_key }
@@ -242,8 +251,14 @@ impl EvalOp {
             resolved_definition: fields.and_then(|f| f.resolved_definition.clone()),
             expanded_definition: fields.and_then(|f| f.expanded_definition.clone()),
             is_explicit: fields.and_then(|f| f.is_explicit),
-            // Anchor surrogate: see field doc. Falls back to `type_alias`.
-            primary_type_symbol: fields.and_then(|f| f.type_alias.clone()),
+            // The real LLM type anchor (#233): the symbol threaded onto the
+            // manifest entry, falling back to the hashed `type_alias` only when
+            // no real symbol was extracted for this op.
+            primary_type_symbol: fields.and_then(|f| {
+                f.primary_type_symbol
+                    .clone()
+                    .or_else(|| f.type_alias.clone())
+            }),
         }
     }
 }
@@ -331,6 +346,7 @@ mod tests {
         type_state: ManifestTypeState,
         is_explicit: bool,
         resolved: Option<&str>,
+        primary_type_symbol: Option<&str>,
     ) -> TypeManifestEntry {
         TypeManifestEntry {
             key,
@@ -352,6 +368,7 @@ mod tests {
             },
             resolved_definition: resolved.map(String::from),
             expanded_definition: None,
+            primary_type_symbol: primary_type_symbol.map(String::from),
         }
     }
 
@@ -377,6 +394,8 @@ mod tests {
             request_type: None,
             response_type: None,
             file_path: PathBuf::from(file_line),
+            repo_name: None,
+            service_name: None,
         }
     }
 
@@ -453,6 +472,7 @@ mod tests {
             ManifestTypeState::Explicit,
             true,
             Some("{ id: number; amountCents: number }"),
+            Some("OrderResponse"),
         )];
 
         let projection = EvalProjection::from_results(&result, &manifest);
@@ -499,8 +519,8 @@ mod tests {
             "{ id: number; amountCents: number }"
         );
         assert_eq!(op["type_alias"], "Endpoint_abc_Response");
-        // primary_type_symbol falls back to type_alias (documented substitution).
-        assert_eq!(op["primary_type_symbol"], "Endpoint_abc_Response");
+        // The real LLM anchor surfaces — NOT the hashed type_alias (#233).
+        assert_eq!(op["primary_type_symbol"], "OrderResponse");
         // expanded_definition was None → omitted.
         assert!(op.get("expanded_definition").is_none());
 

--- a/tests/eval_xrepo.rs
+++ b/tests/eval_xrepo.rs
@@ -720,8 +720,11 @@ fn score_type_anchor_accuracy(
 
 /// Type-resolution correctness (contract §6 row 6): over ops in both sets that
 /// carry an expected resolved type, the fraction where `type_state` is exactly
-/// equal AND the whitespace-collapsed resolved type is equal. The actual
-/// resolved type is `resolved_definition`, falling back to `expanded_definition`.
+/// equal AND the whitespace-collapsed resolved type is equal. The corpus
+/// `resolved_type` labels are the fully-inlined structural form (ts-morph
+/// `getText()` with NoTruncation), so the actual is `expanded_definition`,
+/// falling back to `resolved_definition` (the name-preserving DefinitionResolver
+/// form) only when no inlined definition was emitted.
 fn score_type_resolution_accuracy(
     repo_expected: &[(String, ExpectedRepo)],
     proj: &EvalProjection,
@@ -739,9 +742,9 @@ fn score_type_resolution_accuracy(
         if let Some(actual) = idx.get(&key) {
             total += 1;
             let actual_rt = actual
-                .resolved_definition
+                .expanded_definition
                 .as_deref()
-                .or(actual.expanded_definition.as_deref());
+                .or(actual.resolved_definition.as_deref());
             let state_ok = ts == actual.type_state.as_deref();
             let rt_ok = actual_rt.map(collapse_ws) == Some(collapse_ws(expected_rt));
             if state_ok && rt_ok {

--- a/tests/fixtures/llm-mocked-api/__golden__.json
+++ b/tests/fixtures/llm-mocked-api/__golden__.json
@@ -15,7 +15,7 @@
       "resolved_definition": "export interface Endpoint_a9cce7d0d8d0d9e6_Response {\n  id: number;\n  name: string;\n  email: string;\n}",
       "expanded_definition": "Endpoint_a9cce7d0d8d0d9e6_Response",
       "is_explicit": true,
-      "primary_type_symbol": "Endpoint_a9cce7d0d8d0d9e6_Response"
+      "primary_type_symbol": "User"
     },
     {
       "key": "http|GET|/export",


### PR DESCRIPTION
## Summary
Two cross-repo eval accuracy gaps surfaced by the corpus (epic #207), fixed on top of the merged #237/#238.

### #232 — non-HTTP cross-repo edges were invisible to the scorer
The HTTP matcher emits a `CrossRepoMatch` per matched producer→consumer pair; the exact-key matcher (GraphQL/socket) returned only issue/verified lists, so GraphQL + socket edges never reached `EvalProjection.cross_repo_matches`.

- `ApiEndpointDetails` gains `repo_name`/`service_name`, stamped onto every endpoint/call at the single cross-repo merge point (`build_from_repo_data`). HTTP ops resolve identity from the repo-tagged mount graph; the non-HTTP path had no other source.
- `analyze_exact_key_matches` now emits a `CrossRepoMatch` per matched pair, attributing producer/consumer repos (`service_name ?? repo_name`) and the protocol's canonical key. **Direction-aware for sockets**: the listener (endpoint) is the producer, the emitter (call) the consumer — so `payment:settled` resolves to `producer_repo=web-frontend`, `consumer_repo=payments-svc`, matching the corpus answer key.
- `get_results` extends the edge set with the non-HTTP matches and re-sorts the combined set via a shared `sort_dedup_cross_repo_matches` helper.

### #233 — type-anchor + type-resolution metrics scored 0.00
- **anchor**: `primary_type_symbol` was the synthetic hashed `type_alias` (`Endpoint_<hash>_Response`). Now the real LLM anchor symbol, threaded onto the manifest at build time (`stamp_manifest_anchor_symbols`, joined by `(file_path, line)`), falling back to `type_alias` only when no anchor exists.
- **resolution**: the scorer preferred `resolved_definition`, but the corpus `resolved_type` labels are the fully-inlined ts-morph form, i.e. `expanded_definition`. Reversed the preference.

## Tests
- New `test_exact_key_matches_emit_cross_repo_edges`: asserts GraphQL + socket edges form with correct repo attribution + socket direction.
- Updated the three existing exact-key matcher tests for the new 4-tuple return.
- Re-recorded the cassette golden: `/api/users` anchor is now the real `User` symbol instead of the hash (the one intended output change — the gate caught it, by design).
- Full Rust suite (cassette hard gate included) + ts_check 69/69 + clippy `-D warnings` + fmt all green locally.

Closes #232
Closes #233
Refs #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)