### PR TITLE
feat(extraction): route GraphQL/socket ops into the type pipeline (#245 Phase 1)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1024,6 +1024,73 @@ impl FileOrchestrator {
         (explicit_requests, infer_requests, inline_aliases)
     }
 
+    /// Build `SymbolRequest`s for Socket.IO payload anchors (#245 Phase 1).
+    ///
+    /// Sibling to `collect_type_requests`: it routes the deterministically
+    /// captured socket payload type through the *same* sidecar bundle path the
+    /// HTTP explicit-symbol case uses. Listeners are producers, emitters are
+    /// consumers; each resolves to the Response-kind alias.
+    ///
+    /// The alias MUST be `build_manifest_type_alias(&op.key, role, Response)` —
+    /// byte-identical to the alias `append_protocol_manifest_entry` stamped on
+    /// the manifest entry — or the resolved `.d.ts` never joins back and the
+    /// entry stays `Unknown`. This contract is guarded by a unit test.
+    ///
+    /// Only ops whose extractor captured a `payload_type_symbol` produce a
+    /// request; an absent source means the symbol is declared in the emitting
+    /// file, so it is resolved against that file's absolute path.
+    pub fn collect_socket_type_requests(
+        &self,
+        sockets: &crate::socket_io::SocketExtraction,
+        repo_path: &str,
+    ) -> Vec<SymbolRequest> {
+        let repo_root = std::path::Path::new(repo_path);
+        let repo_root_absolute = if repo_root.is_absolute() {
+            repo_root.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(repo_root))
+                .unwrap_or_else(|_| repo_root.to_path_buf())
+                .canonicalize()
+                .unwrap_or_else(|_| repo_root.to_path_buf())
+        };
+
+        let mut requests: Vec<SymbolRequest> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut push = |op: &crate::socket_io::SocketOp, role: ManifestRole| {
+            let Some(symbol) = op.payload_type_symbol.as_ref() else {
+                return;
+            };
+            let file_abs =
+                Self::to_absolute_path(&op.file_path.to_string_lossy(), &repo_root_absolute);
+            let source_file = match op.payload_type_source.as_ref() {
+                Some(import_source) => Self::resolve_import_path(&file_abs, import_source),
+                // No import → same-file declaration: resolve against the file.
+                None => file_abs,
+            };
+            let alias = build_manifest_type_alias(&op.key, role, ManifestTypeKind::Response);
+            let dedup_key = format!("{}|{}|{}", source_file, symbol, alias);
+            if seen.insert(dedup_key) {
+                requests.push(SymbolRequest {
+                    symbol_name: symbol.clone(),
+                    source_file,
+                    alias: Some(alias),
+                });
+            }
+        };
+        for op in &sockets.listeners {
+            push(op, ManifestRole::Producer);
+        }
+        for op in &sockets.emitters {
+            push(op, ManifestRole::Consumer);
+        }
+        debug!(
+            "[FileOrchestrator] Collected {} socket payload type requests",
+            requests.len()
+        );
+        requests
+    }
+
     /// Parse a file once and extract both the symbol table and the env-var
     /// alias map (`local const -> process.env name`). Sharing the parse keeps
     /// the per-file CPU cost flat — both passes are cheap AST walks.
