### PR TITLE
fix(sidecar): expand resolved request-body type structurally

### DIFF
--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -612,6 +612,19 @@ export class TypeInferrer {
     if (unwrapResult.wasUnwrapped) {
       typeString = unwrapResult.typeString;
       isExplicit = unwrapResult.isExplicit;
+    } else {
+      // No wrapper rule fired: the payload resolved straight to its own type.
+      // For a consumer `fetch(url, { body: JSON.stringify(payload) })` with
+      // `payload: CreatePaymentRequest`, `node` is the unwrapped `payload`
+      // identifier and `payloadType` is the named object — `typeText` keeps the
+      // bare name `CreatePaymentRequest`, which dangles in the source-less
+      // cross-repo `.d.ts` bundle → resolves to `any` → unverifiable. Expand the
+      // resolved object structurally so the real members reach the bundle,
+      // mirroring `inferResponseBody`/`inferFunctionReturn`. A declared cast or
+      // typed binding (handled below) still wins and renders its own structural
+      // form via `extractExplicitTypeFromAncestor`.
+      const resolved = this.unwrapPromiseType(payloadType);
+      typeString = this.expandResolvedTypeStructural(resolved, typeString);
     }
 
     // A declared type — an `as T` cast or a typed variable binding/annotation

--- a/src/sidecar/test/fixtures/sample-repo/src/request-body-structural.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/request-body-structural.ts
@@ -1,0 +1,39 @@
+/**
+ * Fixture for the request_body structural-expansion regression.
+ *
+ * Mirrors the cross-repo corpus `POST /payments` edge: a producer that casts
+ * `req.body` to a named request type, and a consumer that `JSON.stringify`s a
+ * named-typed payload into a `fetch` body. Both used to infer the BARE type
+ * NAME, which dangles in the source-less cross-repo `.d.ts` bundle (alias lines
+ * only) → resolves to `any` → `unverifiable`. The fix expands the resolved
+ * named request type to its STRUCTURAL member shape so the real members reach
+ * the bundle.
+ */
+
+export interface CreatePayment {
+  orderId: number;
+  amountCents: number;
+}
+
+interface ReqLike {
+  body: unknown;
+}
+
+// Producer: the request body is recovered from an explicit `as CreatePayment`
+// cast on `req.body` (whose own type is `unknown`). The cast TARGET must be
+// expanded structurally, not emitted as the bare name `CreatePayment`.
+export function createPaymentHandler(req: ReqLike) {
+  const body = req.body as CreatePayment;
+  return body.orderId;
+}
+
+// Consumer: the `fetch` POST body serializes a `payload: CreatePayment`.
+// Drilling into the serializer yields the named `CreatePayment`; its resolved
+// shape must be expanded structurally, not left as the dangling bare name.
+export async function sendCreatePayment(payload: CreatePayment) {
+  return fetch('/payments', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}

--- a/src/sidecar/test/infer-request-body-structural.test.ts
+++ b/src/sidecar/test/infer-request-body-structural.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Targeted regression for the cross-repo `POST /payments` request-body edge.
+ *
+ * `inferRequestBody` used to render a resolved NAMED request type with
+ * `typeText`, which keeps the bare name (`CreatePayment`). The engine wrote that
+ * verbatim into the cross-repo `<repo>_types.d.ts` as
+ * `export type <alias> = CreatePayment;` — but those bundle files carry only
+ * alias lines, no source declarations. So the name was a dangling reference →
+ * resolved to `any`/`unknown` → ts_check reported `unverifiable` → `compat = None`
+ * on the request edge.
+ *
+ * The fix expands the resolved named request type STRUCTURALLY (shared
+ * `type-structural-expander.ts`, the same recovery `inferResponseBody` and
+ * `inferFunctionReturn` already apply) so the bundle carries the real members
+ * `{ orderId: number; amountCents: number; }`. Two shapes are covered:
+ *
+ *  (a) Consumer — `fetch(url, { body: JSON.stringify(payload) })` with
+ *      `payload: CreatePayment`. The inferrer drills into `JSON.stringify` to
+ *      the argument, whose resolved type is the named interface. No wrapper rule
+ *      and no cast/binding fire, so the resolved object is expanded structurally.
+ *  (b) Producer — `req.body as CreatePayment`. The cast TARGET (recovered via
+ *      `extractExplicitTypeFromAncestor`) is expanded structurally; the inner
+ *      `req.body` (typed `unknown`) is never emitted as the shape.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const FIXTURE = path.join(FIXTURES_PATH, 'src/request-body-structural.ts');
+const FIXTURE_SOURCE = fs.readFileSync(FIXTURE, 'utf-8');
+
+/** Structural form of `interface CreatePayment { orderId; amountCents }`. */
+const CREATE_PAYMENT_STRUCTURAL = '{ orderId: number; amountCents: number; }';
+
+/** Byte span of `text` in the fixture (ASCII-only file, so byte == char offsets). */
+function spanOf(text: string): { start: number; end: number; line: number } {
+  const start = FIXTURE_SOURCE.indexOf(text);
+  assert.ok(start >= 0, `fixture must contain: ${text}`);
+  assert.strictEqual(
+    FIXTURE_SOURCE.indexOf(text, start + 1),
+    -1,
+    `fixture must contain exactly one occurrence of: ${text}`
+  );
+  const line = FIXTURE_SOURCE.slice(0, start).split('\n').length;
+  return { start, end: start + text.length, line };
+}
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    infer_kind: string;
+    is_explicit: boolean;
+    primary_type_symbol?: string;
+  }>;
+  errors?: string[];
+}
+
+describe('request_body structural expansion (cross-repo POST /payments)', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'reqbody-structural-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('(a) consumer: expands `JSON.stringify(payload)` (payload: CreatePayment) to the structural shape, not the bare name', async () => {
+    // Locator covers the `JSON.stringify(payload)` call. inferRequestBody drills
+    // to the serialized argument `payload`, whose type is the named interface
+    // `CreatePayment`. The resolved object must be expanded structurally.
+    const call = spanOf('JSON.stringify(payload)');
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'reqbody-consumer-stringify',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: call.line,
+          span_start: call.start,
+          span_end: call.end,
+          infer_kind: 'request_body',
+          alias: 'ConsumerCreatePayment',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'ConsumerCreatePayment'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+
+    // The bug: a bare `CreatePayment` (dangling in the cross-repo bundle).
+    assert.notStrictEqual(
+      inferred.type_string,
+      'CreatePayment',
+      'must not emit the bare type name — it dangles in the cross-repo bundle'
+    );
+    // Must also not surface the `string` result of JSON.stringify.
+    assert.notStrictEqual(
+      inferred.type_string,
+      'string',
+      'must drill into JSON.stringify(arg), not surface its `string` result'
+    );
+
+    // The fix: the real, self-contained member shape.
+    assert.strictEqual(
+      inferred.type_string,
+      CREATE_PAYMENT_STRUCTURAL,
+      `expected the structural shape, got ${inferred.type_string}`
+    );
+  });
+
+  it('(b) producer: expands the `req.body as CreatePayment` cast target to the structural shape, not the bare name', async () => {
+    // Locator covers the body expression `req.body`. inferRequestBody unwraps the
+    // `as`, then recovers the cast TARGET `CreatePayment` (not the inner `unknown`)
+    // and expands it structurally.
+    const cast = spanOf('req.body as CreatePayment');
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'reqbody-producer-cast',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: cast.line,
+          span_start: cast.start,
+          span_end: cast.end,
+          infer_kind: 'request_body',
+          alias: 'ProducerCreatePayment',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'ProducerCreatePayment'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+
+    // The bug: a bare `CreatePayment` (dangling), or the inner `unknown`/`any`.
+    assert.notStrictEqual(
+      inferred.type_string,
+      'CreatePayment',
+      'must not emit the bare cast-target name — it dangles in the cross-repo bundle'
+    );
+    assert.ok(
+      inferred.type_string !== 'unknown' && inferred.type_string !== 'any',
+      `must recover the cast target, not the inner req.body type, got ${inferred.type_string}`
+    );
+
+    // The fix: the cast target's real member shape.
+    assert.strictEqual(
+      inferred.type_string,
+      CREATE_PAYMENT_STRUCTURAL,
+      `expected the structural shape, got ${inferred.type_string}`
+    );
+    assert.strictEqual(
+      inferred.is_explicit,
+      true,
+      'a recovered declared cast type must be reported explicit'
+    );
+  });
+});

