### PR TITLE
chore(ci): disable dogfooding self-scan (manual-only) to stop wasted inference

### DIFF
--- a/.github/workflows/carrick.yml
+++ b/.github/workflows/carrick.yml
@@ -1,12 +1,14 @@
 name: Carrick
 
+# DISABLED 2026-06-26 (manual-only): the dogfooding self-scan runs the real
+# Carrick Action (Vertex/Gemini inference) on every push/PR. During heavy
+# iteration that's pure wasted inference cost, so it's reduced to on-demand.
+# Re-enable real dogfooding by restoring the triggers below:
+#   push: { branches: [main] }
+#   pull_request: { branches: [main] }
+#   repository_dispatch: { types: [carrick-sibling-updated] }
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  repository_dispatch:
-    types: [carrick-sibling-updated]
+  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
The Carrick self-scan (`carrick.yml`) runs the real published Action (Vertex/Gemini inference) on every push/PR to `main` — pure wasted inference cost during heavy iteration, and it's been failing on LLM quota anyway. Reduced to `workflow_dispatch` (on-demand); re-enable real dogfooding by restoring the `push`/`pull_request`/`repository_dispatch` triggers (documented inline).

Unaffected: the mocked regression test (`ci.yml`, `CARRICK_MOCK_ALL`) stays as the free per-PR gate, and the on-demand evals (`eval-xrepo`/`eval-tier-a`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)