@@ -1413,6 +1480,9 @@ impl FileOrchestrator {
     /// * `extraction_config` - Agent-generated machinery-unwrap rules
     /// * `mount_graph` - Resolved mount graph for canonical method/path aliases
     /// * `config` - Config used for URL normalization
+    /// * `extra_explicit` - Deterministically-collected explicit symbol
+    ///   requests for non-HTTP protocols (socket payload anchors, #245)
+    #[allow(clippy::too_many_arguments)]
     pub fn resolve_types_with_sidecar(
         &self,
         sidecar: &TypeSidecar,
@@ -1421,13 +1491,21 @@ impl FileOrchestrator {
         extraction_config: Option<&ExtractionConfig>,
         mount_graph: &MountGraph,
         config: &Config,
+        extra_explicit: &[SymbolRequest],
     ) -> Result<TypeResolutionResult, Box<dyn std::error::Error>> {
-        let (explicit, infer, inline_aliases) =
+        let (mut explicit, infer, inline_aliases) =
             self.collect_type_requests(file_results, repo_path, mount_graph, config);
 
+        // Deterministically-collected explicit requests for non-HTTP protocols
+        // (today: Socket.IO payload anchors, #245). They use the same
+        // `SymbolRequest` shape and bundle path as the HTTP explicit case; the
+        // alias each carries matches its manifest entry so the enrich-join lands.
+        explicit.extend_from_slice(extra_explicit);
+
         debug!(
-            "[FileOrchestrator] Resolving types: {} explicit, {} inferred",
+            "[FileOrchestrator] Resolving types: {} explicit ({} from non-HTTP protocols), {} inferred",
             explicit.len(),
+            extra_explicit.len(),
             infer.len()
         );
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -978,7 +978,8 @@ async fn analyze_current_repo_incremental(
                 packages,
                 function_definitions,
             );
-            append_deterministic_protocol_operations(&mut cloud_data, repo_path, &files);
+            let protocol_extractions =
+                append_deterministic_protocol_operations(&mut cloud_data, repo_path, &files);
 
             // Populate cache fields
             let mut cached_file_results = merged_results.clone();
@@ -993,9 +994,16 @@ async fn analyze_current_repo_incremental(
             // Build type manifest
             let mut manifest_entries = build_type_manifest_entries(&mount_graph, config);
             stamp_manifest_anchor_symbols(&mut manifest_entries, &merged_results);
+            append_protocol_manifest_entries(&mut manifest_entries, &protocol_extractions);
             if !manifest_entries.is_empty() {
                 cloud_data.type_manifest = Some(manifest_entries);
             }
+
+            // Socket payload anchors resolve through the same sidecar bundle
+            // path as HTTP explicit symbols (#245); GraphQL anchors are deferred
+            // to #248.
+            let socket_requests = file_orchestrator
+                .collect_socket_type_requests(&protocol_extractions.sockets, repo_path);
 
             // Type resolution via sidecar
             resolve_types_if_available(
@@ -1006,6 +1014,7 @@ async fn analyze_current_repo_incremental(
                 extraction_config.as_ref(),
                 &mount_graph,
                 config,
+                &socket_requests,
                 &mut cloud_data,
             );
 
@@ -1102,11 +1111,20 @@ async fn generate_extraction_config(
 /// index data: GraphQL (SDL root fields as endpoints, document top-level
 /// fields as calls) and Socket.IO (listeners as endpoints, emitters as
 /// calls). These protocols never go through the LLM pipeline.
+/// Deterministically-extracted non-HTTP operations (GraphQL + Socket.IO).
+/// Returned by `append_deterministic_protocol_operations` so the same scan
+/// feeds both `cloud_data.endpoints/calls` and the type manifest
+/// (`append_protocol_manifest_entries`) without scanning the files twice.
+struct ProtocolExtractions {
+    graphql: crate::graphql::GraphqlExtraction,
+    sockets: crate::socket_io::SocketExtraction,
+}
+
 fn append_deterministic_protocol_operations(
     cloud_data: &mut CloudRepoData,
     repo_path: &str,
     files: &[PathBuf],
-) {
+) -> ProtocolExtractions {
     // Same "{file}:{line}" convention the mount-graph conversions use
     let to_details = |key: OperationKey, file_path: &Path, line: u32| ApiEndpointDetails {
         owner: None,
@@ -1132,14 +1150,14 @@ fn append_deterministic_protocol_operations(
         cloud_data.endpoints.extend(
             graphql
                 .producers
-                .into_iter()
-                .map(|op| to_details(op.key, &op.file_path, op.line)),
+                .iter()
+                .map(|op| to_details(op.key.clone(), &op.file_path, op.line)),
         );
         cloud_data.calls.extend(
             graphql
                 .consumers
-                .into_iter()
-                .map(|op| to_details(op.key, &op.file_path, op.line)),
+                .iter()
+                .map(|op| to_details(op.key.clone(), &op.file_path, op.line)),
         );
     }
 
@@ -1153,16 +1171,129 @@ fn append_deterministic_protocol_operations(
         cloud_data.endpoints.extend(
             sockets
                 .listeners
-                .into_iter()
-                .map(|op| to_details(op.key, &op.file_path, op.line)),
+                .iter()
+                .map(|op| to_details(op.key.clone(), &op.file_path, op.line)),
         );
         cloud_data.calls.extend(
             sockets
                 .emitters
-                .into_iter()
-                .map(|op| to_details(op.key, &op.file_path, op.line)),
+                .iter()
+                .map(|op| to_details(op.key.clone(), &op.file_path, op.line)),
         );
     }
+
+    ProtocolExtractions { graphql, sockets }
+}
+
+/// Emit type-manifest entries for the deterministically-extracted GraphQL and
+/// Socket.IO operations (#245 Phase 1). Without this, only the HTTP mount-graph
+/// produces manifest entries, so every non-HTTP op reported `type_state=(none)`
+/// with no `type_alias`/anchor.
+///
+/// Each op gets a single Response-kind entry keyed by its real `OperationKey`
+/// (so `OperationKey::canonical()` joins it in the cloud index and eval
+/// projection). Listeners / SDL producers are `Producer`; emitters / document
+/// consumers are `Consumer`. Only the Response kind is emitted: a phantom
+/// Request alias would never resolve and would drag a second `Unknown` entry
+/// into the manifest for ops that have no request body concept.
+///
+/// Socket entries carry `primary_type_symbol` directly (the payload type the
+/// extractor captured), which the sidecar then resolves through the existing
+/// SymbolRequest path. GraphQL entries deliberately leave `primary_type_symbol`
+/// as `None`: mapping an SDL field to its TS resolver return type (or the raw
+/// SDL type expression) is deferred to #248, so Phase 1 only gives GraphQL ops
+/// a stable `type_alias` + projection entry (an honest `Unknown` instead of
+/// `(none)`).
+fn append_protocol_manifest_entries(
+    entries: &mut Vec<TypeManifestEntry>,
+    extractions: &ProtocolExtractions,
+) {
+    for op in &extractions.graphql.producers {
+        add_protocol_manifest_entry(
+            entries,
+            &op.key,
+            ManifestRole::Producer,
+            &op.file_path.to_string_lossy(),
+            op.line,
+            None,
+        );
+    }
+    for op in &extractions.graphql.consumers {
+        add_protocol_manifest_entry(
+            entries,
+            &op.key,
+            ManifestRole::Consumer,
+            &op.file_path.to_string_lossy(),
+            op.line,
+            None,
+        );
+    }
+    for op in &extractions.sockets.listeners {
+        add_protocol_manifest_entry(
+            entries,
+            &op.key,
+            ManifestRole::Producer,
+            &op.file_path.to_string_lossy(),
+            op.line,
+            op.payload_type_symbol.clone(),
+        );
+    }
+    for op in &extractions.sockets.emitters {
+        add_protocol_manifest_entry(
+            entries,
+            &op.key,
+            ManifestRole::Consumer,
+            &op.file_path.to_string_lossy(),
+            op.line,
+            op.payload_type_symbol.clone(),
+        );
+    }
+}
+
+/// Add a single Response-kind manifest entry for a non-HTTP operation. Shared
+/// by `append_protocol_manifest_entries`; the HTTP path uses
+/// `add_manifest_pair` instead (it emits both Request and Response and dispatches
+/// on the HTTP method).
+///
+/// `primary_type_symbol` is threaded straight onto the entry at creation — the
+/// op carries its anchor deterministically, unlike HTTP where it is stamped
+/// later from the LLM result. The `type_alias` MUST be computed with the same
+/// `build_manifest_type_alias(key, role, Response)` the SymbolRequest side uses,
+/// or the enrich-join silently fails to flip `Unknown` → resolved.
+fn add_protocol_manifest_entry(
+    entries: &mut Vec<TypeManifestEntry>,
+    key: &OperationKey,
+    role: ManifestRole,
+    file_path: &str,
+    line_number: u32,
+    primary_type_symbol: Option<String>,
+) {
+    let type_kind = ManifestTypeKind::Response;
+    let type_alias = crate::type_manifest::build_manifest_type_alias(key, role, type_kind);
+    let infer_kind = infer_kind_for_manifest(role, type_kind);
+    let evidence = crate::cloud_storage::TypeEvidence {
+        file_path: file_path.to_string(),
+        span_start: None,
+        span_end: None,
+        line_number,
+        infer_kind,
+        is_explicit: false,
+        type_state: ManifestTypeState::Unknown,
+    };
+    entries.push(TypeManifestEntry {
+        key: key.clone(),
+        role,
+        type_kind,
+        type_alias,
+        file_path: file_path.to_string(),
+        line_number,
+        is_explicit: false,
+        type_state: ManifestTypeState::Unknown,
+        evidence,
+        resolved_definition: None,
+        expanded_definition: None,
+        primary_type_symbol,
+    });
 }
 
 /// Build CloudRepoData from a mount graph (used by incremental path).
@@ -1313,6 +1444,7 @@ fn resolve_types_if_available(
     extraction_config: Option<&crate::services::type_sidecar::ExtractionConfig>,
     mount_graph: &MountGraph,
     config: &Config,
+    extra_explicit: &[crate::services::type_sidecar::SymbolRequest],
     cloud_data: &mut CloudRepoData,
 ) {
     let Some(sidecar) = sidecar else {
@@ -1334,6 +1466,7 @@ fn resolve_types_if_available(
                 extraction_config,
                 mount_graph,
                 config,
+                extra_explicit,
             ) {
                 Ok(type_resolution) => {
                     debug!(
@@ -1957,10 +2090,12 @@ async fn analyze_current_repo(
         Some(packages.clone()),
         function_definitions.clone(),
     );
-    append_deterministic_protocol_operations(&mut cloud_data, repo_path, &files);
+    let protocol_extractions =
+        append_deterministic_protocol_operations(&mut cloud_data, repo_path, &files);
 
     let mut manifest_entries = build_type_manifest_entries(&analysis_result.mount_graph, config);
     stamp_manifest_anchor_symbols(&mut manifest_entries, &analysis_result.file_results);
+    append_protocol_manifest_entries(&mut manifest_entries, &protocol_extractions);
     if !manifest_entries.is_empty() {
         cloud_data.type_manifest = Some(manifest_entries);
     }
@@ -1978,6 +2113,12 @@ async fn analyze_current_repo(
     .await;
     cloud_data.cached_extraction_config = extraction_config.clone();
 
+    // Socket payload anchors resolve through the same sidecar bundle path as
+    // HTTP explicit symbols (#245). GraphQL anchors are deferred to #248, so no
+    // GraphQL SymbolRequests are produced here.
+    let socket_requests =
+        file_orchestrator.collect_socket_type_requests(&protocol_extractions.sockets, repo_path);
+
     resolve_types_if_available(
         sidecar,
         &file_orchestrator,
@@ -1986,6 +2127,7 @@ async fn analyze_current_repo(
         extraction_config.as_ref(),
         &analysis_result.mount_graph,
         config,
+        &socket_requests,
         &mut cloud_data,
     );
 
@@ -3486,5 +3628,145 @@ mod tests {
             !out.contains("export type Payment = unknown;"),
             "an already-defined alias must not be overwritten, got: {out}"
         );
+    }
+
+    // ---- #245 Phase 1: protocol op manifest entries -------------------------
+
+    fn socket_op(
+        event: &str,
+        direction: crate::operation::SocketDirection,
+        symbol: Option<&str>,
+        source: Option<&str>,
+    ) -> crate::socket_io::SocketOp {
+        crate::socket_io::SocketOp {
+            key: OperationKey::socket(event, direction),
+            file_path: PathBuf::from("src/socket.ts"),
+            line: 12,
+            payload_type_symbol: symbol.map(String::from),
+            payload_type_source: source.map(String::from),
+        }
+    }
+
+    fn graphql_op(
+        kind: crate::operation::GraphqlOperationKind,
+        field: &str,
+    ) -> crate::graphql::GraphqlOp {
+        crate::graphql::GraphqlOp {
+            key: OperationKey::graphql(kind, field),
+            file_path: PathBuf::from("src/schema.graphql"),
+            line: 3,
+        }
+    }
+
+    /// A typed socket emitter produces a Response-kind manifest entry keyed by
+    /// the socket OperationKey, carrying the captured payload symbol as the
+    /// anchor. GraphQL ops get an entry but no anchor (deferred to #248).
+    #[test]
+    fn protocol_manifest_entries_anchor_sockets_not_graphql() {
+        use crate::operation::{GraphqlOperationKind, SocketDirection};
+
+        let extractions = ProtocolExtractions {
+            graphql: crate::graphql::GraphqlExtraction {
+                producers: vec![graphql_op(GraphqlOperationKind::Query, "order")],
+                consumers: vec![],
+            },
+            sockets: crate::socket_io::SocketExtraction {
+                listeners: vec![],
+                emitters: vec![socket_op(
+                    "payment:settled",
+                    SocketDirection::ServerToClient,
+                    Some("Payment"),
+                    Some("./types/payment"),
+                )],
+            },
+        };
+
+        let mut entries = Vec::new();
+        append_protocol_manifest_entries(&mut entries, &extractions);
+
+        let socket_entry = entries
+            .iter()
+            .find(|e| e.key.canonical() == "socket|SERVER->CLIENT|payment:settled")
+            .expect("socket manifest entry");
+        assert_eq!(socket_entry.role, ManifestRole::Consumer);
+        assert_eq!(socket_entry.type_kind, ManifestTypeKind::Response);
+        assert_eq!(socket_entry.primary_type_symbol.as_deref(), Some("Payment"));
+        // One entry per op — no phantom Request alias.
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|e| e.key.canonical() == "socket|SERVER->CLIENT|payment:settled")
+                .count(),
+            1
+        );
+
+        let graphql_entry = entries
+            .iter()
+            .find(|e| e.key.canonical() == "graphql|query|order")
+            .expect("graphql manifest entry");
+        assert_eq!(graphql_entry.role, ManifestRole::Producer);
+        // Plumbing only: the entry exists (stable alias + projection), but the
+        // anchor is deferred to #248.
+        assert_eq!(graphql_entry.primary_type_symbol, None);
+        assert!(
+            !graphql_entry.type_alias.is_empty(),
+            "graphql op must get a stable type_alias"
+        );
+        assert_eq!(graphql_entry.type_state, ManifestTypeState::Unknown);
+    }
+
+    /// The fragile contract the whole anchor join hinges on: the alias on the
+    /// socket manifest entry MUST equal the alias on the SymbolRequest, both
+    /// computed by `build_manifest_type_alias(key, role, Response)`. If they
+    /// ever diverge the resolved `.d.ts` never joins back and the entry stays
+    /// `Unknown` — silently. (Plan test #3.)
+    #[test]
+    fn socket_symbol_request_alias_matches_manifest_alias() {
+        use crate::operation::SocketDirection;
+
+        let emitter = socket_op(
+            "payment:settled",
+            SocketDirection::ServerToClient,
+            Some("Payment"),
+            Some("./types/payment"),
+        );
+        let extractions = ProtocolExtractions {
+            graphql: crate::graphql::GraphqlExtraction::default(),
+            sockets: crate::socket_io::SocketExtraction {
+                listeners: vec![],
+                emitters: vec![emitter.clone()],
+            },
+        };
+
+        let mut entries = Vec::new();
+        append_protocol_manifest_entries(&mut entries, &extractions);
+        let manifest_alias = entries
+            .iter()
+            .find(|e| e.key.canonical() == "socket|SERVER->CLIENT|payment:settled")
+            .map(|e| e.type_alias.clone())
+            .expect("socket manifest entry");
+
+        let orchestrator = FileOrchestrator::new(AgentService::new());
+        let requests = orchestrator.collect_socket_type_requests(&extractions.sockets, ".");
+        let request = requests
+            .iter()
+            .find(|r| r.symbol_name == "Payment")
+            .expect("socket SymbolRequest");
+
+        assert_eq!(
+            request.alias.as_deref(),
+            Some(manifest_alias.as_str()),
+            "SymbolRequest.alias must byte-match the manifest entry's alias \
+             (both build_manifest_type_alias(key, Consumer, Response)) or the \
+             enrich-join silently breaks"
+        );
+        // Independently confirm both equal the canonical builder output.
+        let expected = crate::type_manifest::build_manifest_type_alias(
+            &emitter.key,
+            ManifestRole::Consumer,
+            ManifestTypeKind::Response,
+        );
+        assert_eq!(manifest_alias, expected);
+        assert_eq!(request.alias.as_deref(), Some(expected.as_str()));
     }
 }

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -571,4 +571,65 @@ mod tests {
         assert_eq!(json["cross_repo_matches"].as_array().unwrap().len(), 0);
         assert_eq!(json["dependency_conflicts"].as_array().unwrap().len(), 0);
     }
+
+    /// #245 Phase 1: a manifest entry keyed by a *socket* OperationKey joins to
+    /// its op in the projection and surfaces `primary_type_symbol`/`type_state`
+    /// on the EvalOp — proving the projection join is protocol-agnostic, not
+    /// HTTP-only. (Plan test #4.)
+    #[test]
+    fn socket_keyed_manifest_entry_surfaces_on_eval_op() {
+        use crate::operation::SocketDirection;
+
+        let socket_key = OperationKey::socket("payment:settled", SocketDirection::ServerToClient);
+        // A socket emitter lands on `calls` (consumer side).
+        let call = ApiEndpointDetails {
+            owner: None,
+            key: socket_key.clone(),
+            params: vec![],
+            request_body: None,
+            response_body: None,
+            handler_name: None,
+            request_type: None,
+            response_type: None,
+            file_path: PathBuf::from("src/socket.ts:12"),
+            repo_name: None,
+            service_name: None,
+        };
+
+        let result = ApiAnalysisResult {
+            endpoints: vec![],
+            calls: vec![call],
+            issues: empty_issues_with_deps(vec![]),
+            verified_endpoints: vec![],
+            detected_graphql_libraries: vec![],
+            graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
+        };
+
+        let manifest = vec![manifest_entry(
+            socket_key,
+            ManifestTypeState::Explicit,
+            true,
+            Some("{ id: string; amountCents: number }"),
+            Some("Payment"),
+        )];
+
+        let projection = EvalProjection::from_results(&result, &manifest);
+        let json: Value =
+            serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
+        let op = &json["calls"].as_array().unwrap()[0];
+
+        assert_eq!(op["key"], "socket|SERVER->CLIENT|payment:settled");
+        assert_eq!(op["protocol"], "socket");
+        // method is null for non-HTTP (the field is always present); path
+        // carries the event name.
+        assert_eq!(op["method"], Value::Null);
+        assert_eq!(op["path"], "payment:settled");
+        assert_eq!(op["type_state"], "Explicit");
+        assert_eq!(op["primary_type_symbol"], "Payment");
+        assert_eq!(
+            op["resolved_definition"],
+            "{ id: string; amountCents: number }"
+        );
+    }
 }

--- a/src/socket_io.rs
+++ b/src/socket_io.rs
@@ -398,6 +398,19 @@ fn is_builtin_type(name: &str) -> bool {
             | "Map"
             | "Set"
             | "Date"
+            // Capitalized global wrapper / utility types: a payload annotated
+            // with one of these is a TS/lib global, not a user type, so it must
+            // not become a SymbolRequest (the sidecar would try to bundle the
+            // global declaration — noisy and useless).
+            | "Object"
+            | "String"
+            | "Number"
+            | "Boolean"
+            | "Symbol"
+            | "BigInt"
+            | "Function"
+            | "RegExp"
+            | "Error"
     )
 }
 
@@ -746,6 +759,35 @@ const settle = (payment: Payment[]) => { socket.emit("chat:array", payment); };
             assert_eq!(op.payload_type_source, None);
         }
         let listener = find(&result.listeners, "socket|SERVER->CLIENT|chat:broadcast");
+        assert_eq!(listener.payload_type_symbol, None);
+    }
+
+    #[test]
+    fn capitalized_global_payload_types_are_not_anchored() {
+        // Global wrapper/utility types (Object, String, Function, …) are TS/lib
+        // globals, not user types — annotating a payload with one must NOT create
+        // a SymbolRequest (the sidecar would try to bundle the global). Copilot
+        // review of #245 Phase 1.
+        let result = extract(
+            r#"
+import { io } from "socket.io-client";
+const socket = io("https://chat.internal");
+const a = (p: Object) => { socket.emit("e:object", p); };
+const b = (p: String) => { socket.emit("e:string", p); };
+socket.on("e:fn", (p: Function) => p());
+"#,
+        );
+        for canonical in [
+            "socket|CLIENT->SERVER|e:object",
+            "socket|CLIENT->SERVER|e:string",
+        ] {
+            let op = find(&result.emitters, canonical);
+            assert_eq!(
+                op.payload_type_symbol, None,
+                "{canonical} (global type) must not be anchored"
+            );
+        }
+        let listener = find(&result.listeners, "socket|SERVER->CLIENT|e:fn");
         assert_eq!(listener.payload_type_symbol, None);
     }
 }

--- a/src/socket_io.rs
+++ b/src/socket_io.rs
@@ -24,22 +24,38 @@
 
 use crate::operation::{OperationKey, SocketDirection};
 use crate::parser::parse_file;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use swc_common::errors::{ColorConfig, Handler};
 use swc_common::{GLOBALS, Globals, SourceMap, Spanned, sync::Lrc};
 use swc_ecma_ast::{
-    Callee, Expr, ImportDecl, ImportSpecifier, Lit, ModuleExportName, NewExpr, Pat, VarDeclarator,
+    Callee, Expr, ImportDecl, ImportSpecifier, Lit, ModuleExportName, NewExpr, Pat, TsEntityName,
+    TsType, TsTypeAnn, VarDeclarator,
 };
 use swc_ecma_visit::{Visit, VisitWith};
 use tracing::debug;
 
 /// A socket listener or emitter with its source location.
+///
+/// `payload_type_symbol`/`payload_type_source` carry the message payload's TS
+/// type so the op can be anchored and resolved through the existing
+/// SymbolRequest/sidecar bundle path (#245 Phase 1). They are populated only
+/// when the payload is an explicitly-typed named reference whose declaration is
+/// `import`ed (precision over recall): inline object types, generics, unions,
+/// and untyped payloads stay `None` so they degrade to an honest `Unknown`
+/// rather than a phantom anchor.
 #[derive(Debug, Clone)]
 pub struct SocketOp {
     pub key: OperationKey,
     pub file_path: PathBuf,
     pub line: u32,
+    /// Bare symbol name of the payload type (e.g. `Payment`), when explicitly
+    /// annotated as a named reference. `None` for inline/generic/untyped payloads.
+    pub payload_type_symbol: Option<String>,
+    /// Module specifier the payload type is imported from (e.g.
+    /// `./types/payment`), paired with `payload_type_symbol`. `None` when the
+    /// symbol is not imported (same-file or untyped).
+    pub payload_type_source: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -160,6 +176,19 @@ struct SocketRoots {
     /// Bindings holding server roots (`const io = new Server(...)`) or
     /// per-connection sockets (`io.on("connection", (socket) => ...)`).
     server_sockets: HashSet<String>,
+    /// Imported type symbols → their module specifier. Drives payload-anchor
+    /// resolution (#245): an emitted/received payload typed as an imported
+    /// named reference gets a `(symbol, source)` pair the SymbolRequest path
+    /// can bundle. Same-file types are absent here and resolve with `None`
+    /// source.
+    type_imports: HashMap<String, String>,
+    /// Binding name → payload type symbol, from `const x: T = …` declarators
+    /// and typed function parameters. Lets `socket.emit("e", payment)` recover
+    /// `Payment` from the `payment` binding's annotation. File-level and flat
+    /// (binding shadowing is ignored — a precision tradeoff consistent with the
+    /// module's other guardrails); only simple named references are recorded,
+    /// so generics/unions/inline object types never produce an anchor.
+    binding_types: HashMap<String, String>,
 }
 
 impl SocketRoots {
@@ -168,6 +197,8 @@ impl SocketRoots {
             + self.server_classes.len()
             + self.client_sockets.len()
             + self.server_sockets.len()
+            + self.type_imports.len()
+            + self.binding_types.len()
     }
 
     fn direction_for(&self, root: &str, is_listener: bool) -> Option<SocketDirection> {
@@ -198,6 +229,18 @@ struct RootCollector<'a> {
 impl Visit for RootCollector<'_> {
     fn visit_import_decl(&mut self, node: &ImportDecl) {
         let source = node.src.value.as_ref();
+        // Record every named import's local name → module specifier so a
+        // socket payload typed as an imported symbol (`import type { Payment }
+        // from "./types"`) can be anchored. Default/namespace imports are
+        // skipped: payload type references are named, and a default import's
+        // local name is not the exported declaration the bundler resolves by.
+        for specifier in &node.specifiers {
+            if let ImportSpecifier::Named(named) = specifier {
+                self.roots
+                    .type_imports
+                    .insert(named.local.sym.to_string(), source.to_string());
+            }
+        }
         if source != "socket.io" && source != "socket.io-client" {
             return;
         }
@@ -288,6 +331,74 @@ impl Visit for RootCollector<'_> {
         }
         node.visit_children_with(self);
     }
+
+    fn visit_pat(&mut self, node: &Pat) {
+        // Record `const payment: Payment` / `(payment: Payment) => …` style
+        // typed bindings so an emitted payload identifier can recover its
+        // type symbol. Only simple named references count (see
+        // `named_type_symbol`); anything else leaves the binding unanchored.
+        if let Pat::Ident(ident) = node
+            && let Some(type_ann) = ident.type_ann.as_ref()
+            && let Some(symbol) = named_type_symbol(type_ann)
+        {
+            self.roots
+                .binding_types
+                .insert(ident.id.sym.to_string(), symbol);
+        }
+        node.visit_children_with(self);
+    }
+}
+
+/// Bare symbol name of a simple named type annotation (`Payment` from
+/// `: Payment`), or `None` for anything that is not a single unqualified type
+/// reference. Precision over recall: generics (`Foo<T>`), unions, intersections,
+/// inline object types, qualified names (`ns.Type`), and primitives are all
+/// rejected so the socket anchor only fires when there is one resolvable symbol.
+fn named_type_symbol(type_ann: &TsTypeAnn) -> Option<String> {
+    match &*type_ann.type_ann {
+        TsType::TsTypeRef(type_ref) if type_ref.type_params.is_none() => {
+            match &type_ref.type_name {
+                TsEntityName::Ident(ident) => {
+                    let name = ident.sym.to_string();
+                    // Reject TS built-in/primitive references that happen to parse
+                    // as a type ref so they never become a bundle target.
+                    if is_builtin_type(&name) {
+                        None
+                    } else {
+                        Some(name)
+                    }
+                }
+                TsEntityName::TsQualifiedName(_) => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Lowercase/well-known TS types that must never be treated as a resolvable
+/// payload anchor.
+fn is_builtin_type(name: &str) -> bool {
+    matches!(
+        name,
+        "any"
+            | "unknown"
+            | "never"
+            | "void"
+            | "object"
+            | "string"
+            | "number"
+            | "boolean"
+            | "bigint"
+            | "symbol"
+            | "undefined"
+            | "null"
+            | "Array"
+            | "Promise"
+            | "Record"
+            | "Map"
+            | "Set"
+            | "Date"
+    )
 }
 
 struct OpCollector<'a> {
@@ -339,10 +450,28 @@ impl Visit for OpCollector<'_> {
             {
                 let direction = self.roots.direction_for(root_name, is_listener);
                 if let Some(direction) = direction {
+                    let payload_symbol = if is_listener {
+                        // Listener: the handler's first parameter is the
+                        // received payload; read its type annotation directly.
+                        self.listener_payload_symbol(node)
+                    } else {
+                        // Emitter: the second argument is the sent payload;
+                        // recover its symbol from the binding's annotation.
+                        self.emitter_payload_symbol(node)
+                    };
+                    let (payload_type_symbol, payload_type_source) = match payload_symbol {
+                        Some(symbol) => {
+                            let source = self.roots.type_imports.get(&symbol).cloned();
+                            (Some(symbol), source)
+                        }
+                        None => (None, None),
+                    };
                     let op = SocketOp {
                         key: OperationKey::socket(event.value.to_string(), direction),
                         file_path: self.file_path.to_path_buf(),
                         line: self.cm.lookup_char_pos(node.span().lo).line as u32,
+                        payload_type_symbol,
+                        payload_type_source,
                     };
                     if is_listener {
                         self.extraction.listeners.push(op);
@@ -353,6 +482,35 @@ impl Visit for OpCollector<'_> {
             }
         }
         node.visit_children_with(self);
+    }
+}
+
+impl OpCollector<'_> {
+    /// Payload type symbol of a listener call's handler — the type annotation
+    /// on the handler's first parameter (`socket.on("e", (p: Payment) => …)`).
+    fn listener_payload_symbol(&self, node: &swc_ecma_ast::CallExpr) -> Option<String> {
+        let handler = node.args.get(1)?;
+        let first_param: Option<&Pat> = match &*handler.expr {
+            Expr::Arrow(arrow) => arrow.params.first(),
+            Expr::Fn(func) => func.function.params.first().map(|p| &p.pat),
+            _ => None,
+        };
+        match first_param? {
+            Pat::Ident(ident) => ident.type_ann.as_deref().and_then(named_type_symbol),
+            _ => None,
+        }
+    }
+
+    /// Payload type symbol of an emitter call — the second argument's binding
+    /// type (`socket.emit("e", payment)` where `payment: Payment`). Only a bare
+    /// identifier argument resolves; inline literals/expressions stay
+    /// unanchored.
+    fn emitter_payload_symbol(&self, node: &swc_ecma_ast::CallExpr) -> Option<String> {
+        let payload = node.args.get(1)?;
+        match &*payload.expr {
+            Expr::Ident(ident) => self.roots.binding_types.get(ident.sym.as_ref()).cloned(),
+            _ => None,
+        }
     }
 }
 
@@ -496,5 +654,98 @@ socket.emit("chat:message", "hi");
 "#,
         );
         assert!(result.is_empty());
+    }
+
+    fn find(ops: &[SocketOp], canonical: &str) -> SocketOp {
+        ops.iter()
+            .find(|op| op.key.canonical() == canonical)
+            .unwrap_or_else(|| panic!("missing op {canonical} in {ops:?}"))
+            .clone()
+    }
+
+    #[test]
+    fn typed_emitter_payload_captures_symbol_and_source() {
+        // `socket.emit("payment:settled", payment)` where `payment: Payment`
+        // and `Payment` is imported — the corpus's resolvable case.
+        let result = extract(
+            r#"
+import { io } from "socket.io-client";
+import type { Payment } from "./types/payment";
+const socket = io("https://payments.internal");
+const settle = (payment: Payment) => {
+  socket.emit("payment:settled", payment);
+};
+"#,
+        );
+        let op = find(&result.emitters, "socket|CLIENT->SERVER|payment:settled");
+        assert_eq!(op.payload_type_symbol.as_deref(), Some("Payment"));
+        assert_eq!(op.payload_type_source.as_deref(), Some("./types/payment"));
+    }
+
+    #[test]
+    fn typed_listener_payload_captures_handler_param_type() {
+        // server `io.on("connection", socket => socket.on("event", (p: Payment) => …))`
+        let result = extract(
+            r#"
+import { Server } from "socket.io";
+import type { Payment } from "./types/payment";
+const io = new Server(httpServer);
+io.on("connection", (socket) => {
+  socket.on("payment:received", (payment: Payment) => { void payment; });
+});
+"#,
+        );
+        let op = find(&result.listeners, "socket|CLIENT->SERVER|payment:received");
+        assert_eq!(op.payload_type_symbol.as_deref(), Some("Payment"));
+        assert_eq!(op.payload_type_source.as_deref(), Some("./types/payment"));
+    }
+
+    #[test]
+    fn same_file_typed_payload_has_symbol_but_no_source() {
+        // Payload type declared in the same file — symbol resolves, but there is
+        // no import source (the SymbolRequest path resolves it against the
+        // emitting file).
+        let result = extract(
+            r#"
+import { io } from "socket.io-client";
+interface Payment { id: string }
+const socket = io("https://payments.internal");
+const settle = (payment: Payment) => {
+  socket.emit("payment:settled", payment);
+};
+"#,
+        );
+        let op = find(&result.emitters, "socket|CLIENT->SERVER|payment:settled");
+        assert_eq!(op.payload_type_symbol.as_deref(), Some("Payment"));
+        assert_eq!(op.payload_type_source, None);
+    }
+
+    #[test]
+    fn untyped_and_inline_payloads_have_no_symbol() {
+        let result = extract(
+            r#"
+import { io } from "socket.io-client";
+import type { Payment } from "./types/payment";
+const socket = io("https://chat.internal");
+socket.emit("chat:message", "hello");
+socket.emit("chat:object", { ok: true });
+socket.on("chat:broadcast", (msg) => console.log(msg));
+const settle = (payment: Payment[]) => { socket.emit("chat:array", payment); };
+"#,
+        );
+        for canonical in [
+            "socket|CLIENT->SERVER|chat:message",
+            "socket|CLIENT->SERVER|chat:object",
+            "socket|CLIENT->SERVER|chat:array",
+        ] {
+            let op = find(&result.emitters, canonical);
+            assert_eq!(
+                op.payload_type_symbol, None,
+                "{canonical} should be unanchored"
+            );
+            assert_eq!(op.payload_type_source, None);
+        }
+        let listener = find(&result.listeners, "socket|SERVER->CLIENT|chat:broadcast");
+        assert_eq!(listener.payload_type_symbol, None);
     }
 }


### PR DESCRIPTION
## Summary

GraphQL and Socket.IO operations were added to `cloud_data.endpoints/calls` (via `append_deterministic_protocol_operations`) but never to the mount graph, so `build_type_manifest_entries` (HTTP-only) never produced a `TypeManifestEntry` for them. Every non-HTTP op therefore reported `type_state=(none)`, no `type_alias`, and no anchor — the dominant cause of the live eval's anchor/resolution ≈ 0.

This is **Phase 1**: socket ops end-to-end, GraphQL plumbing only.

## Scope

- **Socket ops — full end-to-end.** `SocketOp` now captures the payload type symbol + import source (`socket.emit("e", payment)` where `payment: Payment`, and `socket.on("e", (p: Payment) => …)`). Precision over recall: only explicitly-typed named references are anchored; inline object types, generics, unions, and untyped payloads stay `None` so they degrade to an honest `Unknown` rather than a phantom anchor. A manifest entry keyed by the socket `OperationKey` carries the symbol as `primary_type_symbol`, and a matching `SymbolRequest` routes it through the **existing** sidecar bundle path — so `socket|SERVER->CLIENT|payment:settled` now gets `type_state`/anchor/`resolved_definition` populated.
- **GraphQL ops — plumbing only.** Manifest entries are emitted for producers/consumers so they get a stable `type_alias` + projection entry (real `Unknown` instead of `(none)`, unblocking #236). No GraphQL `primary_type_symbol` and no SDL→resolver anchor resolution — that is deferred to **#248** (a code comment notes the deferral).

`append_deterministic_protocol_operations` now returns the extractions so the same scan feeds both `endpoints/calls` and the manifest (no second scan), wired into both the full and incremental paths.

## Why the alias-match test matters

The alias on the socket manifest entry and the `SymbolRequest.alias` are both computed by `build_manifest_type_alias(&op.key, role, Response)`. If they ever diverge, the resolved `.d.ts` never joins back via `enrich_manifest_with_type_resolution` and the entry stays `Unknown` — silently. A unit test guards this contract.

## Tests (offline)

- socket payload capture: typed emit/listener → `Some("Payment")` + source; same-file typed → symbol but no source; inline/generic/untyped → `None`
- manifest entry keyed by socket OperationKey carries `primary_type_symbol`; graphql entry exists with `None` anchor (deferred)
- the alias-match guard (SymbolRequest.alias == manifest entry alias == `build_manifest_type_alias`)
- eval_output projection join for a non-HTTP (socket) key surfaces `primary_type_symbol`/`type_state`

The live score can't move offline (the mock cassette emits null symbols), so this relies on the unit tests + the cassette hard gate for regression; the next live run confirms the socket anchor via #247's per-op diagnostic.

The cassette golden (`tests/fixtures/llm-mocked-api/__golden__.json`) is a single-repo HTTP fixture with no graphql/socket ops and is **unchanged**.

## Deferred to #248

GraphQL type anchors (SDL field → TS resolver return type, or raw SDL type expression). The corpus's expected GraphQL anchors are internally inconsistent and not derivable from one rule, so Phase 1 deliberately stops at the manifest entry.

Refs #245 (Phase 1), #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)