--- a/src/sidecar/test/request-body-cast.test.ts
+++ b/src/sidecar/test/request-body-cast.test.ts
@@ -232,14 +232,17 @@ describe('Request body cast/binding regressions (#133 A1)', () => {
       'string',
       'must drill into JSON.stringify(arg), not surface its `string` result'
     );
-    // The serialized argument is a plain identifier typed `RegisterRequest`,
-    // so its own type name is read directly (no cast/binding to trigger the
-    // #257 structural recovery). The lever is "not `string`"; the argument's
-    // declared type, which resolves in the consumer's own bundle, is correct.
+    // The serialized argument is a plain identifier typed `RegisterRequest`.
+    // Its own type resolves to the named interface; the bare name `RegisterRequest`
+    // would dangle in the source-less cross-repo `.d.ts` bundle (alias lines only)
+    // → resolve to `any` → `unverifiable`. So the resolved payload is expanded
+    // STRUCTURALLY (shared `type-structural-expander.ts`), the same recovery
+    // `inferResponseBody`/`inferFunctionReturn` apply, landing the real members
+    // in the bundle so the consumer request shape can actually be compared.
     assert.strictEqual(
       inferred.type_string,
-      'RegisterRequest',
-      `expected the serialized argument's payload type, got ${inferred.type_string}`
+      REGISTER_REQUEST_STRUCTURAL,
+      `expected the serialized argument's payload type (structural), got ${inferred.type_string}`
     );
   });
 

