### PR TITLE
feat(graphql): resolve producer types from resolver functions (scanner-only)

### DIFF
--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -301,6 +301,7 @@ impl FileAnalyzerAgent {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn analyze_file_with_candidates(
         &self,
         file_path: &str,
@@ -1561,13 +1562,17 @@ const data = await fetch('/api/users').then(resp => resp.json());
         // newline. A stray blank line here (the `{}\n{}` template bug Copilot flagged)
         // would shift the cacheable prefix and tank the within-scan cache hit rate.
         let triage_hints = &guidance.triage_hints;
-        let pre_feature_join = format!("### FRAMEWORK-SPECIFIC HINTS\n{triage_hints}\n### FRAMEWORK-SPECIFIC PARSING NOTES");
+        let pre_feature_join = format!(
+            "### FRAMEWORK-SPECIFIC HINTS\n{triage_hints}\n### FRAMEWORK-SPECIFIC PARSING NOTES"
+        );
         assert!(
             message.contains(&pre_feature_join),
             "empty hints must render the pre-feature single-newline join, got:\n{message}"
         );
         // And explicitly: no doubled blank line where the section would have gone.
-        let doubled_join = format!("### FRAMEWORK-SPECIFIC HINTS\n{triage_hints}\n\n### FRAMEWORK-SPECIFIC PARSING NOTES");
+        let doubled_join = format!(
+            "### FRAMEWORK-SPECIFIC HINTS\n{triage_hints}\n\n### FRAMEWORK-SPECIFIC PARSING NOTES"
+        );
         assert!(
             !message.contains(&doubled_join),
             "empty hints must NOT leave a doubled blank line before PARSING NOTES, got:\n{message}"

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -625,6 +625,13 @@ impl FileAnalyzerAgent {
         // sits in the cacheable front block alongside the guidance. When the
         // service has no SDL producers this is empty and the section is omitted,
         // leaving every non-GraphQL prompt byte-identical to before.
+        //
+        // The section string carries its OWN leading `\n` (the blank line that
+        // separates it from the triage hints above) and its own trailing `\n`. The
+        // template therefore interpolates it ADJACENT to the triage-hints
+        // placeholder with no surrounding newline of its own — so an empty section
+        // contributes exactly zero bytes and the non-GraphQL message is byte-for-byte
+        // the pre-feature prompt, preserving the Vertex implicit prefix-cache hit.
         let graphql_producers_section = if graphql_producer_hints.is_empty() {
             String::new()
         } else {
@@ -667,8 +674,7 @@ impl FileAnalyzerAgent {
 }}
 
 ### FRAMEWORK-SPECIFIC HINTS
-{}
-{}
+{}{}
 ### FRAMEWORK-SPECIFIC PARSING NOTES
 These notes are generated per-scan by the framework guidance layer and describe how to correctly extract endpoints, mounts, owners, and prefixes for the exact framework(s) detected in this repo. Read them carefully — they override any generic rule in the system prompt when they conflict.
 {}
@@ -1546,6 +1552,25 @@ const data = await fetch('/api/users').then(resp => resp.json());
         assert!(
             !message.contains("GRAPHQL SCHEMA PRODUCERS"),
             "GraphQL producers section must be absent when no hints are passed, got:\n{message}"
+        );
+
+        // Byte-identity guard (Vertex implicit prefix caching): an empty hint list
+        // must contribute ZERO bytes to the assembled message — i.e. the prompt is
+        // byte-for-byte what the pre-feature template produced. The pre-feature form
+        // joined the triage hints directly to the PARSING NOTES header with a SINGLE
+        // newline. A stray blank line here (the `{}\n{}` template bug Copilot flagged)
+        // would shift the cacheable prefix and tank the within-scan cache hit rate.
+        let triage_hints = &guidance.triage_hints;
+        let pre_feature_join = format!("### FRAMEWORK-SPECIFIC HINTS\n{triage_hints}\n### FRAMEWORK-SPECIFIC PARSING NOTES");
+        assert!(
+            message.contains(&pre_feature_join),
+            "empty hints must render the pre-feature single-newline join, got:\n{message}"
+        );
+        // And explicitly: no doubled blank line where the section would have gone.
+        let doubled_join = format!("### FRAMEWORK-SPECIFIC HINTS\n{triage_hints}\n\n### FRAMEWORK-SPECIFIC PARSING NOTES");
+        assert!(
+            !message.contains(&doubled_join),
+            "empty hints must NOT leave a doubled blank line before PARSING NOTES, got:\n{message}"
         );
     }
 

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -586,6 +586,7 @@ impl FileAnalyzerAgent {
     }
 
     /// Build the dynamic user message with patterns, file content, and candidate targets.
+    #[allow(clippy::too_many_arguments)]
     fn build_user_message_with_candidates(
         &self,
         file_path: &str,

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -175,12 +175,42 @@ pub struct DataCallResult {
     pub type_import_source: Option<String>,
 }
 
+/// A GraphQL resolver the file-analyzer found: the schema field it answers and
+/// the resolver function's declared return type (resolved downstream into the
+/// producer-side response contract). Mirrors the `graphql_operations` array in
+/// `AgentSchemas::file_analysis_schema`. The `kind` wire values (query /
+/// mutation / subscription) come from `crate::operation::GraphqlOperationKind`,
+/// the single source of truth shared with the operation graph; the schema enum
+/// is kept in lockstep by `graphql_operations_schema_enum_matches_serde_wire_values`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphqlOperation {
+    /// The GraphQL root operation this resolver implements.
+    pub kind: crate::operation::GraphqlOperationKind,
+    /// The schema field name this resolver answers (e.g., "order").
+    pub field: String,
+    /// Name of the resolver function (e.g., "resolveOrder").
+    pub resolver_function: String,
+    /// Line number where the resolver function is defined.
+    pub resolver_line: i32,
+    /// The primary return type symbol without wrappers (e.g., "ApiResponse" from
+    /// "Promise<ApiResponse>"). `None` for untyped or inline-object returns.
+    pub primary_type_symbol: Option<String>,
+    /// Import path where the type is defined (e.g., "./types/order"), null if
+    /// inline or same file. Null whenever `primary_type_symbol` is null.
+    pub type_import_source: Option<String>,
+}
+
 /// Complete analysis result for a single file
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FileAnalysisResult {
     pub mounts: Vec<MountResult>,
     pub endpoints: Vec<EndpointResult>,
     pub data_calls: Vec<DataCallResult>,
+    /// GraphQL resolvers found in the file. Optional on the wire (a model may
+    /// omit it for non-GraphQL files), so default to empty rather than failing
+    /// the whole file's parse.
+    #[serde(default)]
+    pub graphql_operations: Vec<GraphqlOperation>,
 }
 
 /// Agent that performs file-centric analysis using framework-agnostic patterns.
@@ -901,6 +931,7 @@ mod tests {
             mounts: vec![],
             endpoints: vec![endpoint],
             data_calls: vec![],
+            graphql_operations: vec![],
         };
 
         FileAnalyzerAgent::sanitize_result(&mut result);
@@ -918,6 +949,7 @@ mod tests {
             mounts: vec![],
             endpoints: vec![endpoint],
             data_calls: vec![],
+            graphql_operations: vec![],
         };
         FileAnalyzerAgent::sanitize_result(&mut result);
         assert_eq!(
@@ -1099,6 +1131,7 @@ mod tests {
                 primary_type_symbol: Some("NULL".to_string()),
                 type_import_source: Some("bad import (oops)".to_string()),
             }],
+            graphql_operations: vec![],
         };
 
         let needs_retry = FileAnalyzerAgent::sanitize_result(&mut result);
@@ -1144,6 +1177,7 @@ mod tests {
                 type_import_source: None,
             }],
             data_calls: vec![],
+            graphql_operations: vec![],
         };
 
         let json = serde_json::to_string(&result).unwrap();
@@ -1155,6 +1189,63 @@ mod tests {
         assert_eq!(deserialized.mounts.len(), 1);
         assert_eq!(deserialized.endpoints.len(), 1);
         assert!(deserialized.data_calls.is_empty());
+    }
+
+    #[test]
+    fn graphql_operations_deserialize_from_model_shape() {
+        // The exact wire shape the file-analyzer emits for a GraphQL resolver.
+        let json = r#"{
+            "mounts": [],
+            "endpoints": [],
+            "data_calls": [],
+            "graphql_operations": [
+                {
+                    "kind": "query",
+                    "field": "order",
+                    "resolver_function": "resolveOrder",
+                    "resolver_line": 38,
+                    "primary_type_symbol": "ApiResponse",
+                    "type_import_source": null
+                }
+            ]
+        }"#;
+
+        let result: FileAnalysisResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.graphql_operations.len(), 1);
+        let op = &result.graphql_operations[0];
+        assert_eq!(op.kind, crate::operation::GraphqlOperationKind::Query);
+        assert_eq!(op.field, "order");
+        assert_eq!(op.resolver_function, "resolveOrder");
+        assert_eq!(op.resolver_line, 38);
+        assert_eq!(op.primary_type_symbol.as_deref(), Some("ApiResponse"));
+        assert_eq!(op.type_import_source, None);
+    }
+
+    #[test]
+    fn graphql_operations_default_empty_when_omitted() {
+        // A non-GraphQL file omits graphql_operations entirely; #[serde(default)]
+        // must yield an empty vec rather than failing the whole file's parse.
+        let json = r#"{ "mounts": [], "endpoints": [], "data_calls": [] }"#;
+        let result: FileAnalysisResult = serde_json::from_str(json).unwrap();
+        assert!(result.graphql_operations.is_empty());
+
+        // mutation / subscription wire values round-trip too.
+        let json = r#"{
+            "mounts": [], "endpoints": [], "data_calls": [],
+            "graphql_operations": [
+                { "kind": "mutation", "field": "createOrder", "resolver_function": "createOrder", "resolver_line": 7, "primary_type_symbol": null, "type_import_source": null },
+                { "kind": "subscription", "field": "orderUpdated", "resolver_function": "orderUpdated", "resolver_line": 9, "primary_type_symbol": null, "type_import_source": null }
+            ]
+        }"#;
+        let result: FileAnalysisResult = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            result.graphql_operations[0].kind,
+            crate::operation::GraphqlOperationKind::Mutation
+        );
+        assert_eq!(
+            result.graphql_operations[1].kind,
+            crate::operation::GraphqlOperationKind::Subscription
+        );
     }
 
     #[test]
