### PR TITLE
fix(schema): require endpoint payload locators; scope type-slot to response

### DIFF
--- a/src/agents/schemas.rs
+++ b/src/agents/schemas.rs
@@ -324,15 +324,15 @@ impl AgentSchemas {
                             "primary_type_symbol": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "The named type of the response payload, as a bare identifier. ALWAYS extract it when the payload value has a determinable named type; do not skip it. Trace the sent or returned payload value (the same value as `response_expression_text`) to its declared type: a local variable annotation (`const u: User = ...; res.json(u)` gives `User`), a function return annotation (`(): Promise<User>` gives `User`), a cast on the payload (`res.json(u as User)` gives `User`), or a generic type argument (`get<User>(...)` gives `User`). An imperative send like `res.json(u)` does not suppress this; extract it the same as a returned value. Unwrap `Promise<...>`, arrays (`User[]`), and response wrappers (`Response<User>`) down to the core identifier. Null only for untyped or inline-object-literal payloads with no named type."
+                                "description": "The named type of the RESPONSE payload value ONLY — the exact value emitted as `response_expression_text` — as a bare identifier. ALWAYS extract it when that response value has a determinable named type; do not skip it. Trace ONLY that sent or returned value to its declared type: a local variable annotation (`const u: User = ...; res.json(u)` gives `User`), a function return annotation (`(): Promise<User>` gives `User`), a cast on the payload (`res.json(u as User)` gives `User`), or a generic type argument (`get<User>(...)` gives `User`). An imperative send like `res.json(u)` does not suppress this; extract it the same as a returned value. Unwrap `Promise<...>`, arrays (`User[]`), and response wrappers (`Response<User>`) down to the core identifier. NEVER borrow a named type from elsewhere in the handler — in particular, do NOT put the REQUEST body's type here (the `T` in `req.body as T`); the request type is carried only by `payload_expression_text` and resolved downstream. Null for untyped, inline-object-literal, or otherwise un-annotated response payloads."
                             },
                             "type_import_source": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "Import path where the `primary_type_symbol` type is defined (e.g., './types/user'), or null if it is declared in the same file. Read the import statements at the top of the file."
+                                "description": "Import path where the `primary_type_symbol` type is defined (e.g., './types/user'), or null if it is declared in the same file. Null whenever `primary_type_symbol` is null. Read the import statements at the top of the file."
                             }
                         },
-                        "required": ["candidate_id", "line_number", "owner_node", "method", "path", "handler_name", "pattern_matched", "emission_style"]
+                        "required": ["candidate_id", "line_number", "owner_node", "method", "path", "handler_name", "pattern_matched", "emission_style", "payload_expression_text", "payload_expression_line"]
                     }
                 },
                 "data_calls": {


### PR DESCRIPTION
## Problem

The cross-repo `POST /payments` producer request type resolves as `unknown`, so compat edge 3 fails (compat stuck at 0.50). Prior attempts to fix this with system-prompt prose were "deployed but ineffective".

Root cause, found via the file-analyzer prompt harness against the live model: the endpoint schema left `payload_expression_text` / `payload_expression_line` **optional**, so the small extraction model omitted them under uncertainty. For a route bound to a NAMED handler whose request body is read inside the handler (`const x = req.body as T`), the locator was never emitted → the type sidecar had nowhere to resolve the producer request type from. No prompt change could fix it because the schema never forced the decision (the model was even tracing into the handler correctly — it found the import — but mis-filed it into the response-type slot).

## Change (deterministic, scanner-side — no cloud deploy)

- Add `payload_expression_text` + `payload_expression_line` to the endpoint `required` array (required + nullable, mirroring the existing `emission_style` pattern), so the model always decides them.
- Scope `primary_type_symbol` / `type_import_source` descriptions to the RESPONSE payload value only, and forbid borrowing a named type from elsewhere in the handler — in particular the request body's type (the `T` in `req.body as T`).

## Validation

file-analyzer prompt harness, `named-handler-cast` fixture, live model, 5/5 runs:
- `payload_expression_text="req.body"` at the correct in-handler line — **now emitted reliably** (was absent on every baseline run).
- `type_import_source=null` — **no longer polluted** with the request import.
- single endpoint (the baseline intermittently emitted a duplicate).

Expected eval effect: `POST /payments` producer request type resolves → compat 0.50 → ~0.67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)