--- a/src/sidecar/test/sidecar.test.ts
+++ b/src/sidecar/test/sidecar.test.ts
@@ -522,7 +522,14 @@ describe('Type Sidecar Integration Tests', () => {
       if (response.inferred_types && response.inferred_types.length > 0) {
         const inferred = response.inferred_types[0];
         assert.strictEqual(inferred.infer_kind, 'request_body');
-        assert.ok(inferred.type_string.includes('RequestBody'));
+        // The body resolves to the named `RequestBody`, now expanded
+        // structurally so the real members reach the cross-repo bundle instead
+        // of a dangling bare name. Assert the members, not the name.
+        assert.ok(
+          inferred.type_string.includes('name') &&
+            inferred.type_string.includes('email'),
+          `expected the structural RequestBody shape, got ${inferred.type_string}`
+        );
       }
     });
 
@@ -553,7 +560,14 @@ describe('Type Sidecar Integration Tests', () => {
       if (response.inferred_types && response.inferred_types.length > 0) {
         const inferred = response.inferred_types[0];
         assert.strictEqual(inferred.infer_kind, 'request_body');
-        assert.ok(inferred.type_string.includes('RequestBody'));
+        // The serialized payload resolves to the named `RequestBody`, now
+        // expanded structurally so the real members reach the cross-repo bundle
+        // instead of a dangling bare name. Assert the members, not the name.
+        assert.ok(
+          inferred.type_string.includes('name') &&
+            inferred.type_string.includes('email'),
+          `expected the structural RequestBody shape, got ${inferred.type_string}`
+        );
       }
     });
 


### PR DESCRIPTION
## Problem

In the live cross-repo eval the `POST /payments` edge reports **unverifiable** (compat `None`): *"producer type resolves to unknown … consumer type resolves to any (type missing from bundled types?)"*.

Root cause is in the sidecar's `inferRequestBody` (`src/sidecar/src/type-inferrer.ts`). Unlike `inferResponseBody` and `inferFunctionReturn` (which gained structural expansion in #265), it rendered a resolved **named** request type with `typeText`, which keeps the bare name. In the source-less cross-repo `.d.ts` bundle (alias lines only, no source declarations) that name dangles → `export type <alias> = CreatePaymentRequest;` → resolves to `any`/`unknown` → `ts_check` cannot compare the request edge.

The genuinely-broken half was the **consumer**: `fetch(url, { body: JSON.stringify(payload) })` where `payload: CreatePaymentRequest`. After drilling into `JSON.stringify`, the resolved payload type was emitted as the bare name. The **producer** `req.body as CreatePayment` was already handled correctly by the existing cast-recovery path (`extractExplicitTypeFromAncestor` → `expandAnnotationTypeNode`, which already expands structurally), verified by probe and by the new producer test passing pre-fix.

## Fix

When no wrapper rule fires (and no `as`-cast / typed binding wins), expand the resolved object structurally via the existing deterministic ts-morph inliner (`expandResolvedTypeStructural` / `type-structural-expander.ts`) — the same recovery `inferResponseBody`/`inferFunctionReturn` apply — so the real members reach the bundle. A declared cast/binding still wins and renders its own structural form; the untyped `request.formData()` control stays `FormData`/`any` (a library type the expander leaves by name).

## Validation

- New offline regression `src/sidecar/test/infer-request-body-structural.test.ts` (fixture `request-body-structural.ts`) covers **both** shapes: producer `req.body as CreatePayment` and consumer `JSON.stringify(payload)` with a named type, asserting the structural member shape `{ orderId: number; amountCents: number; }`, not the bare name.
- Proven fails-pre-fix / passes-post-fix: with the production change reverted, the consumer case fails (emits bare `CreatePayment`) while the producer case already passes; restored, both pass.
- Updated three existing assertions (`request-body-cast.test.ts`, `sidecar.test.ts`) that encoded the old bare-name behavior to expect the structural shape.
- Green: sidecar `npm test` (80 pass), full `cargo test` (21 binaries, 0 fail — no cassette goldens changed), `ts_check` `npm test` (73 pass). No ground-truth `expected*.json` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)