@@ -1202,12 +1293,14 @@ mod tests {
                 primary_type_symbol: None,
                 type_import_source: None,
             }],
+            graphql_operations: vec![],
         };
 
         let retry = FileAnalysisResult {
             mounts: vec![],
             endpoints: vec![],
             data_calls: vec![],
+            graphql_operations: vec![],
         };
 
         let chosen = FileAnalyzerAgent::choose_best_result(initial.clone(), retry);

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -254,6 +254,7 @@ impl FileAnalyzerAgent {
             &[],
             &[],
             &HashMap::new(),
+            &[],
         )
         .await
     }
@@ -308,6 +309,7 @@ impl FileAnalyzerAgent {
         candidate_hints: &[String],
         candidate_contexts: &[String],
         imported_symbols: &HashMap<String, ImportedSymbol>,
+        graphql_producer_hints: &[String],
     ) -> Result<FileAnalysisResult, Box<dyn std::error::Error>> {
         // Skip empty files
         if file_content.trim().is_empty() {
@@ -321,6 +323,7 @@ impl FileAnalyzerAgent {
             candidate_hints,
             candidate_contexts,
             imported_symbols,
+            graphql_producer_hints,
         );
 
         debug!("=== FILE ANALYZER AGENT (AST-GATED) ===");
@@ -577,6 +580,7 @@ impl FileAnalyzerAgent {
             &[],
             &[],
             &HashMap::new(),
+            &[],
         )
     }
 
@@ -589,6 +593,7 @@ impl FileAnalyzerAgent {
         candidate_hints: &[String],
         candidate_contexts: &[String],
         imported_symbols: &HashMap<String, ImportedSymbol>,
+        graphql_producer_hints: &[String],
     ) -> String {
         let mount_patterns = self.format_patterns(&guidance.mount_patterns);
         let endpoint_patterns = self.format_patterns(&guidance.endpoint_patterns);
@@ -614,6 +619,27 @@ impl FileAnalyzerAgent {
         };
 
         let imports_section = Self::format_import_table(imported_symbols);
+
+        // GraphQL producer context (Stage B2): the SDL root fields this service
+        // exposes. Repo-global (one list per scan, identical across files), so it
+        // sits in the cacheable front block alongside the guidance. When the
+        // service has no SDL producers this is empty and the section is omitted,
+        // leaving every non-GraphQL prompt byte-identical to before.
+        let graphql_producers_section = if graphql_producer_hints.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "\n### GRAPHQL SCHEMA PRODUCERS (from this repo's SDL)\n\
+                 The fields below are this service's GraphQL schema root fields. If a function in \
+                 this file resolves one of them, emit a `graphql_operations` entry linking the \
+                 resolver function to its `kind`/`field` and its return type.\n{}\n",
+                graphql_producer_hints
+                    .iter()
+                    .map(|line| format!("- {}", line))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        };
 
         // Add line-number prefixes to file content so Gemini can read line numbers directly
         let mut numbered_content =
@@ -642,7 +668,7 @@ impl FileAnalyzerAgent {
 
 ### FRAMEWORK-SPECIFIC HINTS
 {}
-
+{}
 ### FRAMEWORK-SPECIFIC PARSING NOTES
 These notes are generated per-scan by the framework guidance layer and describe how to correctly extract endpoints, mounts, owners, and prefixes for the exact framework(s) detected in this repo. Read them carefully — they override any generic rule in the system prompt when they conflict.
 {}
@@ -700,6 +726,7 @@ Return ONLY the JSON object, no explanations."#,
             endpoint_patterns,
             data_patterns,
             guidance.triage_hints,
+            graphql_producers_section,
             guidance.parsing_notes,
             candidates_section,
             candidate_contexts_section,
@@ -1409,6 +1436,7 @@ const data = await fetch('/api/users').then(resp => resp.json());
             &candidates,
             &candidate_contexts,
             &imported,
+            &[],
         );
 
         assert!(message.contains("IMPORT TABLE"));
@@ -1447,6 +1475,78 @@ const data = await fetch('/api/users').then(resp => resp.json());
                 "stable guidance must precede per-file `{per_file}` for prefix caching"
             );
         }
+    }
+
+    #[test]
+    fn build_user_message_includes_graphql_producers_when_hints_present() {
+        let agent = FileAnalyzerAgent::new(AgentService::new());
+        let guidance = create_test_guidance();
+        let file_content = "export function resolveOrder() { return {}; }\n";
+        let hints = vec![
+            "query order: Order".to_string(),
+            "mutation refundOrder: Order!".to_string(),
+        ];
+
+        let message = agent.build_user_message_with_candidates(
+            "resolvers.ts",
+            file_content,
+            &guidance,
+            &[],
+            &[],
+            &HashMap::new(),
+            &hints,
+        );
+
+        assert!(
+            message.contains("### GRAPHQL SCHEMA PRODUCERS (from this repo's SDL)"),
+            "expected GraphQL producers section, got:\n{message}"
+        );
+        assert!(
+            message.contains("- query order: Order"),
+            "expected formatted producer field line, got:\n{message}"
+        );
+        assert!(
+            message.contains("- mutation refundOrder: Order!"),
+            "expected second producer field line, got:\n{message}"
+        );
+        assert!(
+            message.contains("graphql_operations"),
+            "expected pointer to the graphql_operations output channel, got:\n{message}"
+        );
+
+        // The producer block is repo-global (stable across files), so it must sit
+        // in the cacheable front block, before any per-file section.
+        let pos = |needle: &str| {
+            message
+                .find(needle)
+                .unwrap_or_else(|| panic!("section `{needle}` missing:\n{message}"))
+        };
+        assert!(
+            pos("### GRAPHQL SCHEMA PRODUCERS (from this repo's SDL)") < pos("### FILE CONTENT"),
+            "stable GraphQL producer block must precede per-file content for prefix caching"
+        );
+    }
+
+    #[test]
+    fn build_user_message_omits_graphql_producers_when_hints_empty() {
+        let agent = FileAnalyzerAgent::new(AgentService::new());
+        let guidance = create_test_guidance();
+        let file_content = "const x = 1;\n";
+
+        let message = agent.build_user_message_with_candidates(
+            "plain.ts",
+            file_content,
+            &guidance,
+            &[],
+            &[],
+            &HashMap::new(),
+            &[],
+        );
+
+        assert!(
+            !message.contains("GRAPHQL SCHEMA PRODUCERS"),
+            "GraphQL producers section must be absent when no hints are passed, got:\n{message}"
+        );
     }
 
     #[test]

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -2405,6 +2405,7 @@ mod tests {
                     type_import_source: None,
                 }],
                 data_calls: vec![],
+                graphql_operations: vec![],
             },
         );
 
@@ -2456,6 +2457,7 @@ mod tests {
                     primary_type_symbol: None,
                     type_import_source: None,
                 }],
+                graphql_operations: vec![],
             },
         );
 
@@ -2514,6 +2516,7 @@ mod tests {
                         type_import_source: None,
                     },
                 ],
+                graphql_operations: vec![],
             },
         );
 
@@ -2552,6 +2555,7 @@ mod tests {
                     primary_type_symbol: None,
                     type_import_source: None,
                 }],
+                graphql_operations: vec![],
             },
         );
 
@@ -2610,6 +2614,7 @@ mod tests {
                         type_import_source: None,
                     },
                 ],
+                graphql_operations: vec![],
             },
         );
 
@@ -2662,6 +2667,7 @@ mod tests {
                     type_import_source: None,
                 }],
                 data_calls: vec![],
+                graphql_operations: vec![],
             },
         );
 
@@ -2728,6 +2734,7 @@ mod tests {
                 mounts: vec![],
                 endpoints: vec![endpoint],
                 data_calls: vec![],
+                graphql_operations: vec![],
             },
         );
         let graph = orchestrator.build_mount_graph(&file_results);
@@ -2924,6 +2931,7 @@ mod tests {
                 primary_type_symbol: Some("LocalType".to_string()),
                 type_import_source: None,
             }],
+            graphql_operations: vec![],
         };
 
         let mut imported_symbols = HashMap::new();
@@ -2993,6 +3001,7 @@ mod tests {
                 }],
                 endpoints: vec![],
                 data_calls: vec![],
+                graphql_operations: vec![],
             },
         );
 
