### PR TITLE
fix(graphql): generalize consumer detection + promise unwrap (no eval change)

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -483,11 +483,18 @@ struct TaggedTplVisitor<'a> {
 }
 
 impl TaggedTplVisitor<'_> {
-    /// Capture a `request<T>(DOC)`-style call: a member call whose method is one
-    /// of the GraphQL execution methods, with a TS type argument and a first
-    /// argument that is an ident bound to a `gql` document. Keyed entirely on the
-    /// structural shape (gql-const first arg + generic + method name), never a
-    /// client-identifier allowlist, so it is framework-agnostic.
+    /// Capture a `receiver.method<T>(DOC)`-style GraphQL execution call. The
+    /// capture is keyed entirely on a structural triad, with NO method-name
+    /// allowlist and NO client-identifier allowlist, so it is framework-agnostic:
+    ///   (a) it is a member call (`obj.method(...)`);
+    ///   (b) it carries an explicit TS type generic (`method<OrderView>(...)`);
+    ///   (c) its first positional argument is an ident bound to a tracked `gql`
+    ///       document const (looked up in `gql_const_key`).
+    /// Those three together identify a GraphQL execution by construction — the
+    /// method name (`request`/`query`/`exec`/…) adds nothing over "first arg is a
+    /// known gql document", so it is not inspected. The generic + known-gql-const
+    /// requirements keep precision: a plain `foo.map<T>(x)` is never captured
+    /// because `x` is not a tracked gql document.
     fn capture_request_call(&mut self, node: &CallExpr) {
         let Callee::Expr(callee) = &node.callee else {
             return;
@@ -495,13 +502,9 @@ impl TaggedTplVisitor<'_> {
         let Expr::Member(member) = &**callee else {
             return;
         };
-        let Some(method) = member.prop.as_ident() else {
-            return;
-        };
-        if !matches!(
-            method.sym.as_ref(),
-            "request" | "query" | "mutate" | "subscribe"
-        ) {
+        // The call must be a member call (`obj.method(...)`) — but the method
+        // name itself is intentionally NOT inspected (no allowlist).
+        if member.prop.as_ident().is_none() {
             return;
         }
         // Must carry an explicit TS type argument (`request<OrderView>(...)`).
@@ -928,6 +931,86 @@ async function fetchOrder(id) {
             .find(|op| op.key.canonical() == "graphql|query|order")
             .unwrap();
         assert_eq!(order.payload_type_source.as_deref(), Some("./types"));
+    }
+
+    /// Generalization: the capture is NOT gated on a method-name allowlist, so a
+    /// non-`request` execution method (`gqlClient.exec<T>(DOC)`, Apollo-style
+    /// `useQuery<T>(DOC)`) anchors exactly like `request<T>(DOC)`. Under the old
+    /// `matches!(method.sym, "request" | "query" | "mutate" | "subscribe")` gate
+    /// these returned early and were never captured. The structural triad
+    /// (member call + TS generic + tracked gql-const first arg) is all that's
+    /// required.
+    #[test]
+    fn consumer_anchors_on_non_request_method_name() {
+        // `exec` — not in the old allowlist.
+        let exec_result = extract_ts(
+            r#"
+import { gql } from "graphql-tag";
+import { OrderView } from "./types";
+const gqlClient = makeClient();
+const GET_ORDER = gql`
+  query GetOrder($id: ID!) { order(id: $id) { id } }
+`;
+async function fetchOrder(id) {
+  return gqlClient.exec<OrderView>(GET_ORDER, { id });
+}
+"#,
+        );
+        assert_eq!(
+            payload_anchors(&exec_result.consumers),
+            vec![(
+                "graphql|query|order".to_string(),
+                Some("OrderView".to_string())
+            )]
+        );
+
+        // Apollo-style `useQuery<T>(DOC)` as a member call, single-property
+        // wrapper matching the field — also not in the old allowlist.
+        let use_query_result = extract_ts(
+            r#"
+import { gql } from "graphql-tag";
+import { OrderView } from "./types";
+const apollo = makeClient();
+const GET_ORDER = gql`
+  query GetOrder($id: ID!) { order(id: $id) { id } }
+`;
+function OrderComponent(id) {
+  return apollo.useQuery<{ order: OrderView }>(GET_ORDER, { id });
+}
+"#,
+        );
+        assert_eq!(
+            payload_anchors(&use_query_result.consumers),
+            vec![(
+                "graphql|query|order".to_string(),
+                Some("OrderView".to_string())
+            )]
+        );
+    }
+
+    /// Precision guard survives the method-allowlist removal: a generic member
+    /// call whose first arg is NOT a tracked gql document (`foo.map<T>(x)`) is
+    /// never captured, even though it is a member call with a TS generic.
+    #[test]
+    fn non_gql_generic_member_call_is_not_captured() {
+        let result = extract_ts(
+            r#"
+import { gql } from "graphql-tag";
+import { OrderView } from "./types";
+const GET_ORDER = gql`
+  query GetOrder($id: ID!) { order(id: $id) { id } }
+`;
+function compute(items, x) {
+  return items.map<OrderView>(x);
+}
+"#,
+        );
+        // The gql document is still parsed into a consumer op, but it carries no
+        // payload anchor because no qualifying execution call referenced it.
+        assert_eq!(
+            payload_anchors(&result.consumers),
+            vec![("graphql|query|order".to_string(), None)]
+        );
     }
 
     /// A `request<{ order: OrderView }>(GET_ORDER)` call site — the single

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -870,16 +870,52 @@ export class TypeInferrer {
   // Extraction Config-based Payload Unwrapping (NEW)
   // ===========================================================================
 
-  /** `Promise<T>` → `T` at the type level; any other type passes through. */
+  /**
+   * Resolve the awaited type: `Promise<X>` / `PromiseLike<X>` / `Awaited<X>` →
+   * `X` at the type level (recursively, so `Awaited<Promise<X>>` → `X`); any
+   * non-thenable type passes through UNCHANGED.
+   *
+   * ts-morph 25.0.1 does not expose the compiler's `getAwaitedType` on its
+   * `Type` wrapper (only `AwaitableNode.isAwaited()` on AST nodes, which is
+   * unrelated), so we resolve structurally on the symbol/alias name instead of
+   * gating on the literal `'Promise'` symbol. This generalizes past `Promise<T>`
+   * to `PromiseLike<T>` and the `Awaited<T>` utility type without over-unwrapping:
+   * a non-thenable like `AsyncGenerator<T>` is NOT awaitable and is returned
+   * unchanged, so the `unwrapAsyncIterableType` step that runs right after still
+   * sees (and peels) the iterator wrapper as before.
+   */
   private unwrapPromiseType(type: Type): Type {
-    const symbolName = (type.getSymbol() || type.getAliasSymbol())?.getName();
-    if (symbolName === 'Promise') {
-      const args = type.getTypeArguments();
-      if (args.length === 1) {
-        return args[0];
+    // Bounded recursion guard: a pathological self-referential alias must not
+    // loop. Real promise nesting is shallow; 16 is far more than enough.
+    let current = type;
+    for (let depth = 0; depth < 16; depth++) {
+      const symbolName = current.getSymbol()?.getName();
+      const aliasName = current.getAliasSymbol()?.getName();
+
+      // `Promise<X>` / `PromiseLike<X>` — single type argument is the value.
+      if (symbolName === 'Promise' || symbolName === 'PromiseLike') {
+        const args = current.getTypeArguments();
+        if (args.length === 1) {
+          current = args[0];
+          continue;
+        }
+        return current;
       }
+
+      // `Awaited<X>` utility type — unwrap its alias argument and keep resolving
+      // (TS usually eager-resolves this, but handle the surfaced-alias form too).
+      if (aliasName === 'Awaited') {
+        const aliasArgs = current.getAliasTypeArguments();
+        if (aliasArgs.length === 1) {
+          current = aliasArgs[0];
+          continue;
+        }
+        return current;
+      }
+
+      return current;
     }
-    return type;
+    return current;
   }
 
   /**
@@ -1830,7 +1866,10 @@ export class TypeInferrer {
 
     // Handle nested Promise via type arguments
     const typeArguments = type.getTypeArguments();
-    if (typeArguments.length > 0 && typeString.startsWith('Promise<')) {
+    if (
+      typeArguments.length > 0 &&
+      (typeString.startsWith('Promise<') || typeString.startsWith('PromiseLike<'))
+    ) {
       return typeText(typeArguments[0]);
     }
 
@@ -1838,15 +1877,20 @@ export class TypeInferrer {
   }
 
   /**
-   * Unwrap a single `Promise<...>` type string, only when the inner text is
-   * bracket-balanced (so `Promise<A> | B` is left alone for the caller's
-   * union handling rather than mangled).
+   * Unwrap a single `Promise<...>` / `PromiseLike<...>` type string, only when
+   * the inner text is bracket-balanced (so `Promise<A> | B` is left alone for
+   * the caller's union handling rather than mangled).
    */
   private unwrapPromiseText(part: string): string {
-    if (!part.startsWith('Promise<') || !part.endsWith('>')) {
+    const prefix = part.startsWith('Promise<')
+      ? 'Promise<'
+      : part.startsWith('PromiseLike<')
+        ? 'PromiseLike<'
+        : null;
+    if (prefix === null || !part.endsWith('>')) {
       return part;
     }
-    const inner = part.slice('Promise<'.length, -1);
+    const inner = part.slice(prefix.length, -1);
     return this.isBracketBalanced(inner) ? inner : part;
   }
 

--- a/src/sidecar/test/infer-promiselike-return.test.ts
+++ b/src/sidecar/test/infer-promiselike-return.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Generalization regression for `unwrapPromiseType`: the awaited-type unwrap
+ * used to gate on the literal `Promise` symbol only, so a function returning
+ * `PromiseLike<T>` (or `Awaited<...>`) leaked the wrapper into the contract.
+ *
+ * The fix resolves the awaited type structurally on the symbol/alias name,
+ * accepting `Promise`, `PromiseLike` and the `Awaited<...>` utility type while
+ * leaving any NON-thenable type (e.g. a plain object, or `AsyncGenerator<T>`)
+ * untouched. This test pins:
+ *   - `(): Promise<User>`     → inlined `User` member shape (existing behavior);
+ *   - `(): PromiseLike<User>` → inlined `User` member shape (the new case);
+ *   - a non-promise return    → unchanged (no over-unwrapping);
+ *   - the corpus shape `Promise<ApiResponse<Order>>` → `ApiResponse<Order>`
+ *     (then structurally expanded downstream to `{ data; errors }`), confirming
+ *     no regression on the existing HTTP-resolution output.
+ *
+ * The throwaway source is written to the OS temp dir (NOT under test/fixtures),
+ * so this test never touches ground-truth fixtures. The sidecar inits against
+ * the real sample-repo so the project carries a valid lib/tsconfig and the
+ * global `Promise`/`PromiseLike` types resolve.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    infer_kind: string;
+    is_explicit: boolean;
+    primary_type_symbol?: string;
+  }>;
+  errors?: string[];
+}
+
+const SOURCE = `interface User {
+  id: string;
+  name: string;
+}
+
+interface Order {
+  id: string;
+  total: number;
+}
+
+interface ApiResponse<T> {
+  data: T;
+  errors: string[];
+}
+
+export function getUserPromise(): Promise<User> {
+  return Promise.resolve({ id: 'a', name: 'b' });
+}
+
+export function getUserPromiseLike(): PromiseLike<User> {
+  return Promise.resolve({ id: 'a', name: 'b' });
+}
+
+export function getOrderEnvelope(): Promise<ApiResponse<Order>> {
+  return Promise.resolve({ data: { id: 'o', total: 1 }, errors: [] });
+}
+
+export function getUserSync(): User {
+  return { id: 'a', name: 'b' };
+}
+`;
+
+/** Byte span of `text` in SOURCE (ASCII-only, so byte == char offsets). */
+function spanOf(text: string): { start: number; end: number; line: number } {
+  const start = SOURCE.indexOf(text);
+  assert.ok(start >= 0, `source must contain: ${text}`);
+  const line = SOURCE.slice(0, start).split('\n').length;
+  return { start, end: start + text.length, line };
+}
+
+describe('awaited-type unwrap generalizes to PromiseLike / Awaited', () => {
+  let client: SidecarClient;
+  let tmpDir: string;
+  let fixtureFile: string;
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-promiselike-'));
+    fixtureFile = path.join(tmpDir, 'promise-returns.ts');
+    fs.writeFileSync(fixtureFile, SOURCE, 'utf-8');
+
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'promiselike-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function inferReturn(
+    signature: string,
+    alias: string
+  ): Promise<NonNullable<InferResponseShape['inferred_types']>[number]> {
+    const fn = spanOf(signature);
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: `promiselike-${alias}`,
+      requests: [
+        {
+          file_path: fixtureFile,
+          line_number: fn.line,
+          span_start: fn.start,
+          span_end: fn.end,
+          infer_kind: 'function_return',
+          alias,
+        },
+      ],
+    });
+    const inferred = response.inferred_types?.find((t) => t.alias === alias);
+    assert.ok(
+      inferred,
+      `expected an inferred type for ${alias}, got errors: ${JSON.stringify(
+        response.errors
+      )}`
+    );
+    return inferred;
+  }
+
+  it('inlines `Promise<User>` to the User member shape', async () => {
+    const inferred = await inferReturn(
+      'getUserPromise(): Promise<User>',
+      'PromiseUser'
+    );
+    assert.ok(
+      !/Promise/.test(inferred.type_string),
+      `must peel the Promise wrapper, got: ${inferred.type_string}`
+    );
+    assert.strictEqual(inferred.type_string, '{ id: string; name: string; }');
+    assert.strictEqual(inferred.primary_type_symbol, 'User');
+  });
+
+  it('inlines `PromiseLike<User>` to the User member shape (the new case)', async () => {
+    const inferred = await inferReturn(
+      'getUserPromiseLike(): PromiseLike<User>',
+      'PromiseLikeUser'
+    );
+    assert.ok(
+      !/PromiseLike|Promise/.test(inferred.type_string),
+      `must peel the PromiseLike wrapper, got: ${inferred.type_string}`
+    );
+    assert.strictEqual(inferred.type_string, '{ id: string; name: string; }');
+    assert.strictEqual(inferred.primary_type_symbol, 'User');
+  });
+
+  it('reduces the corpus shape `Promise<ApiResponse<Order>>` to ApiResponse<Order> and expands it', async () => {
+    const inferred = await inferReturn(
+      'getOrderEnvelope(): Promise<ApiResponse<Order>>',
+      'OrderEnvelope'
+    );
+    // No Promise wrapper survives; the envelope is structurally expanded to its
+    // members (the unchanged downstream behavior), and Order is inlined within.
+    assert.ok(
+      !/Promise/.test(inferred.type_string),
+      `must peel the Promise wrapper, got: ${inferred.type_string}`
+    );
+    assert.match(
+      inferred.type_string,
+      /data:/,
+      `expected the ApiResponse envelope members, got: ${inferred.type_string}`
+    );
+    assert.match(
+      inferred.type_string,
+      /errors:/,
+      `expected the ApiResponse envelope members, got: ${inferred.type_string}`
+    );
+    assert.strictEqual(inferred.primary_type_symbol, 'ApiResponse');
+  });
+
+  it('leaves a non-promise return unchanged (no over-unwrapping)', async () => {
+    const inferred = await inferReturn('getUserSync(): User', 'SyncUser');
+    // A plain object return inlines to its member shape, exactly as before — the
+    // awaited unwrap is a no-op on a non-thenable type.
+    assert.strictEqual(inferred.type_string, '{ id: string; name: string; }');
+    assert.strictEqual(inferred.primary_type_symbol, 'User');
+  });
+});


### PR DESCRIPTION
## What

Two generalization fixes from an audit of the graphql type-resolution work. Neither changes the eval result (the corpus shapes already live inside both gates — the full suite + cassette hard gate confirm no output drift); they strictly broaden real-world coverage.

## Fix 1 — remove the consumer client-method allowlist (`src/graphql.rs`)

`capture_request_call` gated on a hardcoded method-name allowlist `{request, query, mutate, subscribe}` — and its doc-comment falsely claimed "never a client-identifier allowlist, framework-agnostic" while keeping a *method* allowlist. Removed the method-name gate; the genuinely-structural triad remains and is sufficient: member call + explicit TS generic + first arg is a tracked `gql` document const. Now captures Apollo `useQuery<T>(DOC)`, custom `gqlClient.exec<T>(DOC)`, etc. Comment rewritten to be accurate. Tests added for a non-`request` method (captured) and a non-gql generic member call (correctly ignored).

## Fix 2 — generalize Promise unwrap to PromiseLike/Awaited (`src/sidecar/src/type-inferrer.ts`)

`unwrapPromiseType` gated on the literal `Promise` symbol, missing `PromiseLike<T>`, `Awaited<T>`, thenables. Now unwraps all of them (ts-morph 25 doesn't expose `getAwaitedType` on `Type`, so done structurally on the symbol/alias name, bounded). Non-thenables pass through unchanged; `AsyncGenerator` stays for the async-iterable unwrap. `Promise<ApiResponse<Order>>` → `ApiResponse<Order>` unchanged.

## Validation

Full Rust suite + cassette hard gate green (no golden drift → output-neutral on the HTTP pipeline); sidecar suite green; fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)