### PR TITLE
fix(sidecar): producer structural expansion + deterministic type anchor

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1958,18 +1958,17 @@ fn enrich_manifest_with_type_resolution(
     // Deterministic anchor source (#240): the sidecar resolves each inferred
     // type's real source symbol (`Payment`) off the ts-morph `Type`, so a
     // manifest entry whose anchor the LLM left unset can be filled from it.
-    // Join by `(file_path, start_line)` — the same coordinates
-    // `stamp_manifest_anchor_symbols` uses — so the symbol lands on the right
-    // op. First non-None wins per location, so a later inferred entry can't
+    // Join by `alias` — the same key the resolved-type lookup below uses to
+    // marry an `InferredType` to its manifest entry. A `(file_path, line)` join
+    // would be fragile: the sidecar's `source_location` is an absolute ts-morph
+    // path while `entry.file_path` is repo-relative, so the coordinates need not
+    // line up. First non-None wins per alias, so a later inferred entry can't
     // clobber an earlier real symbol.
-    let mut inferred_symbols: HashMap<(String, u32), String> = HashMap::new();
+    let mut inferred_symbols: HashMap<String, String> = HashMap::new();
     for inferred in &type_resolution.inferred_types {
         if let Some(symbol) = inferred.primary_type_symbol.as_ref() {
             inferred_symbols
-                .entry((
-                    inferred.source_location.file_path.clone(),
-                    inferred.source_location.start_line,
-                ))
+                .entry(inferred.alias.clone())
                 .or_insert_with(|| symbol.clone());
         }
     }
@@ -2009,8 +2008,7 @@ fn enrich_manifest_with_type_resolution(
         // socket) are never regressed. Stamping runs before enrichment, so any
         // entry still `None` here had no LLM anchor.
         if entry.primary_type_symbol.is_none()
-            && let Some(symbol) =
-                inferred_symbols.get(&(entry.file_path.clone(), entry.line_number))
+            && let Some(symbol) = inferred_symbols.get(&entry.type_alias)
         {
             entry.primary_type_symbol = Some(symbol.clone());
         }
@@ -3681,14 +3679,15 @@ mod tests {
         assert_eq!(manifest[0].type_state, ManifestTypeState::Unknown);
     }
 
-    /// An inferred type carrying a deterministic symbol at the entry's location
-    /// (`lib/api.ts:5`), with a hashed alias that doesn't match `type_alias`.
-    /// `consumer_entry` sits at `lib/api.ts:5`, so the location join fires.
+    /// An inferred type carrying a deterministic symbol, keyed by the same
+    /// `alias` as the manifest entry it enriches — the join the anchor fill
+    /// uses. `type_string` is a resolved object, so only the anchor (not the
+    /// type-state path) is under test here.
     fn inferred_with_symbol(symbol: &str) -> InferredType {
         InferredType {
-            // A hashed alias that deliberately does NOT equal the manifest
-            // `type_alias` — the anchor join is by location, not alias.
-            alias: "Endpoint_abc123_Response".to_string(),
+            // Matches `consumer_entry("OrderView").type_alias`, so the anchor
+            // join (by alias) fires.
+            alias: "OrderView".to_string(),
             type_string: "{ id: string; currency: string }".to_string(),
             is_explicit: false,
             source_location: SourceLocation {
@@ -3704,7 +3703,7 @@ mod tests {
     }
 
     /// #240: the deterministic anchor fills `primary_type_symbol` from the
-    /// inferred symbol, joined by `(file_path, line)`, when the LLM left it None.
+    /// inferred symbol, joined by `alias`, when the LLM left it None.
     #[test]
     fn enrich_fills_anchor_from_inferred_symbol_when_llm_none() {
         let mut manifest = vec![consumer_entry("OrderView")];

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1955,6 +1955,25 @@ fn enrich_manifest_with_type_resolution(
         }
     }
 
+    // Deterministic anchor source (#240): the sidecar resolves each inferred
+    // type's real source symbol (`Payment`) off the ts-morph `Type`, so a
+    // manifest entry whose anchor the LLM left unset can be filled from it.
+    // Join by `(file_path, start_line)` — the same coordinates
+    // `stamp_manifest_anchor_symbols` uses — so the symbol lands on the right
+    // op. First non-None wins per location, so a later inferred entry can't
+    // clobber an earlier real symbol.
+    let mut inferred_symbols: HashMap<(String, u32), String> = HashMap::new();
+    for inferred in &type_resolution.inferred_types {
+        if let Some(symbol) = inferred.primary_type_symbol.as_ref() {
+            inferred_symbols
+                .entry((
+                    inferred.source_location.file_path.clone(),
+                    inferred.source_location.start_line,
+                ))
+                .or_insert_with(|| symbol.clone());
+        }
+    }
+
     // Also check the bundled .d.ts content for defined types
     // This catches types that were successfully bundled but not in the manifest.
     // Exclude aliases defined as `= unknown` — those are placeholders for failed
@@ -1985,6 +2004,17 @@ fn enrich_manifest_with_type_resolution(
 
     // Update manifest entries
     for entry in manifest.iter_mut() {
+        // Fill the deterministic anchor ONLY when the LLM left it unset, so the
+        // ops where the model already emitted a correct symbol (POST /payments,
+        // socket) are never regressed. Stamping runs before enrichment, so any
+        // entry still `None` here had no LLM anchor.
+        if entry.primary_type_symbol.is_none()
+            && let Some(symbol) =
+                inferred_symbols.get(&(entry.file_path.clone(), entry.line_number))
+        {
+            entry.primary_type_symbol = Some(symbol.clone());
+        }
+
         if let Some((type_string, is_explicit)) = resolved_types.get(&entry.type_alias) {
             // Check if the type is actually resolved (not "unknown")
             let is_unknown_type = type_string.trim() == "unknown"
@@ -3616,6 +3646,7 @@ mod tests {
                 end_column: None,
             },
             infer_kind: InferKind::CallResult,
+            primary_type_symbol: None,
         });
 
         enrich_manifest_with_type_resolution(&mut manifest, &resolution, None);
@@ -3642,11 +3673,80 @@ mod tests {
                 end_column: None,
             },
             infer_kind: InferKind::CallResult,
+            primary_type_symbol: None,
         });
 
         enrich_manifest_with_type_resolution(&mut manifest, &resolution, None);
 
         assert_eq!(manifest[0].type_state, ManifestTypeState::Unknown);
+    }
+
+    /// An inferred type carrying a deterministic symbol at the entry's location
+    /// (`lib/api.ts:5`), with a hashed alias that doesn't match `type_alias`.
+    /// `consumer_entry` sits at `lib/api.ts:5`, so the location join fires.
+    fn inferred_with_symbol(symbol: &str) -> InferredType {
+        InferredType {
+            // A hashed alias that deliberately does NOT equal the manifest
+            // `type_alias` — the anchor join is by location, not alias.
+            alias: "Endpoint_abc123_Response".to_string(),
+            type_string: "{ id: string; currency: string }".to_string(),
+            is_explicit: false,
+            source_location: SourceLocation {
+                file_path: "lib/api.ts".to_string(),
+                start_line: 5,
+                end_line: 5,
+                start_column: None,
+                end_column: None,
+            },
+            infer_kind: InferKind::ResponseBody,
+            primary_type_symbol: Some(symbol.to_string()),
+        }
+    }
+
+    /// #240: the deterministic anchor fills `primary_type_symbol` from the
+    /// inferred symbol, joined by `(file_path, line)`, when the LLM left it None.
+    #[test]
+    fn enrich_fills_anchor_from_inferred_symbol_when_llm_none() {
+        let mut manifest = vec![consumer_entry("OrderView")];
+        // The LLM stamped nothing onto this op.
+        assert_eq!(manifest[0].primary_type_symbol, None);
+
+        let mut resolution = empty_resolution();
+        resolution
+            .inferred_types
+            .push(inferred_with_symbol("OrderView"));
+
+        enrich_manifest_with_type_resolution(&mut manifest, &resolution, None);
+
+        assert_eq!(
+            manifest[0].primary_type_symbol.as_deref(),
+            Some("OrderView"),
+            "anchor must be filled from the inferred symbol when the LLM left it None"
+        );
+    }
+
+    /// #240: an op the LLM already anchored correctly must NOT be overwritten by
+    /// the inferred symbol — the deterministic fill is None-only so POST
+    /// /payments and socket ops keep their model-emitted symbol.
+    #[test]
+    fn enrich_does_not_override_existing_llm_anchor() {
+        let mut manifest = vec![consumer_entry("OrderView")];
+        // The LLM already stamped the real symbol for this op.
+        manifest[0].primary_type_symbol = Some("Payment".to_string());
+
+        let mut resolution = empty_resolution();
+        // The sidecar inferred a DIFFERENT symbol at the same location.
+        resolution
+            .inferred_types
+            .push(inferred_with_symbol("OrderView"));
+
+        enrich_manifest_with_type_resolution(&mut manifest, &resolution, None);
+
+        assert_eq!(
+            manifest[0].primary_type_symbol.as_deref(),
+            Some("Payment"),
+            "an existing LLM anchor must never be regressed by the inferred symbol"
+        );
     }
 
     /// The Carrick-injected `= unknown` placeholder (carrying the marker) in the

--- a/src/services/type_sidecar.rs
+++ b/src/services/type_sidecar.rs
@@ -239,6 +239,12 @@ pub struct InferredType {
     pub source_location: SourceLocation,
     /// The kind of inference that was performed
     pub infer_kind: InferKind,
+    /// Deterministic source symbol of the resolved type (`Payment`), from the
+    /// sidecar's `getSymbol() || getAliasSymbol()` name with TS/lib globals
+    /// filtered out. Fills the manifest anchor (`primary_type_symbol`) when the
+    /// LLM emitted none, removing the anchor's sole dependency on the model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_type_symbol: Option<String>,
 }
 
 /// Information about a symbol that failed to resolve

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -46,6 +46,43 @@ import { validateInferRequestItem } from './validators.js';
 import { expandTypeStructural } from './type-structural-expander.js';
 
 /**
+ * TS/lib globals and primitives that must never be emitted as a deterministic
+ * type anchor (`primary_type_symbol`). A payload whose resolved symbol is one of
+ * these is library machinery, not a user contract — mirror of the Rust-side
+ * `is_builtin_type` filter in `socket_io.rs` so the HTTP-inference anchor and the
+ * socket anchor reject the same set.
+ */
+const BUILTIN_ANCHOR_SYMBOLS = new Set<string>([
+  'any',
+  'unknown',
+  'never',
+  'void',
+  'object',
+  'string',
+  'number',
+  'boolean',
+  'bigint',
+  'symbol',
+  'undefined',
+  'null',
+  'Array',
+  'Promise',
+  'Record',
+  'Map',
+  'Set',
+  'Date',
+  'Object',
+  'String',
+  'Number',
+  'Boolean',
+  'Symbol',
+  'BigInt',
+  'Function',
+  'RegExp',
+  'Error',
+]);
+
+/**
  * Print a `Type` to its string form WITHOUT the compiler's default truncation.
  *
  * `Type.getText()` truncates large/anonymous object types to ~160 chars and inserts
@@ -253,6 +290,13 @@ export class TypeInferrer {
     const unwrapResult = this.unwrapTypeWithConfig(awaitedType, func, extractionConfig);
     if (unwrapResult.wasUnwrapped) {
       typeString = unwrapResult.typeString;
+    } else {
+      // No wrapper rule fired: the (awaited) return resolved to its own type.
+      // A named object return (`async (): Promise<Payment> => …`) renders as the
+      // bare name `Payment`, which dangles in the source-less cross-repo bundle.
+      // Expand the resolved object structurally so the real members reach the
+      // bundle. `unwrapPromise` below is then a no-op on the structural form.
+      typeString = this.expandResolvedTypeStructural(awaitedType, typeString);
     }
 
     typeString = this.unwrapPromise(typeString, returnType);
@@ -262,7 +306,8 @@ export class TypeInferrer {
       typeString,
       isExplicit,
       this.getNodeLocation(func),
-      unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined
+      unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined,
+      this.primaryTypeSymbol(awaitedType)
     );
   }
 
@@ -391,6 +436,14 @@ export class TypeInferrer {
     );
     if (unwrapResult.wasUnwrapped) {
       typeString = unwrapResult.typeString;
+    } else {
+      // No wrapper rule fired: the payload resolved straight to its own type.
+      // If that's a named object (`res.json(payment)` with `payment: Payment`),
+      // `typeText` keeps the bare name `Payment`, which dangles in the
+      // source-less cross-repo bundle → `any` → unverifiable. Expand the
+      // resolved object structurally so the real members land in the bundle.
+      const resolved = this.unwrapPromiseType(payloadType);
+      typeString = this.expandResolvedTypeStructural(resolved, typeString);
     }
 
     return this.createInferredType(
@@ -398,7 +451,8 @@ export class TypeInferrer {
       typeString,
       false,
       this.getNodeLocation(payloadNode),
-      unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined
+      unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined,
+      this.primaryTypeSymbol(this.unwrapPromiseType(payloadType))
     );
   }
 
@@ -1261,6 +1315,48 @@ export class TypeInferrer {
     }
   }
 
+  /**
+   * Producer-side analogue of `expandAnnotationTypeNode` that works from a
+   * resolved `Type` rather than a syntactic annotation node.
+   *
+   * `inferResponseBody`/`inferFunctionReturn` resolve a payload to a named
+   * object type (e.g. `Payment`), then render it with `typeText`, which keeps
+   * the bare name. In the source-less cross-repo `.d.ts` bundle that name is a
+   * dangling `export type <alias> = Payment;` → resolves to `any` →
+   * `unverifiable` → `compat = None`. Expanding the resolved object structurally
+   * lands the real members (`{ id: string; … }`) in the bundle so the producer
+   * can be compared. Mirror of #257's consumer-side fix; keeps the bare text for
+   * primitives, library types, and anything the expander leaves by name.
+   *
+   * `fallback` is the already-computed type text (post Promise/wrapper unwrap),
+   * preserved verbatim when expansion does not inline an object.
+   */
+  private expandResolvedTypeStructural(type: Type, fallback: string): string {
+    try {
+      const expanded = expandTypeStructural(type);
+      return expanded.startsWith('{') ? expanded : fallback;
+    } catch {
+      return fallback;
+    }
+  }
+
+  /**
+   * The deterministic source symbol of a resolved type (`Payment` for a payload
+   * typed `Payment`), or `undefined` when there is no single user-defined
+   * symbol to anchor on. This is the same `getSymbol() || getAliasSymbol()` name
+   * the socket anchor already derives (`socket_io.rs`), filtered through
+   * `BUILTIN_ANCHOR_SYMBOLS` so TS/lib globals (`Promise`, `Array`, `Date`,
+   * primitives, …) never become an anchor. Used to populate
+   * `primary_type_symbol` so the manifest anchor no longer depends on the LLM.
+   */
+  private primaryTypeSymbol(type: Type): string | undefined {
+    const name = (type.getSymbol() || type.getAliasSymbol())?.getName();
+    if (!name || name === '__type' || BUILTIN_ANCHOR_SYMBOLS.has(name)) {
+      return undefined;
+    }
+    return name;
+  }
+
   // ===========================================================================
   // Node Finding
   // ===========================================================================
@@ -1709,7 +1805,8 @@ export class TypeInferrer {
     typeString: string,
     isExplicit: boolean,
     sourceLocation: SourceLocation,
-    payloadTypeString?: string
+    payloadTypeString?: string,
+    primaryTypeSymbol?: string
   ): InferredType {
     const alias =
       request.alias ||
@@ -1722,6 +1819,7 @@ export class TypeInferrer {
       source_location: sourceLocation,
       infer_kind: request.infer_kind,
       payload_type_string: payloadTypeString,
+      primary_type_symbol: primaryTypeSymbol,
     };
   }
 

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -1334,7 +1334,13 @@ export class TypeInferrer {
   private expandResolvedTypeStructural(type: Type, fallback: string): string {
     try {
       const expanded = expandTypeStructural(type);
-      return expanded.startsWith('{') ? expanded : fallback;
+      // Prefer the expanded form whenever an object got inlined, not only when
+      // it leads with `{`. `expandTypeStructural` wraps arrays and unions, so a
+      // resolved `Payment[]` or `(Payment | null)[]` renders as `{…}[]` or
+      // `({…} | null)[]`; a `startsWith('{')` test would miss those and fall
+      // back to the bare, dangling name. Any `{` means real members reached the
+      // bundle.
+      return expanded.includes('{') ? expanded : fallback;
     } catch {
       return fallback;
     }
@@ -1351,7 +1357,10 @@ export class TypeInferrer {
    */
   private primaryTypeSymbol(type: Type): string | undefined {
     const name = (type.getSymbol() || type.getAliasSymbol())?.getName();
-    if (!name || name === '__type' || BUILTIN_ANCHOR_SYMBOLS.has(name)) {
+    // Reject the compiler's synthetic names for anonymous shapes (`__type`,
+    // `__object`, `__function`, …). They are not user-facing type names, so
+    // they would be a meaningless — and non-resolvable — anchor.
+    if (!name || name.startsWith('__') || BUILTIN_ANCHOR_SYMBOLS.has(name)) {
       return undefined;
     }
     return name;

--- a/src/sidecar/src/types.ts
+++ b/src/sidecar/src/types.ts
@@ -543,6 +543,14 @@ export interface InferredType {
   infer_kind: InferKind;
   /** The unwrapped/extracted payload type (if different from type_string) */
   payload_type_string?: string;
+  /**
+   * The deterministic source symbol of the resolved type (`Payment`), derived
+   * from the ts-morph `Type`'s `getSymbol() || getAliasSymbol()` name with
+   * TS/lib globals filtered out. Lets the manifest anchor (`primary_type_symbol`)
+   * be filled without depending on the LLM. `undefined` when the resolved type
+   * has no single user-defined symbol to anchor on.
+   */
+  primary_type_symbol?: string;
 }
 
 /**

--- a/src/sidecar/test/fixtures/sample-repo/src/fetch-json.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/fetch-json.ts
@@ -17,3 +17,24 @@ export interface OrderView {
 export async function loadOrder(res: Response) {
   return res.json() as Promise<OrderView>;
 }
+
+// #257/#240: PRODUCER-side structural expansion + deterministic anchor.
+// A producer emitting a payload typed `Payment` used to infer the bare name
+// `Payment`, which dangles in the source-less cross-repo bundle as
+// `export type <alias> = Payment;` → resolves to `any` → unverifiable →
+// `compat = None`. The payload must be expanded STRUCTURALLY to its members,
+// and the inferred type must carry `primary_type_symbol: "Payment"` so the
+// manifest anchor no longer depends on the LLM.
+export interface Payment {
+  id: string;
+  amountCents: number;
+  currency: string;
+}
+
+interface ResLike {
+  json: (data: unknown) => void;
+}
+
+export function sendPayment(res: ResLike, payment: Payment) {
+  res.json(payment);
+}

--- a/src/sidecar/test/gap-regression.test.ts
+++ b/src/sidecar/test/gap-regression.test.ts
@@ -133,9 +133,12 @@ describe('Type inferrer gap regressions', () => {
       (t) => t.alias === 'GapSubstringControl'
     );
     assert.ok(inferred, 'expected inferred type for accurate locator');
-    assert.ok(
-      inferred.type_string.includes('User'),
-      `expected User[], got ${inferred.type_string}`
+    // #257/#240: the named payload is now expanded structurally, not the
+    // dangling bare `User[]`.
+    assert.strictEqual(
+      inferred.type_string,
+      '{ id: number; name: string; }[]',
+      `expected structural User[], got ${inferred.type_string}`
     );
   });
 
@@ -195,9 +198,11 @@ describe('Type inferrer gap regressions', () => {
       (t) => t.alias === 'GapPayloadSpanControl'
     );
     assert.ok(inferred, 'expected inferred type for payload-emission span');
-    assert.ok(
-      inferred.type_string.includes('User'),
-      `expected User[], got ${inferred.type_string}`
+    // #257/#240: structural members, not the dangling bare `User[]`.
+    assert.strictEqual(
+      inferred.type_string,
+      '{ id: number; name: string; }[]',
+      `expected structural User[], got ${inferred.type_string}`
     );
   });
 
@@ -224,7 +229,9 @@ describe('Type inferrer gap regressions', () => {
       inferred,
       `expected line-anchored function_return to resolve, got errors: ${JSON.stringify(response.errors)}`
     );
-    assert.strictEqual(inferred.type_string, 'User');
+    // #257/#240: a named object return is expanded structurally, not the
+    // dangling bare `User`.
+    assert.strictEqual(inferred.type_string, '{ id: number; name: string; }');
   });
 
   it('unwraps a union of Promises per member', async () => {

--- a/src/sidecar/test/infer-response-body-structural.test.ts
+++ b/src/sidecar/test/infer-response-body-structural.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Targeted regression for issues #257 (producer expansion) and #240
+ * (deterministic anchor), the PRODUCER-side analogues of #259's consumer fix.
+ *
+ * A producer `res.json(payment)` where `payment: Payment` routes through the
+ * `response_body` inference path. The inferrer used to render the resolved
+ * payload type with `typeText`, which keeps the bare NAME `Payment`. The engine
+ * wrote that verbatim into the cross-repo `<repo>_types.d.ts` as
+ * `export type <alias> = Payment;` — but those bundle files carry only alias
+ * lines, no source declarations. So `Payment` was a dangling reference →
+ * resolved to `any` → ts_check reported `unverifiable` → `compat = None`,
+ * masking the producer's real, recoverable shape (deterministically explaining
+ * `payments-svc|POST|/payments -> web-frontend` reading `None`).
+ *
+ * The fix:
+ *  (a) expands the resolved named object STRUCTURALLY (shared
+ *      `type-structural-expander.ts`), so the bundle carries the real members
+ *      `{ id: string; amountCents: number; currency: string }`; and
+ *  (b) carries the deterministic source symbol on `primary_type_symbol`
+ *      (`Payment`), derived from the ts-morph `Type` symbol with TS/lib globals
+ *      filtered out, so the manifest anchor no longer depends on the LLM.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const FIXTURE = path.join(FIXTURES_PATH, 'src/fetch-json.ts');
+const FIXTURE_SOURCE = fs.readFileSync(FIXTURE, 'utf-8');
+
+/** Byte span of `text` in the fixture (ASCII-only file, so byte == char offsets). */
+function spanOf(text: string): { start: number; end: number; line: number } {
+  const start = FIXTURE_SOURCE.indexOf(text);
+  assert.ok(start >= 0, `fixture must contain: ${text}`);
+  assert.strictEqual(
+    FIXTURE_SOURCE.indexOf(text, start + 1),
+    -1,
+    `fixture must contain exactly one occurrence of: ${text}`
+  );
+  const line = FIXTURE_SOURCE.slice(0, start).split('\n').length;
+  return { start, end: start + text.length, line };
+}
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    infer_kind: string;
+    is_explicit: boolean;
+    primary_type_symbol?: string;
+  }>;
+  errors?: string[];
+}
+
+describe('response_body producer structural expansion + anchor (#257 #240)', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'producer-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('expands `res.json(payment)` (payment: Payment) to the structural shape, not the bare name, and carries the anchor symbol', async () => {
+    // Locator covers the `res.json(payment)` call. inferResponseBody drills to
+    // the first argument `payment`, whose type is the named interface `Payment`.
+    const call = spanOf('res.json(payment)');
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'producer-response-body',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: call.line,
+          span_start: call.start,
+          span_end: call.end,
+          infer_kind: 'response_body',
+          alias: 'PaymentProducer',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'PaymentProducer'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+
+    // (a) The bug: a bare `Payment` (dangling in the cross-repo bundle).
+    assert.notStrictEqual(
+      inferred.type_string,
+      'Payment',
+      'must not emit the bare type name — it dangles in the cross-repo bundle'
+    );
+
+    // (a) The fix: the real, self-contained member shape.
+    assert.strictEqual(
+      inferred.type_string,
+      '{ id: string; amountCents: number; currency: string; }',
+      `expected the structural shape, got ${inferred.type_string}`
+    );
+
+    // (b) The deterministic anchor: the real source symbol, not a hash.
+    assert.strictEqual(
+      inferred.primary_type_symbol,
+      'Payment',
+      `expected primary_type_symbol "Payment", got ${inferred.primary_type_symbol}`
+    );
+  });
+});

--- a/src/sidecar/test/sidecar.test.ts
+++ b/src/sidecar/test/sidecar.test.ts
@@ -329,6 +329,10 @@ describe('Type Sidecar Integration Tests', () => {
     // not the surrounding call (`res.json(users)`). The sidecar resolves the
     // node by text and returns its type, working identically across
     // res.json(...), ctx.body = ..., h.response(...), and bare return.
+    //
+    // #257/#240: the resolved named payload is now expanded STRUCTURALLY (so the
+    // cross-repo bundle carries the real members, not a dangling name). The
+    // assertions check the inlined member shape rather than the bare type name.
     it('should resolve response payload via text locator — Express res.json(x)', async () => {
       const response = await client.send<{
         inferred_types?: Array<{ type_string: string; infer_kind: string }>;
@@ -349,7 +353,12 @@ describe('Type Sidecar Integration Tests', () => {
       if (response.inferred_types && response.inferred_types.length > 0) {
         const inferred = response.inferred_types[0];
         assert.strictEqual(inferred.infer_kind, 'response_body');
-        assert.ok(inferred.type_string.includes('User'), `expected User[], got ${inferred.type_string}`);
+        // Structural, not the dangling bare `User[]`.
+        assert.strictEqual(
+          inferred.type_string,
+          '{ id: number; name: string; }[]',
+          `expected structural User[], got ${inferred.type_string}`
+        );
       } else {
         assert.fail('expected inferred_types for Express payload');
       }
@@ -374,7 +383,12 @@ describe('Type Sidecar Integration Tests', () => {
 
       if (response.inferred_types && response.inferred_types.length > 0) {
         const inferred = response.inferred_types[0];
-        assert.ok(inferred.type_string.includes('User'), `expected User[], got ${inferred.type_string}`);
+        // Structural, not the dangling bare `User[]`.
+        assert.strictEqual(
+          inferred.type_string,
+          '{ id: number; name: string; }[]',
+          `expected structural User[], got ${inferred.type_string}`
+        );
       } else {
         assert.fail('expected inferred_types for Koa payload');
       }
@@ -399,7 +413,12 @@ describe('Type Sidecar Integration Tests', () => {
 
       if (response.inferred_types && response.inferred_types.length > 0) {
         const inferred = response.inferred_types[0];
-        assert.ok(inferred.type_string.includes('Order'), `expected Order, got ${inferred.type_string}`);
+        // Structural, not the dangling bare `Order`.
+        assert.strictEqual(
+          inferred.type_string,
+          '{ id: number; total: number; }',
+          `expected structural Order, got ${inferred.type_string}`
+        );
       } else {
         assert.fail('expected inferred_types for Hapi payload');
       }
@@ -424,7 +443,12 @@ describe('Type Sidecar Integration Tests', () => {
 
       if (response.inferred_types && response.inferred_types.length > 0) {
         const inferred = response.inferred_types[0];
-        assert.ok(inferred.type_string.includes('User'), `expected User, got ${inferred.type_string}`);
+        // Structural, not the dangling bare `User`.
+        assert.strictEqual(
+          inferred.type_string,
+          '{ id: number; name: string; }',
+          `expected structural User, got ${inferred.type_string}`
+        );
       } else {
         assert.fail('expected inferred_types for bare-return payload');
       }

--- a/tests/fixtures/llm-mocked-api/__golden__.json
+++ b/tests/fixtures/llm-mocked-api/__golden__.json
@@ -81,7 +81,7 @@
       "resolved_definition": "export type Endpoint_7624e36e7268b452_Request = { name: string; email: string; };",
       "expanded_definition": "{ name: string; email: string; }",
       "is_explicit": false,
-      "primary_type_symbol": "Endpoint_7624e36e7268b452_Request"
+      "primary_type_symbol": "User"
     }
   ],
   "calls": [


### PR DESCRIPTION
Two related sidecar/inference fixes that clear dangling type names from the cross-repo bundle and remove the type anchor's sole dependency on the LLM.

## FIX 1 — Producer structural expansion (#257)

Producer-side inference rendered a resolved named object as a **bare name** (`Payment`), not a structural body. That bare name landed as a dangling `export type <alias> = Payment;` in the source-less cross-repo `.d.ts` → ts_check resolved it to `any` → `unverifiable` → `compat=None` (e.g. `payments→web`).

#257 already wired `expandTypeStructural` into the consumer `call_result` path and the request-body cast path via `expandAnnotationTypeNode`. This mirrors it on the producer/HTTP path: after the Promise/wrapper unwrap in `inferResponseBody` (`type-inferrer.ts`) and `inferFunctionReturn`, the resolved object type is expanded structurally and the structural form is preferred when it inlines an object — keeping the bare name for primitives/library/non-object types, exactly as `expandAnnotationTypeNode` does.

## FIX 2 — Deterministic anchor (#240)

The manifest anchor (`primary_type_symbol`) had one source — the LLM — and a miss fell back to the hashed `type_alias`. The symbol name already exists deterministically on the resolved ts-morph `Type` via `(getSymbol() || getAliasSymbol())?.getName()` (the same derivation the passing **socket** anchor uses, with an `is_builtin_type`-style filter).

- New `primary_type_symbol` field on the sidecar `InferredType` (`type-inferrer.ts` / `types.ts`), populated from the resolved type's symbol with a builtin/library filter (never `Promise`, `Array`, `Date`, primitives, …).
- Mirrored onto the Rust `InferredType` (`src/services/type_sidecar.rs`).
- `enrich_manifest_with_type_resolution` (`src/engine/mod.rs`) fills the manifest entry's `primary_type_symbol` from the inferred symbol, joined by `(file_path, line)`, **only when the LLM left it None** — so the ops the LLM already anchors correctly (POST /payments, socket) are never regressed. Stamping runs before enrichment, so any entry still `None` had no LLM anchor.

## Tests

- New sidecar test: a producer `res.json(payment)` where `payment: Payment` now infers the **structural** `{ id: string; amountCents: number; currency: string; }`, not the bare `Payment`, and the inferred type carries `primary_type_symbol: "Payment"`.
- New Rust tests: the deterministic anchor fills only when the LLM symbol is None, and never overrides an existing one.
- Existing sidecar producer-payload assertions (`sidecar.test.ts`, `gap-regression.test.ts`) updated from the bare name to the structural form — the behavior this fix corrects. #257's `infer-call-result-structural` and #246's expansion tests stay green.

## Verification

- Sidecar: `npm run build` + `npm test` (78 tests, 0 fail), `tsc --noEmit` clean.
- Rust: full `cargo test` green incl. `cassette_hard_gate_llm_mocked_api`; `cargo fmt`; `cargo clippy --all-targets -- -D warnings` clean.
- `ts_check` suite green (73 tests).
- Prompt-leak-guard: counts identical to baseline (no new `.rs` matches).
- **Cassette golden unchanged** — the mocked fixture's payloads don't hit the bare-named-producer case, so no re-record was needed.

Refs #257 #240 #207