@@ -3040,6 +3049,7 @@ mod tests {
                     },
                 ],
                 data_calls: vec![],
+                graphql_operations: vec![],
             },
         );
 

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1159,6 +1159,81 @@ impl FileOrchestrator {
         requests
     }
 
+    /// Build `FunctionReturn` infer requests for GraphQL SDL producers whose
+    /// resolver location was joined in from the file-analyzer (`graphql_operations`,
+    /// Stage B1).
+    ///
+    /// Producers do NOT use the `SymbolRequest`/bundle path the consumer/socket
+    /// anchors use: bundling the SDL anchor symbol (`ApiResponse`) would emit the
+    /// still-generic wrapper, not the producer's real response contract. The
+    /// producer's contract is the resolver function's RETURN type expanded
+    /// (`Promise<ApiResponse<Order>>` → `{ data: …, errors }`), so this points an
+    /// `InferKind::FunctionReturn` at the resolver's file/line — exactly the
+    /// file-based-route handler path. The sidecar resolves the fn return,
+    /// Promise/async-iterator-unwraps it, and structurally expands it.
+    ///
+    /// The alias MUST be `build_manifest_type_alias(&op.key, Producer, Response)`
+    /// — byte-identical to the alias `add_protocol_manifest_entry` stamped on the
+    /// producer manifest entry — or the inferred type never joins back and the
+    /// entry stays `Unknown`. This is the load-bearing join, guarded by a unit
+    /// test exactly as the consumer side is.
+    ///
+    /// Only producers with BOTH `resolver_file` and `resolver_line` set produce a
+    /// request; an SDL producer with no matched LLM op stays inferred-from-nothing
+    /// (it keeps its SDL anchor, but no expanded response contract).
+    pub fn collect_graphql_producer_infer_requests(
+        &self,
+        graphql: &crate::graphql::GraphqlExtraction,
+        repo_path: &str,
+    ) -> Vec<InferRequestItem> {
+        let repo_root = std::path::Path::new(repo_path);
+        let repo_root_absolute = if repo_root.is_absolute() {
+            repo_root.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(repo_root))
+                .unwrap_or_else(|_| repo_root.to_path_buf())
+                .canonicalize()
+                .unwrap_or_else(|_| repo_root.to_path_buf())
+        };
+
+        let mut requests: Vec<InferRequestItem> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        for op in &graphql.producers {
+            let (Some(resolver_file), Some(resolver_line)) =
+                (op.resolver_file.as_ref(), op.resolver_line)
+            else {
+                continue;
+            };
+            let file_abs =
+                Self::to_absolute_path(&resolver_file.to_string_lossy(), &repo_root_absolute);
+            let alias = build_manifest_type_alias(
+                &op.key,
+                ManifestRole::Producer,
+                ManifestTypeKind::Response,
+            );
+            let dedup_key = format!("{}|{}|{}", file_abs, resolver_line, alias);
+            if seen.insert(dedup_key) {
+                requests.push(InferRequestItem {
+                    file_path: file_abs,
+                    line_number: resolver_line,
+                    span_start: None,
+                    span_end: None,
+                    expression_text: None,
+                    expression_line: None,
+                    infer_kind: InferKind::FunctionReturn,
+                    alias: Some(alias),
+                    param_name: None,
+                });
+            }
+        }
+        debug!(
+            "[FileOrchestrator] Collected {} graphql producer infer requests",
+            requests.len()
+        );
+        requests
+    }
+
     /// Parse a file once and extract both the symbol table and the env-var
     /// alias map (`local const -> process.env name`). Sharing the parse keeps
     /// the per-file CPU cost flat — both passes are cheap AST walks.
