### PR TITLE
fix: keep ts_check manifests HTTP-only so compat verdicts survive non-HTTP entries

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2292,6 +2292,17 @@ fn write_manifest_files(
     for repo_data in all_repo_data {
         if let Some(entries) = &repo_data.type_manifest {
             for entry in entries {
+                // ts_check manifests are HTTP-only by contract: `ManifestEntry`
+                // (ts_check/lib/manifest-matcher.ts) requires `method`/`path`,
+                // which GraphQL/socket OperationKeys never serialise. Those
+                // protocols are scored by their own pipelines (#236/#248), so
+                // they stay in `cloud_data.type_manifest` (cloud index + eval
+                // projection) but must not reach the producer/consumer manifest
+                // files. Without this filter a single non-HTTP entry makes
+                // `validateEntry` throw, zeroing out every cross-repo verdict (#253).
+                if entry.key.protocol() != crate::operation::Protocol::Http {
+                    continue;
+                }
                 match entry.role {
                     ManifestRole::Producer => producer_entries.push(entry.clone()),
                     ManifestRole::Consumer => consumer_entries.push(entry.clone()),
@@ -3861,5 +3872,115 @@ mod tests {
         );
         assert_eq!(manifest_alias, expected);
         assert_eq!(request.alias.as_deref(), Some(expected.as_str()));
+    }
+
+    /// #253 regression: `write_manifest_files` feeds the HTTP-only ts_check
+    /// matcher, so it must emit ONLY HTTP entries. GraphQL/socket entries are
+    /// kept in `cloud_data.type_manifest` (cloud index + eval projection) but
+    /// must never reach producer/consumer manifest files — a single non-HTTP
+    /// entry there makes ts_check's `validateEntry` throw and zeros out every
+    /// cross-repo verdict.
+    #[test]
+    fn write_manifest_files_emits_only_http_entries() {
+        use crate::cloud_storage::TypeEvidence;
+        use crate::operation::{GraphqlOperationKind, OperationKey, SocketDirection};
+        use crate::services::type_sidecar::InferKind;
+
+        fn entry(key: OperationKey, alias: &str) -> TypeManifestEntry {
+            TypeManifestEntry {
+                key,
+                role: ManifestRole::Producer,
+                type_kind: ManifestTypeKind::Response,
+                type_alias: alias.to_string(),
+                file_path: "src/x.ts".to_string(),
+                line_number: 1,
+                is_explicit: true,
+                type_state: ManifestTypeState::Explicit,
+                evidence: TypeEvidence {
+                    file_path: "src/x.ts".to_string(),
+                    span_start: None,
+                    span_end: None,
+                    line_number: 1,
+                    infer_kind: InferKind::ResponseBody,
+                    is_explicit: true,
+                    type_state: ManifestTypeState::Explicit,
+                },
+                resolved_definition: None,
+                expanded_definition: None,
+                primary_type_symbol: None,
+            }
+        }
+
+        let manifest = vec![
+            entry(OperationKey::http("GET", "/orders/:id"), "OrderResponse"),
+            entry(
+                OperationKey::graphql(GraphqlOperationKind::Query, "order"),
+                "OrderQueryResult",
+            ),
+            entry(
+                OperationKey::socket("order.created", SocketDirection::ServerToClient),
+                "OrderCreatedEvent",
+            ),
+        ];
+
+        let repo_data = CloudRepoData {
+            repo_name: "orders-svc".to_string(),
+            service_name: None,
+            endpoints: vec![],
+            calls: vec![],
+            mounts: vec![],
+            apps: std::collections::HashMap::new(),
+            imported_handlers: vec![],
+            function_definitions: std::collections::HashMap::new(),
+            config_json: None,
+            package_json: None,
+            packages: None,
+            last_updated: chrono::Utc::now(),
+            commit_hash: "test-hash".to_string(),
+            mount_graph: None,
+            bundled_types: None,
+            type_manifest: Some(manifest),
+            file_results: None,
+            cached_detection: None,
+            cached_guidance: None,
+            cached_extraction_config: None,
+            package_json_hash: None,
+            cache_version: None,
+            type_extraction_status: None,
+        };
+
+        // Local mirror of TypeManifestFile for reading back the written JSON
+        // (the production struct is serialize-only).
+        #[derive(serde::Deserialize)]
+        struct ManifestFileForTest {
+            entries: Vec<TypeManifestEntry>,
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_manifest_files(std::slice::from_ref(&repo_data), dir.path())
+            .expect("write_manifest_files");
+
+        let producer: ManifestFileForTest = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("producer-manifest.json")).unwrap(),
+        )
+        .unwrap();
+
+        // Only the HTTP producer survives into the ts_check manifest.
+        assert_eq!(
+            producer.entries.len(),
+            1,
+            "non-HTTP entries must be filtered out of the ts_check manifest"
+        );
+        assert_eq!(
+            producer.entries[0].key.protocol(),
+            crate::operation::Protocol::Http
+        );
+        assert!(
+            producer
+                .entries
+                .iter()
+                .all(|e| e.key.protocol() == crate::operation::Protocol::Http),
+            "producer manifest must contain only HTTP entries"
+        );
     }
 }

--- a/ts_check/lib/manifest-matcher.test.ts
+++ b/ts_check/lib/manifest-matcher.test.ts
@@ -219,18 +219,151 @@ describe('ManifestMatcher', () => {
       );
     });
 
-    it('should throw error for invalid entry', () => {
+    it('should throw error for a structurally-invalid HTTP entry', () => {
       const filePath = path.join(tempDir, 'invalid-entry.json');
+      // An HTTP entry (protocol/method/path present) missing other required
+      // fields is a genuine data bug and must still throw — it is not a
+      // skippable non-HTTP entry.
       fs.writeFileSync(
         filePath,
         JSON.stringify({
           repo_name: 'test',
           commit_hash: 'abc123',
-          entries: [{ method: 'GET' }], // Missing required fields
+          entries: [{ protocol: 'http', method: 'GET', path: '/api/users' }],
         })
       );
 
       assert.throws(() => matcher.loadManifest(filePath), /missing required field/);
+    });
+
+    // --- #253 regression: non-HTTP entries must be skipped, not fatal ---
+
+    it('should skip non-HTTP entries and still load the HTTP ones', () => {
+      const httpEntry = createManifestEntry(
+        'GET',
+        '/orders/:id',
+        'OrderResponse',
+        'producer',
+        'src/routes.ts',
+        10
+      );
+      // GraphQL/socket OperationKeys serialise without method/path; previously
+      // these threw in validateEntry and zeroed out every verdict (#253).
+      const graphqlEntry = {
+        protocol: 'graphql',
+        kind: 'query',
+        field: 'order',
+        type_alias: 'OrderQueryResult',
+        role: 'producer',
+        type_kind: 'response',
+        file_path: 'src/schema.ts',
+        line_number: 5,
+        is_explicit: true,
+        type_state: 'explicit',
+        evidence: {
+          file_path: 'src/schema.ts',
+          span_start: null,
+          span_end: null,
+          line_number: 5,
+          infer_kind: 'response_body',
+          is_explicit: true,
+          type_state: 'explicit',
+        },
+      };
+      const socketEntry = {
+        protocol: 'socket',
+        event: 'order.created',
+        direction: 'server_to_client',
+        type_alias: 'OrderCreatedEvent',
+        role: 'producer',
+        type_kind: 'response',
+        file_path: 'src/sockets.ts',
+        line_number: 7,
+        is_explicit: true,
+        type_state: 'explicit',
+        evidence: {
+          file_path: 'src/sockets.ts',
+          span_start: null,
+          span_end: null,
+          line_number: 7,
+          infer_kind: 'response_body',
+          is_explicit: true,
+          type_state: 'explicit',
+        },
+      };
+
+      const filePath = path.join(tempDir, 'mixed-protocol.json');
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({
+          repo_name: 'orders-svc',
+          commit_hash: 'abc123',
+          entries: [graphqlEntry, httpEntry, socketEntry],
+        })
+      );
+
+      // Must NOT throw, and must keep only the HTTP entry.
+      const loaded = matcher.loadManifest(filePath);
+      assert.strictEqual(loaded.entries.length, 1);
+      assert.strictEqual(loaded.entries[0].protocol, 'http');
+      assert.strictEqual(loaded.entries[0].path, '/orders/:id');
+    });
+
+    it('should still match HTTP edges when a non-HTTP entry is present', () => {
+      const producerPath = path.join(tempDir, 'producer.json');
+      const consumerPath = path.join(tempDir, 'consumer.json');
+
+      const graphqlEntry = {
+        protocol: 'graphql',
+        kind: 'query',
+        field: 'order',
+        type_alias: 'OrderQueryResult',
+        role: 'producer',
+        type_kind: 'response',
+        file_path: 'src/schema.ts',
+        line_number: 5,
+        is_explicit: true,
+        type_state: 'explicit',
+        evidence: {
+          file_path: 'src/schema.ts',
+          span_start: null,
+          span_end: null,
+          line_number: 5,
+          infer_kind: 'response_body',
+          is_explicit: true,
+          type_state: 'explicit',
+        },
+      };
+
+      fs.writeFileSync(
+        producerPath,
+        JSON.stringify({
+          repo_name: 'orders-svc',
+          commit_hash: 'abc123',
+          entries: [
+            graphqlEntry,
+            createManifestEntry('GET', '/orders/:id', 'OrderResponse', 'producer', 'src/routes.ts', 10),
+          ],
+        })
+      );
+      fs.writeFileSync(
+        consumerPath,
+        JSON.stringify({
+          repo_name: 'web-frontend',
+          commit_hash: 'def456',
+          entries: [
+            createManifestEntry('GET', '/orders/:id', 'OrderData', 'consumer', 'src/api.ts', 20),
+          ],
+        })
+      );
+
+      const producers = matcher.loadManifest(producerPath);
+      const consumers = matcher.loadManifest(consumerPath);
+
+      const result = matcher.matchEndpoints(producers, consumers);
+      assert.strictEqual(result.matches.length, 1);
+      assert.strictEqual(result.matches[0].producer.path, '/orders/:id');
+      assert.strictEqual(result.matches[0].consumer.path, '/orders/:id');
     });
   });
 

