### PR TITLE
fix(ts_check): tag injected `= unknown` placeholder so genuine unknown isn't downgraded (#244)

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2167,6 +2167,13 @@ fn write_manifest_files(
     Ok(())
 }
 
+/// Trailing marker stamped onto every `= unknown` alias that
+/// `append_missing_aliases` injects for a manifest entry that never reached the
+/// bundle. It lets `dts_alias_is_trivially_unknown` recognise *our* placeholder
+/// without misclassifying a developer-authored `type X = unknown` in a real API
+/// type (which keeps its resolved shape rather than being downgraded).
+const MISSING_ALIAS_MARKER: &str = "// carrick:missing-alias";
+
 fn append_missing_aliases(content: String, manifest: Option<&Vec<TypeManifestEntry>>) -> String {
     let Some(entries) = manifest else {
         return content;
@@ -2189,7 +2196,9 @@ fn append_missing_aliases(content: String, manifest: Option<&Vec<TypeManifestEnt
         }
         updated.push_str("export type ");
         updated.push_str(&entry.type_alias);
-        updated.push_str(" = unknown;\n");
+        updated.push_str(" = unknown; ");
+        updated.push_str(MISSING_ALIAS_MARKER);
+        updated.push('\n');
     }
 
     updated
@@ -2204,11 +2213,20 @@ fn dts_defines_alias(content: &str, alias: &str) -> bool {
     }
 }
 
