### PR TITLE
fix(graphql): scope SDL discovery to the service's own roots (#242)

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -978,8 +978,12 @@ async fn analyze_current_repo_incremental(
                 packages,
                 function_definitions,
             );
-            let protocol_extractions =
-                append_deterministic_protocol_operations(&mut cloud_data, repo_path, &files);
+            let protocol_extractions = append_deterministic_protocol_operations(
+                &mut cloud_data,
+                repo_path,
+                service,
+                &files,
+            );
 
             // Populate cache fields
             let mut cached_file_results = merged_results.clone();
@@ -1120,9 +1124,27 @@ struct ProtocolExtractions {
     sockets: crate::socket_io::SocketExtraction,
 }
 
+/// The directories to walk for a service's own GraphQL SDL files: its
+/// `directory` (or the repo root for a flat single-service config) plus any
+/// `include` roots. Mirrors `find_service_files`' scoping so a monorepo
+/// package's schema is attributed only to the package that declares it, not its
+/// siblings (#242).
+fn service_graphql_roots(repo_path: &str, service: &Config) -> Vec<PathBuf> {
+    let root = Path::new(repo_path);
+    let mut roots = vec![match &service.directory {
+        Some(dir) => root.join(dir),
+        None => root.to_path_buf(),
+    }];
+    for inc in &service.include {
+        roots.push(root.join(inc));
+    }
+    roots
+}
+
 fn append_deterministic_protocol_operations(
     cloud_data: &mut CloudRepoData,
     repo_path: &str,
+    service: &Config,
     files: &[PathBuf],
 ) -> ProtocolExtractions {
     // Same "{file}:{line}" convention the mount-graph conversions use
@@ -1140,7 +1162,8 @@ fn append_deterministic_protocol_operations(
         service_name: None,
     };
 
-    let graphql = crate::graphql::scan_repo(Path::new(repo_path), files);
+    let scan_roots = service_graphql_roots(repo_path, service);
+    let graphql = crate::graphql::scan_repo(&scan_roots, files);
     if !graphql.is_empty() {
         debug!(
             producers = graphql.producers.len(),
@@ -2091,7 +2114,7 @@ async fn analyze_current_repo(
         function_definitions.clone(),
     );
     let protocol_extractions =
-        append_deterministic_protocol_operations(&mut cloud_data, repo_path, &files);
+        append_deterministic_protocol_operations(&mut cloud_data, repo_path, service, &files);
 
     let mut manifest_entries = build_type_manifest_entries(&analysis_result.mount_graph, config);
     stamp_manifest_anchor_symbols(&mut manifest_entries, &analysis_result.file_results);

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -63,34 +63,47 @@ const SKIP_DIRS: &[&str] = &[
     "__generated__", // Relay artifacts — out of scope
 ];
 
-/// Extract GraphQL operations from a repository: `.graphql`/`.gql` files
-/// under `repo_root` plus tagged template literals in the given service
-/// files (the same TS/JS set the rest of the pipeline analyzes).
-pub fn scan_repo(repo_root: &Path, service_files: &[PathBuf]) -> GraphqlExtraction {
+/// Extract GraphQL operations for a single service: `.graphql`/`.gql` SDL files
+/// under the service's own `scan_roots` plus tagged template literals in the
+/// given service files (the same TS/JS set the rest of the pipeline analyzes).
+///
+/// `scan_roots` are the service's own directories (its `directory` plus any
+/// `include` roots), NOT the whole monorepo. Walking the repo root here would
+/// attribute a sibling package's schema to every service in the monorepo (#242):
+/// `orders-pkg` would be credited with `gateway`'s `query order` producer.
+pub fn scan_repo(scan_roots: &[PathBuf], service_files: &[PathBuf]) -> GraphqlExtraction {
     let mut extraction = GraphqlExtraction::default();
 
-    for entry in WalkDir::new(repo_root)
-        .into_iter()
-        .filter_entry(|e| {
-            !e.file_name()
-                .to_str()
-                .map(|name| SKIP_DIRS.contains(&name))
-                .unwrap_or(false)
-        })
-        .filter_map(Result::ok)
-    {
-        let path = entry.path();
-        let is_graphql_file = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .is_some_and(|ext| ext == "graphql" || ext == "gql");
-        if !is_graphql_file {
-            continue;
+    // Overlapping roots (a service `include` that overlaps its `directory`) must
+    // not extract the same schema twice, so dedup SDL paths across roots.
+    let mut seen_sdl: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    for root in scan_roots {
+        for entry in WalkDir::new(root)
+            .into_iter()
+            .filter_entry(|e| {
+                !e.file_name()
+                    .to_str()
+                    .map(|name| SKIP_DIRS.contains(&name))
+                    .unwrap_or(false)
+            })
+            .filter_map(Result::ok)
+        {
+            let path = entry.path();
+            let is_graphql_file = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|ext| ext == "graphql" || ext == "gql");
+            if !is_graphql_file {
+                continue;
+            }
+            if !seen_sdl.insert(path.to_path_buf()) {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(path) else {
+                continue;
+            };
+            extraction.merge(extract_from_document_text(&content, path, 1));
         }
-        let Ok(content) = std::fs::read_to_string(path) else {
-            continue;
-        };
-        extraction.merge(extract_from_document_text(&content, path, 1));
     }
 
     for file in service_files {
@@ -432,5 +445,40 @@ export const typeDefs = gql`
         std::fs::remove_dir_all(&dir).ok();
 
         assert_eq!(keys(&result.producers), vec!["graphql|query|orders"]);
+    }
+
+    #[test]
+    fn sdl_walk_is_scoped_to_service_roots() {
+        // #242: a monorepo package's SDL must be attributed only to that
+        // package's own roots, never to a sibling. Walking the repo root (as the
+        // old signature did) would credit package `b` with package `a`'s schema.
+        let base = std::env::temp_dir().join(format!("carrick-gql-scope-{}", std::process::id()));
+        let pkg_a = base.join("packages/a/src");
+        let pkg_b = base.join("packages/b/src");
+        std::fs::create_dir_all(&pkg_a).unwrap();
+        std::fs::create_dir_all(&pkg_b).unwrap();
+        std::fs::write(
+            pkg_a.join("schema.graphql"),
+            "type Query { order(id: ID!): String }",
+        )
+        .unwrap();
+
+        let a_root = base.join("packages/a");
+        let b_root = base.join("packages/b");
+        let no_files: &[PathBuf] = &[];
+        let scoped_a = scan_repo(std::slice::from_ref(&a_root), no_files);
+        let scoped_b = scan_repo(std::slice::from_ref(&b_root), no_files);
+        std::fs::remove_dir_all(&base).ok();
+
+        assert_eq!(
+            keys(&scoped_a.producers),
+            vec!["graphql|query|order"],
+            "package a's own root must find its schema"
+        );
+        assert!(
+            scoped_b.producers.is_empty(),
+            "package b must NOT be credited with sibling a's schema, got {:?}",
+            keys(&scoped_b.producers)
+        );
     }
 }

--- a/tests/graphql_extraction_test.rs
+++ b/tests/graphql_extraction_test.rs
@@ -14,7 +14,7 @@ fn scan_repo_extracts_schema_and_documents() {
     let root = fixture_root();
     let service_files = vec![root.join("src/client.ts")];
 
-    let extraction = scan_repo(&root, &service_files);
+    let extraction = scan_repo(std::slice::from_ref(&root), &service_files);
 
     let mut producers: Vec<String> = extraction
         .producers


### PR DESCRIPTION
`scan_repo` walked the whole repo root for `.graphql`/`.gql` SDL files while only scoping the TS *consumer* files per-service. In a monorepo, every service's scan re-discovered every sibling package's schema and was credited with its producers — `orders-pkg` was attributed `gateway`'s `graphql|query|order` and `subscription|orderUpdated`, producing spurious cross-repo edges (visible once #239's multi-producer emission landed).

- `scan_repo` now takes `scan_roots: &[PathBuf]` (the service's own roots) and walks each, deduping SDL paths across overlapping roots, instead of the monorepo root.
- `append_deterministic_protocol_operations` takes `service: &Config` and computes its roots via `service_graphql_roots` (its `directory`, or the repo root for a flat config, plus any `include` roots) — mirroring `find_service_files`.
- Sockets were already service-scoped (`scan_files(files)`), so no change there.

Tests: `sdl_walk_is_scoped_to_service_roots`; updated the one integration-test caller.

Closes #242 · Refs #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)