### PR TITLE
fix(sidecar): expand inferred consumer types structurally (#257)

### DIFF
--- a/src/sidecar/src/definition-resolver.ts
+++ b/src/sidecar/src/definition-resolver.ts
@@ -10,15 +10,13 @@
  * `type.getText(node, NoTruncation)` does NOT inline named members — the
  * compiler prints a referenced type by its symbol name when that symbol is in
  * scope (`total: Money`, not `total: { amountCents: number; currency: string }`).
- * To get the inlined form we walk the resolved `Type` ourselves and rebuild the
- * structural text, expanding named object/interface types into their members
- * while leaving primitives, literals and library types (e.g. `Date`, tuples) by
- * name. Bounded recursion + a per-branch cycle set guard against blow-ups; any
- * type that can't be safely expanded falls back to the non-expanded text rather
- * than throwing.
+ * The structural form is produced by `expandTypeStructural` (shared with the
+ * inference path in `type-inferrer.ts`), which walks the resolved `Type` and
+ * rebuilds the inlined text.
  */
 
-import { Project, type SourceFile, type Symbol, type Type, ts } from 'ts-morph';
+import { Project, type SourceFile } from 'ts-morph';
+import { expandTypeStructural } from './type-structural-expander.js';
 
 export interface ResolvedDefinition {
   type_alias: string;
@@ -27,13 +25,6 @@ export interface ResolvedDefinition {
   /** Fully structural form: named member types inlined to their structure */
   expanded: string;
 }
-
-/**
- * Bound on the structural-expansion recursion. Deep enough for every realistic
- * request/response shape; a backstop against pathological/recursive types the
- * cycle set somehow misses.
- */
-const MAX_EXPANSION_DEPTH = 12;
 
 export class DefinitionResolver {
   private readonly project: Project;
@@ -99,7 +90,7 @@ export class DefinitionResolver {
       const definition = decl.getText();
 
       // Structural form — every named member inlined to its shape.
-      const expanded = this.expandType(decl.getType(), new Set(), 0);
+      const expanded = expandTypeStructural(decl.getType());
 
       return { type_alias: alias, definition, expanded };
     } catch (err) {
@@ -107,199 +98,6 @@ export class DefinitionResolver {
         `Failed to resolve ${alias}: ${err instanceof Error ? err.message : String(err)}`,
       );
       return null;
-    }
-  }
-
-  /**
-   * Recursively render a `Type` as fully-inlined structural text.
-   *
-   * Named object/interface types are expanded to their member structure;
-   * primitives, literals, library types (`Date`, `Promise`, tuples, …) and
-   * functions stay by name. The `seen` set (object type ids on the current
-   * branch) breaks reference cycles; `depth` is a hard backstop.
-   */
-  private expandType(type: Type, seen: Set<number>, depth: number): string {
-    if (depth > MAX_EXPANSION_DEPTH) return this.namedText(type);
-
-    // Primitives & literals: nothing to inline.
-    if (
-      type.isString() ||
-      type.isNumber() ||
-      type.isBoolean() ||
-      type.isBooleanLiteral() ||
-      type.isUndefined() ||
-      type.isNull() ||
-      type.isVoid() ||
-      type.isAny() ||
-      type.isUnknown() ||
-      type.isNever() ||
-      type.isStringLiteral() ||
-      type.isNumberLiteral() ||
-      type.isEnumLiteral()
-    ) {
-      return this.namedText(type);
-    }
-
-    // Unions / intersections: expand each member.
-    if (type.isUnion()) {
-      return type
-        .getUnionTypes()
-        .map((member) => this.expandType(member, seen, depth + 1))
-        .join(' | ');
-    }
-    if (type.isIntersection()) {
-      return type
-        .getIntersectionTypes()
-        .map((member) => this.expandType(member, seen, depth + 1))
-        .join(' & ');
-    }
-
-    // Tuples are array-like but must keep their `[a, b]` shape, not be walked
-    // as objects (which explodes into `Array.prototype`). Handle before arrays.
-    if (this.isTuple(type)) {
-      return this.namedText(type);
-    }
-
-    if (type.isArray()) {
-      const element = type.getArrayElementType();
-      if (!element) return this.namedText(type);
-      const inner = this.expandType(element, seen, depth + 1);
-      // Parenthesise unions/intersections so `(A | B)[]` doesn't read as
-      // `A | B[]`; object literals already self-delimit with braces.
-      const needsParens = /[|&]/.test(inner) && !inner.startsWith('{');
-      return needsParens ? `(${inner})[]` : `${inner}[]`;
-    }
-
-    // Library / built-in types (Date, Promise, RegExp, …): keep by name.
-    if (this.isLibraryType(type)) {
-      return this.namedText(type);
-    }
-
-    // Callable/constructable object types (functions): keep by name; their
-    // structural form is the signature, which `getText` already renders.
-    if (
-      type.getCallSignatures().length > 0 ||
-      type.getConstructSignatures().length > 0
-    ) {
-      return this.namedText(type);
-    }
-
-    if (type.isObject() || type.isInterface()) {
-      const id = (type.compilerType as { id?: number }).id;
-      if (id != null && seen.has(id)) return this.namedText(type);
-      const nextSeen = id != null ? new Set(seen).add(id) : seen;
-
-      const props = type.getProperties();
-      if (props.length === 0) return this.namedText(type);
-
-      const parts = props.map((prop) =>
-        this.expandProperty(prop, nextSeen, depth),
-      );
-      return `{ ${parts.join('; ')}; }`;
-    }
-
-    return this.namedText(type);
-  }
-
-  /** Render a single property as `name[?]: <expanded>`. */
-  private expandProperty(
-    prop: Symbol,
-    seen: Set<number>,
-    depth: number,
-  ): string {
-    const optional = (prop.getFlags() & ts.SymbolFlags.Optional) !== 0;
-
-    const propDecl = prop.getDeclarations()[0];
-    // Render the key from the declaration's name node so quoted/computed keys
-    // ('x-y', "x y", [Symbol.iterator]) survive as valid TS text rather than
-    // being unquoted into invalid output; fall back to the bare symbol name.
-    const name = this.renderPropertyName(prop, propDecl);
-    let propType = propDecl
-      ? prop.getTypeAtLocation(propDecl)
-      : prop.getDeclaredType();
-
-    // An optional property's type includes `undefined`; the structural label
-    // drops it (`note?: string`, not `note?: string | undefined`).
-    if (optional && propType.isUnion()) {
-      const nonUndefined = propType
-        .getUnionTypes()
-        .filter((member) => !member.isUndefined());
-      if (nonUndefined.length === 1) {
-        propType = nonUndefined[0];
-      } else if (nonUndefined.length > 1) {
-        const inner = nonUndefined
-          .map((member) => this.expandType(member, seen, depth + 1))
-          .join(' | ');
-        return `${name}?: ${inner}`;
-      }
-    }
-
-    const inner = this.expandType(propType, seen, depth + 1);
-    return `${name}${optional ? '?' : ''}: ${inner}`;
-  }
-
-  /**
-   * The property key as valid TS text. Uses the declaration's name node so a
-   * quoted (`'x-y'`) or computed (`[Symbol.iterator]`) key keeps its syntax;
-   * `Symbol.getName()` would drop the quoting and emit invalid output. Falls
-   * back to the bare symbol name when there's no usable name node.
-   */
-  private renderPropertyName(prop: Symbol, decl: unknown): string {
-    const node = decl as
-      | { getNameNode?: () => { getText(): string } | undefined }
-      | undefined;
-    const text = node?.getNameNode?.()?.getText();
-    return text && text.length > 0 ? text : prop.getName();
-  }
-
-  /** True for tuple types (`[a, b]`), which must not be walked as objects. */
-  private isTuple(type: Type): boolean {
-    const compiler = type.compilerType as {
-      objectFlags?: number;
-      target?: { objectFlags?: number };
-    };
-    const target = compiler.target ?? compiler;
-    return ((target.objectFlags ?? 0) & ts.ObjectFlags.Tuple) !== 0;
-  }
-
-  /**
-   * True for types declared in `node_modules` or a TS `lib.*.d.ts` (Date,
-   * Promise, RegExp, …). These stay by name rather than being inlined.
-   */
-  private isLibraryType(type: Type): boolean {
-    const symbol = type.getSymbol() ?? type.getAliasSymbol();
-    if (!symbol) return false;
-    const decls = symbol.getDeclarations();
-    if (decls.length === 0) return false;
-    return decls.some((decl) => {
-      const sf = decl.getSourceFile();
-      if (sf.isInNodeModules()) return true;
-      return (
-        sf.isDeclarationFile() &&
-        // Normalize separators so a Windows `\\` path still matches lib.*.d.ts.
-        /(^|\/)lib\.[^/]*\.d\.ts$/.test(sf.getFilePath().replace(/\\/g, '/'))
-      );
-    });
-  }
-
-  /**
-   * Non-expanded text for a type. Passes `undefined` as the enclosing node so
-   * the compiler can't throw on an invalid node context (tuples and some
-   * generic instantiations do), falling back to the bare `getText()` and
-   * finally to `unknown` so a single bad type never aborts the whole resolve.
-   */
-  private namedText(type: Type): string {
-    try {
-      return type.getText(
-        undefined,
-        ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.InTypeAlias,
-      );
-    } catch {
-      try {
-        return type.getText();
-      } catch {
-        return 'unknown';
-      }
     }
   }
 

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -43,6 +43,7 @@ import type {
   ExtractionRule,
 } from './types.js';
 import { validateInferRequestItem } from './validators.js';
+import { expandTypeStructural } from './type-structural-expander.js';
 
 /**
  * Print a `Type` to its string form WITHOUT the compiler's default truncation.
@@ -1197,29 +1198,67 @@ export class TypeInferrer {
     if (varDecl) {
       const typeNode = varDecl.getTypeNode();
       if (typeNode) {
-        return typeNode.getText();
+        return this.expandAnnotationTypeNode(typeNode);
       }
     }
 
-    const asExpr = node.getFirstAncestorByKind(SyntaxKind.AsExpression);
+    // Consider the node ITSELF as well as its ancestors: the `call_result`
+    // path's terminal node for `return res.json() as Promise<T>` IS the
+    // `as` cast (an ancestor walk from it would miss it), so the #257 consumer
+    // shape would never be recovered. `as T` and `<T>x` assertions both apply.
+    const asExpr = Node.isAsExpression(node)
+      ? node
+      : node.getFirstAncestorByKind(SyntaxKind.AsExpression);
     if (asExpr) {
       const typeNode = asExpr.getTypeNode();
       if (typeNode) {
-        return typeNode.getText();
+        return this.expandAnnotationTypeNode(typeNode);
       }
     }
 
-    const typeAssertion = node.getFirstAncestorByKind(
-      SyntaxKind.TypeAssertionExpression
-    );
+    const typeAssertion = Node.isTypeAssertion(node)
+      ? node
+      : node.getFirstAncestorByKind(SyntaxKind.TypeAssertionExpression);
     if (typeAssertion) {
       const typeNode = typeAssertion.getTypeNode();
       if (typeNode) {
-        return typeNode.getText();
+        return this.expandAnnotationTypeNode(typeNode);
       }
     }
 
     return null;
+  }
+
+  /**
+   * Render an explicit annotation (`as T`, `<T>`, or a typed binding) as
+   * fully-structural text.
+   *
+   * `typeNode.getText()` keeps a named type as its bare identifier
+   * (`OrderView`, `Promise<Payment>`). A bare name is fine inside the source
+   * project but becomes a dangling reference in the cross-repo `.d.ts` bundle,
+   * which carries only alias lines and no source declarations — it resolves to
+   * `any` and the comparison reads `unverifiable`. Resolving the annotation to
+   * its `Type`, stripping `Promise<…>` at the type level, and expanding the
+   * object structurally (shared with `definition-resolver.ts`) lands the real
+   * shape (`{ id: string; currency: string }`) in the bundle so the consumer
+   * can actually be compared.
+   *
+   * Falls back to the bare annotation text when the resolved type can't be
+   * expanded to a structural form (primitives, library types, unresolvable
+   * references), so a non-object annotation behaves exactly as before.
+   */
+  private expandAnnotationTypeNode(typeNode: Node): string {
+    const fallback = typeNode.getText();
+    try {
+      const annotationType = this.unwrapPromiseType(typeNode.getType());
+      const expanded = expandTypeStructural(annotationType);
+      // Only prefer the structural form when expansion actually inlined an
+      // object shape; otherwise keep the annotation text (e.g. a bare
+      // primitive or a library type the expander leaves by name).
+      return expanded.startsWith('{') ? expanded : fallback;
+    } catch {
+      return fallback;
+    }
   }
 
   // ===========================================================================

--- a/src/sidecar/src/type-structural-expander.ts
+++ b/src/sidecar/src/type-structural-expander.ts
@@ -1,0 +1,224 @@
+/**
+ * Structural type expansion — renders a ts-morph `Type` as fully-inlined
+ * structural text, with every named object/interface member expanded to its
+ * member structure recursively.
+ *
+ * `Type.getText()` does NOT inline named members: the compiler prints a
+ * referenced type by its symbol name when that symbol is in scope
+ * (`total: Money`, not `total: { amountCents: number; currency: string }`).
+ * That is fine inside a single project, but a cross-repo bundle carries only
+ * the alias lines — no source declarations — so a named reference is a
+ * dangling identifier that resolves to `any` downstream. Expanding the shape
+ * structurally puts the real members in the bundle so the type checker can
+ * compare them.
+ *
+ * Object/interface types are expanded to their members; primitives, literals,
+ * library types (`Date`, `Promise`, tuples, …) and functions stay by name.
+ * Bounded recursion + a per-branch cycle set guard against blow-ups; any type
+ * that can't be safely expanded falls back to the non-expanded text rather
+ * than throwing.
+ *
+ * Shared by `definition-resolver.ts` (bundle alias resolution) and
+ * `type-inferrer.ts` (consumer-side inference), so both paths emit the same
+ * structural form rather than a dangling name.
+ */
+
+import { type Symbol, type Type, ts } from 'ts-morph';
+
+/**
+ * Bound on the structural-expansion recursion. Deep enough for every realistic
+ * request/response shape; a backstop against pathological/recursive types the
+ * cycle set somehow misses.
+ */
+export const MAX_EXPANSION_DEPTH = 12;
+
+/**
+ * Recursively render a `Type` as fully-inlined structural text.
+ *
+ * Named object/interface types are expanded to their member structure;
+ * primitives, literals, library types (`Date`, `Promise`, tuples, …) and
+ * functions stay by name. The `seen` set (object type ids on the current
+ * branch) breaks reference cycles; `depth` is a hard backstop.
+ */
+export function expandTypeStructural(
+  type: Type,
+  seen: Set<number> = new Set(),
+  depth = 0,
+): string {
+  if (depth > MAX_EXPANSION_DEPTH) return namedText(type);
+
+  // Primitives & literals: nothing to inline.
+  if (
+    type.isString() ||
+    type.isNumber() ||
+    type.isBoolean() ||
+    type.isBooleanLiteral() ||
+    type.isUndefined() ||
+    type.isNull() ||
+    type.isVoid() ||
+    type.isAny() ||
+    type.isUnknown() ||
+    type.isNever() ||
+    type.isStringLiteral() ||
+    type.isNumberLiteral() ||
+    type.isEnumLiteral()
+  ) {
+    return namedText(type);
+  }
+
+  // Unions / intersections: expand each member.
+  if (type.isUnion()) {
+    return type
+      .getUnionTypes()
+      .map((member) => expandTypeStructural(member, seen, depth + 1))
+      .join(' | ');
+  }
+  if (type.isIntersection()) {
+    return type
+      .getIntersectionTypes()
+      .map((member) => expandTypeStructural(member, seen, depth + 1))
+      .join(' & ');
+  }
+
+  // Tuples are array-like but must keep their `[a, b]` shape, not be walked
+  // as objects (which explodes into `Array.prototype`). Handle before arrays.
+  if (isTuple(type)) {
+    return namedText(type);
+  }
+
+  if (type.isArray()) {
+    const element = type.getArrayElementType();
+    if (!element) return namedText(type);
+    const inner = expandTypeStructural(element, seen, depth + 1);
+    // Parenthesise unions/intersections so `(A | B)[]` doesn't read as
+    // `A | B[]`; object literals already self-delimit with braces.
+    const needsParens = /[|&]/.test(inner) && !inner.startsWith('{');
+    return needsParens ? `(${inner})[]` : `${inner}[]`;
+  }
+
+  // Library / built-in types (Date, Promise, RegExp, …): keep by name.
+  if (isLibraryType(type)) {
+    return namedText(type);
+  }
+
+  // Callable/constructable object types (functions): keep by name; their
+  // structural form is the signature, which `getText` already renders.
+  if (
+    type.getCallSignatures().length > 0 ||
+    type.getConstructSignatures().length > 0
+  ) {
+    return namedText(type);
+  }
+
+  if (type.isObject() || type.isInterface()) {
+    const id = (type.compilerType as { id?: number }).id;
+    if (id != null && seen.has(id)) return namedText(type);
+    const nextSeen = id != null ? new Set(seen).add(id) : seen;
+
+    const props = type.getProperties();
+    if (props.length === 0) return namedText(type);
+
+    const parts = props.map((prop) => expandProperty(prop, nextSeen, depth));
+    return `{ ${parts.join('; ')}; }`;
+  }
+
+  return namedText(type);
+}
+
+/** Render a single property as `name[?]: <expanded>`. */
+function expandProperty(prop: Symbol, seen: Set<number>, depth: number): string {
+  const optional = (prop.getFlags() & ts.SymbolFlags.Optional) !== 0;
+
+  const propDecl = prop.getDeclarations()[0];
+  // Render the key from the declaration's name node so quoted/computed keys
+  // ('x-y', "x y", [Symbol.iterator]) survive as valid TS text rather than
+  // being unquoted into invalid output; fall back to the bare symbol name.
+  const name = renderPropertyName(prop, propDecl);
+  let propType = propDecl
+    ? prop.getTypeAtLocation(propDecl)
+    : prop.getDeclaredType();
+
+  // An optional property's type includes `undefined`; the structural label
+  // drops it (`note?: string`, not `note?: string | undefined`).
+  if (optional && propType.isUnion()) {
+    const nonUndefined = propType
+      .getUnionTypes()
+      .filter((member) => !member.isUndefined());
+    if (nonUndefined.length === 1) {
+      propType = nonUndefined[0];
+    } else if (nonUndefined.length > 1) {
+      const inner = nonUndefined
+        .map((member) => expandTypeStructural(member, seen, depth + 1))
+        .join(' | ');
+      return `${name}?: ${inner}`;
+    }
+  }
+
+  const inner = expandTypeStructural(propType, seen, depth + 1);
+  return `${name}${optional ? '?' : ''}: ${inner}`;
+}
+
+/**
+ * The property key as valid TS text. Uses the declaration's name node so a
+ * quoted (`'x-y'`) or computed (`[Symbol.iterator]`) key keeps its syntax;
+ * `Symbol.getName()` would drop the quoting and emit invalid output. Falls
+ * back to the bare symbol name when there's no usable name node.
+ */
+function renderPropertyName(prop: Symbol, decl: unknown): string {
+  const node = decl as
+    | { getNameNode?: () => { getText(): string } | undefined }
+    | undefined;
+  const text = node?.getNameNode?.()?.getText();
+  return text && text.length > 0 ? text : prop.getName();
+}
+
+/** True for tuple types (`[a, b]`), which must not be walked as objects. */
+function isTuple(type: Type): boolean {
+  const compiler = type.compilerType as {
+    objectFlags?: number;
+    target?: { objectFlags?: number };
+  };
+  const target = compiler.target ?? compiler;
+  return ((target.objectFlags ?? 0) & ts.ObjectFlags.Tuple) !== 0;
+}
+
+/**
+ * True for types declared in `node_modules` or a TS `lib.*.d.ts` (Date,
+ * Promise, RegExp, …). These stay by name rather than being inlined.
+ */
+function isLibraryType(type: Type): boolean {
+  const symbol = type.getSymbol() ?? type.getAliasSymbol();
+  if (!symbol) return false;
+  const decls = symbol.getDeclarations();
+  if (decls.length === 0) return false;
+  return decls.some((decl) => {
+    const sf = decl.getSourceFile();
+    if (sf.isInNodeModules()) return true;
+    return (
+      sf.isDeclarationFile() &&
+      // Normalize separators so a Windows `\\` path still matches lib.*.d.ts.
+      /(^|\/)lib\.[^/]*\.d\.ts$/.test(sf.getFilePath().replace(/\\/g, '/'))
+    );
+  });
+}
+
+/**
+ * Non-expanded text for a type. Passes `undefined` as the enclosing node so
+ * the compiler can't throw on an invalid node context (tuples and some
+ * generic instantiations do), falling back to the bare `getText()` and
+ * finally to `unknown` so a single bad type never aborts the whole resolve.
+ */
+export function namedText(type: Type): string {
+  try {
+    return type.getText(
+      undefined,
+      ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.InTypeAlias,
+    );
+  } catch {
+    try {
+      return type.getText();
+    } catch {
+      return 'unknown';
+    }
+  }
+}

--- a/src/sidecar/src/type-structural-expander.ts
+++ b/src/sidecar/src/type-structural-expander.ts
@@ -90,9 +90,11 @@ export function expandTypeStructural(
     const element = type.getArrayElementType();
     if (!element) return namedText(type);
     const inner = expandTypeStructural(element, seen, depth + 1);
-    // Parenthesise unions/intersections so `(A | B)[]` doesn't read as
-    // `A | B[]`; object literals already self-delimit with braces.
-    const needsParens = /[|&]/.test(inner) && !inner.startsWith('{');
+    // Parenthesise a union/intersection element so `(A | B)[]` doesn't misparse
+    // as `A | B[]`. Decide from the TYPE, not the string: a single object
+    // literal like `{ a: A | B }` is NOT a union and must not be parenthesised,
+    // and a union led by an object literal (`{ a: string } | null`) MUST be.
+    const needsParens = element.isUnion() || element.isIntersection();
     return needsParens ? `(${inner})[]` : `${inner}[]`;
   }
 

--- a/src/sidecar/test/expander-array-parens.test.ts
+++ b/src/sidecar/test/expander-array-parens.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression for the array-element parenthesisation in the shared structural
+ * expander (#257 Copilot review). A union/intersection array element must be
+ * wrapped in parens before `[]` — `(A | B)[]`, not `A | B[]` — decided from the
+ * TYPE, not by string inspection (a union led by an object literal,
+ * `{ a: string } | null`, must still be parenthesised; a plain object array
+ * `{ a: string }[]` must NOT).
+ */
+
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { Project } from 'ts-morph';
+import { expandTypeStructural } from '../src/type-structural-expander.js';
+
+const noWs = (s: string) => s.replace(/\s/g, '');
+
+describe('expandTypeStructural array parenthesisation (#257)', () => {
+  // strict on, so `Box | null` stays a real union (non-strict absorbs null).
+  const project = new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: { strict: true },
+  });
+  const sf = project.createSourceFile(
+    'arr.ts',
+    `
+    interface Box { a: string }
+    type ArrOfUnion = (Box | null)[];
+    type UnionLedByObject = ({ a: string } | null)[];
+    type ArrOfObject = Box[];
+    `,
+  );
+  const expand = (name: string) =>
+    expandTypeStructural(sf.getTypeAliasOrThrow(name).getType());
+
+  it('parenthesises a union array element', () => {
+    const out = expand('ArrOfUnion');
+    assert.match(out, /^\(.*\)\[\]$/, `expected (…)[], got: ${out}`);
+    assert.ok(out.includes('null'), `expected null member, got: ${out}`);
+    assert.ok(noWs(out).includes('a:string'), `expected the Box shape, got: ${out}`);
+  });
+
+  it('parenthesises a union led by an object literal (the bug)', () => {
+    const out = expand('UnionLedByObject');
+    assert.match(out, /^\(.*\)\[\]$/, `expected (…)[], got: ${out}`);
+    assert.ok(out.includes('null'), `expected null member, got: ${out}`);
+  });
+
+  it('does NOT parenthesise a plain object array', () => {
+    const out = expand('ArrOfObject');
+    assert.ok(!out.startsWith('('), `must not parenthesise an object array, got: ${out}`);
+    assert.match(out, /\}\[\]$/, `expected {…}[], got: ${out}`);
+  });
+});