@@ -1550,6 +1625,10 @@ impl FileOrchestrator {
     /// * `config` - Config used for URL normalization
     /// * `extra_explicit` - Deterministically-collected explicit symbol
     ///   requests for non-HTTP protocols (socket payload anchors, #245)
+    /// * `extra_infer` - Deterministically-collected `FunctionReturn` infer
+    ///   requests for non-HTTP protocols (GraphQL producer resolver returns,
+    ///   Stage B1). Unlike `extra_explicit`, these go through the infer path so
+    ///   the resolver return is expanded, not bundled as the generic SDL anchor.
     #[allow(clippy::too_many_arguments)]
     pub fn resolve_types_with_sidecar(
         &self,
@@ -1560,8 +1639,9 @@ impl FileOrchestrator {
         mount_graph: &MountGraph,
         config: &Config,
         extra_explicit: &[SymbolRequest],
+        extra_infer: &[InferRequestItem],
     ) -> Result<TypeResolutionResult, Box<dyn std::error::Error>> {
-        let (mut explicit, infer, inline_aliases) =
+        let (mut explicit, mut infer, inline_aliases) =
             self.collect_type_requests(file_results, repo_path, mount_graph, config);
 
         // Deterministically-collected explicit requests for non-HTTP protocols
@@ -1570,11 +1650,20 @@ impl FileOrchestrator {
         // alias each carries matches its manifest entry so the enrich-join lands.
         explicit.extend_from_slice(extra_explicit);
 
+        // Deterministically-collected infer requests for non-HTTP protocols
+        // (today: GraphQL producer resolver returns, Stage B1). A producer's real
+        // response contract is the resolver's RETURN type expanded, so it takes
+        // the `FunctionReturn` infer path (mirroring file-based routes), NOT the
+        // bundle path — bundling the SDL anchor would emit the generic wrapper.
+        // The alias each carries matches its manifest entry so the join lands.
+        infer.extend_from_slice(extra_infer);
+
         debug!(
-            "[FileOrchestrator] Resolving types: {} explicit ({} from non-HTTP protocols), {} inferred",
+            "[FileOrchestrator] Resolving types: {} explicit ({} from non-HTTP protocols), {} inferred ({} from non-HTTP protocols)",
             explicit.len(),
             extra_explicit.len(),
-            infer.len()
+            infer.len(),
+            extra_infer.len()
         );
 
         let result = sidecar

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -330,6 +330,15 @@ impl FileOrchestrator {
             // PRODUCERS section gives the model the field list to link against.
             let is_graphql_resolver_file = !graphql_producer_hints.is_empty()
                 && graphql_producer_hints.file_within_scan_roots(file_path)
+                // Cheap `export` substring pre-check before the expensive
+                // `exported_handlers` SWC reparse: `scan_content` (Step 1) already
+                // parsed this file, and a resolver file must contain at least one
+                // `export`. `&&` short-circuits, so the reparse runs only when the
+                // keyword is present — the common no-exports file avoids a second
+                // parse entirely. (Reusing the Step-1 parse directly would mean
+                // threading exported-handler data through `ScanResult`, which it
+                // does not currently carry; the substring guard is the cheap win.)
+                && content.contains("export")
                 && !self
                     .swc_scanner
                     .exported_handlers(file_path, &content)

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -163,6 +163,7 @@ impl FileOrchestrator {
         guidance: &ProtocolGuidance,
         framework_detection: &DetectionResult,
         repo_root: &Path,
+        graphql_producer_hints: &crate::graphql::GraphqlProducerHints,
     ) -> Result<FileCentricAnalysisResult, Box<dyn std::error::Error>> {
         debug!("=== AST-GATED FILE-CENTRIC ORCHESTRATOR ===");
         debug!("Processing {} files with SWC gatekeeper", files.len());
@@ -208,6 +209,12 @@ impl FileOrchestrator {
             /// LLM ignores route-as-data, so these are the authoritative source
             /// for such endpoints. Empty for files with no route descriptors.
             descriptor_endpoints: Vec<EndpointResult>,
+            /// Repo-global GraphQL producer hint lines (Stage B2), injected into
+            /// the user message so the model can link resolver functions in this
+            /// file to schema fields. Identical for every file; cloned per-pending
+            /// so the concurrent dispatch closure owns its copy. Empty for repos
+            /// with no SDL producers.
+            graphql_producer_hints: Vec<String>,
         }
 
         // PHASE 1 (serial, CPU-bound): run the SWC gatekeeper on every file and build the
@@ -310,6 +317,24 @@ impl FileOrchestrator {
                 .filter(|c| !descriptor_spans.contains(&(c.span_start, c.span_end)))
                 .collect();
 
+            // GraphQL resolver routing (Stage B2): a resolver file is loose
+            // exported functions with no HTTP route candidate, so the
+            // candidate-less skip below would drop it before the file-analyzer
+            // ever sees it — and without the SDL producer context it couldn't
+            // link a resolver to its field anyway. Rescue it from the skip when
+            // ALL of: this repo has SDL producers, the file is co-located with
+            // the schema (under an SDL scan root), and it has at least one
+            // exported binding (resolver-shaped). Scoped this tightly so only
+            // schema-adjacent resolver files reach the LLM, not every
+            // exported-function file in the repo. The injected GRAPHQL SCHEMA
+            // PRODUCERS section gives the model the field list to link against.
+            let is_graphql_resolver_file = !graphql_producer_hints.is_empty()
+                && graphql_producer_hints.file_within_scan_roots(file_path)
+                && !self
+                    .swc_scanner
+                    .exported_handlers(file_path, &content)
+                    .is_empty();
+
             // STEP 2: Check Relevance - if there are no candidates for a routed
             // protocol, SKIP the (expensive) LLM call. File-based route and
             // route-descriptor endpoints are still recorded: they're derived
@@ -337,12 +362,22 @@ impl FileOrchestrator {
                             ..Default::default()
                         },
                     );
+                    continue;
+                } else if is_graphql_resolver_file {
+                    // Fall through to the LLM pass with empty HTTP candidates:
+                    // the file-analyzer reads the producer-field context and the
+                    // file content to emit `graphql_operations`.
+                    debug!(
+                        "Routed GraphQL resolver file (no HTTP candidates): {}",
+                        path_str
+                    );
                 } else if unrouted_candidates.is_empty() {
                     debug!("Skipped (no API patterns): {} [0 candidates]", path_str);
                     stats.files_skipped += 1;
                     stats.files_skipped_no_candidates += 1;
                     // Store empty result so incremental cache knows this file was processed
                     file_results.insert(path_str, FileAnalysisResult::default());
+                    continue;
                 } else {
                     debug!(
                         "Skipped (only unrouted-protocol candidates): {} [{} candidate(s)]",
@@ -352,8 +387,8 @@ impl FileOrchestrator {
                     stats.files_skipped += 1;
                     stats.files_skipped_unrouted_protocol += 1;
                     file_results.insert(path_str, FileAnalysisResult::default());
+                    continue;
                 }
-                continue;
             }
 
             debug!(
@@ -388,6 +423,7 @@ impl FileOrchestrator {
                 env_alias_map,
                 route_endpoints,
                 descriptor_endpoints,
+                graphql_producer_hints: graphql_producer_hints.lines.clone(),
             });
         }
 
@@ -415,6 +451,7 @@ impl FileOrchestrator {
                         &pf.candidate_hints,
                         &pf.candidate_contexts,
                         &pf.symbol_table.imported_symbols,
+                        &pf.graphql_producer_hints,
                     )
                     .await
                     .map_err(|e| e.to_string());

--- a/src/agents/schemas.rs
+++ b/src/agents/schemas.rs
@@ -731,13 +731,13 @@ mod tests {
         use crate::operation::GraphqlOperationKind;
 
         let schema = AgentSchemas::file_analysis_schema();
-        let schema_values: Vec<String> = schema["properties"]["graphql_operations"]["items"]
-            ["properties"]["kind"]["enum"]
-            .as_array()
-            .expect("graphql_operations kind enum must exist")
-            .iter()
-            .map(|v| v.as_str().unwrap().to_string())
-            .collect();
+        let schema_values: Vec<String> =
+            schema["properties"]["graphql_operations"]["items"]["properties"]["kind"]["enum"]
+                .as_array()
+                .expect("graphql_operations kind enum must exist")
+                .iter()
+                .map(|v| v.as_str().unwrap().to_string())
+                .collect();
 
         let serde_values: Vec<String> = [
             GraphqlOperationKind::Query,

--- a/src/agents/schemas.rs
+++ b/src/agents/schemas.rs
@@ -400,6 +400,42 @@ impl AgentSchemas {
                         },
                         "required": ["candidate_id", "line_number", "target", "pattern_matched"]
                     }
+                },
+                "graphql_operations": {
+                    "type": "ARRAY",
+                    "items": {
+                        "type": "OBJECT",
+                        "properties": {
+                            "kind": {
+                                "type": "STRING",
+                                "enum": ["query", "mutation", "subscription"],
+                                "description": "The GraphQL root operation this resolver implements: query, mutation, or subscription."
+                            },
+                            "field": {
+                                "type": "STRING",
+                                "description": "The schema field name this resolver answers (e.g., 'order', 'createUser')."
+                            },
+                            "resolver_function": {
+                                "type": "STRING",
+                                "description": "Name of the resolver function implementing this field (e.g., 'resolveOrder')."
+                            },
+                            "resolver_line": {
+                                "type": "INTEGER",
+                                "description": "Line number where the resolver function is defined (read from the line-number prefix in the source code)."
+                            },
+                            "primary_type_symbol": {
+                                "type": "STRING",
+                                "nullable": true,
+                                "description": "The named return type of the resolver as a bare identifier (e.g., 'ApiResponse'). Unwrap Promise<...>, arrays, and async-iterator wrappers down to the core identifier. Null for untyped, inline-object-literal, or otherwise un-annotated resolver returns."
+                            },
+                            "type_import_source": {
+                                "type": "STRING",
+                                "nullable": true,
+                                "description": "Import path where the `primary_type_symbol` type is defined (e.g., './types/order'), or null if it is declared in the same file. Null whenever `primary_type_symbol` is null."
+                            }
+                        },
+                        "required": ["kind", "field", "resolver_function", "resolver_line"]
+                    }
                 }
             },
             "required": ["mounts", "endpoints", "data_calls"]
@@ -684,6 +720,57 @@ mod tests {
             .as_array()
             .unwrap();
         assert!(!required.iter().any(|v| v == "call_kind"));
+    }
+
+    #[test]
+    fn graphql_operations_schema_enum_matches_serde_wire_values() {
+        // The graphql_operations `kind` enum and GraphqlOperationKind's serde
+        // output must stay in lockstep, or a value the schema advertises but the
+        // enum can't parse is silently lost when the file-analyzer response is
+        // deserialized (mirrors call_kind / emission_style).
+        use crate::operation::GraphqlOperationKind;
+
+        let schema = AgentSchemas::file_analysis_schema();
+        let schema_values: Vec<String> = schema["properties"]["graphql_operations"]["items"]
+            ["properties"]["kind"]["enum"]
+            .as_array()
+            .expect("graphql_operations kind enum must exist")
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+
+        let serde_values: Vec<String> = [
+            GraphqlOperationKind::Query,
+            GraphqlOperationKind::Mutation,
+            GraphqlOperationKind::Subscription,
+        ]
+        .iter()
+        .map(|k| {
+            serde_json::to_value(k)
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+
+        assert_eq!(schema_values, serde_values);
+
+        // The four locating fields must always be present; the type slots
+        // (primary_type_symbol / type_import_source) stay optional/nullable.
+        let required = schema["properties"]["graphql_operations"]["items"]["required"]
+            .as_array()
+            .expect("graphql_operations item required array must exist");
+        for field in ["kind", "field", "resolver_function", "resolver_line"] {
+            assert!(
+                required.iter().any(|v| v == field),
+                "graphql_operations item required must contain {field}"
+            );
+        }
+
+        // graphql_operations is optional at the top level: a model may omit it.
+        let top_required = schema["required"].as_array().unwrap();
+        assert!(!top_required.iter().any(|v| v == "graphql_operations"));
     }
 
     #[test]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -902,6 +902,16 @@ async fn analyze_current_repo_incremental(
             let agent_service = AgentService::new();
             let file_orchestrator = FileOrchestrator::new(agent_service.clone());
 
+            // Stage B2: GraphQL producer field-list from the service's SDL,
+            // derived deterministically so the file-analyzer can emit
+            // `graphql_operations` linking resolvers to schema fields. Scanned
+            // over the full service `files` (not just `files_to_analyze`) so the
+            // producer list is complete; empty for non-GraphQL services.
+            let graphql_producer_hints = crate::graphql::GraphqlProducerHints::collect(
+                service_graphql_roots(repo_path, service),
+                &files,
+            );
+
             let new_file_results = if !files_to_analyze.is_empty() {
                 let result = file_orchestrator
                     .analyze_files(
@@ -909,6 +919,7 @@ async fn analyze_current_repo_incremental(
                         &guidance,
                         &detection,
                         Path::new(repo_path),
+                        &graphql_producer_hints,
                     )
                     .await?;
                 result.file_results
@@ -2178,9 +2189,25 @@ async fn analyze_current_repo(
     // 3. Create MultiAgentOrchestrator (auth is via GitHub Actions OIDC)
     let orchestrator = MultiAgentOrchestrator::new(cm.clone());
 
+    // Stage B2: derive the GraphQL producer field-list from the service's SDL
+    // (deterministic, cheap) so the file-analyzer can link resolver functions to
+    // schema fields and emit `graphql_operations`. Empty (a no-op) for non-GraphQL
+    // services. `append_deterministic_protocol_operations` scans the SDL again
+    // later for the operation index; the duplicate parse is acceptable.
+    let graphql_producer_hints = crate::graphql::GraphqlProducerHints::collect(
+        service_graphql_roots(repo_path, service),
+        &files,
+    );
+
     // 4. Run the complete multi-agent analysis
     let analysis_result = orchestrator
-        .run_complete_analysis(files.clone(), packages, &all_imported_symbols, repo_path)
+        .run_complete_analysis(
+            files.clone(),
+            packages,
+            &all_imported_symbols,
+            repo_path,
+            &graphql_producer_hints,
+        )
         .await?;
 
     // 4b. Generate function intents using LLM

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -983,6 +983,7 @@ async fn analyze_current_repo_incremental(
                 repo_path,
                 service,
                 &files,
+                &merged_results,
             );
 
             // Populate cache fields
@@ -1013,6 +1014,12 @@ async fn analyze_current_repo_incremental(
                     .collect_graphql_type_requests(&protocol_extractions.graphql, repo_path),
             );
 
+            // GraphQL producers take the infer path, not the bundle path: their
+            // response contract is the resolver's expanded RETURN type, so they
+            // become `FunctionReturn` infer requests (Stage B1).
+            let graphql_producer_infer = file_orchestrator
+                .collect_graphql_producer_infer_requests(&protocol_extractions.graphql, repo_path);
+
             // Type resolution via sidecar
             resolve_types_if_available(
                 sidecar,
@@ -1023,6 +1030,7 @@ async fn analyze_current_repo_incremental(
                 &mount_graph,
                 config,
                 &protocol_requests,
+                &graphql_producer_infer,
                 &mut cloud_data,
             );
 
@@ -1150,6 +1158,7 @@ fn append_deterministic_protocol_operations(
     repo_path: &str,
     service: &Config,
     files: &[PathBuf],
+    file_results: &HashMap<String, crate::agents::file_analyzer_agent::FileAnalysisResult>,
 ) -> ProtocolExtractions {
     // Same "{file}:{line}" convention the mount-graph conversions use
     let to_details = |key: OperationKey, file_path: &Path, line: u32| ApiEndpointDetails {
@@ -1167,7 +1176,8 @@ fn append_deterministic_protocol_operations(
     };
 
     let scan_roots = service_graphql_roots(repo_path, service);
-    let graphql = crate::graphql::scan_repo(&scan_roots, files);
+    let mut graphql = crate::graphql::scan_repo(&scan_roots, files);
+    merge_graphql_resolver_locations(&mut graphql, file_results);
     if !graphql.is_empty() {
         debug!(
             producers = graphql.producers.len(),
@@ -1210,6 +1220,56 @@ fn append_deterministic_protocol_operations(
     }
 
     ProtocolExtractions { graphql, sockets }
+}
+
+/// Fold the file-analyzer's `graphql_operations` into the SDL-derived producers
+/// (Stage B1). The SDL `scan_repo` gives the producer's canonical
+/// `OperationKey` and its SDL anchor, but NOT where the resolver lives — and the
+/// producer's real response contract is the resolver function's RETURN type
+/// expanded (`Promise<ApiResponse<Order>>` → `{ data: …, errors }`), which only
+/// a `FunctionReturn` infer at the resolver's file/line can give.
+///
+/// For each LLM `graphql_operation`, build its canonical `OperationKey` and match
+/// it to the SDL producer with the same key; populate that producer's
+/// `resolver_file` (the file the op came from — `file_results` is keyed by path)
+/// and `resolver_line`. An LLM op with no matching SDL producer is ignored
+/// (logged at debug): without an SDL producer there is no manifest entry to join
+/// back to, so a resolver location alone is inert.
+///
+/// Consumers are never touched — they anchor on `payload_type_symbol`.
+fn merge_graphql_resolver_locations(
+    graphql: &mut crate::graphql::GraphqlExtraction,
+    file_results: &HashMap<String, crate::agents::file_analyzer_agent::FileAnalysisResult>,
+) {
+    // Canonical producer key -> index, so each LLM op joins in O(1) without an
+    // N×M scan. A schema field has at most one root producer, so the last write
+    // wins is moot (keys are unique across producers).
+    let mut by_key: HashMap<String, usize> = HashMap::new();
+    for (idx, op) in graphql.producers.iter().enumerate() {
+        by_key.insert(op.key.canonical(), idx);
+    }
+
+    for (path, result) in file_results {
+        for llm_op in &result.graphql_operations {
+            let key = OperationKey::graphql(llm_op.kind, llm_op.field.clone());
+            let Some(&idx) = by_key.get(&key.canonical()) else {
+                debug!(
+                    op = %key.canonical(),
+                    file = %path,
+                    "graphql_operation has no matching SDL producer; ignoring resolver location"
+                );
+                continue;
+            };
+            let producer = &mut graphql.producers[idx];
+            producer.resolver_file = Some(PathBuf::from(path));
+            // The LLM line is a 1-based source line; clamp non-positive values to
+            // None rather than wrapping into a bogus u32 (the infer request's
+            // line_number is u32, and a 0/negative line can't anchor a function).
+            producer.resolver_line = u32::try_from(llm_op.resolver_line)
+                .ok()
+                .filter(|&line| line > 0);
+        }
+    }
 }
 
 /// Emit type-manifest entries for the deterministically-extracted GraphQL and
@@ -1476,6 +1536,7 @@ fn resolve_types_if_available(
     mount_graph: &MountGraph,
     config: &Config,
     extra_explicit: &[crate::services::type_sidecar::SymbolRequest],
+    extra_infer: &[crate::services::type_sidecar::InferRequestItem],
     cloud_data: &mut CloudRepoData,
 ) {
     let Some(sidecar) = sidecar else {
@@ -1498,6 +1559,7 @@ fn resolve_types_if_available(
                 mount_graph,
                 config,
                 extra_explicit,
+                extra_infer,
             ) {
                 Ok(type_resolution) => {
                     debug!(
@@ -2149,8 +2211,13 @@ async fn analyze_current_repo(
         Some(packages.clone()),
         function_definitions.clone(),
     );
-    let protocol_extractions =
-        append_deterministic_protocol_operations(&mut cloud_data, repo_path, service, &files);
+    let protocol_extractions = append_deterministic_protocol_operations(
+        &mut cloud_data,
+        repo_path,
+        service,
+        &files,
+        &analysis_result.file_results,
+    );
 
     let mut manifest_entries = build_type_manifest_entries(&analysis_result.mount_graph, config);
     stamp_manifest_anchor_symbols(&mut manifest_entries, &analysis_result.file_results);
@@ -2181,6 +2248,12 @@ async fn analyze_current_repo(
         file_orchestrator.collect_graphql_type_requests(&protocol_extractions.graphql, repo_path),
     );
 
+    // GraphQL producers take the infer path, not the bundle path: their response
+    // contract is the resolver's expanded RETURN type, so they become
+    // `FunctionReturn` infer requests (Stage B1).
+    let graphql_producer_infer = file_orchestrator
+        .collect_graphql_producer_infer_requests(&protocol_extractions.graphql, repo_path);
+
     resolve_types_if_available(
         sidecar,
         &file_orchestrator,
@@ -2190,6 +2263,7 @@ async fn analyze_current_repo(
         &analysis_result.mount_graph,
         config,
         &protocol_requests,
+        &graphql_producer_infer,
         &mut cloud_data,
     );
 
@@ -3932,6 +4006,8 @@ mod tests {
             primary_type_symbol: anchor.map(String::from),
             payload_type_symbol: None,
             payload_type_source: None,
+            resolver_file: None,
+            resolver_line: None,
         }
     }
 
@@ -3949,7 +4025,96 @@ mod tests {
             primary_type_symbol: None,
             payload_type_symbol: payload_symbol.map(String::from),
             payload_type_source: payload_source.map(String::from),
+            resolver_file: None,
+            resolver_line: None,
         }
+    }
+
+    /// Stage B1 merge: the file-analyzer's `graphql_operations` join their
+    /// resolver location onto the SDL producer sharing the same canonical key.
+    /// The SDL producer alone has no resolver location; after the merge it points
+    /// at the resolver file/line so the producer can take the `FunctionReturn`
+    /// infer path (its real response contract is the resolver's expanded return).
+    #[test]
+    fn merge_graphql_resolver_locations_joins_llm_op_onto_sdl_producer() {
+        use crate::agents::file_analyzer_agent::GraphqlOperation;
+        use crate::operation::GraphqlOperationKind;
+
+        // SDL producer `graphql|query|order` with no resolver location yet.
+        let mut graphql = crate::graphql::GraphqlExtraction {
+            producers: vec![
+                graphql_op(GraphqlOperationKind::Query, "order", Some("Order")),
+                // A second producer the LLM never reports a resolver for: it must
+                // stay `None` (no spurious join).
+                graphql_op(GraphqlOperationKind::Query, "orders", Some("[Order!]!")),
+            ],
+            consumers: vec![],
+        };
+
+        // file_results keyed by path, carrying the matching LLM graphql_operation
+        // plus one op (`createOrder`) with NO SDL producer (must be ignored).
+        let mut file_results: HashMap<String, FileAnalysisResult> = HashMap::new();
+        file_results.insert(
+            "packages/gateway/src/orders.resolver.ts".to_string(),
+            FileAnalysisResult {
+                mounts: vec![],
+                endpoints: vec![],
+                data_calls: vec![],
+                graphql_operations: vec![
+                    GraphqlOperation {
+                        kind: GraphqlOperationKind::Query,
+                        field: "order".to_string(),
+                        resolver_function: "resolveOrder".to_string(),
+                        resolver_line: 38,
+                        primary_type_symbol: Some("ApiResponse".to_string()),
+                        type_import_source: None,
+                    },
+                    GraphqlOperation {
+                        kind: GraphqlOperationKind::Mutation,
+                        field: "createOrder".to_string(),
+                        resolver_function: "createOrder".to_string(),
+                        resolver_line: 7,
+                        primary_type_symbol: None,
+                        type_import_source: None,
+                    },
+                ],
+            },
+        );
+
+        merge_graphql_resolver_locations(&mut graphql, &file_results);
+
+        let order = graphql
+            .producers
+            .iter()
+            .find(|op| op.key.canonical() == "graphql|query|order")
+            .expect("order producer");
+        assert_eq!(
+            order.resolver_file,
+            Some(PathBuf::from("packages/gateway/src/orders.resolver.ts")),
+            "the resolver file must come from the file_results key"
+        );
+        assert_eq!(order.resolver_line, Some(38));
+        // The SDL anchor is untouched by the merge.
+        assert_eq!(order.primary_type_symbol.as_deref(), Some("Order"));
+
+        // The producer with no matching LLM op keeps both resolver fields None.
+        let orders = graphql
+            .producers
+            .iter()
+            .find(|op| op.key.canonical() == "graphql|query|orders")
+            .expect("orders producer");
+        assert_eq!(orders.resolver_file, None);
+        assert_eq!(orders.resolver_line, None);
+
+        // The LLM op with no SDL producer (`mutation createOrder`) created no
+        // new producer — it was ignored.
+        assert!(
+            !graphql
+                .producers
+                .iter()
+                .any(|op| op.key.canonical() == "graphql|mutation|createOrder"),
+            "an LLM op with no matching SDL producer must not create a producer"
+        );
     }
 
     /// A typed socket emitter produces a Response-kind manifest entry keyed by
@@ -4137,6 +4302,96 @@ mod tests {
         );
         assert_eq!(manifest_alias, expected);
         assert_eq!(request.alias.as_deref(), Some(expected.as_str()));
+    }
+
+    /// Stage B1 producer infer join: a GraphQL PRODUCER whose resolver location
+    /// was merged in (`resolver_file`/`resolver_line`) becomes a `FunctionReturn`
+    /// infer request whose alias byte-matches the PRODUCER manifest entry's
+    /// `type_alias` — both `build_manifest_type_alias(key, Producer, Response)`.
+    /// This is the load-bearing join: if they diverge, the inferred expanded
+    /// resolver-return `.d.ts` never lands on the producer entry and it stays
+    /// `Unknown`. Mirrors `graphql_symbol_request_alias_matches_manifest_alias`,
+    /// but on the producer/infer side.
+    #[test]
+    fn graphql_producer_infer_request_alias_matches_manifest_alias() {
+        use crate::operation::GraphqlOperationKind;
+
+        // A producer with its SDL anchor AND a resolver location (post-merge).
+        let mut producer = graphql_op(GraphqlOperationKind::Query, "order", Some("Order"));
+        producer.resolver_file = Some(PathBuf::from("packages/gateway/src/orders.resolver.ts"));
+        producer.resolver_line = Some(38);
+
+        let extractions = ProtocolExtractions {
+            graphql: crate::graphql::GraphqlExtraction {
+                producers: vec![producer.clone()],
+                consumers: vec![],
+            },
+            sockets: crate::socket_io::SocketExtraction::default(),
+        };
+
+        // The producer manifest entry's alias (Producer, Response).
+        let mut entries = Vec::new();
+        append_protocol_manifest_entries(&mut entries, &extractions);
+        let manifest_entry = entries
+            .iter()
+            .find(|e| {
+                e.key.canonical() == "graphql|query|order" && e.role == ManifestRole::Producer
+            })
+            .expect("graphql producer manifest entry");
+        let manifest_alias = manifest_entry.type_alias.clone();
+
+        let orchestrator = FileOrchestrator::new(AgentService::new());
+        let infer = orchestrator.collect_graphql_producer_infer_requests(&extractions.graphql, ".");
+        assert_eq!(infer.len(), 1, "exactly one producer infer request");
+        let request = &infer[0];
+
+        // The load-bearing alias join.
+        assert_eq!(
+            request.alias.as_deref(),
+            Some(manifest_alias.as_str()),
+            "InferRequestItem.alias must byte-match the producer manifest entry's \
+             alias (both build_manifest_type_alias(key, Producer, Response)) or the \
+             expanded resolver-return type never joins back and the entry stays Unknown"
+        );
+        // Independently confirm both equal the canonical builder output.
+        let expected = crate::type_manifest::build_manifest_type_alias(
+            &producer.key,
+            ManifestRole::Producer,
+            ManifestTypeKind::Response,
+        );
+        assert_eq!(manifest_alias, expected);
+        assert_eq!(request.alias.as_deref(), Some(expected.as_str()));
+
+        // The producer takes the INFER path (FunctionReturn at the resolver), not
+        // the bundle path: file/line come from the merged resolver location.
+        assert_eq!(request.infer_kind, InferKind::FunctionReturn);
+        assert_eq!(request.line_number, 38);
+        assert!(
+            request
+                .file_path
+                .ends_with("packages/gateway/src/orders.resolver.ts"),
+            "infer file must be the resolver file, got: {}",
+            request.file_path
+        );
+
+        // A producer without a merged resolver location yields no infer request.
+        let bare = ProtocolExtractions {
+            graphql: crate::graphql::GraphqlExtraction {
+                producers: vec![graphql_op(
+                    GraphqlOperationKind::Query,
+                    "order",
+                    Some("Order"),
+                )],
+                consumers: vec![],
+            },
+            sockets: crate::socket_io::SocketExtraction::default(),
+        };
+        assert!(
+            orchestrator
+                .collect_graphql_producer_infer_requests(&bare.graphql, ".")
+                .is_empty(),
+            "an SDL producer with no merged resolver location produces no infer request"
+        );
     }
 
     /// `write_manifest_files` feeds the ts_check matcher, which now checks HTTP

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2866,6 +2866,7 @@ mod tests {
                     type_import_source: None,
                 })
                 .collect(),
+            graphql_operations: vec![],
         }
     }
 
@@ -3233,6 +3234,7 @@ mod tests {
                         type_import_source: None,
                     }],
                     data_calls: vec![],
+                    graphql_operations: vec![],
                 },
             );
         }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -54,6 +54,18 @@ pub struct GraphqlOp {
     /// `payload_type_symbol`. `None` when the symbol is declared in the same file
     /// or no call site was matched.
     pub payload_type_source: Option<String>,
+    /// PRODUCER-only: the file whose resolver implements this schema field,
+    /// joined in from the file-analyzer's `graphql_operations` (Stage B1). The
+    /// producer's real response contract is the resolver function's RETURN type
+    /// expanded (`Promise<ApiResponse<Order>>` → `{ data: …, errors }`), which
+    /// the SDL alone can't give, so this points the `FunctionReturn` infer
+    /// request at the resolver. `None` for SDL producers with no matched LLM op,
+    /// and always `None` for consumers (they anchor on `payload_type_symbol`).
+    pub resolver_file: Option<PathBuf>,
+    /// PRODUCER-only: 1-based line where the resolver function is defined,
+    /// paired with `resolver_file`. Anchors the `FunctionReturn` infer request.
+    /// `None` whenever `resolver_file` is `None`.
+    pub resolver_line: Option<u32>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -223,6 +235,10 @@ pub fn extract_from_document_text(
                     // Producers carry no consumer-side bound type.
                     payload_type_symbol: None,
                     payload_type_source: None,
+                    // SDL alone has no resolver location; the file-analyzer's
+                    // graphql_operations fill these in the engine merge (Stage B1).
+                    resolver_file: None,
+                    resolver_line: None,
                 });
             }
         }
@@ -276,6 +292,9 @@ pub fn extract_from_document_text(
                     primary_type_symbol: None,
                     payload_type_symbol: None,
                     payload_type_source: None,
+                    // Consumers never carry a resolver location.
+                    resolver_file: None,
+                    resolver_line: None,
                 });
             }
         }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -87,6 +87,67 @@ impl GraphqlExtraction {
     }
 }
 
+/// Repo-global GraphQL producer context for the file-analyzer (Stage B2).
+///
+/// The file-analyzer needs two things to link a resolver function to a schema
+/// field and emit a `graphql_operations` entry: (1) the list of SDL producer
+/// fields this service exposes (so it knows which functions are resolvers), and
+/// (2) the SDL scan roots (so the orchestrator can route an otherwise-skipped,
+/// candidate-less resolver file co-located with the schema into analysis). Both
+/// are derived deterministically from the SDL — no LLM, no per-file cost.
+///
+/// `lines` is one formatted string per producer field (`"query order: Order"`),
+/// stable across every file in a scan, so it lives in the cacheable front block
+/// of the user message. Empty `lines` means the service has no SDL producers and
+/// nothing changes.
+#[derive(Debug, Clone, Default)]
+pub struct GraphqlProducerHints {
+    /// One `"{kind} {field}: {sdl_type}"` line per SDL root field.
+    pub lines: Vec<String>,
+    /// The service's SDL scan roots (its `directory` + `include` roots),
+    /// used to gate the don't-skip routing to schema-co-located files.
+    pub scan_roots: Vec<PathBuf>,
+}
+
+impl GraphqlProducerHints {
+    /// Build the producer hint context for a service: run the (cheap,
+    /// deterministic) SDL scan over `scan_roots` + `service_files` and format
+    /// each producer field as a hint line. `scan_roots` are retained for the
+    /// co-location check in the don't-skip routing.
+    pub fn collect(scan_roots: Vec<PathBuf>, service_files: &[PathBuf]) -> Self {
+        let extraction = scan_repo(&scan_roots, service_files);
+        let lines = extraction
+            .producers
+            .iter()
+            .filter_map(Self::format_producer)
+            .collect();
+        Self { lines, scan_roots }
+    }
+
+    /// Format a single producer op as `"{kind} {field}: {sdl_type}"`
+    /// (e.g. `"query order: Order"`). `None` if the op is not a GraphQL
+    /// producer key (should never happen for `.producers`) or has no SDL type.
+    fn format_producer(op: &GraphqlOp) -> Option<String> {
+        let OperationKey::Graphql { kind, field } = &op.key else {
+            return None;
+        };
+        let sdl_type = op.primary_type_symbol.as_deref()?;
+        Some(format!("{} {}: {}", kind.as_str(), field, sdl_type))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.lines.is_empty()
+    }
+
+    /// Whether `file` lives under one of the SDL scan roots — i.e. it is
+    /// co-located with this service's schema. Used to scope the don't-skip
+    /// routing tightly: only schema-co-located resolver files are rescued from
+    /// the zero-candidate skip, never every exported-function file in the repo.
+    pub fn file_within_scan_roots(&self, file: &Path) -> bool {
+        self.scan_roots.iter().any(|root| file.starts_with(root))
+    }
+}
+
 /// Directories never scanned for GraphQL sources.
 const SKIP_DIRS: &[&str] = &[
     "node_modules",
@@ -698,6 +759,87 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    /// Stage B2: a producer op formats as `"{kind} {field}: {sdl_type}"`, the
+    /// exact line shape injected into the file-analyzer's GRAPHQL SCHEMA
+    /// PRODUCERS context block.
+    #[test]
+    fn producer_hint_lines_format_kind_field_and_sdl_type() {
+        let sdl = r#"
+            type Order { id: ID! }
+            type Query {
+                order(id: ID!): Order
+                orders: [Order!]!
+            }
+            type Mutation { refundOrder(id: ID!): Order! }
+        "#;
+        let extraction = extract_from_document_text(sdl, Path::new("schema.graphql"), 1);
+        let mut lines: Vec<String> = extraction
+            .producers
+            .iter()
+            .filter_map(GraphqlProducerHints::format_producer)
+            .collect();
+        lines.sort();
+        assert_eq!(
+            lines,
+            vec![
+                "mutation refundOrder: Order!".to_string(),
+                "query order: Order".to_string(),
+                "query orders: [Order!]!".to_string(),
+            ]
+        );
+    }
+
+    /// `file_within_scan_roots` gates the don't-skip routing: only files under an
+    /// SDL scan root (schema-co-located) are eligible, so a resolver in the
+    /// schema package is routed while an unrelated exported-function file is not.
+    #[test]
+    fn file_within_scan_roots_matches_only_co_located_files() {
+        let hints = GraphqlProducerHints {
+            lines: vec!["query order: Order".to_string()],
+            scan_roots: vec![PathBuf::from("/repo/services/orders")],
+        };
+        assert!(hints.file_within_scan_roots(Path::new("/repo/services/orders/src/resolvers.ts")));
+        assert!(!hints.file_within_scan_roots(Path::new("/repo/services/billing/src/handlers.ts")));
+        assert!(
+            !GraphqlProducerHints::default()
+                .file_within_scan_roots(Path::new("/repo/services/orders/src/resolvers.ts"))
+        );
+    }
+
+    /// End-to-end of the deterministic hint builder: a real SDL file under the
+    /// scan root yields formatted producer lines, and a co-located file is
+    /// recognised by the routing gate. A root with no SDL yields empty hints.
+    #[test]
+    fn collect_builds_hints_from_sdl_under_scan_root() {
+        let dir = std::env::temp_dir().join(format!(
+            "carrick-gql-hints-{}-{:016x}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as u64)
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("schema.graphql"),
+            "type Order { id: ID! }\ntype Query { order(id: ID!): Order }\n",
+        )
+        .unwrap();
+
+        let hints = GraphqlProducerHints::collect(vec![dir.clone()], &[]);
+        assert_eq!(hints.lines, vec!["query order: Order".to_string()]);
+        assert!(!hints.is_empty());
+        assert!(hints.file_within_scan_roots(&dir.join("resolvers.ts")));
+
+        // A scan root with no SDL produces no hints (the no-op path).
+        let empty_root = dir.join("nested-empty");
+        std::fs::create_dir_all(&empty_root).unwrap();
+        let empty = GraphqlProducerHints::collect(vec![empty_root], &[]);
+        assert!(empty.is_empty());
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// Document consumers carry no SDL type, so their anchor is left unset (the

--- a/src/multi_agent_orchestrator.rs
+++ b/src/multi_agent_orchestrator.rs
@@ -80,6 +80,7 @@ impl MultiAgentOrchestrator {
         packages: &Packages,
         imported_symbols: &HashMap<String, ImportedSymbol>,
         repo_path: &str,
+        graphql_producer_hints: &crate::graphql::GraphqlProducerHints,
     ) -> Result<MultiAgentAnalysisResult, Box<dyn std::error::Error>> {
         debug!("Starting AST-Gated File-Centric analysis...");
 
@@ -122,6 +123,7 @@ impl MultiAgentOrchestrator {
                 &framework_guidance,
                 &framework_detection,
                 std::path::Path::new(repo_path),
+                graphql_producer_hints,
             )
             .await?;
 

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -52,7 +52,24 @@ import { expandTypeStructural } from './type-structural-expander.js';
  * `is_builtin_type` filter in `socket_io.rs` so the HTTP-inference anchor and the
  * socket anchor reject the same set.
  */
+/**
+ * Async-iterator / generator transport wrappers. A resolver written as an async
+ * generator (`async function* x(): AsyncGenerator<Order>`) carries its contract
+ * in the yield position; these symbol names gate `unwrapAsyncIterableType`, which
+ * peels them down to the yield type before structural expansion. They are also
+ * folded into `BUILTIN_ANCHOR_SYMBOLS` so the wrapper itself can never become a
+ * `primary_type_symbol` anchor.
+ */
+const ASYNC_ITERABLE_SYMBOLS = new Set<string>([
+  'AsyncGenerator',
+  'AsyncIterableIterator',
+  'AsyncIterator',
+  'Generator',
+  'IterableIterator',
+]);
+
 const BUILTIN_ANCHOR_SYMBOLS = new Set<string>([
+  ...ASYNC_ITERABLE_SYMBOLS,
   'any',
   'unknown',
   'never',
@@ -286,7 +303,14 @@ export class TypeInferrer {
     // async handler's return is Promise<Wrapper<T>>, whose symbol is
     // `Promise` — a rule naming the wrapper could never match it, and the
     // textual unwrapPromise below runs too late for the rules to see T.
-    const awaitedType = this.unwrapPromiseType(returnType);
+    //
+    // Then peel any async-iterator transport: an async generator resolver
+    // resolves to `AsyncGenerator<Order>` (or `Promise<AsyncGenerator<Order>>`),
+    // whose contract lives in the yield position. Unwrap it to the yield type so
+    // both forms reduce to `Order` before structural expansion / rule matching.
+    const awaitedType = this.unwrapAsyncIterableType(
+      this.unwrapPromiseType(returnType)
+    );
     const unwrapResult = this.unwrapTypeWithConfig(awaitedType, func, extractionConfig);
     if (unwrapResult.wasUnwrapped) {
       typeString = unwrapResult.typeString;
@@ -852,6 +876,26 @@ export class TypeInferrer {
     if (symbolName === 'Promise') {
       const args = type.getTypeArguments();
       if (args.length === 1) {
+        return args[0];
+      }
+    }
+    return type;
+  }
+
+  /**
+   * `AsyncGenerator<T, …>` / `AsyncIterableIterator<T>` / `AsyncIterator<T>` /
+   * `Generator<T, …>` / `IterableIterator<T>` → `T` (the yield type) at the type
+   * level; any other type passes through. A GraphQL subscription resolver written
+   * as `async function* x(): AsyncGenerator<Order>` carries its contract in the
+   * yield position, so the iterator wrapper must be peeled the same way Promise is
+   * before structural expansion — otherwise the response contract resolves to the
+   * library `AsyncGenerator<…>` machinery instead of the bare `Order`.
+   */
+  private unwrapAsyncIterableType(type: Type): Type {
+    const symbolName = (type.getSymbol() || type.getAliasSymbol())?.getName();
+    if (symbolName && ASYNC_ITERABLE_SYMBOLS.has(symbolName)) {
+      const args = type.getTypeArguments();
+      if (args.length >= 1) {
         return args[0];
       }
     }

--- a/src/sidecar/test/infer-async-generator-return.test.ts
+++ b/src/sidecar/test/infer-async-generator-return.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Stage A scaffolding for GraphQL producer type resolution: a subscription
+ * resolver written as an async generator carries its response contract in the
+ * YIELD position, not at the top level. Before this change `inferFunctionReturn`
+ * unwrapped only `Promise<T>`, so a resolver
+ *
+ *     async function* f(): AsyncGenerator<Order> { ... }
+ *
+ * resolved to the library wrapper `AsyncGenerator<Order, …>` instead of the bare
+ * `Order`. The fix adds `unwrapAsyncIterableType`, called right after the Promise
+ * unwrap, so both `AsyncGenerator<T>` and `Promise<AsyncGenerator<T>>` reduce to
+ * `T` before structural expansion — the named object is then expanded to its real
+ * member shape, exactly as a plain `Promise<Order>` resolver already was.
+ *
+ * The throwaway source is written to the OS temp dir (NOT under test/fixtures),
+ * so this test never touches ground-truth fixtures. The sidecar still inits
+ * against the real sample-repo so the project carries a valid lib/tsconfig and
+ * the global `AsyncGenerator` type resolves.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    infer_kind: string;
+    is_explicit: boolean;
+    primary_type_symbol?: string;
+  }>;
+  errors?: string[];
+}
+
+const SOURCE = `interface Order {
+  id: string;
+  total: number;
+}
+
+export async function* streamOrders(): AsyncGenerator<Order> {
+  yield { id: 'a', total: 1 };
+}
+
+export async function* streamOrdersPromised(): Promise<AsyncGenerator<Order>> {
+  return streamOrders();
+}
+`;
+
+/** Byte span of \`text\` in SOURCE (ASCII-only, so byte == char offsets). */
+function spanOf(text: string): { start: number; end: number; line: number } {
+  const start = SOURCE.indexOf(text);
+  assert.ok(start >= 0, `source must contain: ${text}`);
+  const line = SOURCE.slice(0, start).split('\n').length;
+  return { start, end: start + text.length, line };
+}
+
+describe('async-generator resolver return unwrapping (GraphQL subscription scaffolding)', () => {
+  let client: SidecarClient;
+  let tmpDir: string;
+  let fixtureFile: string;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-asyncgen-'));
+    fixtureFile = path.join(tmpDir, 'stream-orders.ts');
+    fs.writeFileSync(fixtureFile, SOURCE, 'utf-8');
+
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'asyncgen-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reduces `AsyncGenerator<Order>` to the inlined member shape, not the iterator wrapper', async () => {
+    const fn = spanOf('streamOrders(): AsyncGenerator<Order>');
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'asyncgen-return',
+      requests: [
+        {
+          file_path: fixtureFile,
+          line_number: fn.line,
+          span_start: fn.start,
+          span_end: fn.end,
+          infer_kind: 'function_return',
+          alias: 'StreamOrdersReturn',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'StreamOrdersReturn'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+
+    // The bug: the iterator wrapper leaking into the contract.
+    assert.ok(
+      !/AsyncGenerator/.test(inferred.type_string),
+      `must peel the async-iterator wrapper, got: ${inferred.type_string}`
+    );
+
+    // The fix: the yield type's real member shape (structurally expanded, like
+    // a plain Promise<Order> resolver).
+    assert.strictEqual(
+      inferred.type_string,
+      '{ id: string; total: number; }',
+      `expected the inlined yield shape, got: ${inferred.type_string}`
+    );
+
+    // The anchor is the yield type's source symbol, never the wrapper.
+    assert.strictEqual(
+      inferred.primary_type_symbol,
+      'Order',
+      `expected primary_type_symbol "Order", got: ${inferred.primary_type_symbol}`
+    );
+  });
+
+  it('peels `Promise<AsyncGenerator<Order>>` through both layers to the yield shape', async () => {
+    const fn = spanOf('streamOrdersPromised(): Promise<AsyncGenerator<Order>>');
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'asyncgen-promised-return',
+      requests: [
+        {
+          file_path: fixtureFile,
+          line_number: fn.line,
+          span_start: fn.start,
+          span_end: fn.end,
+          infer_kind: 'function_return',
+          alias: 'StreamOrdersPromisedReturn',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'StreamOrdersPromisedReturn'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.ok(
+      !/AsyncGenerator|Promise/.test(inferred.type_string),
+      `must peel both Promise and async-iterator wrappers, got: ${inferred.type_string}`
+    );
+    assert.strictEqual(
+      inferred.type_string,
+      '{ id: string; total: number; }',
+      `expected the inlined yield shape, got: ${inferred.type_string}`
+    );
+    assert.strictEqual(inferred.primary_type_symbol, 'Order');
+  });
+});

--- a/tests/file_centric_analysis_test.rs
+++ b/tests/file_centric_analysis_test.rs
@@ -787,6 +787,7 @@ app.post('/users', (req, res) => res.json({ created: true }));
             &http_guidance(&guidance),
             &detection,
             temp_dir.path(),
+            &Default::default(),
         )
         .await;
 
@@ -825,6 +826,7 @@ async fn test_file_orchestrator_handles_empty_files() {
             &http_guidance(&guidance),
             &detection,
             temp_dir.path(),
+            &Default::default(),
         )
         .await;
 
@@ -858,6 +860,7 @@ async fn test_file_orchestrator_handles_missing_files() {
             &http_guidance(&guidance),
             &detection,
             PathBuf::from("/").as_path(),
+            &Default::default(),
         )
         .await;
 

--- a/tests/file_centric_analysis_test.rs
+++ b/tests/file_centric_analysis_test.rs
@@ -160,6 +160,7 @@ fn test_file_analysis_result_default() {
 #[test]
 fn test_file_analysis_result_serialization() {
     let result = FileAnalysisResult {
+        graphql_operations: vec![],
         mounts: vec![MountResult {
             line_number: 5,
             parent_node: "app".to_string(),
@@ -331,6 +332,7 @@ fn test_cross_file_import_resolution() {
     file_results.insert(
         "src/app.ts".to_string(),
         FileAnalysisResult {
+            graphql_operations: vec![],
             mounts: vec![
                 MountResult {
                     line_number: 10,
@@ -358,6 +360,7 @@ fn test_cross_file_import_resolution() {
     file_results.insert(
         "src/routes/users.ts".to_string(),
         FileAnalysisResult {
+            graphql_operations: vec![],
             mounts: vec![],
             endpoints: vec![
                 EndpointResult {
@@ -423,6 +426,7 @@ fn test_cross_file_import_resolution() {
     file_results.insert(
         "src/routes/api.ts".to_string(),
         FileAnalysisResult {
+            graphql_operations: vec![],
             mounts: vec![],
             endpoints: vec![
                 EndpointResult {
@@ -489,6 +493,7 @@ fn test_cross_file_import_resolution() {
 #[test]
 fn test_data_call_extraction() {
     let result = FileAnalysisResult {
+        graphql_operations: vec![],
         mounts: vec![],
         endpoints: vec![],
         data_calls: vec![
@@ -568,6 +573,7 @@ fn test_nested_router_mounts() {
     file_results.insert(
         "src/app.ts".to_string(),
         FileAnalysisResult {
+            graphql_operations: vec![],
             mounts: vec![MountResult {
                 line_number: 5,
                 parent_node: "app".to_string(),
@@ -584,6 +590,7 @@ fn test_nested_router_mounts() {
     file_results.insert(
         "src/routes/api.ts".to_string(),
         FileAnalysisResult {
+            graphql_operations: vec![],
             mounts: vec![MountResult {
                 line_number: 5,
                 parent_node: "router".to_string(),
@@ -600,6 +607,7 @@ fn test_nested_router_mounts() {
     file_results.insert(
         "src/routes/v1/index.ts".to_string(),
         FileAnalysisResult {
+            graphql_operations: vec![],
             mounts: vec![MountResult {
                 line_number: 5,
                 parent_node: "router".to_string(),
@@ -616,6 +624,7 @@ fn test_nested_router_mounts() {
     file_results.insert(
         "src/routes/v1/users.ts".to_string(),
         FileAnalysisResult {
+            graphql_operations: vec![],
             mounts: vec![],
             endpoints: vec![EndpointResult {
                 candidate_id: "span:830-860".to_string(),
@@ -652,6 +661,7 @@ fn test_nested_router_mounts() {
 #[test]
 fn test_multiple_http_methods_on_same_path() {
     let result = FileAnalysisResult {
+        graphql_operations: vec![],
         mounts: vec![],
         endpoints: vec![
             EndpointResult {

--- a/tests/llm_mock_pipeline_test.rs
+++ b/tests/llm_mock_pipeline_test.rs
@@ -93,6 +93,7 @@ async fn mock_llm_output_flows_through_validation_and_mount_graph() {
             &ProtocolGuidance::from([(Protocol::Http, express_guidance())]),
             &express_detection(),
             &root,
+            &Default::default(),
         )
         .await
         .expect("analysis should succeed");


### PR DESCRIPTION
## What

GraphQL **producer** operations now resolve their type from the TS resolver function's return type — the last big piece of cross-repo graphql type resolution. Entirely scanner-side: **no cloud prompt deploy needed** (the new `graphql_operations` schema channel and the SDL-context instruction are both posted by the scanner; validated live against the currently-deployed prompt).

## How (Stages A/B1/B2)

- **Schema channel** (`schemas.rs`): new optional `graphql_operations` array (kind/field/resolver_function/resolver_line/primary_type_symbol/type_import_source). The LLM emits one entry per resolver linking it to its SDL root field.
- **AsyncGenerator unwrap** (sidecar): `AsyncGenerator<T>`/`AsyncIterableIterator<T>` → `T` (subscriptions).
- **B1 — consumption**: merges the LLM linkage onto the SDL producer ops by canonical key, then emits a `FunctionReturn` infer request at the resolver line (alias byte-matches the producer manifest entry). The sidecar resolves the return type, unwraps Promise/AsyncGenerator, and structural-expands — so `Promise<ApiResponse<Order>>` → `{ data: {...}, errors }`, `AsyncGenerator<Order>` → `{...}`.
- **B2 — routing**: extracts the SDL producer field-list before file-analysis and injects it as a `### GRAPHQL SCHEMA PRODUCERS` context section; routes resolver files (tightly scoped: service has SDL producers + file under the SDL roots + has an exported function) to the LLM even with no HTTP candidates.

## Validation

- Live harness (real model, deployed prompt, 3/3 runs): emits `query order→resolveOrder L38`, `mutation refundOrder→resolveRefundOrder L51`, `subscription orderUpdated→resolveOrderUpdated L67`, byte-perfect; correctly omits the field with no resolver.
- Full Rust suite + cassette hard gate green; sidecar suite green. Unit tests guard the merge + the load-bearing alias-join invariant.
- End-to-end eval running on this branch ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)