-/// Returns true when the .d.ts defines the alias as exactly `= unknown`,
-/// i.e. it's a placeholder for a failed inference, not a real type.
+/// Returns true only when the .d.ts carries the *Carrick-injected* `= unknown`
+/// placeholder for this alias, identified by the `MISSING_ALIAS_MARKER` comment
+/// that `append_missing_aliases` stamps on it. A developer-authored
+/// `type X = unknown` in a real API type carries no marker and is therefore not
+/// treated as a placeholder, so its cross-repo edge keeps its resolved state
+/// instead of being silently downgraded to `Unknown` (#244).
 fn dts_alias_is_trivially_unknown(content: &str, alias: &str) -> bool {
     let escaped = regex::escape(alias);
-    let pattern = format!(r"type\s+{}\s*=\s*unknown\s*;", escaped);
+    let marker = regex::escape(MISSING_ALIAS_MARKER);
+    // Anchor on the exact form append_missing_aliases emits:
+    //   export type <alias> = unknown; // carrick:missing-alias
+    // The optional `export`, generics, and modifiers are tolerated, but the
+    // trailing marker on the same line is what actually identifies it as ours.
+    let pattern = format!(r"\btype\s+{escaped}\b[^\n]*=\s*unknown\s*;[^\n]*{marker}");
     match regex::Regex::new(&pattern) {
         Ok(re) => re.is_match(content),
         Err(_) => false,
@@ -3455,18 +3473,63 @@ mod tests {
         assert_eq!(manifest[0].type_state, ManifestTypeState::Unknown);
     }
 
-    /// A `= unknown` placeholder in the bundled .d.ts must NOT promote the entry,
-    /// even if the bundle nominally "defines" the alias — it is downgraded to
-    /// `Unknown` (#235).
+    /// The Carrick-injected `= unknown` placeholder (carrying the marker) in the
+    /// bundled .d.ts must NOT promote the entry, even if the bundle nominally
+    /// "defines" the alias — it is downgraded to `Unknown` (#235).
     #[test]
     fn enrich_downgrades_trivially_unknown_dts_alias() {
         let mut manifest = vec![consumer_entry("OrderView")];
         let resolution = empty_resolution();
-        let dts = "export type OrderView = unknown;\n";
+        let dts = format!("export type OrderView = unknown; {MISSING_ALIAS_MARKER}\n");
 
-        enrich_manifest_with_type_resolution(&mut manifest, &resolution, Some(dts));
+        enrich_manifest_with_type_resolution(&mut manifest, &resolution, Some(&dts));
 
         assert_eq!(manifest[0].type_state, ManifestTypeState::Unknown);
+    }
+
+    /// A *developer-authored* `type X = unknown` in a real API type carries no
+    /// Carrick marker and must NOT be mistaken for the injected placeholder, so
+    /// the entry keeps its state rather than being downgraded to `Unknown`
+    /// (#244). The genuine `unknown` shape is still surfaced as unverifiable
+    /// downstream by ts_check's compiler-level `isUnknown()` gate, not by a
+    /// silent recall-losing downgrade here.
+    #[test]
+    fn enrich_does_not_downgrade_developer_authored_unknown() {
+        // No resolution entry and no marker: the alias is "defined" in the
+        // bundle as a genuine `= unknown`, so dts_defined_aliases promotes it to
+        // Implicit and the trivially-unknown gate stays shut.
+        let mut manifest = vec![consumer_entry("OrderView")];
+        let resolution = empty_resolution();
+        let bare = "export type OrderView = unknown;\n";
+
+        enrich_manifest_with_type_resolution(&mut manifest, &resolution, Some(bare));
+
+        assert_ne!(
+            manifest[0].type_state,
+            ManifestTypeState::Unknown,
+            "a developer-authored `type X = unknown` must not be downgraded to Unknown"
+        );
+
+        // And other forms a developer might write are equally not the marker.
+        for form in [
+            "export type OrderView = unknown;\n",
+            "type OrderView = unknown;\n",
+            "export type OrderView<T> = unknown;\n",
+            "export declare type OrderView = unknown;\n",
+            "export type OrderView = unknown; // genuinely unknown\n",
+        ] {
+            assert!(
+                !dts_alias_is_trivially_unknown(form, "OrderView"),
+                "developer-authored form must not match the placeholder marker: {form:?}"
+            );
+        }
+
+        // The tagged placeholder, in the form append_missing_aliases emits, does.
+        let tagged = format!("export type OrderView = unknown; {MISSING_ALIAS_MARKER}\n");
+        assert!(
+            dts_alias_is_trivially_unknown(&tagged, "OrderView"),
+            "the Carrick-injected marker form must match the placeholder gate"
+        );
     }
 
     /// append_missing_aliases injects a `= unknown` placeholder for a manifest
@@ -3479,12 +3542,19 @@ mod tests {
         let out = append_missing_aliases(dts, Some(&manifest));
 
         assert!(
-            out.contains("export type OrderView = unknown;"),
-            "missing alias should be injected as a placeholder, got: {out}"
+            out.contains(&format!(
+                "export type OrderView = unknown; {MISSING_ALIAS_MARKER}"
+            )),
+            "missing alias should be injected as a marked placeholder, got: {out}"
         );
         assert!(
-            !out.contains("export type Payment = unknown;"),
+            !out.contains("export type Payment = unknown"),
             "an already-defined alias must not be overwritten, got: {out}"
+        );
+        // The injected placeholder must be recognised as the Carrick placeholder.
+        assert!(
+            dts_alias_is_trivially_unknown(&out, "OrderView"),
+            "the injected marker must be detected by the placeholder gate, got: {out}"
         );
     }
 }

--- a/ts_check/lib/type-checker.test.ts
+++ b/ts_check/lib/type-checker.test.ts
@@ -465,6 +465,97 @@ describe('TypeCompatibilityChecker', () => {
       assert.strictEqual(result.mismatches.length, 1);
     });
 
+    it('flags only the Carrick-marked `= unknown` as the injected placeholder (#244)', async () => {
+      // The marked alias is the injected placeholder: it short-circuits on the
+      // type_state=unknown path. The unmarked, developer-authored `= unknown`
+      // resolves to a genuine `unknown` and is caught by the compiler-level
+      // isUnknown() gate instead. Both are unverifiable, but only the marked one
+      // is treated as our placeholder, with the corresponding reason text.
+      const markedProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      markedProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type Order = { id: number };
+        export type OrderView = unknown; // carrick:missing-alias
+        `,
+        { overwrite: true }
+      );
+
+      const bareProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      bareProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type Order = { id: number };
+        export type OrderView = unknown;
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'orders-api',
+        commit_hash: 'abc',
+        entries: [
+          createManifestEntry('GET', '/orders/:id', 'Order', 'producer', 'routes.ts', 10),
+        ],
+      };
+      // type_state='unknown' so resolveTypeInfo (and isPlaceholderUnknown) runs.
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def',
+        entries: [
+          createManifestEntry(
+            'GET',
+            '/orders/:id',
+            'OrderView',
+            'consumer',
+            'api.ts',
+            5,
+            'response',
+            false,
+            'unknown'
+          ),
+        ],
+      };
+
+      const marked = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        markedProject
+      );
+      assert.strictEqual(marked.unknownPairs.length, 1);
+      assert.strictEqual(marked.compatiblePairs, 0);
+      assert.strictEqual(marked.incompatiblePairs, 0);
+      // Marked placeholder takes the early type_state=unknown short-circuit.
+      assert.ok(
+        marked.unknownPairs[0].reason.includes('type_state=unknown'),
+        `marked placeholder should report type_state=unknown, got: ${marked.unknownPairs[0].reason}`
+      );
+
+      const bareChecker = new TypeCompatibilityChecker(bareProject);
+      const bare = await bareChecker.checkCompatibility(
+        producers,
+        consumers,
+        bareProject
+      );
+      assert.strictEqual(bare.unknownPairs.length, 1);
+      assert.strictEqual(bare.compatiblePairs, 0);
+      assert.strictEqual(bare.incompatiblePairs, 0);
+      // Developer-authored `= unknown` is NOT the placeholder: it falls through
+      // to the compiler-level gate, whose reason names the resolved `unknown`.
+      assert.ok(
+        !bare.unknownPairs[0].reason.includes('type_state=unknown'),
+        `developer-authored unknown must not be flagged as the placeholder, got: ${bare.unknownPairs[0].reason}`
+      );
+      assert.ok(
+        bare.unknownPairs[0].reason.includes('unknown'),
+        `developer-authored unknown should still be unverifiable, got: ${bare.unknownPairs[0].reason}`
+      );
+    });
+
     it('should match with path parameter normalization', async () => {
       const producers: TypeManifest = {
         repo_name: 'producer-api',

--- a/ts_check/lib/type-checker.ts
+++ b/ts_check/lib/type-checker.ts
@@ -22,6 +22,16 @@ import {
   TypeEvidence,
 } from "./manifest-matcher";
 
+/**
+ * Trailing marker the Rust scanner (`append_missing_aliases` in
+ * `src/engine/mod.rs`) stamps onto every `= unknown` alias it injects for a
+ * manifest entry missing from the bundle. ts_check uses it to recognise the
+ * injected placeholder without misclassifying a developer-authored
+ * `type X = unknown` as one (#244). Must stay byte-identical to the Rust
+ * `MISSING_ALIAS_MARKER` constant.
+ */
+const MISSING_ALIAS_MARKER = "// carrick:missing-alias";
+
 // ============================================================================
 // Type Definitions
 // ============================================================================
@@ -402,10 +412,17 @@ export class TypeCompatibilityChecker {
       const typeAlias = sourceFile.getTypeAlias(typeName);
       if (typeAlias) {
         const typeNode = typeAlias.getTypeNode();
-        const typeText = typeNode?.getText().trim();
-        const isPlaceholderUnknown =
+        const resolvesToUnknown =
           typeNode?.getKind() === SyntaxKind.UnknownKeyword ||
-          typeText === "unknown";
+          typeNode?.getText().trim() === "unknown";
+        // Only the Carrick-injected `= unknown` placeholder carries the marker
+        // comment. A developer-authored `type X = unknown` resolves to unknown
+        // too, but it is a genuine (if uninformative) API type, not our
+        // failed-inference stand-in (#244). The compiler-level isUnknown() gate
+        // in compareTypes still surfaces a genuine `unknown` as unverifiable, so
+        // dropping it here does not let a real shape mismatch read compatible.
+        const isPlaceholderUnknown =
+          resolvesToUnknown && this.hasMissingAliasMarker(typeAlias);
         return { type: typeAlias.getType(), isPlaceholderUnknown };
       }
 
@@ -416,6 +433,21 @@ export class TypeCompatibilityChecker {
     }
 
     return { type: null, isPlaceholderUnknown: false };
+  }
+
+  /**
+   * True when the type alias carries the Carrick `MISSING_ALIAS_MARKER` trailing
+   * comment that marks it as an injected `= unknown` placeholder. ts-morph's
+   * `getText()` omits trailing same-line comments, so this inspects the source
+   * line that holds the alias rather than the node text.
+   */
+  private hasMissingAliasMarker(typeAlias: TypeAliasDeclaration): boolean {
+    const sourceFile = typeAlias.getSourceFile();
+    const fullText = sourceFile.getFullText();
+    const declEnd = typeAlias.getEnd();
+    const lineEnd = fullText.indexOf("\n", declEnd);
+    const tail = fullText.slice(declEnd, lineEnd === -1 ? undefined : lineEnd);
+    return tail.includes(MISSING_ALIAS_MARKER);
   }
 
   private formatEntryLocation(entry: ManifestEntry): string {


### PR DESCRIPTION
## Problem

`dts_alias_is_trivially_unknown` (`src/engine/mod.rs`) regex-matched `type X = unknown;` over raw `.d.ts` text. It could not distinguish Carrick's injected `append_missing_aliases` placeholder from a developer who genuinely wrote `type X = unknown` in a real API type. The latter was silently downgraded to `type_state: Unknown` and its cross-repo edge dropped to unverifiable (a recall loss, low severity, fails safe). It also only matched the bare form, not `export`, generics, or modifiers.

## Fix

Tag the placeholder uniquely at injection and match only the tagged form.

- `append_missing_aliases` now stamps a `MISSING_ALIAS_MARKER` (`// carrick:missing-alias`) trailing comment on every `= unknown` alias it injects.
- `dts_alias_is_trivially_unknown` matches only the marked form, tolerating `export`/generics/modifiers but anchored on the trailing marker, so a developer-authored `type X = unknown` (any form) is no longer treated as the placeholder and is not downgraded.
- ts_check `resolveTypeInfo.isPlaceholderUnknown` is made marker-aware too (new `hasMissingAliasMarker` helper), keeping the downstream gate consistent. A genuine `unknown` is still surfaced as unverifiable by the compiler-level `isUnknown()` gate in `compareTypes`, so #238's behavior holds (unknown-as-unverifiable, real string-vs-number still incompatible).

## Files changed

- `src/engine/mod.rs` — marker constant + injection + tag-only matcher; updated `enrich_downgrades_trivially_unknown_dts_alias` and `append_missing_aliases_injects_unknown_placeholder` to the tagged form; added `enrich_does_not_downgrade_developer_authored_unknown`.
- `ts_check/lib/type-checker.ts` — marker constant, marker-aware `isPlaceholderUnknown`, `hasMissingAliasMarker` helper (reads the trailing same-line comment ts-morph's `getText()` omits).
- `ts_check/lib/type-checker.test.ts` — added the marked-vs-bare placeholder distinction test (#244).

## Tests

- ts_check: 70/70 pass (was 69, +1).
- Rust: full suite green incl. `cassette_hard_gate_llm_mocked_api`; new + updated engine tests pass.
- `cargo fmt` clean, `cargo clippy --all-targets -- -D warnings` clean, `tsc --noEmit` clean.
- Cassette golden (`tests/fixtures/llm-mocked-api/__golden__.json`) unchanged — the bundled `.d.ts` content is not in the golden, so the gate is unaffected.

Closes #244
Refs #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)