--- a/src/sidecar/test/fixtures/sample-repo/src/fetch-json.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/fetch-json.ts
@@ -3,3 +3,17 @@ export async function loadUser() {
   const user: { id: string; name: string } = await response.json();
   return user;
 }
+
+// #257: cross-repo consumer shape. An `as Promise<NamedInterface>` cast on a
+// json() call is the exact pattern that produced a dangling `= OrderView`
+// alias in the bundle. The named interface must be recovered STRUCTURALLY so
+// the cross-repo .d.ts carries the real members
+// (`{ id: string; currency: string }`), not a name that resolves to `any`.
+export interface OrderView {
+  id: string;
+  currency: string;
+}
+
+export async function loadOrder(res: Response) {
+  return res.json() as Promise<OrderView>;
+}

--- a/src/sidecar/test/infer-call-result-structural.test.ts
+++ b/src/sidecar/test/infer-call-result-structural.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Targeted regression for issue #257.
+ *
+ * A consumer like `return res.json() as Promise<OrderView>` routes through the
+ * `call_result` inference path. The inferrer used to resolve the `as
+ * Promise<OrderView>` annotation to its TEXT, then string-unwrap the Promise,
+ * yielding the bare type NAME `"OrderView"`. The engine wrote that verbatim
+ * into the cross-repo `<repo>_types.d.ts` as `export type <alias> = OrderView;`
+ * — but those bundle files carry only alias lines, no source declarations. So
+ * `OrderView` was a dangling reference → resolved to `any` → ts_check reported
+ * `unverifiable` → `compat = None`. The consumer's real, recoverable shape was
+ * discarded.
+ *
+ * The fix expands the annotation's named object type STRUCTURALLY (the same
+ * inliner #246 shipped for the definition-resolver, now shared via
+ * `type-structural-expander.ts`), so the inferred type carries the real
+ * members `{ id: string; currency: string }` and lands in the bundle as a
+ * self-contained shape the type checker can actually compare.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const FIXTURE = path.join(FIXTURES_PATH, 'src/fetch-json.ts');
+const FIXTURE_SOURCE = fs.readFileSync(FIXTURE, 'utf-8');
+
+/** Byte span of `text` in the fixture (ASCII-only file, so byte == char offsets). */
+function spanOf(text: string): { start: number; end: number; line: number } {
+  const start = FIXTURE_SOURCE.indexOf(text);
+  assert.ok(start >= 0, `fixture must contain: ${text}`);
+  assert.strictEqual(
+    FIXTURE_SOURCE.indexOf(text, start + 1),
+    -1,
+    `fixture must contain exactly one occurrence of: ${text}`
+  );
+  const line = FIXTURE_SOURCE.slice(0, start).split('\n').length;
+  return { start, end: start + text.length, line };
+}
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    infer_kind: string;
+    is_explicit: boolean;
+  }>;
+  errors?: string[];
+}
+
+describe('call_result structural expansion (#257)', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'infer257-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('expands a `res.json() as Promise<T>` consumer to T\'s structural shape, not the bare name', async () => {
+    // Locator covers the `res.json()` call inside
+    // `return res.json() as Promise<OrderView>`. The `as Promise<OrderView>`
+    // annotation must win AND be emitted structurally.
+    const call = spanOf('res.json() as Promise<OrderView>');
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'infer257-call-result',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: call.line,
+          span_start: call.start,
+          span_end: call.start + 'res.json()'.length,
+          infer_kind: 'call_result',
+          alias: 'OrderViewConsumer',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'OrderViewConsumer'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+
+    // The bug: a bare `OrderView` (dangling in the cross-repo bundle).
+    assert.notStrictEqual(
+      inferred.type_string,
+      'OrderView',
+      'must not emit the bare type name — it dangles in the cross-repo bundle'
+    );
+    assert.notStrictEqual(
+      inferred.type_string,
+      'Promise<OrderView>',
+      'Promise must be unwrapped at the type level'
+    );
+
+    // The fix: the real, self-contained member shape.
+    assert.strictEqual(
+      inferred.type_string,
+      '{ id: string; currency: string; }',
+      `expected the structural shape, got ${inferred.type_string}`
+    );
+    assert.strictEqual(
+      inferred.is_explicit,
+      true,
+      'a recovered declared type must be reported explicit'
+    );
+  });
+});

