### PR TITLE
fix(sidecar): inline named member types in expanded_definition (#246)

### DIFF
--- a/src/sidecar/src/definition-resolver.ts
+++ b/src/sidecar/src/definition-resolver.ts
@@ -1,20 +1,39 @@
 /**
  * DefinitionResolver - Resolves type aliases from bundled .d.ts content
- * using the TypeScript compiler to produce fully expanded type definitions.
+ * using the TypeScript compiler.
  *
- * Instead of walking AST nodes or regex-extracting types, we ask the compiler
- * "what is this type?" and get the fully resolved answer.
+ * Two forms are produced per alias:
+ *  - `definition`: the declaration *as written* (named refs preserved).
+ *  - `expanded`: the fully *structural* form, with every named member type
+ *    inlined to its member structure, recursively.
+ *
+ * `type.getText(node, NoTruncation)` does NOT inline named members — the
+ * compiler prints a referenced type by its symbol name when that symbol is in
+ * scope (`total: Money`, not `total: { amountCents: number; currency: string }`).
+ * To get the inlined form we walk the resolved `Type` ourselves and rebuild the
+ * structural text, expanding named object/interface types into their members
+ * while leaving primitives, literals and library types (e.g. `Date`, tuples) by
+ * name. Bounded recursion + a per-branch cycle set guard against blow-ups; any
+ * type that can't be safely expanded falls back to the non-expanded text rather
+ * than throwing.
  */
 
-import { Project, type SourceFile, ts } from 'ts-morph';
+import { Project, type SourceFile, type Symbol, type Type, ts } from 'ts-morph';
 
 export interface ResolvedDefinition {
   type_alias: string;
   /** Original declaration text as written (preserves named types) */
   definition: string;
-  /** Compiler-expanded form with all types fully inlined */
+  /** Fully structural form: named member types inlined to their structure */
   expanded: string;
 }
+
+/**
+ * Bound on the structural-expansion recursion. Deep enough for every realistic
+ * request/response shape; a backstop against pathological/recursive types the
+ * cycle set somehow misses.
+ */
+const MAX_EXPANSION_DEPTH = 12;
 
 export class DefinitionResolver {
   private readonly project: Project;
@@ -25,7 +44,7 @@ export class DefinitionResolver {
 
   /**
    * Resolve multiple type aliases from a bundled .d.ts string.
-   * Returns both the original declaration and the compiler-expanded form.
+   * Returns both the original declaration and the structural form.
    */
   resolve(bundledDts: string, aliases: string[]): ResolvedDefinition[] {
     const tempFileName = `__carrick_resolve_${Date.now()}.d.ts`;
@@ -61,7 +80,7 @@ export class DefinitionResolver {
   }
 
   /**
-   * Resolve a single alias: get the original text and the compiler-expanded form.
+   * Resolve a single alias: the original text and the structural form.
    */
   private resolveAlias(
     sourceFile: SourceFile,
@@ -76,15 +95,11 @@ export class DefinitionResolver {
     if (!decl) return null;
 
     try {
-      // Original declaration text as written
+      // Original declaration text as written.
       const definition = decl.getText();
 
-      // Compiler-expanded form — fully resolved, no truncation
-      const type = decl.getType();
-      const expanded = type.getText(
-        decl,
-        ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.InTypeAlias,
-      );
+      // Structural form — every named member inlined to its shape.
+      const expanded = this.expandType(decl.getType(), new Set(), 0);
 
       return { type_alias: alias, definition, expanded };
     } catch (err) {
@@ -92,6 +107,180 @@ export class DefinitionResolver {
         `Failed to resolve ${alias}: ${err instanceof Error ? err.message : String(err)}`,
       );
       return null;
+    }
+  }
+
+  /**
+   * Recursively render a `Type` as fully-inlined structural text.
+   *
+   * Named object/interface types are expanded to their member structure;
+   * primitives, literals, library types (`Date`, `Promise`, tuples, …) and
+   * functions stay by name. The `seen` set (object type ids on the current
+   * branch) breaks reference cycles; `depth` is a hard backstop.
+   */
+  private expandType(type: Type, seen: Set<number>, depth: number): string {
+    if (depth > MAX_EXPANSION_DEPTH) return this.namedText(type);
+
+    // Primitives & literals: nothing to inline.
+    if (
+      type.isString() ||
+      type.isNumber() ||
+      type.isBoolean() ||
+      type.isBooleanLiteral() ||
+      type.isUndefined() ||
+      type.isNull() ||
+      type.isVoid() ||
+      type.isAny() ||
+      type.isUnknown() ||
+      type.isNever() ||
+      type.isStringLiteral() ||
+      type.isNumberLiteral() ||
+      type.isEnumLiteral()
+    ) {
+      return this.namedText(type);
+    }
+
+    // Unions / intersections: expand each member.
+    if (type.isUnion()) {
+      return type
+        .getUnionTypes()
+        .map((member) => this.expandType(member, seen, depth + 1))
+        .join(' | ');
+    }
+    if (type.isIntersection()) {
+      return type
+        .getIntersectionTypes()
+        .map((member) => this.expandType(member, seen, depth + 1))
+        .join(' & ');
+    }
+
+    // Tuples are array-like but must keep their `[a, b]` shape, not be walked
+    // as objects (which explodes into `Array.prototype`). Handle before arrays.
+    if (this.isTuple(type)) {
+      return this.namedText(type);
+    }
+
+    if (type.isArray()) {
+      const element = type.getArrayElementType();
+      if (!element) return this.namedText(type);
+      const inner = this.expandType(element, seen, depth + 1);
+      // Parenthesise unions/intersections so `(A | B)[]` doesn't read as
+      // `A | B[]`; object literals already self-delimit with braces.
+      const needsParens = /[|&]/.test(inner) && !inner.startsWith('{');
+      return needsParens ? `(${inner})[]` : `${inner}[]`;
+    }
+
+    // Library / built-in types (Date, Promise, RegExp, …): keep by name.
+    if (this.isLibraryType(type)) {
+      return this.namedText(type);
+    }
+
+    // Callable/constructable object types (functions): keep by name; their
+    // structural form is the signature, which `getText` already renders.
+    if (
+      type.getCallSignatures().length > 0 ||
+      type.getConstructSignatures().length > 0
+    ) {
+      return this.namedText(type);
+    }
+
+    if (type.isObject() || type.isInterface()) {
+      const id = (type.compilerType as { id?: number }).id;
+      if (id != null && seen.has(id)) return this.namedText(type);
+      const nextSeen = id != null ? new Set(seen).add(id) : seen;
+
+      const props = type.getProperties();
+      if (props.length === 0) return this.namedText(type);
+
+      const parts = props.map((prop) =>
+        this.expandProperty(prop, nextSeen, depth),
+      );
+      return `{ ${parts.join('; ')}; }`;
+    }
+
+    return this.namedText(type);
+  }
+
+  /** Render a single property as `name[?]: <expanded>`. */
+  private expandProperty(
+    prop: Symbol,
+    seen: Set<number>,
+    depth: number,
+  ): string {
+    const name = prop.getName();
+    const optional = (prop.getFlags() & ts.SymbolFlags.Optional) !== 0;
+
+    const propDecl = prop.getDeclarations()[0];
+    let propType = propDecl
+      ? prop.getTypeAtLocation(propDecl)
+      : prop.getDeclaredType();
+
+    // An optional property's type includes `undefined`; the structural label
+    // drops it (`note?: string`, not `note?: string | undefined`).
+    if (optional && propType.isUnion()) {
+      const nonUndefined = propType
+        .getUnionTypes()
+        .filter((member) => !member.isUndefined());
+      if (nonUndefined.length === 1) {
+        propType = nonUndefined[0];
+      } else if (nonUndefined.length > 1) {
+        const inner = nonUndefined
+          .map((member) => this.expandType(member, seen, depth + 1))
+          .join(' | ');
+        return `${name}?: ${inner}`;
+      }
+    }
+
+    const inner = this.expandType(propType, seen, depth + 1);
+    return `${name}${optional ? '?' : ''}: ${inner}`;
+  }
+
+  /** True for tuple types (`[a, b]`), which must not be walked as objects. */
+  private isTuple(type: Type): boolean {
+    const compiler = type.compilerType as {
+      objectFlags?: number;
+      target?: { objectFlags?: number };
+    };
+    const target = compiler.target ?? compiler;
+    return ((target.objectFlags ?? 0) & ts.ObjectFlags.Tuple) !== 0;
+  }
+
+  /**
+   * True for types declared in `node_modules` or a TS `lib.*.d.ts` (Date,
+   * Promise, RegExp, …). These stay by name rather than being inlined.
+   */
+  private isLibraryType(type: Type): boolean {
+    const symbol = type.getSymbol() ?? type.getAliasSymbol();
+    if (!symbol) return false;
+    const decls = symbol.getDeclarations();
+    if (decls.length === 0) return false;
+    return decls.some((decl) => {
+      const sf = decl.getSourceFile();
+      if (sf.isInNodeModules()) return true;
+      return (
+        sf.isDeclarationFile() && /(^|\/)lib\.[^/]*\.d\.ts$/.test(sf.getFilePath())
+      );
+    });
+  }
+
+  /**
+   * Non-expanded text for a type. Passes `undefined` as the enclosing node so
+   * the compiler can't throw on an invalid node context (tuples and some
+   * generic instantiations do), falling back to the bare `getText()` and
+   * finally to `unknown` so a single bad type never aborts the whole resolve.
+   */
+  private namedText(type: Type): string {
+    try {
+      return type.getText(
+        undefined,
+        ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.InTypeAlias,
+      );
+    } catch {
+      try {
+        return type.getText();
+      } catch {
+        return 'unknown';
+      }
     }
   }
 

--- a/src/sidecar/src/definition-resolver.ts
+++ b/src/sidecar/src/definition-resolver.ts
@@ -207,10 +207,13 @@ export class DefinitionResolver {
     seen: Set<number>,
     depth: number,
   ): string {
-    const name = prop.getName();
     const optional = (prop.getFlags() & ts.SymbolFlags.Optional) !== 0;
 
     const propDecl = prop.getDeclarations()[0];
+    // Render the key from the declaration's name node so quoted/computed keys
+    // ('x-y', "x y", [Symbol.iterator]) survive as valid TS text rather than
+    // being unquoted into invalid output; fall back to the bare symbol name.
+    const name = this.renderPropertyName(prop, propDecl);
     let propType = propDecl
       ? prop.getTypeAtLocation(propDecl)
       : prop.getDeclaredType();
@@ -233,6 +236,20 @@ export class DefinitionResolver {
 
     const inner = this.expandType(propType, seen, depth + 1);
     return `${name}${optional ? '?' : ''}: ${inner}`;
+  }
+
+  /**
+   * The property key as valid TS text. Uses the declaration's name node so a
+   * quoted (`'x-y'`) or computed (`[Symbol.iterator]`) key keeps its syntax;
+   * `Symbol.getName()` would drop the quoting and emit invalid output. Falls
+   * back to the bare symbol name when there's no usable name node.
+   */
+  private renderPropertyName(prop: Symbol, decl: unknown): string {
+    const node = decl as
+      | { getNameNode?: () => { getText(): string } | undefined }
+      | undefined;
+    const text = node?.getNameNode?.()?.getText();
+    return text && text.length > 0 ? text : prop.getName();
   }
 
   /** True for tuple types (`[a, b]`), which must not be walked as objects. */
@@ -258,7 +275,9 @@ export class DefinitionResolver {
       const sf = decl.getSourceFile();
       if (sf.isInNodeModules()) return true;
       return (
-        sf.isDeclarationFile() && /(^|\/)lib\.[^/]*\.d\.ts$/.test(sf.getFilePath())
+        sf.isDeclarationFile() &&
+        // Normalize separators so a Windows `\\` path still matches lib.*.d.ts.
+        /(^|\/)lib\.[^/]*\.d\.ts$/.test(sf.getFilePath().replace(/\\/g, '/'))
       );
     });
   }

--- a/src/sidecar/test/sidecar.test.ts
+++ b/src/sidecar/test/sidecar.test.ts
@@ -1319,8 +1319,13 @@ describe('Type Sidecar Integration Tests', () => {
       // definition should contain the original interface text
       assert.ok(def.definition.includes('interface User'), 'definition should have original interface');
       assert.ok(def.definition.includes('name'), 'definition should include name field');
-      // expanded for interfaces returns the type name (nominal) — that's expected
+      // expanded is the structural form: members inlined, not the nominal name (#246)
       assert.ok(def.expanded, 'expanded should be present');
+      assert.ok(def.expanded.startsWith('{'), 'expanded should be a structural object literal');
+      assert.ok(def.expanded.includes('id: string'), 'expanded should inline id member');
+      assert.ok(def.expanded.includes('name: string'), 'expanded should inline name member');
+      // Date is a library type — it stays by name, not inlined to its members.
+      assert.ok(def.expanded.includes('createdAt: Date'), 'expanded should keep Date by name');
     });
 
     it('should resolve a type alias with union', async () => {
@@ -1373,8 +1378,20 @@ describe('Type Sidecar Integration Tests', () => {
       assert.ok(def.definition.includes('UserSettings'), 'definition should reference UserSettings');
       // definition should show the extends clause
       assert.ok(def.definition.includes('extends User'), 'definition should show extends User');
-      // expanded for interfaces returns the nominal name — definition has the full text
-      assert.ok(def.expanded, 'expanded should be present');
+      // expanded inlines the transitive members: the named `settings: UserSettings`
+      // becomes its structural shape, and the inherited `User` members are flattened in (#246).
+      assert.ok(def.expanded.startsWith('{'), 'expanded should be a structural object literal');
+      assert.ok(
+        !/settings: UserSettings/.test(def.expanded),
+        'expanded must NOT leave the named member ref `settings: UserSettings`',
+      );
+      assert.ok(
+        /settings: \{[^}]*theme:/.test(def.expanded),
+        'expanded should inline UserSettings into the settings member structure',
+      );
+      assert.ok(def.expanded.includes('notifications: boolean'), 'expanded should inline a nested member');
+      // Inherited (extends User) members are present structurally.
+      assert.ok(def.expanded.includes('id: string'), 'expanded should flatten inherited User members');
     });
 
     it('should resolve multiple aliases in one call', async () => {
@@ -1429,6 +1446,106 @@ describe('Type Sidecar Integration Tests', () => {
       // Should only resolve the one that exists
       assert.strictEqual(response.definitions.length, 1);
       assert.strictEqual(response.definitions[0].type_alias, 'User');
+    });
+
+    // #246: expanded_definition must be the fully-inlined STRUCTURAL form —
+    // named member types expanded to their structure, recursively. These shapes
+    // mirror the xrepo-corpus-1 gateway resolver (Money / ApiResponse<T> /
+    // OrderStatus / optional note) and pin the exact strings the eval scores.
+    describe('expanded inlines named member types (#246)', () => {
+      // Self-contained .d.ts equivalent to the corpus gateway shapes.
+      const corpusDts = [
+        'export interface Money { amountCents: number; currency: string }',
+        'export type OrderStatus =',
+        '  | { kind: "placed"; placedAt: string }',
+        '  | { kind: "refunded"; refundedAt: string; reason?: string };',
+        'export interface Order { id: string; total: Money; status: OrderStatus; note?: string }',
+        'export interface ApiResponse<T> { data: T; errors: string[] }',
+        'export type Endpoint_OrderResp = ApiResponse<Order>;',
+        'export type Endpoint_OrdersResp = Order[];',
+        'export type Endpoint_OrderUpdated = Order;',
+        'export type WithDate = { id: string; created: Date };',
+        'export type Pair = [number, string];',
+      ].join('\n');
+
+      async function resolveOne(
+        requestId: string,
+        alias: string,
+      ): Promise<string> {
+        const response = await client.send<{
+          status: string;
+          definitions?: Array<{
+            type_alias: string;
+            definition: string;
+            expanded: string;
+          }>;
+        }>({
+          action: 'resolve_definitions',
+          request_id: requestId,
+          bundled_dts: corpusDts,
+          aliases: [alias],
+        });
+        assert.strictEqual(response.status, 'success');
+        const def = response.definitions?.find((d) => d.type_alias === alias);
+        assert.ok(def, `expected a definition for ${alias}`);
+        return def.expanded;
+      }
+
+      it('inlines a nested named object (Money -> { amountCents; currency })', async () => {
+        const expanded = await resolveOne('resolve-money', 'Endpoint_OrderUpdated');
+        assert.ok(
+          !/total: Money/.test(expanded),
+          'must NOT leave the named member ref `total: Money`',
+        );
+        assert.ok(
+          expanded.includes('total: { amountCents: number; currency: string; }'),
+          `nested Money should inline structurally; got: ${expanded}`,
+        );
+      });
+
+      it('inlines a generic wrapper (ApiResponse<Order>) fully', async () => {
+        const expanded = await resolveOne('resolve-generic', 'Endpoint_OrderResp');
+        assert.strictEqual(
+          expanded,
+          '{ data: { id: string; total: { amountCents: number; currency: string; }; status: { kind: "placed"; placedAt: string; } | { kind: "refunded"; refundedAt: string; reason?: string; }; note?: string; }; errors: string[]; }',
+        );
+      });
+
+      it('inlines a discriminated union field (OrderStatus)', async () => {
+        const expanded = await resolveOne('resolve-union', 'OrderStatus');
+        assert.strictEqual(
+          expanded,
+          '{ kind: "placed"; placedAt: string; } | { kind: "refunded"; refundedAt: string; reason?: string; }',
+        );
+      });
+
+      it('renders an optional field as `note?: string` (strips undefined)', async () => {
+        const expanded = await resolveOne('resolve-optional', 'Endpoint_OrderUpdated');
+        assert.ok(
+          expanded.includes('note?: string'),
+          `optional note should render as note?: string; got: ${expanded}`,
+        );
+        assert.ok(
+          !expanded.includes('note?: string | undefined'),
+          'optional field must not carry an explicit `| undefined`',
+        );
+      });
+
+      it('inlines an array element while keeping the [] suffix', async () => {
+        const expanded = await resolveOne('resolve-array', 'Endpoint_OrdersResp');
+        assert.ok(expanded.endsWith('}[]'), `should be a structural object array; got: ${expanded}`);
+        assert.ok(expanded.includes('total: { amountCents: number; currency: string; }'));
+      });
+
+      it('keeps library types by name (Date is not inlined)', async () => {
+        const expanded = await resolveOne('resolve-date', 'WithDate');
+        assert.strictEqual(expanded, '{ id: string; created: Date; }');
+      });
+
+      it('keeps tuple types as `[a, b]` without exploding into Array.prototype', async () => {
+        const expanded = await resolveOne('resolve-tuple', 'Pair');
+        assert.strictEqual(expanded, '[number, string]');
+      });
     });
 
     it('should fail before init', async () => {

--- a/tests/fixtures/llm-mocked-api/__golden__.json
+++ b/tests/fixtures/llm-mocked-api/__golden__.json
@@ -13,7 +13,7 @@
       "type_alias": "Endpoint_a9cce7d0d8d0d9e6_Response",
       "type_state": "Explicit",
       "resolved_definition": "export interface Endpoint_a9cce7d0d8d0d9e6_Response {\n  id: number;\n  name: string;\n  email: string;\n}",
-      "expanded_definition": "Endpoint_a9cce7d0d8d0d9e6_Response",
+      "expanded_definition": "{ id: number; name: string; email: string; }",
       "is_explicit": true,
       "primary_type_symbol": "User"
     },


### PR DESCRIPTION
## Problem

`expanded_definition` was `decl.getType().getText(decl, NoTruncation | InTypeAlias)`. `NoTruncation` only defeats the `...` width cutoff; it does **not** inline *named* member types — TypeScript prints a referenced type by its symbol name when that symbol is in scope. So a field `total: Money` was printed as `total: Money`, not `total: { amountCents: number; currency: string }`.

The corpus `resolved_type` labels (and the eval's `type-resolution` metric) are the fully-inlined structural form, so expansion stopping at the alias name meant the metric couldn't match even when resolution worked (~0.07).

## Fix

Replace the flag-based `getText` with a recursive structural walk of the resolved `Type` in `src/sidecar/src/definition-resolver.ts`:

- **Named object/interface members** are expanded to their member structure, recursively — nested objects (`Money` inside `Order.total`), generic wrappers (`ApiResponse<Order>`), discriminated unions (`OrderStatus`), and inherited (`extends`) members are all flattened.
- **Optional fields** render as `note?: string` (the synthetic `| undefined` from the optional union is stripped).
- **Primitives, literals, library types** (`Date`, `Promise`, …), **tuples**, and **functions** stay by name.
- **Cycle + depth guards**: a per-branch `seen` set of object-type ids breaks reference cycles; a depth bound (12) backstops anything the set misses.
- **Crash safety**: every `getText` is called with `undefined` as the enclosing node (tuples and some generic instantiations throw on an invalid node context) and wrapped try/catch down to the bare `getText()` and finally `unknown`. A type that can't be safely expanded falls back to the named form rather than throwing — precision over crashes.

`resolved_definition` (the as-written, named form) is unchanged. This is sidecar-side only: no Rust manifest/projection plumbing, no `resolved_definition` semantics, no compat-checking logic touched. The compat verdict is unaffected because `compareTypes` uses live `Type.isAssignableTo` on `Type` objects, not this text — this improves the resolution metric and reports only.

## Verification

- New `#246` describe block in `sidecar.test.ts` pins the exact inlined strings for the corpus shapes (nested object, `ApiResponse<Order>` generic, discriminated `OrderStatus`, optional `note?: string`, object array, `Date`-stays-by-name, tuple-stays-as-`[a, b]`). The `User`/`UserProfile` resolver tests were updated from the old "interfaces stay nominal" assertion to assert structural inlining.
- Sidecar: `tsc` clean; `npm test` 72 pass / 1 pre-existing skip.
- Rust: full `cargo test` green (incl. cassette hard gate + xrepo harness); `cargo fmt` and `cargo clippy --all-targets -- -D warnings` clean. ts_check suite 70/70.

### Cassette golden diff

One line changed, exactly the bug being fixed — the `GET /api/users` endpoint's `expanded_definition` went from the leaking alias name to the inlined structure:

```diff
-      "expanded_definition": "Endpoint_a9cce7d0d8d0d9e6_Response",
+      "expanded_definition": "{ id: number; name: string; email: string; }",
```

`resolved_definition` (the `export interface ... { id; name; email }` declaration) is untouched, and every other field across the projection is byte-identical. This is purely a better-inlined `expanded_definition`, which is the authorized re-record case.

Closes #246
Refs #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)