--- a/ts_check/lib/manifest-matcher.ts
+++ b/ts_check/lib/manifest-matcher.ts
@@ -269,13 +269,12 @@ export class ManifestMatcher {
    * a single summary line is logged so the drop is never silent. A stray
    * non-HTTP entry can thus never zero out the entire verdict set again (#253).
    */
-  private retainHttpEntries(entries: ManifestEntry[], source: string): ManifestEntry[] {
+  private retainHttpEntries(entries: unknown[], source: string): ManifestEntry[] {
     const retained: ManifestEntry[] = [];
     let skipped = 0;
 
     for (const entry of entries) {
-      const isHttp = entry.protocol === 'http' && !!entry.method && !!entry.path;
-      if (isHttp) {
+      if (this.isHttpManifestEntry(entry)) {
         retained.push(entry);
       } else {
         skipped++;
@@ -284,12 +283,34 @@ export class ManifestMatcher {
 
     if (skipped > 0) {
       console.warn(
-        `[manifest] Skipped ${skipped} non-HTTP entr${skipped === 1 ? 'y' : 'ies'} in ${source} ` +
-          `(ts_check is HTTP-only; other protocols are checked by their own pipelines)`
+        `[manifest] Skipped ${skipped} non-checkable entr${skipped === 1 ? 'y' : 'ies'} in ${source} ` +
+          `(not HTTP, or missing method/path; ts_check is HTTP-only — other protocols are checked by their own pipelines)`
       );
     }
 
     return retained;
+  }
+
+  /**
+   * Shape guard for raw, possibly-malformed manifest JSON: an entry ts_check can
+   * check is an object whose `protocol` is "http" with non-empty string `method`
+   * and `path`. GraphQL/socket keys serialise without method/path and are
+   * filtered out here (#253). Full structural validation of the surviving HTTP
+   * entries is `validateEntry`'s job — a genuinely-malformed HTTP entry still
+   * throws there.
+   */
+  private isHttpManifestEntry(entry: unknown): entry is ManifestEntry {
+    if (typeof entry !== 'object' || entry === null) {
+      return false;
+    }
+    const e = entry as Record<string, unknown>;
+    return (
+      e.protocol === 'http' &&
+      typeof e.method === 'string' &&
+      e.method.length > 0 &&
+      typeof e.path === 'string' &&
+      e.path.length > 0
+    );
   }
 
   /**

--- a/ts_check/lib/manifest-matcher.ts
+++ b/ts_check/lib/manifest-matcher.ts
@@ -237,7 +237,16 @@ export class ManifestMatcher {
         throw new Error('Manifest missing required field: entries (must be an array)');
       }
 
-      // Validate entries
+      // ts_check is the HTTP TS-assignability checker; non-HTTP entries
+      // (GraphQL/socket OperationKeys, which serialise without method/path)
+      // are scored by their own pipelines and must be skipped here. The
+      // scanner already filters them out of the manifest files it writes
+      // (write_manifest_files), but a stray non-HTTP entry must never crash
+      // the whole verdict run again (#253), so we drop them defensively and
+      // leave a trace rather than throwing.
+      manifest.entries = this.retainHttpEntries(manifest.entries, absolutePath);
+
+      // Validate the surviving HTTP entries.
       for (const entry of manifest.entries) {
         this.validateEntry(entry);
       }
@@ -249,6 +258,38 @@ export class ManifestMatcher {
       }
       throw err;
     }
+  }
+
+  /**
+   * Filter a manifest entry list down to the HTTP entries ts_check can check.
+   *
+   * An entry is non-HTTP when its `protocol` is not "http" or it lacks the
+   * `method`/`path` an HTTP key carries (GraphQL/socket keys serialise without
+   * them). Those are skipped — they belong to other pipelines (#236/#248) — and
+   * a single summary line is logged so the drop is never silent. A stray
+   * non-HTTP entry can thus never zero out the entire verdict set again (#253).
+   */
+  private retainHttpEntries(entries: ManifestEntry[], source: string): ManifestEntry[] {
+    const retained: ManifestEntry[] = [];
+    let skipped = 0;
+
+    for (const entry of entries) {
+      const isHttp = entry.protocol === 'http' && !!entry.method && !!entry.path;
+      if (isHttp) {
+        retained.push(entry);
+      } else {
+        skipped++;
+      }
+    }
+
+    if (skipped > 0) {
+      console.warn(
+        `[manifest] Skipped ${skipped} non-HTTP entr${skipped === 1 ? 'y' : 'ies'} in ${source} ` +
+          `(ts_check is HTTP-only; other protocols are checked by their own pipelines)`
+      );
+    }
+
+    return retained;
   }
 
   /**
@@ -271,6 +312,9 @@ export class ManifestMatcher {
       throw new Error('Manifest missing required field: entries (must be an array)');
     }
 
+    // Skip non-HTTP entries before validating (see loadManifest / #253).
+    manifest.entries = this.retainHttpEntries(manifest.entries, '<string>');
+
     for (const entry of manifest.entries) {
       this.validateEntry(entry);
     }
@@ -279,7 +323,11 @@ export class ManifestMatcher {
   }
 
   /**
-   * Validate a manifest entry has all required fields
+   * Validate a manifest entry has all required fields.
+   *
+   * Callers must drop non-HTTP entries via `retainHttpEntries` first; by the
+   * time an entry reaches here it is expected to be HTTP, so a missing
+   * `method`/`path`/`protocol` is a genuine data bug and still throws.
    */
   private validateEntry(entry: ManifestEntry): void {
     if (!entry.method) {


### PR DESCRIPTION
## Problem (#253)

After #245, the compat-verdict eval dimension dropped from `0.50` to **UNSCORED**: every cross-repo edge — HTTP, GraphQL, and socket alike — reported `compat=None`.

### Root cause

#245's `append_protocol_manifest_entries` began pushing GraphQL/socket `TypeManifestEntry`s into the same `Vec` that `write_manifest_files` (`src/engine/mod.rs`) splits — with **no protocol filter** — into the `producer-manifest.json` / `consumer-manifest.json` files that ts_check reads.

Those keys serialise without `method`/`path` (`OperationKey` is `#[serde(tag="protocol")]`). ts_check's `validateEntry` hard-throws on the first such entry at load time; the throw writes `{error: ...}` to `type-check-results.json`; `check_type_compatibility` returns `Err`; `overlay_compat_verdicts` early-returns, leaving **every** cross-repo edge (HTTP included) at its default `type_compatible: None`.

CI missed it because the ts_check unit suite and the cassette golden are HTTP-only — no test exercised a non-HTTP manifest entry, so the throw never fired offline.

## Fix

1. **Primary** — `write_manifest_files` now `continue`s past any entry whose `entry.key.protocol() != Protocol::Http` when building the producer/consumer manifests. Non-HTTP entries stay in `cloud_data.type_manifest` (cloud index + eval projection); only the ts_check input is HTTP-only. GraphQL/socket edges are scored by their own pipelines (#236/#248).
2. **Defense-in-depth** — `loadManifest`/`parseManifest` in `ts_check/lib/manifest-matcher.ts` now **skip** (and log a count of) non-HTTP / missing-`method`/`path` entries instead of throwing, so a stray non-HTTP entry can never again zero out the whole verdict set. A structurally-invalid *HTTP* entry still throws.
3. **Regression coverage** (the gap that let CI miss this):
   - Rust: `write_manifest_files_emits_only_http_entries` asserts a mixed-protocol manifest yields an HTTP-only producer manifest file.
   - ts_check: a mixed-protocol manifest loads without throwing and keeps only the HTTP entry; HTTP edges still match end-to-end with a non-HTTP entry present.

## Verification

- `cd src/sidecar && npm install && npm run build` — clean
- `cd ts_check && npm ci && npm test` — 72 pass, 0 fail
- `cargo test` (cassette hard gate) — all green; `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean
- Cassette golden (`tests/fixtures/llm-mocked-api/__golden__.json`) — **unchanged** (HTTP-only fixture)

The compat dimension recovering can only be confirmed by a **live eval re-run** (offline cassettes are HTTP-only by design); the new regression tests are the offline proof that the loader survives non-HTTP entries.

Closes #253
Refs #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)