--- a/src/sidecar/test/request-body-cast.test.ts
+++ b/src/sidecar/test/request-body-cast.test.ts
@@ -8,11 +8,21 @@
  * `await`/`as`/paren/`!` wrappers and let an explicit `as T` cast or typed
  * binding/annotation on an ancestor win over the call's raw type.
  *
+ * Per #257 the recovered annotation is now emitted STRUCTURALLY (the object's
+ * member shape), not as the bare type name. A bare name is fine inside the
+ * source project but becomes a dangling reference in the cross-repo `.d.ts`
+ * bundle (alias lines only, no source declarations) → resolves to `any` →
+ * `unverifiable`. So `RegisterRequest` is recovered as
+ * `{ username: string; password: string; }`.
+ *
  * The control case proves the genuinely-untyped path is preserved: an
  * untyped `await request.formData()` must stay `FormData`/`any` (faithful,
  * not a bug — #133 lists it as NOT-a-bug), never "recovered" into a
  * declared type that was never written.
  */
+
+/** Structural form of `interface RegisterRequest { username; password }`. */
+const REGISTER_REQUEST_STRUCTURAL = '{ username: string; password: string; }';
 
 import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert';
@@ -68,7 +78,8 @@ describe('Request body cast/binding regressions (#133 A1)', () => {
   it('follows an `as T` cast on an awaited request.json()', async () => {
     // Locator covers the `request.json()` call inside
     // `(await request.json()) as RegisterRequest`. The raw type is
-    // `Promise<any>`; the `as RegisterRequest` cast must win.
+    // `Promise<any>`; the `as RegisterRequest` cast must win — recovered as
+    // the structural member shape (#257), not the dangling name.
     const call = spanOf('(await request.json()) as RegisterRequest');
     const innerStart = call.start + '(await '.length;
     const response = await client.send<InferResponseShape>({
@@ -95,8 +106,8 @@ describe('Request body cast/binding regressions (#133 A1)', () => {
     );
     assert.strictEqual(
       inferred.type_string,
-      'RegisterRequest',
-      `expected the cast type to win, got ${inferred.type_string}`
+      REGISTER_REQUEST_STRUCTURAL,
+      `expected the cast type to win (structural), got ${inferred.type_string}`
     );
     assert.strictEqual(
       inferred.is_explicit,
@@ -137,8 +148,8 @@ describe('Request body cast/binding regressions (#133 A1)', () => {
     );
     assert.strictEqual(
       inferred.type_string,
-      'RegisterRequest',
-      `expected the cast type to win when located ON the cast, got ${inferred.type_string}`
+      REGISTER_REQUEST_STRUCTURAL,
+      `expected the cast type to win when located ON the cast (structural), got ${inferred.type_string}`
     );
     assert.strictEqual(
       inferred.is_explicit,
@@ -176,8 +187,8 @@ describe('Request body cast/binding regressions (#133 A1)', () => {
     );
     assert.strictEqual(
       inferred.type_string,
-      'RegisterRequest',
-      `expected the typed binding to win, got ${inferred.type_string}`
+      REGISTER_REQUEST_STRUCTURAL,
+      `expected the typed binding to win (structural), got ${inferred.type_string}`
     );
     assert.strictEqual(
       inferred.is_explicit,
@@ -218,7 +229,7 @@ describe('Request body cast/binding regressions (#133 A1)', () => {
     );
     assert.notStrictEqual(
       inferred.type_string,
-      'RegisterRequest',
+      REGISTER_REQUEST_STRUCTURAL,
       'must not invent a declared type that was never written'
     );
   });

--- a/ts_check/lib/type-checker.test.ts
+++ b/ts_check/lib/type-checker.test.ts
@@ -465,6 +465,98 @@ describe('TypeCompatibilityChecker', () => {
       assert.strictEqual(result.mismatches.length, 1);
     });
 
+    it('reads a dangling consumer name as unverifiable but its structural shape as incompatible (#257)', async () => {
+      // The #257 inference bug: a consumer like `res.json() as Promise<OrderView>`
+      // wrote the bare NAME `= OrderView` into the cross-repo bundle. The bundle
+      // carries only alias lines and no source declaration for `OrderView`, so
+      // the name dangles → resolves to `any` → the edge reads unverifiable and
+      // the genuine string-vs-number mismatch is masked.
+      //
+      // Producer `Order.id` is number; consumer `OrderView.id` is string. The two
+      // halves of this test pin both ends of the fix:
+      //  - bundling the bare dangling name reproduces the masked `unverifiable`;
+      //  - bundling the STRUCTURAL shape the fixed inferrer now emits surfaces the
+      //    real `incompatible`.
+      const danglingProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      // `= MissingShape` referencing a type with no declaration in the bundle —
+      // exactly the dangling alias the old inference path produced. It resolves
+      // to `any`, so the comparison is unverifiable.
+      danglingProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type Order = { id: number; amountCents: number; currency: string };
+        export type OrderView = MissingShape;
+        `,
+        { overwrite: true }
+      );
+
+      const structuralProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      // The member shape the fixed inferrer now emits for the same consumer.
+      structuralProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type Order = { id: number; amountCents: number; currency: string };
+        export type OrderView = { id: string; currency: string };
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'orders-api',
+        commit_hash: 'abc',
+        entries: [
+          createManifestEntry(
+            'GET',
+            '/orders/:id',
+            'Order',
+            'producer',
+            'routes.ts',
+            10
+          ),
+        ],
+      };
+
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def',
+        entries: [
+          createManifestEntry(
+            'GET',
+            '/orders/:id',
+            'OrderView',
+            'consumer',
+            'api.ts',
+            5
+          ),
+        ],
+      };
+
+      const dangling = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        danglingProject
+      );
+      // Before the fix: the dangling name masks the mismatch as unverifiable.
+      assert.strictEqual(dangling.incompatiblePairs, 0);
+      assert.strictEqual(dangling.compatiblePairs, 0);
+      assert.strictEqual(dangling.unknownPairs.length, 1);
+
+      const structural = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        structuralProject
+      );
+      // After the fix: the real shape surfaces the genuine string-vs-number mismatch.
+      assert.strictEqual(structural.incompatiblePairs, 1);
+      assert.strictEqual(structural.compatiblePairs, 0);
+      assert.strictEqual(structural.unknownPairs.length, 0);
+      assert.strictEqual(structural.mismatches.length, 1);
+    });
+
     it('flags only the Carrick-marked `= unknown` as the injected placeholder (#244)', async () => {
       // The marked alias is the injected placeholder: it short-circuits on the
       // type_state=unknown path. The unmarked, developer-authored `= unknown`


### PR DESCRIPTION
## Summary

A consumer like `return res.json() as Promise<OrderView>` (and awaited call results) routed through the inference path, where the inferrer emitted the **bare type NAME** `OrderView`. The engine wrote that verbatim into the cross-repo `<repo>_types.d.ts` as `export type <alias> = OrderView;` — but those bundle files carry only alias lines, no source declarations. So the name **dangled → resolved to `any` → ts_check reported `unverifiable` → `compat = None`**, masking the consumer's real, recoverable shape (this deterministically explains `payments-svc|POST|/payments -> web-frontend` reading `None`).

## Fix

Expand a recovered named object annotation **structurally** (walk `getProperties()` recursively) in the inference path, so the bundle carries the real members `{ id: string; currency: string }` instead of a dangling reference.

This is the same technique #246 shipped for the definition-resolver. That recursive inliner is **factored out into a shared `src/sidecar/src/type-structural-expander.ts` module and reused by both paths** rather than duplicated:

- `type-inferrer.ts` — `extractExplicitTypeFromAncestor` now expands the `as T` / `<T>` / typed-binding annotation structurally (Promise unwrapped at the type level), and also matches the cast when the located node **is** the cast itself (the `call_result` terminal node for `return <expr> as T`, which an ancestor-only walk missed).
- `definition-resolver.ts` — delegates to the shared expander (no behaviour change; the #246 expansion tests still pass).

Non-object annotations (primitives, library types) fall back to the bare text, so behaviour outside the dangling-name class is unchanged. `compareTypes` and the Rust manifest plumbing are untouched.

## Tests

- **sidecar**: new `call_result` test proving `res.json() as Promise<T>` where `T` is a named interface yields the **structural shape** `{ id: string; currency: string; }`, not the bare name `T`.
- **ts_check**: new test proving a dangling consumer name reads `unverifiable`, while its structural `{id:string}` shape vs producer `{id:number}` reads `incompatible` — i.e. once inference produces the real shape, the pipeline gets it right.
- request-body cast/binding tests updated to assert the structural form.
- Full `cargo test` (incl. cassette hard gate), `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, sidecar `npm test`, `ts_check npm test` all green.

## Cassette golden

**Unchanged** — the mock emits null types, so inference never runs on it.

Closes #257
Refs #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)