### PR TITLE
feat(compat): type-check cross-repo SOCKET edges end-to-end

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -226,10 +226,14 @@ pub fn filter_graphql_libraries(data_fetchers: &[String]) -> Vec<String> {
         .collect()
 }
 
-/// Parse a ts_check compat `endpoint` string back into `(METHOD, path)`. The
-/// string is built as `"<METHOD> <path> (<request|response>)"` by ts_check's
-/// type-checker, so split off the leading method and the trailing
-/// `" (type_kind)"` suffix. Returns `None` for an unrecognized shape.
+/// Parse a ts_check compat `endpoint` string back into the verdict-join
+/// `(pseudo-method, identity)` pair. ts_check builds the string as
+/// `"<METHOD> <path> (<request|response>)"` for HTTP and
+/// `"SOCKET <DIRECTION>|<event> (response)"` for socket, so the same split —
+/// leading token off the front, trailing `" (type_kind)"` off the back — yields
+/// `("METHOD", "path")` or `("SOCKET", "DIRECTION|event")`, matching what
+/// `parse_producer_key` recovers from the edge's `producer_key`. Returns `None`
+/// for an unrecognized shape.
 fn parse_compat_endpoint(endpoint: &str) -> Option<(String, String)> {
     let (method, rest) = endpoint.split_once(' ')?;
     // Drop the trailing " (request)" / " (response)" annotation if present.
@@ -243,13 +247,27 @@ fn parse_compat_endpoint(endpoint: &str) -> Option<(String, String)> {
     Some((method.to_uppercase(), path.to_string()))
 }
 
-/// Recover `(METHOD, path)` from a canonical HTTP producer key
-/// (`"http|METHOD|path"`). Returns `None` for non-HTTP keys.
+/// Recover the verdict-join `(pseudo-method, identity)` from a canonical
+/// producer key, for the protocols ts_check type-checks (HTTP + socket):
+///
+/// - HTTP (`"http|METHOD|path"`) → `("METHOD", "path")`, the HTTP join key.
+/// - Socket (`"socket|DIRECTION|event"`) → `("SOCKET", "DIRECTION|event")`. The
+///   matching ts_check endpoint label is `"SOCKET DIRECTION|event (response)"`,
+///   which `parse_compat_endpoint` reduces to the SAME pair, so a socket edge
+///   joins its ts_check verdict exactly like an HTTP one.
+///
+/// Returns `None` for any other protocol (e.g. GraphQL): ts_check produced no
+/// verdict for it, so its edge stays `None` rather than fabricating one.
 fn parse_producer_key(key: &str) -> Option<(String, String)> {
     let mut parts = key.splitn(3, '|');
     match (parts.next(), parts.next(), parts.next()) {
         (Some("http"), Some(method), Some(path)) if !method.is_empty() && !path.is_empty() => {
             Some((method.to_uppercase(), path.to_string()))
+        }
+        (Some("socket"), Some(direction), Some(event))
+            if !direction.is_empty() && !event.is_empty() =>
+        {
+            Some(("SOCKET".to_string(), format!("{}|{}", direction, event)))
         }
         _ => None,
     }
@@ -350,10 +368,11 @@ fn apply_compat_verdicts(result: &serde_json::Value, matches: &mut [CrossRepoMat
     }
 
     for edge in matches.iter_mut() {
-        // producer_key is `http|METHOD|path`; recover (METHOD, path). A non-HTTP
-        // key (GraphQL/socket edge) is not type-checked by ts_check (HTTP-only),
-        // so its verdict is genuinely unknown — leave it `None` rather than
-        // fabricate `Some(true)` (#260, part 2).
+        // Recover the join key from the producer_key. ts_check type-checks HTTP
+        // (`http|METHOD|path`) and socket (`socket|DIRECTION|event`), so both
+        // join here. A key for any other protocol (e.g. GraphQL) is not checked
+        // by ts_check, so its verdict is genuinely unknown — leave it `None`
+        // rather than fabricate `Some(true)` (#260, part 2).
         let Some((method, path)) = parse_producer_key(&edge.producer_key) else {
             edge.type_compatible = None;
             continue;
@@ -3183,39 +3202,85 @@ mod tests {
         );
     }
 
-    /// A GraphQL/socket edge has a non-HTTP `producer_key`, so `parse_producer_key`
-    /// returns `None`. ts_check is HTTP-only and never produced a verdict for it,
-    /// so the verdict is genuinely unknown: the edge must stay `None`, NOT the
-    /// fabricated `Some(true)` the old default returned (#260, part 2 — the worst
-    /// direction for a drift detector).
+    /// A GraphQL edge has a `producer_key` ts_check does not type-check, so
+    /// `parse_producer_key` returns `None` and the verdict is genuinely unknown:
+    /// the edge must stay `None`, NOT the fabricated `Some(true)` the old default
+    /// returned (#260, part 2 — the worst direction for a drift detector).
+    /// Socket edges, by contrast, ARE type-checked and join their verdict (see
+    /// `apply_compat_verdicts_joins_socket_edge`).
     #[test]
-    fn overlay_compat_verdicts_non_http_producer_key_stays_none() {
+    fn overlay_compat_verdicts_graphql_producer_key_stays_none() {
         let dir = tempfile::tempdir().expect("tempdir");
         let results = r#"{ "mismatches": [], "unknownPairs": [],
                            "totalChecked": 0, "compatibleCount": 0 }"#;
         let analyzer = analyzer_with_results(dir.path(), Some(results));
 
-        let mut matches = vec![
-            edge_at(
-                "graphql|query|order",
-                "web-frontend",
-                "web-frontend/src/query.ts:7",
-            ),
-            edge_at(
-                "socket|SERVER->CLIENT|payment:settled",
-                "payments-svc",
-                "payments-svc/src/socket.ts:9",
-            ),
-        ];
+        let mut matches = vec![edge_at(
+            "graphql|query|order",
+            "web-frontend",
+            "web-frontend/src/query.ts:7",
+        )];
         analyzer.overlay_compat_verdicts(&mut matches);
 
         assert_eq!(
             matches[0].type_compatible, None,
             "a GraphQL edge ts_check never checked must stay None, not fake true"
         );
+    }
+
+    /// The socket cross-repo join (this PR). A `socket|DIRECTION|event` edge is
+    /// now type-checked by ts_check, which emits its verdict under the endpoint
+    /// label `"SOCKET <DIRECTION>|<event> (response)"`. `parse_producer_key`
+    /// recovers `("SOCKET", "<DIRECTION>|<event>")` from the edge and
+    /// `parse_compat_endpoint` recovers the SAME pair from the label, so the
+    /// verdict lands on the socket edge — `Some(false)` + reason when ts_check
+    /// reports a mismatch, `Some(true)` when it doesn't.
+    #[test]
+    fn apply_compat_verdicts_joins_socket_edge() {
+        // The xrepo-corpus-1 `payment:settled` edge: producer (listener) is
+        // web-frontend, consumer (emitter) is payments-svc. The compatible case
+        // is absent from both lists, so it reads Some(true). The mismatch case
+        // (a second event) lands on its edge with the reason.
+        let result = serde_json::json!({
+            "mismatches": [{
+                "endpoint": "SOCKET CLIENT->SERVER|chat:bad (response)",
+                "consumerLocation": "client/src/chat.ts:20",
+                "error": "Sent type is not assignable to listener type"
+            }],
+            "unknownPairs": [],
+            "totalChecked": 2,
+            "compatibleCount": 1
+        });
+
+        let mut matches = vec![
+            edge_at(
+                "socket|SERVER->CLIENT|payment:settled",
+                "payments-svc",
+                "payments-svc/realtime/server.ts:27",
+            ),
+            edge_at(
+                "socket|CLIENT->SERVER|chat:bad",
+                "chat-svc",
+                "client/src/chat.ts:20:5",
+            ),
+        ];
+        apply_compat_verdicts(&result, &mut matches);
+
         assert_eq!(
-            matches[1].type_compatible, None,
-            "a socket edge ts_check never checked must stay None, not fake true"
+            matches[0].type_compatible,
+            Some(true),
+            "the compatible socket edge (absent from both lists) reads Some(true)"
+        );
+        assert!(matches[0].mismatch_reason.is_none());
+
+        assert_eq!(
+            matches[1].type_compatible,
+            Some(false),
+            "the socket edge in the mismatch list reads Some(false)"
+        );
+        assert_eq!(
+            matches[1].mismatch_reason.as_deref(),
+            Some("Sent type is not assignable to listener type"),
         );
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2376,15 +2376,17 @@ fn write_manifest_files(
     for repo_data in all_repo_data {
         if let Some(entries) = &repo_data.type_manifest {
             for entry in entries {
-                // ts_check manifests are HTTP-only by contract: `ManifestEntry`
-                // (ts_check/lib/manifest-matcher.ts) requires `method`/`path`,
-                // which GraphQL/socket OperationKeys never serialise. Those
-                // protocols are scored by their own pipelines (#236/#248), so
-                // they stay in `cloud_data.type_manifest` (cloud index + eval
-                // projection) but must not reach the producer/consumer manifest
-                // files. Without this filter a single non-HTTP entry makes
-                // `validateEntry` throw, zeroing out every cross-repo verdict (#253).
-                if entry.key.protocol() != crate::operation::Protocol::Http {
+                // HTTP and socket entries reach the ts_check manifest; GraphQL
+                // does not. ts_check checks HTTP by `method`/`path` and socket by
+                // the canonical `OperationKey` (event+direction), reusing the same
+                // `TypeCompatibilityChecker` assignability for both. GraphQL is
+                // still filtered here: its cross-repo resolution is blocked on
+                // separate work (#268), and its OperationKey serialises without a
+                // checkable identity for the matcher, so a GraphQL entry would
+                // only ever orphan. Those entries stay in `cloud_data.type_manifest`
+                // (cloud index + eval projection). The matcher drops any stray
+                // non-checkable entry defensively rather than throwing (#253).
+                if entry.key.protocol() == crate::operation::Protocol::Graphql {
                     continue;
                 }
                 match entry.role {
@@ -4050,14 +4052,15 @@ mod tests {
         assert_eq!(request.alias.as_deref(), Some(expected.as_str()));
     }
 
-    /// #253 regression: `write_manifest_files` feeds the HTTP-only ts_check
-    /// matcher, so it must emit ONLY HTTP entries. GraphQL/socket entries are
-    /// kept in `cloud_data.type_manifest` (cloud index + eval projection) but
-    /// must never reach producer/consumer manifest files — a single non-HTTP
-    /// entry there makes ts_check's `validateEntry` throw and zeros out every
-    /// cross-repo verdict.
+    /// `write_manifest_files` feeds the ts_check matcher, which now checks HTTP
+    /// and socket. So HTTP + socket entries pass through; GraphQL is still
+    /// filtered (its cross-repo resolution is blocked on #268 and its key
+    /// carries no checkable identity for the matcher). GraphQL entries stay in
+    /// `cloud_data.type_manifest` (cloud index + eval projection). The #253
+    /// throw-guard now lives in the matcher, which drops any stray non-checkable
+    /// entry defensively rather than crashing the verdict run.
     #[test]
-    fn write_manifest_files_emits_only_http_entries() {
+    fn write_manifest_files_emits_http_and_socket_not_graphql() {
         use crate::cloud_storage::TypeEvidence;
         use crate::operation::{GraphqlOperationKind, OperationKey, SocketDirection};
         use crate::services::type_sidecar::InferKind;
@@ -4141,22 +4144,32 @@ mod tests {
         )
         .unwrap();
 
-        // Only the HTTP producer survives into the ts_check manifest.
+        // HTTP and socket producers survive; GraphQL is filtered out.
         assert_eq!(
             producer.entries.len(),
-            1,
-            "non-HTTP entries must be filtered out of the ts_check manifest"
-        );
-        assert_eq!(
-            producer.entries[0].key.protocol(),
-            crate::operation::Protocol::Http
+            2,
+            "HTTP + socket entries reach the ts_check manifest; GraphQL is filtered"
         );
         assert!(
             producer
                 .entries
                 .iter()
-                .all(|e| e.key.protocol() == crate::operation::Protocol::Http),
-            "producer manifest must contain only HTTP entries"
+                .any(|e| e.key.protocol() == crate::operation::Protocol::Http),
+            "the HTTP producer must reach the manifest"
+        );
+        assert!(
+            producer
+                .entries
+                .iter()
+                .any(|e| e.key.protocol() == crate::operation::Protocol::Websocket),
+            "the socket producer must now reach the manifest"
+        );
+        assert!(
+            producer
+                .entries
+                .iter()
+                .all(|e| e.key.protocol() != crate::operation::Protocol::Graphql),
+            "GraphQL entries must not reach the ts_check manifest (#268)"
         );
     }
 

--- a/ts_check/lib/manifest-matcher.test.ts
+++ b/ts_check/lib/manifest-matcher.test.ts
@@ -238,7 +238,7 @@ describe('ManifestMatcher', () => {
 
     // --- #253 regression: non-HTTP entries must be skipped, not fatal ---
 
-    it('should skip non-HTTP entries and still load the HTTP ones', () => {
+    it('should keep HTTP and socket entries and drop GraphQL', () => {
       const httpEntry = createManifestEntry(
         'GET',
         '/orders/:id',
@@ -247,8 +247,9 @@ describe('ManifestMatcher', () => {
         'src/routes.ts',
         10
       );
-      // GraphQL/socket OperationKeys serialise without method/path; previously
-      // these threw in validateEntry and zeroed out every verdict (#253).
+      // GraphQL serialises without a checkable identity for the matcher and is
+      // dropped; socket (event+direction) is now checked alongside HTTP. A
+      // non-checkable entry must never throw in validateEntry (#253).
       const graphqlEntry = {
         protocol: 'graphql',
         kind: 'query',
@@ -302,11 +303,26 @@ describe('ManifestMatcher', () => {
         })
       );
 
-      // Must NOT throw, and must keep only the HTTP entry.
+      // Must NOT throw. Keeps the HTTP + socket entries, drops GraphQL.
       const loaded = matcher.loadManifest(filePath);
-      assert.strictEqual(loaded.entries.length, 1);
-      assert.strictEqual(loaded.entries[0].protocol, 'http');
-      assert.strictEqual(loaded.entries[0].path, '/orders/:id');
+      assert.strictEqual(loaded.entries.length, 2);
+      assert.ok(
+        loaded.entries.some((e) => e.protocol === 'http' && e.path === '/orders/:id'),
+        'HTTP entry must survive'
+      );
+      assert.ok(
+        loaded.entries.some(
+          (e) => e.protocol === 'socket' && e.event === 'order.created'
+        ),
+        'socket entry must survive'
+      );
+      // Length 2 (from 3 inputs) with the http + socket survivors above proves
+      // the GraphQL entry was dropped. Assert the surviving protocols are only
+      // the two checkable ones.
+      assert.deepStrictEqual(
+        loaded.entries.map((e) => e.protocol).sort(),
+        ['http', 'socket']
+      );
     });
 
     it('should still match HTTP edges when a non-HTTP entry is present', () => {
@@ -635,6 +651,98 @@ describe('ManifestMatcher', () => {
       assert.strictEqual(result.matches.length, 0);
       assert.strictEqual(result.orphanedProducers.length, 0);
       assert.strictEqual(result.orphanedConsumers.length, 0);
+    });
+
+    it('should match a socket producer and consumer on the canonical key', () => {
+      const socketEntry = (
+        typeAlias: string,
+        role: 'producer' | 'consumer'
+      ): ManifestEntry => ({
+        protocol: 'socket',
+        event: 'payment:settled',
+        direction: 'server_to_client',
+        type_alias: typeAlias,
+        role,
+        type_kind: 'response',
+        file_path: role === 'producer' ? 'lib/realtime.ts' : 'realtime/server.ts',
+        line_number: 31,
+        is_explicit: true,
+        type_state: 'explicit',
+        evidence: {
+          file_path: role === 'producer' ? 'lib/realtime.ts' : 'realtime/server.ts',
+          span_start: null,
+          span_end: null,
+          line_number: 31,
+          infer_kind: 'response_body',
+          is_explicit: true,
+          type_state: 'explicit',
+        },
+      });
+
+      const producers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'abc123',
+        entries: [socketEntry('SettledPayment', 'producer')],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'payments-svc',
+        commit_hash: 'def456',
+        entries: [socketEntry('Payment', 'consumer')],
+      };
+
+      const result = matcher.matchEndpoints(producers, consumers);
+
+      assert.strictEqual(result.matches.length, 1);
+      assert.strictEqual(result.matches[0].method, 'SOCKET');
+      assert.strictEqual(result.matches[0].path, 'SERVER->CLIENT|payment:settled');
+      assert.strictEqual(result.matches[0].producer.type_alias, 'SettledPayment');
+      assert.strictEqual(result.matches[0].consumer.type_alias, 'Payment');
+      assert.strictEqual(result.orphanedProducers.length, 0);
+      assert.strictEqual(result.orphanedConsumers.length, 0);
+    });
+
+    it('should not match socket entries flowing in different directions', () => {
+      const entry = (
+        direction: 'server_to_client' | 'client_to_server',
+        role: 'producer' | 'consumer'
+      ): ManifestEntry => ({
+        protocol: 'socket',
+        event: 'payment:settled',
+        direction,
+        type_alias: 'Payment',
+        role,
+        type_kind: 'response',
+        file_path: 'f.ts',
+        line_number: 1,
+        is_explicit: true,
+        type_state: 'explicit',
+        evidence: {
+          file_path: 'f.ts',
+          span_start: null,
+          span_end: null,
+          line_number: 1,
+          infer_kind: 'response_body',
+          is_explicit: true,
+          type_state: 'explicit',
+        },
+      });
+
+      const producers: TypeManifest = {
+        repo_name: 'a',
+        commit_hash: 'x',
+        entries: [entry('server_to_client', 'producer')],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'b',
+        commit_hash: 'y',
+        entries: [entry('client_to_server', 'consumer')],
+      };
+
+      const result = matcher.matchEndpoints(producers, consumers);
+
+      assert.strictEqual(result.matches.length, 0);
+      assert.strictEqual(result.orphanedProducers.length, 1);
+      assert.strictEqual(result.orphanedConsumers.length, 1);
     });
   });
 

--- a/ts_check/lib/manifest-matcher.ts
+++ b/ts_check/lib/manifest-matcher.ts
@@ -50,18 +50,25 @@ export interface TypeEvidence {
   type_state: ManifestTypeState;
 }
 
+/** Socket message-flow direction, serialised snake_case by the Rust scanner. */
+export type SocketDirection = 'server_to_client' | 'client_to_server';
+
 export interface ManifestEntry {
   /**
-   * Protocol tag carried by the operation key. ts_check is the
-   * TS-assignability checker for HTTP contracts, so only "http" entries are
-   * valid here; other protocols are checked by their own pipelines and must
-   * not be written into these manifests.
+   * Protocol tag carried by the operation key. ts_check runs the same
+   * `TypeCompatibilityChecker` assignability for every protocol it understands:
+   * "http" (matched by method/path) and "socket" (matched by event+direction).
+   * Other protocols are checked by their own pipelines and are dropped here.
    */
-  protocol: 'http';
-  /** HTTP method (GET, POST, PUT, DELETE, etc.) */
-  method: string;
-  /** API path (e.g., /api/users/:id) */
-  path: string;
+  protocol: 'http' | 'socket';
+  /** HTTP method (GET, POST, …). Present on HTTP entries; absent on socket. */
+  method?: string;
+  /** API path (e.g., /api/users/:id). Present on HTTP entries; absent on socket. */
+  path?: string;
+  /** Socket event name (e.g. `payment:settled`). Present on socket entries only. */
+  event?: string;
+  /** Socket message-flow direction. Present on socket entries only. */
+  direction?: SocketDirection;
   /** The type alias for this endpoint */
   type_alias: string;
   /** Whether this is a producer or consumer */
@@ -84,9 +91,18 @@ export interface ManifestEntry {
  * Result of matching a producer-consumer pair
  */
 export interface MatchResult {
-  /** The HTTP method */
+  /**
+   * The pseudo-method this match is keyed on: the HTTP method for HTTP edges,
+   * or the literal `SOCKET` for socket edges. Combined with `path` it forms the
+   * `endpoint` label the Rust verdict-join parses back (`parse_compat_endpoint`).
+   */
   method: string;
-  /** The normalized API path */
+  /**
+   * The identity this match is keyed on: the normalized API path for HTTP, or
+   * the socket canonical `<DIRECTION>|<event>` tail for socket edges (so the
+   * full label `SOCKET <DIRECTION>|<event>` parses back into the same join key
+   * as the Rust `socket|<DIRECTION>|<event>` producer key).
+   */
   path: string;
   /** The type kind being matched */
   type_kind: ManifestTypeKind;
@@ -192,6 +208,51 @@ export function normalizeMethod(method: string): string {
 }
 
 // ============================================================================
+// Socket Identity
+// ============================================================================
+
+/** The pseudo-method socket matches are keyed on, mirroring HTTP's method. */
+export const SOCKET_PSEUDO_METHOD = 'SOCKET';
+
+/**
+ * ASCII direction label used in the canonical socket key, byte-identical to the
+ * Rust `SocketDirection::label()` (`SERVER->CLIENT` / `CLIENT->SERVER`). The
+ * Rust scanner serialises the direction snake_case (`server_to_client`); the
+ * canonical key it builds with `OperationKey::canonical()` uses these labels, so
+ * ts_check must reconstruct the same label to join a socket edge to its verdict.
+ */
+export function socketDirectionLabel(direction: SocketDirection): string {
+  return direction === 'server_to_client' ? 'SERVER->CLIENT' : 'CLIENT->SERVER';
+}
+
+/**
+ * Stable identity for a socket entry: `<DIRECTION>|<event>`. Two socket entries
+ * match iff this string is equal (same event flowing the same direction), the
+ * exact-key semantics the Rust `analyze_exact_key_matches` uses. The full
+ * canonical key on the Rust side is `socket|<DIRECTION>|<event>`; this is its
+ * `<DIRECTION>|<event>` tail, which becomes the `path` of the socket
+ * `MatchResult` so the assembled `endpoint` label round-trips through the
+ * verdict-join.
+ */
+export function socketKey(entry: ManifestEntry): string | null {
+  if (entry.protocol !== 'socket' || !entry.event || !entry.direction) {
+    return null;
+  }
+  return `${socketDirectionLabel(entry.direction)}|${entry.event}`;
+}
+
+/**
+ * Human label for an entry in orphan/diagnostic strings: `<METHOD> <path>` for
+ * HTTP, `socket <DIRECTION>|<event>` for socket.
+ */
+export function entryLabel(entry: ManifestEntry): string {
+  if (entry.protocol === 'socket') {
+    return `socket ${socketKey(entry) ?? entry.event ?? '<unknown>'}`;
+  }
+  return `${entry.method} ${entry.path}`;
+}
+
+// ============================================================================
 // ManifestMatcher Class
 // ============================================================================
 
@@ -237,16 +298,16 @@ export class ManifestMatcher {
         throw new Error('Manifest missing required field: entries (must be an array)');
       }
 
-      // ts_check is the HTTP TS-assignability checker; non-HTTP entries
-      // (GraphQL/socket OperationKeys, which serialise without method/path)
-      // are scored by their own pipelines and must be skipped here. The
-      // scanner already filters them out of the manifest files it writes
-      // (write_manifest_files), but a stray non-HTTP entry must never crash
-      // the whole verdict run again (#253), so we drop them defensively and
-      // leave a trace rather than throwing.
-      manifest.entries = this.retainHttpEntries(manifest.entries, absolutePath);
+      // ts_check checks HTTP (by method/path) and socket (by event+direction)
+      // entries with the same assignability checker. Any other protocol
+      // (GraphQL, which serialises without a checkable identity) is scored by
+      // its own pipeline and skipped here. The scanner already filters those out
+      // of the manifest files it writes (write_manifest_files), but a stray
+      // non-checkable entry must never crash the whole verdict run (#253), so we
+      // drop them defensively and leave a trace rather than throwing.
+      manifest.entries = this.retainCheckableEntries(manifest.entries, absolutePath);
 
-      // Validate the surviving HTTP entries.
+      // Validate the surviving (HTTP + socket) entries.
       for (const entry of manifest.entries) {
         this.validateEntry(entry);
       }
@@ -261,20 +322,20 @@ export class ManifestMatcher {
   }
 
   /**
-   * Filter a manifest entry list down to the HTTP entries ts_check can check.
+   * Filter a manifest entry list down to the entries ts_check can check: HTTP
+   * (keyed by method/path) and socket (keyed by event+direction).
    *
-   * An entry is non-HTTP when its `protocol` is not "http" or it lacks the
-   * `method`/`path` an HTTP key carries (GraphQL/socket keys serialise without
-   * them). Those are skipped — they belong to other pipelines (#236/#248) — and
-   * a single summary line is logged so the drop is never silent. A stray
-   * non-HTTP entry can thus never zero out the entire verdict set again (#253).
+   * Any other protocol — or a malformed entry missing the identity its protocol
+   * needs — is skipped: it belongs to another pipeline (e.g. GraphQL, #268) or
+   * is junk. A single summary line is logged so the drop is never silent. A
+   * stray non-checkable entry can thus never zero out the verdict set (#253).
    */
-  private retainHttpEntries(entries: unknown[], source: string): ManifestEntry[] {
+  private retainCheckableEntries(entries: unknown[], source: string): ManifestEntry[] {
     const retained: ManifestEntry[] = [];
     let skipped = 0;
 
     for (const entry of entries) {
-      if (this.isHttpManifestEntry(entry)) {
+      if (this.isCheckableManifestEntry(entry)) {
         retained.push(entry);
       } else {
         skipped++;
@@ -284,7 +345,7 @@ export class ManifestMatcher {
     if (skipped > 0) {
       console.warn(
         `[manifest] Skipped ${skipped} non-checkable entr${skipped === 1 ? 'y' : 'ies'} in ${source} ` +
-          `(not HTTP, or missing method/path; ts_check is HTTP-only — other protocols are checked by their own pipelines)`
+          `(not HTTP/socket, or missing its identity fields; other protocols are checked by their own pipelines)`
       );
     }
 
@@ -292,25 +353,34 @@ export class ManifestMatcher {
   }
 
   /**
-   * Shape guard for raw, possibly-malformed manifest JSON: an entry ts_check can
-   * check is an object whose `protocol` is "http" with non-empty string `method`
-   * and `path`. GraphQL/socket keys serialise without method/path and are
-   * filtered out here (#253). Full structural validation of the surviving HTTP
-   * entries is `validateEntry`'s job — a genuinely-malformed HTTP entry still
-   * throws there.
+   * Shape guard for raw, possibly-malformed manifest JSON. A checkable entry is
+   * either an HTTP key (`protocol: "http"` with non-empty `method`+`path`) or a
+   * socket key (`protocol: "socket"` with non-empty `event`+`direction`).
+   * Everything else (GraphQL keys, junk) is filtered out here (#253). Full
+   * structural validation of the survivors is `validateEntry`'s job — a
+   * genuinely-malformed HTTP/socket entry still throws there.
    */
-  private isHttpManifestEntry(entry: unknown): entry is ManifestEntry {
+  private isCheckableManifestEntry(entry: unknown): entry is ManifestEntry {
     if (typeof entry !== 'object' || entry === null) {
       return false;
     }
     const e = entry as Record<string, unknown>;
-    return (
-      e.protocol === 'http' &&
-      typeof e.method === 'string' &&
-      e.method.length > 0 &&
-      typeof e.path === 'string' &&
-      e.path.length > 0
-    );
+    if (e.protocol === 'http') {
+      return (
+        typeof e.method === 'string' &&
+        e.method.length > 0 &&
+        typeof e.path === 'string' &&
+        e.path.length > 0
+      );
+    }
+    if (e.protocol === 'socket') {
+      return (
+        typeof e.event === 'string' &&
+        e.event.length > 0 &&
+        (e.direction === 'server_to_client' || e.direction === 'client_to_server')
+      );
+    }
+    return false;
   }
 
   /**
@@ -333,8 +403,8 @@ export class ManifestMatcher {
       throw new Error('Manifest missing required field: entries (must be an array)');
     }
 
-    // Skip non-HTTP entries before validating (see loadManifest / #253).
-    manifest.entries = this.retainHttpEntries(manifest.entries, '<string>');
+    // Skip non-checkable entries before validating (see loadManifest / #253).
+    manifest.entries = this.retainCheckableEntries(manifest.entries, '<string>');
 
     for (const entry of manifest.entries) {
       this.validateEntry(entry);
@@ -346,19 +416,31 @@ export class ManifestMatcher {
   /**
    * Validate a manifest entry has all required fields.
    *
-   * Callers must drop non-HTTP entries via `retainHttpEntries` first; by the
-   * time an entry reaches here it is expected to be HTTP, so a missing
-   * `method`/`path`/`protocol` is a genuine data bug and still throws.
+   * Callers must drop non-checkable entries via `retainCheckableEntries` first;
+   * by the time an entry reaches here it is expected to be HTTP or socket. An
+   * HTTP entry missing `method`/`path`, or a socket entry missing
+   * `event`/`direction`, is a genuine data bug and still throws (the #253
+   * guard — a malformed entry must fail loud, not silently pass).
    */
   private validateEntry(entry: ManifestEntry): void {
-    if (!entry.method) {
-      throw new Error('ManifestEntry missing required field: method');
-    }
-    if (!entry.path) {
-      throw new Error('ManifestEntry missing required field: path');
-    }
-    if (entry.protocol !== 'http') {
-      throw new Error('ManifestEntry missing or invalid field: protocol (must be "http")');
+    if (entry.protocol === 'http') {
+      if (!entry.method) {
+        throw new Error('ManifestEntry missing required field: method');
+      }
+      if (!entry.path) {
+        throw new Error('ManifestEntry missing required field: path');
+      }
+    } else if (entry.protocol === 'socket') {
+      if (!entry.event) {
+        throw new Error('ManifestEntry missing required field: event');
+      }
+      if (entry.direction !== 'server_to_client' && entry.direction !== 'client_to_server') {
+        throw new Error(
+          'ManifestEntry missing or invalid field: direction (must be "server_to_client" or "client_to_server")'
+        );
+      }
+    } else {
+      throw new Error('ManifestEntry missing or invalid field: protocol (must be "http" or "socket")');
     }
     if (!entry.type_alias) {
       throw new Error('ManifestEntry missing required field: type_alias');
@@ -431,11 +513,12 @@ export class ManifestMatcher {
 
     return manifest.entries.filter((entry) => {
       if (entry.role !== 'producer') return false;
+      if (entry.protocol !== 'http') return false;
       if (typeKind && entry.type_kind !== typeKind) return false;
 
-      const entryMethod = normalizeMethod(entry.method);
+      const entryMethod = normalizeMethod(entry.method!);
 
-      return entryMethod === normalizedMethod && pathsMatch(entry.path, inputPath);
+      return entryMethod === normalizedMethod && pathsMatch(entry.path!, inputPath);
     });
   }
 
@@ -457,11 +540,12 @@ export class ManifestMatcher {
 
     return manifest.entries.filter((entry) => {
       if (entry.role !== 'consumer') return false;
+      if (entry.protocol !== 'http') return false;
       if (typeKind && entry.type_kind !== typeKind) return false;
 
-      const entryMethod = normalizeMethod(entry.method);
+      const entryMethod = normalizeMethod(entry.method!);
 
-      return entryMethod === normalizedMethod && pathsMatch(entry.path, inputPath);
+      return entryMethod === normalizedMethod && pathsMatch(entry.path!, inputPath);
     });
   }
 
@@ -478,8 +562,9 @@ export class ManifestMatcher {
     const endpoints: Array<{ method: string; path: string; type_kind: ManifestTypeKind }> = [];
 
     for (const entry of manifest.entries) {
-      const normalizedMethod = normalizeMethod(entry.method);
-      const normalizedPath = normalizePath(entry.path);
+      if (entry.protocol !== 'http') continue;
+      const normalizedMethod = normalizeMethod(entry.method!);
+      const normalizedPath = normalizePath(entry.path!);
       const key = `${normalizedMethod} ${normalizedPath} ${entry.type_kind}`;
 
       if (!seen.has(key)) {
@@ -522,27 +607,28 @@ export class ManifestMatcher {
     const producerEntries = producers.entries.filter((e) => e.role === 'producer');
     const consumerEntries = consumers.entries.filter((e) => e.role === 'consumer');
 
-    // For each consumer, find candidate producers, then keep only the most
-    // specific ones. This mirrors routing semantics: a request to /users/me
-    // is served by a literal /users/me route when one exists, not by
+    // HTTP edges: for each consumer, find candidate producers, then keep only
+    // the most specific ones. This mirrors routing semantics: a request to
+    // /users/me is served by a literal /users/me route when one exists, not by
     // /users/:id — matching both would produce duplicate or contradictory
     // verdicts. Equally specific candidates (e.g. the same route registered
     // by two service versions) are all kept.
     for (let ci = 0; ci < consumerEntries.length; ci++) {
       const consumer = consumerEntries[ci];
-      const consumerMethod = normalizeMethod(consumer.method);
-      const consumerPath = normalizePath(consumer.path);
+      if (consumer.protocol !== 'http') continue;
+      const consumerMethod = normalizeMethod(consumer.method!);
+      const consumerPath = normalizePath(consumer.path!);
 
       const candidates: Array<{ pi: number; score: number }> = [];
 
       for (let pi = 0; pi < producerEntries.length; pi++) {
         const producer = producerEntries[pi];
-        const producerMethod = normalizeMethod(producer.method);
+        if (producer.protocol !== 'http') continue;
+        const producerMethod = normalizeMethod(producer.method!);
 
         if (
-          consumer.protocol === producer.protocol &&
           consumerMethod === producerMethod &&
-          pathsMatch(consumer.path, producer.path) &&
+          pathsMatch(consumer.path!, producer.path!) &&
           consumer.type_kind === producer.type_kind
         ) {
           candidates.push({
@@ -577,13 +663,53 @@ export class ManifestMatcher {
       }
     }
 
+    // Socket edges: exact-key match on `<DIRECTION>|<event>`, the same identity
+    // the Rust `analyze_exact_key_matches` uses (no path/route to resolve, so no
+    // specificity ranking — a socket consumer matches every producer carrying
+    // the same key). The assembled label `SOCKET <DIRECTION>|<event>` round-trips
+    // through the Rust verdict-join (`parse_compat_endpoint`/`parse_producer_key`).
+    for (let ci = 0; ci < consumerEntries.length; ci++) {
+      const consumer = consumerEntries[ci];
+      if (consumer.protocol !== 'socket') continue;
+      const consumerKey = socketKey(consumer);
+      if (consumerKey === null) continue;
+
+      let matched = false;
+      for (let pi = 0; pi < producerEntries.length; pi++) {
+        const producer = producerEntries[pi];
+        if (producer.protocol !== 'socket') continue;
+        if (socketKey(producer) !== consumerKey) continue;
+        if (producer.type_kind !== consumer.type_kind) continue;
+
+        matches.push({
+          method: SOCKET_PSEUDO_METHOD,
+          path: consumerKey,
+          type_kind: consumer.type_kind,
+          producer,
+          consumer,
+          match_score: 1.0,
+        });
+        matchedProducerIndices.add(pi);
+        matched = true;
+      }
+
+      if (matched) {
+        matchedConsumerIndices.add(ci);
+      } else {
+        orphanedConsumers.push({
+          entry: consumer,
+          reason: `No producer found for socket ${consumerKey} (${consumer.type_kind})`,
+        });
+      }
+    }
+
     // Find orphaned producers (producers with no matching consumers)
     for (let pi = 0; pi < producerEntries.length; pi++) {
       if (!matchedProducerIndices.has(pi)) {
         const producer = producerEntries[pi];
         orphanedProducers.push({
           entry: producer,
-          reason: `No consumer found for ${producer.method} ${producer.path} (${producer.type_kind})`,
+          reason: `No consumer found for ${this.entryLabel(producer)} (${producer.type_kind})`,
         });
       }
     }
@@ -596,6 +722,15 @@ export class ManifestMatcher {
   }
 
   /**
+   * Human label for an entry in orphan/diagnostic strings. Delegates to the
+   * module-level `entryLabel` so the matcher and the type-checker format
+   * orphans identically.
+   */
+  private entryLabel(entry: ManifestEntry): string {
+    return entryLabel(entry);
+  }
+
+  /**
    * Calculate a match score between producer and consumer
    *
    * Currently returns 1.0 for all matches, but could be extended
@@ -605,8 +740,9 @@ export class ManifestMatcher {
    * - Version compatibility
    */
   private calculateMatchScore(producer: ManifestEntry, consumer: ManifestEntry): number {
-    const norm1 = normalizePath(producer.path);
-    const norm2 = normalizePath(consumer.path);
+    // Only ever called from the HTTP matching loop, so both paths are present.
+    const norm1 = normalizePath(producer.path!);
+    const norm2 = normalizePath(consumer.path!);
 
     // Exact normalized match (both parameterized or both identical)
     if (norm1 === norm2) {

--- a/ts_check/lib/type-checker.test.ts
+++ b/ts_check/lib/type-checker.test.ts
@@ -15,7 +15,40 @@ import * as path from 'path';
 import * as os from 'os';
 import { Project } from 'ts-morph';
 import { TypeCompatibilityChecker } from './type-checker';
-import { TypeManifest, createManifestEntry } from './manifest-matcher';
+import { TypeManifest, ManifestEntry, createManifestEntry } from './manifest-matcher';
+
+/**
+ * Build a socket `payment:settled` SERVER->CLIENT manifest entry. Socket entries
+ * carry `protocol: 'socket'` + `event` + `direction` instead of HTTP method/path.
+ */
+function socketEntry(
+  typeAlias: string,
+  role: 'producer' | 'consumer',
+  filePath: string,
+  lineNumber: number
+): ManifestEntry {
+  return {
+    protocol: 'socket',
+    event: 'payment:settled',
+    direction: 'server_to_client',
+    type_alias: typeAlias,
+    role,
+    type_kind: 'response',
+    file_path: filePath,
+    line_number: lineNumber,
+    is_explicit: true,
+    type_state: 'explicit',
+    evidence: {
+      file_path: filePath,
+      span_start: null,
+      span_end: null,
+      line_number: lineNumber,
+      infer_kind: 'response_body',
+      is_explicit: true,
+      type_state: 'explicit',
+    },
+  };
+}
 
 // ============================================================================
 // TypeCompatibilityChecker Tests
@@ -463,6 +496,108 @@ describe('TypeCompatibilityChecker', () => {
       assert.strictEqual(result.compatiblePairs, 0);
       assert.strictEqual(result.unknownPairs.length, 0);
       assert.strictEqual(result.mismatches.length, 1);
+    });
+
+    it('type-checks a socket SERVER->CLIENT edge end-to-end as compatible', async () => {
+      // The xrepo-corpus-1 `payment:settled` edge. Carrick keys the *listener*
+      // (web-frontend, `SettledPayment`) as the producer and the *emitter*
+      // (payments-svc, `Payment`) as the consumer. The bytes flow emitter →
+      // listener, so the emitter payload must satisfy what the listener expects:
+      // `Payment.status: "pending" | "settled"` ⊑ `SettledPayment.status: string`
+      // → compatible. (Reusing the HTTP direction would wrongly read this as
+      // incompatible.)
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type SettledPayment = { id: string; orderId: number; amountCents: number; status: string };
+        export type Payment = { id: string; orderId: number; amountCents: number; status: "pending" | "settled" };
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'abc',
+        entries: [
+          socketEntry('SettledPayment', 'producer', 'lib/realtime.ts', 31),
+        ],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'payments-svc',
+        commit_hash: 'def',
+        entries: [
+          socketEntry('Payment', 'consumer', 'realtime/server.ts', 27),
+        ],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.matchDetails?.length, 1, 'the socket pair must match');
+      assert.strictEqual(
+        result.matchDetails?.[0].method,
+        'SOCKET',
+        'the match is keyed on the SOCKET pseudo-method'
+      );
+      assert.strictEqual(
+        result.matchDetails?.[0].path,
+        'SERVER->CLIENT|payment:settled',
+        'the match path is the canonical socket key tail'
+      );
+      assert.strictEqual(result.compatiblePairs, 1);
+      assert.strictEqual(result.incompatiblePairs, 0);
+      assert.strictEqual(result.unknownPairs.length, 0);
+    });
+
+    it('reads a socket edge whose emitted payload widens the listener type as incompatible', async () => {
+      // Direction proof: if the emitter sends a *wider* type than the listener
+      // accepts, the edge is incompatible. Here the emitter sends
+      // `status: string` but the listener only accepts `"pending" | "settled"`,
+      // so `string` is NOT assignable → incompatible. This is the mirror of the
+      // compatible case and fails if the assignability direction is not flipped
+      // for sockets.
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type StrictPayment = { id: string; status: "pending" | "settled" };
+        export type LoosePayment = { id: string; status: string };
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'listener-repo',
+        commit_hash: 'abc',
+        entries: [socketEntry('StrictPayment', 'producer', 'lib/realtime.ts', 31)],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'emitter-repo',
+        commit_hash: 'def',
+        entries: [socketEntry('LoosePayment', 'consumer', 'realtime/server.ts', 27)],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.incompatiblePairs, 1);
+      assert.strictEqual(result.compatiblePairs, 0);
+      assert.strictEqual(result.mismatches.length, 1);
+      assert.ok(
+        result.mismatches[0].endpoint.startsWith('SOCKET '),
+        'the mismatch endpoint must carry the SOCKET label'
+      );
     });
 
     it('reads a dangling consumer name as unverifiable but its structural shape as incompatible (#257)', async () => {

--- a/ts_check/lib/type-checker.ts
+++ b/ts_check/lib/type-checker.ts
@@ -20,6 +20,7 @@ import {
   ManifestEntry,
   MatchResult,
   TypeEvidence,
+  entryLabel,
 } from "./manifest-matcher";
 
 /**
@@ -161,11 +162,11 @@ export class TypeCompatibilityChecker {
       mismatches: [],
       orphanedProducers: orphanedProducers.map(
         (o) =>
-          `${o.entry.method} ${o.entry.path} (${o.entry.type_kind}, ${o.entry.type_alias})`
+          `${entryLabel(o.entry)} (${o.entry.type_kind}, ${o.entry.type_alias})`
       ),
       orphanedConsumers: orphanedConsumers.map(
         (o) =>
-          `${o.entry.method} ${o.entry.path} (${o.entry.type_kind}, ${o.entry.type_alias})`
+          `${entryLabel(o.entry)} (${o.entry.type_kind}, ${o.entry.type_alias})`
       ),
       unknownPairs: [],
       matchDetails: matches,
@@ -344,22 +345,41 @@ export class TypeCompatibilityChecker {
       };
     }
 
-    // Producer payload must satisfy what the consumer expects.
-    if (producerType.isAssignableTo(consumerType)) {
+    // Assignability runs in the DATA-flow direction: the value that is sent
+    // must satisfy the type the receiver expects.
+    //
+    // HTTP: the manifest producer (endpoint) emits the response and the manifest
+    // consumer (call) receives it, so the producer payload must satisfy the
+    // consumer — `producer ⊑ consumer`.
+    //
+    // Socket: the role mapping is inverted relative to data flow. Carrick keys a
+    // *listener* (`socket.on`) as the producer (endpoint) and an *emitter*
+    // (`socket.emit`) as the consumer (call). The bytes flow emitter → listener,
+    // so the *emitter's* payload (manifest consumer) must satisfy what the
+    // *listener* expects (manifest producer) — `consumer ⊑ producer`. Checking
+    // the HTTP direction here would read a widening listener type (e.g.
+    // `status: string` accepting a producer `"pending" | "settled"`) as
+    // incompatible, the opposite of the truth. (See xrepo-corpus-1 README,
+    // "Socket producer/consumer direction".) The same `isAssignableTo` relation
+    // and the same resolved Type objects are used either way.
+    const socket = producer.protocol === "socket";
+    const sentType = socket ? consumerType : producerType;
+    const expectedType = socket ? producerType : consumerType;
+    if (sentType.isAssignableTo(expectedType)) {
       return { kind: "compatible" };
     }
 
-    const producerText = this.typeText(producerType);
-    const consumerText = this.typeText(consumerType);
+    const sentText = this.typeText(sentType);
+    const expectedText = this.typeText(expectedType);
     return {
       kind: "incompatible",
       mismatch: {
         endpoint,
-        producerType: producerText,
+        producerType: sentText,
         consumerCall: consumer.type_alias,
-        consumerType: consumerText,
+        consumerType: expectedText,
         isAssignable: false,
-        errorDetails: `Type '${producerText}' is not assignable to type '${consumerText}'`,
+        errorDetails: `Type '${sentText}' is not assignable to type '${expectedText}'`,
         producerLocation: this.formatEntryLocation(producer),
         consumerLocation: this.formatEntryLocation(consumer),
         producerEvidence: producer.evidence,


### PR DESCRIPTION
## What

Makes the cross-repo socket edge `socket|SERVER->CLIENT|payment:settled`
(payments-svc emits → web-frontend listens) type-checked end-to-end, so it gets
a real compat verdict instead of `None`. This lifts cross-repo compat past the
HTTP-only ceiling. ts_check was HTTP-only; both socket sides already resolve to
the settled-payment shape `{ id: string; orderId: number; amountCents: number;
status: "pending" | "settled" }` in the bundles, so the gap was purely the
HTTP-only plumbing.

## Why it was `None`

Three HTTP-only choke points, each fixed here (HTTP path 100% intact):

1. **`src/engine/mod.rs` `write_manifest_files`** dropped every non-HTTP entry
   before the producer/consumer manifests. Now HTTP **and** socket pass through;
   GraphQL stays filtered — its cross-repo resolution is blocked on separate
   work (#268) and its `OperationKey` carries no checkable identity for the
   matcher.
2. **`ts_check/lib/manifest-matcher.ts` + `type-checker.ts`** rejected non-HTTP
   entries (`validateEntry` threw on missing method/path — the #253 hazard). Now
   socket entries are validated by `event` + `direction`, matched producer↔
   consumer on the canonical `<DIRECTION>|<event>` key, and run through the
   **same** `TypeCompatibilityChecker` assignability as HTTP. The assignability
   runs in the **data-flow** direction: for sockets the role mapping is inverted
   (listener = producer, emitter = consumer), so the emitter payload must satisfy
   what the listener expects. The #253 throw-guard still protects genuinely
   malformed HTTP/socket entries.
3. **`src/analyzer/mod.rs` `apply_compat_verdicts`** forced socket edges to
   `None`: `parse_producer_key` accepted only `http|…`. It now also parses
   `socket|DIRECTION|event` → `("SOCKET", "DIRECTION|event")`, the same pair
   `parse_compat_endpoint` already recovers from the socket endpoint label
   `"SOCKET DIRECTION|event (response)"`, so the verdict lands on the socket
   edge. The #271 param-name-agnostic HTTP join is unchanged.

## Verification

- **Both socket sides resolve to a real shape**: emitter (payments-svc,
  `Payment`, imported) and listener (web-frontend, `SettledPayment`, same-file)
  both yield a `SymbolRequest` the sidecar resolves via ts-morph
  (`collect_socket_type_requests` handles the no-import same-file case).
- New tests:
  - ts_check end-to-end: two socket entries with the real settled-payment shape
    → `compatible`; a direction-proof case where the emitter widens the listener
    type → `incompatible`.
  - Rust `apply_compat_verdicts_joins_socket_edge`: a
    `socket|SERVER->CLIENT|payment:settled` edge joins its ts_check verdict.
    **Proven to fail pre-fix** (edge forced `None`), **pass post-fix**.
- Full `cargo test` (434 lib + 441 bin + integration), `cargo fmt --check`,
  `cargo clippy --all-targets --all-features -D warnings`, and ts_check
  `npm test` (77) all green. No cassette golden change. No ground-truth
  (`expected*.json`) or carrick-cloud changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)