### PR TITLE
feat(schema): trace-rule primary_type_symbol descriptions (anchor accuracy)

### DIFF
--- a/src/agents/schemas.rs
+++ b/src/agents/schemas.rs
@@ -324,12 +324,12 @@ impl AgentSchemas {
                             "primary_type_symbol": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "The primary type symbol name without wrappers (e.g., 'User' from 'Response<User[]>'). Extract just the identifier, not the full type."
+                                "description": "The named type of the response payload, as a bare identifier. ALWAYS extract it when the payload value has a determinable named type — do not skip it. Trace the sent/returned value (the same value as `response_expression_text`) to its declared type: a local variable's annotation (`const u: User = ...; res.json(u)` gives `User`), a function return annotation (`(): Promise<User>` gives `User`), an `as` cast (`res.json() as Promise<User>` gives `User`), or a generic type argument (`get<User>(...)` gives `User`). An imperative send (`res.json(u)`) does NOT suppress this — extract it the same as a returned value. Unwrap `Promise<...>`, arrays (`User[]`), and response wrappers (`Response<User>`) down to the core identifier. Null ONLY for untyped or inline-object-literal payloads with no named type."
                             },
                             "type_import_source": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "Import path where the type is defined (e.g., './types/user'), null if inline or defined in the same file. Look at import statements at the top of the file."
+                                "description": "Import path where the `primary_type_symbol` type is defined (e.g., './types/user'), or null if it is declared in the same file. Read the import statements at the top of the file."
                             }
                         },
                         "required": ["candidate_id", "line_number", "owner_node", "method", "path", "handler_name", "pattern_matched", "emission_style"]
@@ -390,12 +390,12 @@ impl AgentSchemas {
                             "primary_type_symbol": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "The primary type symbol name without wrappers (e.g., 'User' from 'Promise<User>'). Extract just the identifier, not the full type."
+                                "description": "The named type the call expects back, as a bare identifier. ALWAYS extract it when the result has a determinable named type — do not skip it. Trace the call's result to its declared type: an `as` cast on the result (`(await res.json()) as Promise<User>` gives `User`), the awaited value's annotated type, or a generic type argument on the call. Unwrap `Promise<...>`, arrays (`User[]`), and response wrappers (`Response<User>`) down to the core identifier. Null ONLY for untyped results with no named type."
                             },
                             "type_import_source": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "Import path where the type is defined (e.g., './types/user'), null if inline or defined in the same file. Look at import statements at the top of the file."
+                                "description": "Import path where the `primary_type_symbol` type is defined (e.g., './types/user'), or null if it is declared in the same file. Read the import statements at the top of the file."
                             }
                         },
                         "required": ["candidate_id", "line_number", "target", "pattern_matched"]

--- a/src/agents/schemas.rs
+++ b/src/agents/schemas.rs
@@ -324,7 +324,7 @@ impl AgentSchemas {
                             "primary_type_symbol": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "The named type of the response payload, as a bare identifier. ALWAYS extract it when the payload value has a determinable named type — do not skip it. Trace the sent/returned value (the same value as `response_expression_text`) to its declared type: a local variable's annotation (`const u: User = ...; res.json(u)` gives `User`), a function return annotation (`(): Promise<User>` gives `User`), an `as` cast (`res.json() as Promise<User>` gives `User`), or a generic type argument (`get<User>(...)` gives `User`). An imperative send (`res.json(u)`) does NOT suppress this — extract it the same as a returned value. Unwrap `Promise<...>`, arrays (`User[]`), and response wrappers (`Response<User>`) down to the core identifier. Null ONLY for untyped or inline-object-literal payloads with no named type."
+                                "description": "The named type of the response payload, as a bare identifier. ALWAYS extract it when the payload value has a determinable named type; do not skip it. Trace the sent or returned payload value (the same value as `response_expression_text`) to its declared type: a local variable annotation (`const u: User = ...; res.json(u)` gives `User`), a function return annotation (`(): Promise<User>` gives `User`), a cast on the payload (`res.json(u as User)` gives `User`), or a generic type argument (`get<User>(...)` gives `User`). An imperative send like `res.json(u)` does not suppress this; extract it the same as a returned value. Unwrap `Promise<...>`, arrays (`User[]`), and response wrappers (`Response<User>`) down to the core identifier. Null only for untyped or inline-object-literal payloads with no named type."
                             },
                             "type_import_source": {
                                 "type": "STRING",
@@ -390,7 +390,7 @@ impl AgentSchemas {
                             "primary_type_symbol": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "The named type the call expects back, as a bare identifier. ALWAYS extract it when the result has a determinable named type — do not skip it. Trace the call's result to its declared type: an `as` cast on the result (`(await res.json()) as Promise<User>` gives `User`), the awaited value's annotated type, or a generic type argument on the call. Unwrap `Promise<...>`, arrays (`User[]`), and response wrappers (`Response<User>`) down to the core identifier. Null ONLY for untyped results with no named type."
+                                "description": "The named type the call expects back, as a bare identifier. ALWAYS extract it when the result has a determinable named type; do not skip it. Trace the call result to its declared type: an `as` cast on the returned promise (`res.json() as Promise<User>` gives `User`), an annotation on the awaited value (`const u: User = await res.json()` gives `User`), or a generic type argument on the call. Unwrap `Promise<...>`, arrays (`User[]`), and response wrappers (`Response<User>`) down to the core identifier. Null only for untyped results with no named type."
                             },
                             "type_import_source": {
                                 "type": "STRING",


### PR DESCRIPTION
The file-analyzer `response_schema` is **sent by the scanner** to the Lambda (`file_analyzer_agent.rs:305` → `index.ts:293-352`), so its field descriptions are part of what Gemini reads for structured output — and they live in carrick (live on merge, **no Lambda deploy**).

The old `primary_type_symbol` description (*"extract just the identifier"*) was thin and effectively optional, so the model emitted the anchor inconsistently — present for a `POST` handler but dropped for a byte-identical `GET` one (Wave-B / #257 finding: emission non-determinism, not a carrick join bug). Rewrote both anchor descriptions (endpoint + data_call) with the **trace rule**: always extract when a named type is determinable; trace the sent/returned value to its declared type (local-var annotation, return annotation, `as` cast, generic arg); imperative send (`res.json(u)`) doesn't suppress it; unwrap `Promise`/arrays/`Response` wrappers; null only for untyped/inline literals.

Carrick-side anchor lever (no deploy). `system_prompt.txt` §D is a separate deploy-gated lever if this is insufficient. Confirmation needs a live eval (anchor is live-only; the cassette mocks the LLM so the offline gate is unaffected).

Refs #257, #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)