### PR TITLE
fix(sidecar): drill through JSON.stringify(arg) for request-body inference

### DIFF
--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -591,7 +591,13 @@ export class TypeInferrer {
 
     // Mirror inferCallResult: strip `await`/`as`/parens/`!` so the inner
     // expression's type (not the surrounding `Promise<any>`) is read.
-    const node = this.unwrapExpressionNode(located);
+    const unwrapped = this.unwrapExpressionNode(located);
+
+    // A `fetch` body is almost always `JSON.stringify(payload)`, whose own type
+    // is the useless `string`. Drill to the serialized argument so the consumer
+    // request shape is the payload's type, not `string`. General: any
+    // `JSON.stringify(x)` resolves to the type of `x`.
+    const node = this.unwrapJsonStringifyArg(unwrapped);
 
     const payloadType = node.getType();
     let typeString = typeText(payloadType, node);
@@ -1245,6 +1251,35 @@ export class TypeInferrer {
       break;
     }
     return current ?? node!;
+  }
+
+  /**
+   * If `node` is a `JSON.stringify(arg)` call, return the (expression-unwrapped)
+   * first argument so its type is read instead of the call's `string` result.
+   * Otherwise return `node` unchanged. Any non-`JSON.stringify` call, or a
+   * `JSON.stringify()` with no argument, is left alone.
+   */
+  private unwrapJsonStringifyArg(node: Node): Node {
+    if (!Node.isCallExpression(node)) {
+      return node;
+    }
+    const callee = node.getExpression();
+    if (!Node.isPropertyAccessExpression(callee)) {
+      return node;
+    }
+    const obj = callee.getExpression();
+    if (
+      !Node.isIdentifier(obj) ||
+      obj.getText() !== "JSON" ||
+      callee.getName() !== "stringify"
+    ) {
+      return node;
+    }
+    const args = node.getArguments();
+    if (args.length === 0) {
+      return node;
+    }
+    return this.unwrapExpressionNode(args[0]);
   }
 
   private extractExplicitTypeFromAncestor(node: Node): string | null {

--- a/src/sidecar/test/fixtures/sample-repo/src/request-bodies.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/request-bodies.ts
@@ -45,3 +45,13 @@ export async function uploadUntyped(request: globalThis.Request) {
   const form = await request.formData();
   return form;
 }
+
+// B: consumer-side `fetch` POST whose `body` is `JSON.stringify(payload)`. The
+// call's own type is the useless `string`; the inferred request body must be
+// the SERIALIZED ARGUMENT's type (`RegisterRequest`), not `string`.
+export async function postViaStringify(payload: RegisterRequest) {
+  return fetch('/api/register', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}

--- a/src/sidecar/test/request-body-cast.test.ts
+++ b/src/sidecar/test/request-body-cast.test.ts
@@ -197,6 +197,52 @@ describe('Request body cast/binding regressions (#133 A1)', () => {
     );
   });
 
+  it('drills through JSON.stringify(payload) to the serialized argument type (B)', async () => {
+    // Consumer `fetch` POST body is `JSON.stringify(payload)`. The call's own
+    // type is `string`; the request shape must be the argument's type
+    // (`RegisterRequest`), so the cross-repo edge resolves to the real payload
+    // shape and not the useless `string`.
+    const bodyLine = spanOf('body: JSON.stringify(payload),');
+    const callStart = bodyLine.start + 'body: '.length;
+    const callEnd = callStart + 'JSON.stringify(payload)'.length;
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'reqbody-stringify',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: bodyLine.line,
+          span_start: callStart,
+          span_end: callEnd,
+          infer_kind: 'request_body',
+          alias: 'StringifyBody',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'StringifyBody'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.notStrictEqual(
+      inferred.type_string,
+      'string',
+      'must drill into JSON.stringify(arg), not surface its `string` result'
+    );
+    // The serialized argument is a plain identifier typed `RegisterRequest`,
+    // so its own type name is read directly (no cast/binding to trigger the
+    // #257 structural recovery). The lever is "not `string`"; the argument's
+    // declared type, which resolves in the consumer's own bundle, is correct.
+    assert.strictEqual(
+      inferred.type_string,
+      'RegisterRequest',
+      `expected the serialized argument's payload type, got ${inferred.type_string}`
+    );
+  });
+
   it('leaves an untyped request.formData() as FormData/any (NOT-a-bug control)', async () => {
     // No cast, no typed binding → nothing to recover. Must stay faithful.
     const stmt = spanOf('const form = await request.formData();');


### PR DESCRIPTION
## Lever (compat): B-json-stringify-request

The live cross-repo eval reported the `POST /payments` edge as incompatible — producer request `{ orderId: number; amountCents: number; }` vs consumer `string` — but the corpus expects it compatible.

### Root cause

The consumer (`tests/fixtures/xrepo-corpus-1/web-frontend/lib/api.ts:45`) does:

```ts
fetch(PAYMENTS_BASE + '/payments', { method: "POST", body: JSON.stringify(body) })
```

`inferRequestBody` read the type of the located body expression `JSON.stringify(body)` directly. The return type of `JSON.stringify(...)` is `string`, so the consumer request body was inferred as `string` instead of the serialized argument's type (`CreatePaymentRequest`).

### Fix

`inferRequestBody` now unwraps a `JSON.stringify(x)` call to its (expression-unwrapped) first argument and reads that argument's type, mirroring the call-expression drilling `inferResponseBody` already performs. General: any `JSON.stringify(x)` resolves to the type of `x`. Non-`JSON.stringify` calls, argument-less `JSON.stringify()`, and genuine string literals/variables/other expressions are left unchanged.

### Validation

- New focused sidecar regression in `src/sidecar/test/request-body-cast.test.ts`: a `fetch` POST whose `body` is `JSON.stringify(payload)` (payload typed `RegisterRequest`) now infers the payload type, asserting it is NOT `string`. Backed by a new fixture function in `src/sidecar/test/fixtures/sample-repo/src/request-bodies.ts`.
- Full `cargo test` (including the cassette hard gate — golden unchanged, no re-record needed), `src/sidecar` `npm test`, and `ts_check` `npm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)