### PR TITLE
feat(graphql): cross-repo compat checking (edge query|order → compatible)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -3069,6 +3069,54 @@ mod tests {
         );
     }
 
+    /// The `graphql|subscription|orderUpdated` false-positive at the verdict-join
+    /// layer. Its consumer alias dangles to `unknown` in the bundle, so ts_check
+    /// reports the pair in `unknownPairs` with the graphql endpoint label
+    /// `"GRAPHQL subscription|orderUpdated (response)"`. That must join the edge
+    /// whose `producer_key` is `"graphql|subscription|orderUpdated"` and pin the
+    /// verdict to `None` — NOT the optimistic `Some(true)` the edge would default
+    /// to if the unresolved consumer had been dropped from the manifest (so the
+    /// pair never reached ts_check at all). This is the join the live eval's
+    /// resolved graphql edges never exercise (they are compatible by default).
+    #[test]
+    fn apply_compat_verdicts_graphql_unverifiable_edge_none() {
+        let result = serde_json::json!({
+            "mismatches": [],
+            "unknownPairs": [{
+                "endpoint": "GRAPHQL subscription|orderUpdated (response)",
+                "consumerLocation": "web-frontend/lib/graphql.ts:84",
+                "reason": "consumer type resolves to unknown (type missing from bundled types?)"
+            }],
+            "totalChecked": 1,
+            "compatibleCount": 0
+        });
+        let mut matches = vec![
+            edge_at(
+                "graphql|subscription|orderUpdated",
+                "web-frontend",
+                "web-frontend/lib/graphql.ts:84",
+            ),
+            edge_at(
+                "graphql|query|order",
+                "web-frontend",
+                "web-frontend/lib/graphql.ts:76",
+            ),
+        ];
+        apply_compat_verdicts(&result, &mut matches);
+
+        assert_eq!(
+            matches[0].type_compatible, None,
+            "an unresolved graphql consumer makes the edge unverifiable (None), \
+             never a fake Some(true) from being dropped + absent"
+        );
+        assert!(matches[0].mismatch_reason.is_none());
+        assert_eq!(
+            matches[1].type_compatible,
+            Some(true),
+            "the resolved graphql edge, absent from both lists, stays compatible"
+        );
+    }
+
     /// THE live compat=1/6 regression. ts_check builds its `endpoint` from the
     /// normalized manifest (`/orders/:param`), while the cross-repo edge's
     /// `producer_key` keeps the SOURCE param name (`/orders/:id`). The verdict

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -3312,7 +3312,10 @@ mod tests {
         );
         assert_eq!(
             parse_producer_key("graphql|subscription|orderUpdated"),
-            Some(("GRAPHQL".to_string(), "subscription|orderUpdated".to_string())),
+            Some((
+                "GRAPHQL".to_string(),
+                "subscription|orderUpdated".to_string()
+            )),
         );
         // A round-trip through the ts_check endpoint label must yield the SAME
         // pair, so a graphql verdict joins its edge.

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -248,16 +248,22 @@ fn parse_compat_endpoint(endpoint: &str) -> Option<(String, String)> {
 }
 
 /// Recover the verdict-join `(pseudo-method, identity)` from a canonical
-/// producer key, for the protocols ts_check type-checks (HTTP + socket):
+/// producer key, for the protocols ts_check type-checks (HTTP + socket + graphql):
 ///
 /// - HTTP (`"http|METHOD|path"`) → `("METHOD", "path")`, the HTTP join key.
 /// - Socket (`"socket|DIRECTION|event"`) → `("SOCKET", "DIRECTION|event")`. The
 ///   matching ts_check endpoint label is `"SOCKET DIRECTION|event (response)"`,
 ///   which `parse_compat_endpoint` reduces to the SAME pair, so a socket edge
 ///   joins its ts_check verdict exactly like an HTTP one.
+/// - GraphQL (`"graphql|KIND|field"`) → `("GRAPHQL", "KIND|field")`. The
+///   matching ts_check endpoint label is `"GRAPHQL KIND|field (response)"`,
+///   which `parse_compat_endpoint` reduces to the SAME pair, so a graphql edge
+///   joins its verdict exactly like socket. The `KIND` (`query`/`mutation`/
+///   `subscription`) stays lowercase here AND in the ts_check label, so the two
+///   sides agree without any case folding.
 ///
-/// Returns `None` for any other protocol (e.g. GraphQL): ts_check produced no
-/// verdict for it, so its edge stays `None` rather than fabricating one.
+/// Returns `None` for any other protocol: ts_check produced no verdict for it,
+/// so its edge stays `None` rather than fabricating one.
 fn parse_producer_key(key: &str) -> Option<(String, String)> {
     let mut parts = key.splitn(3, '|');
     match (parts.next(), parts.next(), parts.next()) {
@@ -268,6 +274,9 @@ fn parse_producer_key(key: &str) -> Option<(String, String)> {
             if !direction.is_empty() && !event.is_empty() =>
         {
             Some(("SOCKET".to_string(), format!("{}|{}", direction, event)))
+        }
+        (Some("graphql"), Some(kind), Some(field)) if !kind.is_empty() && !field.is_empty() => {
+            Some(("GRAPHQL".to_string(), format!("{}|{}", kind, field)))
         }
         _ => None,
     }
@@ -369,10 +378,11 @@ fn apply_compat_verdicts(result: &serde_json::Value, matches: &mut [CrossRepoMat
 
     for edge in matches.iter_mut() {
         // Recover the join key from the producer_key. ts_check type-checks HTTP
-        // (`http|METHOD|path`) and socket (`socket|DIRECTION|event`), so both
-        // join here. A key for any other protocol (e.g. GraphQL) is not checked
-        // by ts_check, so its verdict is genuinely unknown — leave it `None`
-        // rather than fabricate `Some(true)` (#260, part 2).
+        // (`http|METHOD|path`), socket (`socket|DIRECTION|event`), and graphql
+        // (`graphql|KIND|field`), so all three join here. A key for any other
+        // protocol is not checked by ts_check, so its verdict is genuinely
+        // unknown — leave it `None` rather than fabricate `Some(true)`
+        // (#260, part 2).
         let Some((method, path)) = parse_producer_key(&edge.producer_key) else {
             edge.type_compatible = None;
             continue;
@@ -1577,10 +1587,10 @@ impl Analyzer {
                             producer_key: canonical.clone(),
                             consumer_repo: consumer_repo.clone(),
                             consumer_key: canonical.clone(),
-                            // Exact-key protocols (GraphQL/socket) are not checked
-                            // by ts_check (HTTP-only), so this never feeds the
-                            // compat overlay — but recording the consumer call site
-                            // keeps the dedup identity precise.
+                            // Exact-key protocols (GraphQL/socket) ARE type-checked
+                            // by ts_check now, so this consumer location feeds the
+                            // compat overlay (`apply_compat_verdicts`) and also keeps
+                            // the dedup identity precise.
                             consumer_location: Some(call.file_path.display().to_string()),
                             match_score: 1.0,
                             type_compatible: None,
@@ -3119,8 +3129,10 @@ mod tests {
             "POST /payments is unverifiable → None, never a fake compatible"
         );
         assert_eq!(
-            matches[3].type_compatible, None,
-            "a non-HTTP edge is not ts_check-verifiable → None"
+            matches[3].type_compatible,
+            Some(true),
+            "a graphql edge is now ts_check-verifiable and is absent from both \
+             lists → genuinely-checked compatible (Some(true)), not None"
         );
     }
 
@@ -3202,17 +3214,18 @@ mod tests {
         );
     }
 
-    /// A GraphQL edge has a `producer_key` ts_check does not type-check, so
-    /// `parse_producer_key` returns `None` and the verdict is genuinely unknown:
-    /// the edge must stay `None`, NOT the fabricated `Some(true)` the old default
-    /// returned (#260, part 2 — the worst direction for a drift detector).
-    /// Socket edges, by contrast, ARE type-checked and join their verdict (see
-    /// `apply_compat_verdicts_joins_socket_edge`).
+    /// A GraphQL edge is now type-checked by ts_check (the graphql-compat
+    /// machinery), so its `producer_key` joins a verdict just like socket. With
+    /// the edge absent from both the mismatch and unknown lists, ts_check
+    /// genuinely checked it and found it compatible, so the overlay reads
+    /// `Some(true)` — NOT the old `None` (which meant "never checked") and NOT a
+    /// fabricated true. The incompatible direction is pinned by
+    /// `apply_compat_verdicts_joins_graphql_edge`.
     #[test]
-    fn overlay_compat_verdicts_graphql_producer_key_stays_none() {
+    fn overlay_compat_verdicts_graphql_edge_joins_compatible() {
         let dir = tempfile::tempdir().expect("tempdir");
         let results = r#"{ "mismatches": [], "unknownPairs": [],
-                           "totalChecked": 0, "compatibleCount": 0 }"#;
+                           "totalChecked": 1, "compatibleCount": 1 }"#;
         let analyzer = analyzer_with_results(dir.path(), Some(results));
 
         let mut matches = vec![edge_at(
@@ -3223,9 +3236,12 @@ mod tests {
         analyzer.overlay_compat_verdicts(&mut matches);
 
         assert_eq!(
-            matches[0].type_compatible, None,
-            "a GraphQL edge ts_check never checked must stay None, not fake true"
+            matches[0].type_compatible,
+            Some(true),
+            "a GraphQL edge genuinely checked and absent from both lists is \
+             compatible (Some(true)), now that graphql joins its verdict"
         );
+        assert!(matches[0].mismatch_reason.is_none());
     }
 
     /// The socket cross-repo join (this PR). A `socket|DIRECTION|event` edge is
@@ -3281,6 +3297,86 @@ mod tests {
         assert_eq!(
             matches[1].mismatch_reason.as_deref(),
             Some("Sent type is not assignable to listener type"),
+        );
+    }
+
+    /// `parse_producer_key` recovers the `(pseudo-method, identity)` join pair
+    /// from a graphql canonical key. The KIND stays lowercase on BOTH the key and
+    /// the ts_check endpoint label (`GRAPHQL query|order (response)`), so the two
+    /// sides agree with no case folding on the identity tail.
+    #[test]
+    fn parse_producer_key_recovers_graphql_pair() {
+        assert_eq!(
+            parse_producer_key("graphql|query|order"),
+            Some(("GRAPHQL".to_string(), "query|order".to_string())),
+        );
+        assert_eq!(
+            parse_producer_key("graphql|subscription|orderUpdated"),
+            Some(("GRAPHQL".to_string(), "subscription|orderUpdated".to_string())),
+        );
+        // A round-trip through the ts_check endpoint label must yield the SAME
+        // pair, so a graphql verdict joins its edge.
+        assert_eq!(
+            parse_compat_endpoint("GRAPHQL query|order (response)"),
+            parse_producer_key("graphql|query|order"),
+        );
+        // Malformed (missing field) → no join key, edge stays None.
+        assert_eq!(parse_producer_key("graphql|query|"), None);
+        assert_eq!(parse_producer_key("graphql|query"), None);
+    }
+
+    /// The graphql cross-repo join (the graphql-compat machinery). A
+    /// `graphql|KIND|field` edge is type-checked by ts_check, which emits its
+    /// verdict under the endpoint label `"GRAPHQL <KIND>|<field> (response)"`.
+    /// `parse_producer_key` recovers `("GRAPHQL", "<KIND>|<field>")` from the edge
+    /// and `parse_compat_endpoint` recovers the SAME pair from the label, so the
+    /// verdict lands on the graphql edge — `Some(true)` when ts_check finds it
+    /// compatible, `Some(false)` + reason when it reports a mismatch.
+    #[test]
+    fn apply_compat_verdicts_joins_graphql_edge() {
+        // The xrepo-corpus-1 graphql edges: `query|order` is compatible (absent
+        // from both lists → Some(true)); a second field is in the mismatch list
+        // and lands on its edge with the reason.
+        let result = serde_json::json!({
+            "mismatches": [{
+                "endpoint": "GRAPHQL subscription|orderUpdated (response)",
+                "consumerLocation": "web-frontend/lib/graphql.ts:80",
+                "error": "note?: optional producer field is not assignable to required consumer field"
+            }],
+            "unknownPairs": [],
+            "totalChecked": 2,
+            "compatibleCount": 1
+        });
+
+        let mut matches = vec![
+            edge_at(
+                "graphql|query|order",
+                "web-frontend",
+                "web-frontend/lib/graphql.ts:76",
+            ),
+            edge_at(
+                "graphql|subscription|orderUpdated",
+                "web-frontend",
+                "web-frontend/lib/graphql.ts:80:5",
+            ),
+        ];
+        apply_compat_verdicts(&result, &mut matches);
+
+        assert_eq!(
+            matches[0].type_compatible,
+            Some(true),
+            "the compatible graphql edge (absent from both lists) reads Some(true)"
+        );
+        assert!(matches[0].mismatch_reason.is_none());
+
+        assert_eq!(
+            matches[1].type_compatible,
+            Some(false),
+            "the graphql edge in the mismatch list reads Some(false)"
+        );
+        assert_eq!(
+            matches[1].mismatch_reason.as_deref(),
+            Some("note?: optional producer field is not assignable to required consumer field"),
         );
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2487,51 +2487,28 @@ fn write_manifest_files(
     for repo_data in all_repo_data {
         if let Some(entries) = &repo_data.type_manifest {
             for entry in entries {
-                // HTTP, socket, and graphql entries reach the ts_check manifest.
-                // ts_check checks HTTP by `method`/`path`, socket by the canonical
-                // `OperationKey` (event+direction), and graphql by (kind+field),
-                // reusing the same `TypeCompatibilityChecker` assignability for all
-                // three. The matcher drops any stray non-checkable entry
-                // defensively rather than throwing (#253).
+                // HTTP, socket, and graphql entries all reach the ts_check manifest
+                // unfiltered. ts_check checks HTTP by `method`/`path`, socket by the
+                // canonical `OperationKey` (event+direction), and graphql by
+                // (kind+field), reusing the same `TypeCompatibilityChecker`
+                // assignability for all three. The matcher drops any stray
+                // non-checkable entry defensively rather than throwing (#253).
                 //
-                // GraphQL is gated on a RESOLVED anchor: only a graphql entry whose
-                // type actually reached the bundle is emitted. Two ways an
-                // unresolved graphql entry can sneak past, both dropped here:
-                //
-                //  1. `type_state == Unknown` — the type never resolved (the
-                //     `subscription` with no `request<T>` call site, so no captured
-                //     payload symbol). The clean case.
-                //
-                //  2. A graphql CONSUMER with no resolved anchor symbol
-                //     (`primary_type_symbol == None`). This closes the
-                //     subscription-orderUpdated false-positive: that consumer's only
-                //     candidate alias is the synthetic `Endpoint_<hash>` fallback,
-                //     which `enrich_manifest_with_type_resolution` can wrongly
-                //     PROMOTE to `Implicit` when the bundle textually defines the
-                //     synthetic alias as a non-`= unknown` but top-ish form (e.g. an
-                //     index-any record `Record<string, any>`) — not caught by the
-                //     trivially-unknown filter, so `type_state` lies and check (1)
-                //     misses it. Such a consumer resolves to `any`/`unknown` in the
-                //     bundle and would read `producer ⊑ any` = compatible (a FALSE
-                //     POSITIVE). A consumer that genuinely resolved carries a real
-                //     anchor symbol (threaded at creation from the `request<T>`
-                //     payload, or filled from the deterministic inferred anchor
-                //     during enrichment), so a still-`None` symbol means no real
-                //     resolved type. Producers are unaffected: an SDL producer
-                //     always carries its deterministic SDL-field anchor.
-                //
-                // HTTP/socket carry no such gate: their Unknown entries are handled
-                // downstream as `unknownPairs`.
-                let is_graphql = entry.key.protocol() == crate::operation::Protocol::Graphql;
-                if is_graphql && entry.type_state == ManifestTypeState::Unknown {
-                    continue;
-                }
-                if is_graphql
-                    && entry.role == ManifestRole::Consumer
-                    && entry.primary_type_symbol.is_none()
-                {
-                    continue;
-                }
+                // An UNRESOLVED entry — `type_state == Unknown`, or an alias that
+                // dangles to `any`/`unknown` in the bundle — is NOT dropped here.
+                // ts_check still matches its pair and reports it as an `unknownPair`
+                // (unverifiable), which `apply_compat_verdicts` maps to a `None`
+                // verdict. Dropping it instead removes the pair from ts_check's
+                // output entirely, and `apply_compat_verdicts` treats an edge absent
+                // from BOTH `mismatches` and `unknownPairs` as compatible — a FALSE
+                // `Some(true)`. That was the `graphql|subscription|orderUpdated`
+                // false-positive: the consumer's only alias is the synthetic
+                // `Endpoint_<hash> = unknown` missing-alias fallback, so the entry
+                // was dropped, the edge went absent, and the verdict defaulted to
+                // compatible. Keeping it lets the `any`/`unknown` comparand guard in
+                // `type-checker.ts` route the pair to `unknownPairs` → `None`. This
+                // is exactly how HTTP/socket Unknown entries have always been
+                // handled; graphql is no longer a special case.
                 match entry.role {
                     ManifestRole::Producer => producer_entries.push(entry.clone()),
                     ManifestRole::Consumer => consumer_entries.push(entry.clone()),
@@ -4453,15 +4430,16 @@ mod tests {
         );
     }
 
-    /// `write_manifest_files` feeds the ts_check matcher, which now checks HTTP,
-    /// socket, AND graphql. HTTP + socket entries always pass through. A graphql
-    /// entry passes through ONLY when its anchor resolved (`type_state !=
-    /// Unknown`) — an unresolved graphql entry (e.g. a subscription consumer with
-    /// no `request<T>` call site) would only orphan-noise the verdict run, so it
-    /// is dropped here. The #253 throw-guard lives in the matcher, which drops any
-    /// stray non-checkable entry defensively rather than crashing the run.
+    /// `write_manifest_files` feeds the ts_check matcher, which checks HTTP,
+    /// socket, AND graphql. Every entry passes through unfiltered, including an
+    /// UNRESOLVED graphql entry (`type_state == Unknown`, e.g. a subscription
+    /// consumer with no `request<T>` call site). Such an entry must reach ts_check
+    /// so its pair is reported as an `unknownPair` (→ `None`); dropping it would
+    /// make the edge absent and `apply_compat_verdicts` would default it to a
+    /// false `Some(true)`. The #253 throw-guard lives in the matcher, which drops
+    /// any stray non-checkable entry defensively rather than crashing the run.
     #[test]
-    fn write_manifest_files_emits_http_socket_and_resolved_graphql() {
+    fn write_manifest_files_emits_http_socket_and_all_graphql() {
         use crate::cloud_storage::TypeEvidence;
         use crate::operation::{GraphqlOperationKind, OperationKey, SocketDirection};
         use crate::services::type_sidecar::InferKind;
@@ -4507,8 +4485,9 @@ mod tests {
                 OperationKey::graphql(GraphqlOperationKind::Query, "order"),
                 "OrderQueryResult",
             ),
-            // Unresolved graphql producer (Unknown anchor) → DROPPED so it can't
-            // orphan-noise the verdict run (the subscription-consumer case).
+            // Unresolved graphql producer (Unknown anchor) → KEPT so ts_check can
+            // report its pair as an unknownPair (→ None); dropping it would make
+            // the edge absent and default the verdict to a false Some(true).
             entry_with_state(
                 OperationKey::graphql(GraphqlOperationKind::Subscription, "orderUpdated"),
                 "OrderUpdatedUnknown",
@@ -4562,13 +4541,13 @@ mod tests {
         )
         .unwrap();
 
-        // HTTP, socket, and the RESOLVED graphql producer survive; the Unknown
-        // graphql producer is filtered out.
+        // HTTP, socket, and BOTH graphql producers (resolved and Unknown) survive:
+        // the Unknown one must reach ts_check to be reported as an unknownPair.
         assert_eq!(
             producer.entries.len(),
-            3,
-            "HTTP + socket + resolved graphql reach the manifest; the Unknown \
-             graphql entry is dropped"
+            4,
+            "HTTP + socket + both graphql producers reach the manifest; the \
+             Unknown graphql entry is kept, not dropped"
         );
         assert!(
             producer
@@ -4591,38 +4570,37 @@ mod tests {
             .collect();
         assert_eq!(
             graphql_entries.len(),
-            1,
-            "exactly the resolved graphql producer reaches the manifest"
-        );
-        assert_eq!(
-            graphql_entries[0].type_alias, "OrderQueryResult",
-            "the kept graphql entry is the resolved one, not the Unknown one"
+            2,
+            "both graphql producers reach the manifest (resolved + Unknown)"
         );
         assert!(
-            producer
-                .entries
+            graphql_entries
                 .iter()
-                .all(|e| e.type_state != ManifestTypeState::Unknown
-                    || e.key.protocol() != crate::operation::Protocol::Graphql),
-            "no Unknown graphql entry may reach the ts_check manifest"
+                .any(|e| e.type_alias == "OrderQueryResult"),
+            "the resolved graphql producer is kept"
+        );
+        assert!(
+            graphql_entries
+                .iter()
+                .any(|e| e.type_state == ManifestTypeState::Unknown),
+            "the Unknown graphql producer is kept so ts_check can mark it \
+             unverifiable rather than the edge defaulting to compatible"
         );
     }
 
-    /// The `graphql|subscription|orderUpdated` false-positive: an UNRESOLVED
-    /// graphql CONSUMER must never reach the consumer manifest, or it forms a
-    /// match whose synthetic dangling anchor resolves to `any`/`unknown` and reads
-    /// `producer ⊑ any` = compatible.
+    /// The `graphql|subscription|orderUpdated` false-positive fix: an UNRESOLVED
+    /// graphql CONSUMER must REACH the consumer manifest, so ts_check reports its
+    /// pair as an `unknownPair` (→ `None`). Dropping it instead removed the pair
+    /// from ts_check's output, and `apply_compat_verdicts` defaulted the absent
+    /// edge to a false `Some(true)` (`producer ⊑ any` was never actually run — the
+    /// edge just looked compatible because nothing contradicted it).
     ///
-    /// Two shapes are dropped:
-    ///  - `type_state == Unknown` (the clean unresolved case);
-    ///  - a consumer wrongly PROMOTED to `Implicit` (the enrichment bug where the
-    ///    bundle defines the synthetic `Endpoint_<hash>` alias as a top-ish form),
-    ///    recognised by its still-`None` resolved anchor symbol.
-    ///
-    /// A genuinely resolved consumer (real `primary_type_symbol`) is KEPT, so the
-    /// `query|order` compatible edge is not regressed.
+    /// All three consumer shapes are KEPT — `type_state == Unknown`, an `Implicit`
+    /// consumer with no resolved anchor symbol (the synthetic missing-alias case),
+    /// and a genuinely resolved consumer. ts_check's `any`/`unknown` comparand
+    /// guard distinguishes the unverifiable ones at verdict time, not here.
     #[test]
-    fn write_manifest_files_drops_unresolved_graphql_consumer() {
+    fn write_manifest_files_keeps_unresolved_graphql_consumer() {
         use crate::cloud_storage::TypeEvidence;
         use crate::operation::{GraphqlOperationKind, OperationKey};
         use crate::services::type_sidecar::InferKind;
@@ -4660,16 +4638,18 @@ mod tests {
         }
 
         let manifest = vec![
-            // Clean unresolved consumer (type_state Unknown) → DROPPED.
+            // Clean unresolved consumer (type_state Unknown) → KEPT (ts_check
+            // reports its pair as an unknownPair → None).
             consumer(
                 "orderUpdated",
                 "Endpoint_unknown_Response",
                 ManifestTypeState::Unknown,
                 None,
             ),
-            // The false-positive shape: enrichment wrongly promoted the synthetic
-            // alias to Implicit, but no real anchor was ever resolved
-            // (primary_type_symbol still None) → DROPPED.
+            // Enrichment wrongly promoted the synthetic alias to Implicit, but no
+            // real anchor was ever resolved (primary_type_symbol still None) →
+            // KEPT; its alias dangles to `any`/`unknown` in the bundle so the
+            // ts_check comparand guard marks the pair unverifiable.
             consumer(
                 "orderPromoted",
                 "Endpoint_promoted_Response",
@@ -4727,21 +4707,33 @@ mod tests {
 
         assert_eq!(
             consumers.entries.len(),
-            1,
-            "only the genuinely-resolved graphql consumer reaches the manifest; \
-             the Unknown one and the wrongly-promoted anchorless one are dropped"
-        );
-        assert_eq!(
-            consumers.entries[0].type_alias, "Endpoint_resolved_Response",
-            "the kept consumer is the one with a real resolved anchor symbol"
+            3,
+            "all graphql consumers reach the manifest — the Unknown one and the \
+             anchorless wrongly-promoted one are KEPT so ts_check can mark their \
+             pairs unverifiable (→ None) instead of the edge defaulting to a \
+             false Some(true)"
         );
         assert!(
             consumers
                 .entries
                 .iter()
-                .all(|e| e.primary_type_symbol.is_some()
-                    || e.key.protocol() != crate::operation::Protocol::Graphql),
-            "no anchorless graphql consumer may reach the ts_check manifest"
+                .any(|e| e.type_alias == "Endpoint_resolved_Response"),
+            "the genuinely-resolved consumer is kept"
+        );
+        assert!(
+            consumers
+                .entries
+                .iter()
+                .any(|e| e.type_state == ManifestTypeState::Unknown),
+            "the Unknown consumer is kept (unverifiable, not dropped)"
+        );
+        assert!(
+            consumers
+                .entries
+                .iter()
+                .any(|e| e.primary_type_symbol.is_none()),
+            "the anchorless wrongly-promoted consumer is kept (unverifiable, not \
+             dropped)"
         );
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2495,14 +2495,40 @@ fn write_manifest_files(
                 // defensively rather than throwing (#253).
                 //
                 // GraphQL is gated on a RESOLVED anchor: only a graphql entry whose
-                // type actually reached the bundle (`type_state != Unknown`) is
-                // emitted. An unresolved graphql consumer (e.g. a `subscription`
-                // with no `request<T>` call site, so no captured payload symbol)
-                // stays `Unknown` and would only ever orphan-noise the verdict run,
-                // so it is dropped here. HTTP/socket carry no such gate: their
-                // Unknown entries are handled downstream as `unknownPairs`.
-                if entry.key.protocol() == crate::operation::Protocol::Graphql
-                    && entry.type_state == ManifestTypeState::Unknown
+                // type actually reached the bundle is emitted. Two ways an
+                // unresolved graphql entry can sneak past, both dropped here:
+                //
+                //  1. `type_state == Unknown` — the type never resolved (the
+                //     `subscription` with no `request<T>` call site, so no captured
+                //     payload symbol). The clean case.
+                //
+                //  2. A graphql CONSUMER with no resolved anchor symbol
+                //     (`primary_type_symbol == None`). This closes the
+                //     subscription-orderUpdated false-positive: that consumer's only
+                //     candidate alias is the synthetic `Endpoint_<hash>` fallback,
+                //     which `enrich_manifest_with_type_resolution` can wrongly
+                //     PROMOTE to `Implicit` when the bundle textually defines the
+                //     synthetic alias as a non-`= unknown` but top-ish form (e.g. an
+                //     index-any record `Record<string, any>`) — not caught by the
+                //     trivially-unknown filter, so `type_state` lies and check (1)
+                //     misses it. Such a consumer resolves to `any`/`unknown` in the
+                //     bundle and would read `producer ⊑ any` = compatible (a FALSE
+                //     POSITIVE). A consumer that genuinely resolved carries a real
+                //     anchor symbol (threaded at creation from the `request<T>`
+                //     payload, or filled from the deterministic inferred anchor
+                //     during enrichment), so a still-`None` symbol means no real
+                //     resolved type. Producers are unaffected: an SDL producer
+                //     always carries its deterministic SDL-field anchor.
+                //
+                // HTTP/socket carry no such gate: their Unknown entries are handled
+                // downstream as `unknownPairs`.
+                let is_graphql = entry.key.protocol() == crate::operation::Protocol::Graphql;
+                if is_graphql && entry.type_state == ManifestTypeState::Unknown {
+                    continue;
+                }
+                if is_graphql
+                    && entry.role == ManifestRole::Consumer
+                    && entry.primary_type_symbol.is_none()
                 {
                     continue;
                 }
@@ -4579,6 +4605,143 @@ mod tests {
                 .all(|e| e.type_state != ManifestTypeState::Unknown
                     || e.key.protocol() != crate::operation::Protocol::Graphql),
             "no Unknown graphql entry may reach the ts_check manifest"
+        );
+    }
+
+    /// The `graphql|subscription|orderUpdated` false-positive: an UNRESOLVED
+    /// graphql CONSUMER must never reach the consumer manifest, or it forms a
+    /// match whose synthetic dangling anchor resolves to `any`/`unknown` and reads
+    /// `producer ⊑ any` = compatible.
+    ///
+    /// Two shapes are dropped:
+    ///  - `type_state == Unknown` (the clean unresolved case);
+    ///  - a consumer wrongly PROMOTED to `Implicit` (the enrichment bug where the
+    ///    bundle defines the synthetic `Endpoint_<hash>` alias as a top-ish form),
+    ///    recognised by its still-`None` resolved anchor symbol.
+    ///
+    /// A genuinely resolved consumer (real `primary_type_symbol`) is KEPT, so the
+    /// `query|order` compatible edge is not regressed.
+    #[test]
+    fn write_manifest_files_drops_unresolved_graphql_consumer() {
+        use crate::cloud_storage::TypeEvidence;
+        use crate::operation::{GraphqlOperationKind, OperationKey};
+        use crate::services::type_sidecar::InferKind;
+
+        fn consumer(
+            field: &str,
+            alias: &str,
+            type_state: ManifestTypeState,
+            primary_type_symbol: Option<&str>,
+        ) -> TypeManifestEntry {
+            let is_explicit = type_state == ManifestTypeState::Explicit;
+            let key = OperationKey::graphql(GraphqlOperationKind::Subscription, field);
+            TypeManifestEntry {
+                key,
+                role: ManifestRole::Consumer,
+                type_kind: ManifestTypeKind::Response,
+                type_alias: alias.to_string(),
+                file_path: "lib/graphql.ts".to_string(),
+                line_number: 1,
+                is_explicit,
+                type_state,
+                evidence: TypeEvidence {
+                    file_path: "lib/graphql.ts".to_string(),
+                    span_start: None,
+                    span_end: None,
+                    line_number: 1,
+                    infer_kind: InferKind::CallResult,
+                    is_explicit,
+                    type_state,
+                },
+                resolved_definition: None,
+                expanded_definition: None,
+                primary_type_symbol: primary_type_symbol.map(str::to_string),
+            }
+        }
+
+        let manifest = vec![
+            // Clean unresolved consumer (type_state Unknown) → DROPPED.
+            consumer(
+                "orderUpdated",
+                "Endpoint_unknown_Response",
+                ManifestTypeState::Unknown,
+                None,
+            ),
+            // The false-positive shape: enrichment wrongly promoted the synthetic
+            // alias to Implicit, but no real anchor was ever resolved
+            // (primary_type_symbol still None) → DROPPED.
+            consumer(
+                "orderPromoted",
+                "Endpoint_promoted_Response",
+                ManifestTypeState::Implicit,
+                None,
+            ),
+            // Genuinely resolved consumer (real anchor symbol) → KEPT.
+            consumer(
+                "orderResolved",
+                "Endpoint_resolved_Response",
+                ManifestTypeState::Implicit,
+                Some("OrderView"),
+            ),
+        ];
+
+        let repo_data = CloudRepoData {
+            repo_name: "web-frontend".to_string(),
+            service_name: None,
+            endpoints: vec![],
+            calls: vec![],
+            mounts: vec![],
+            apps: std::collections::HashMap::new(),
+            imported_handlers: vec![],
+            function_definitions: std::collections::HashMap::new(),
+            config_json: None,
+            package_json: None,
+            packages: None,
+            last_updated: chrono::Utc::now(),
+            commit_hash: "test-hash".to_string(),
+            mount_graph: None,
+            bundled_types: None,
+            type_manifest: Some(manifest),
+            file_results: None,
+            cached_detection: None,
+            cached_guidance: None,
+            cached_extraction_config: None,
+            package_json_hash: None,
+            cache_version: None,
+            type_extraction_status: None,
+        };
+
+        #[derive(serde::Deserialize)]
+        struct ManifestFileForTest {
+            entries: Vec<TypeManifestEntry>,
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_manifest_files(std::slice::from_ref(&repo_data), dir.path())
+            .expect("write_manifest_files");
+
+        let consumers: ManifestFileForTest = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join("consumer-manifest.json")).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            consumers.entries.len(),
+            1,
+            "only the genuinely-resolved graphql consumer reaches the manifest; \
+             the Unknown one and the wrongly-promoted anchorless one are dropped"
+        );
+        assert_eq!(
+            consumers.entries[0].type_alias, "Endpoint_resolved_Response",
+            "the kept consumer is the one with a real resolved anchor symbol"
+        );
+        assert!(
+            consumers
+                .entries
+                .iter()
+                .all(|e| e.primary_type_symbol.is_some()
+                    || e.key.protocol() != crate::operation::Protocol::Graphql),
+            "no anchorless graphql consumer may reach the ts_check manifest"
         );
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2487,17 +2487,23 @@ fn write_manifest_files(
     for repo_data in all_repo_data {
         if let Some(entries) = &repo_data.type_manifest {
             for entry in entries {
-                // HTTP and socket entries reach the ts_check manifest; GraphQL
-                // does not. ts_check checks HTTP by `method`/`path` and socket by
-                // the canonical `OperationKey` (event+direction), reusing the same
-                // `TypeCompatibilityChecker` assignability for both. GraphQL is
-                // still filtered here: its cross-repo resolution is blocked on
-                // separate work (#268), and its OperationKey serialises without a
-                // checkable identity for the matcher, so a GraphQL entry would
-                // only ever orphan. Those entries stay in `cloud_data.type_manifest`
-                // (cloud index + eval projection). The matcher drops any stray
-                // non-checkable entry defensively rather than throwing (#253).
-                if entry.key.protocol() == crate::operation::Protocol::Graphql {
+                // HTTP, socket, and graphql entries reach the ts_check manifest.
+                // ts_check checks HTTP by `method`/`path`, socket by the canonical
+                // `OperationKey` (event+direction), and graphql by (kind+field),
+                // reusing the same `TypeCompatibilityChecker` assignability for all
+                // three. The matcher drops any stray non-checkable entry
+                // defensively rather than throwing (#253).
+                //
+                // GraphQL is gated on a RESOLVED anchor: only a graphql entry whose
+                // type actually reached the bundle (`type_state != Unknown`) is
+                // emitted. An unresolved graphql consumer (e.g. a `subscription`
+                // with no `request<T>` call site, so no captured payload symbol)
+                // stays `Unknown` and would only ever orphan-noise the verdict run,
+                // so it is dropped here. HTTP/socket carry no such gate: their
+                // Unknown entries are handled downstream as `unknownPairs`.
+                if entry.key.protocol() == crate::operation::Protocol::Graphql
+                    && entry.type_state == ManifestTypeState::Unknown
+                {
                     continue;
                 }
                 match entry.role {
@@ -4421,20 +4427,25 @@ mod tests {
         );
     }
 
-    /// `write_manifest_files` feeds the ts_check matcher, which now checks HTTP
-    /// and socket. So HTTP + socket entries pass through; GraphQL is still
-    /// filtered (its cross-repo resolution is blocked on #268 and its key
-    /// carries no checkable identity for the matcher). GraphQL entries stay in
-    /// `cloud_data.type_manifest` (cloud index + eval projection). The #253
-    /// throw-guard now lives in the matcher, which drops any stray non-checkable
-    /// entry defensively rather than crashing the verdict run.
+    /// `write_manifest_files` feeds the ts_check matcher, which now checks HTTP,
+    /// socket, AND graphql. HTTP + socket entries always pass through. A graphql
+    /// entry passes through ONLY when its anchor resolved (`type_state !=
+    /// Unknown`) — an unresolved graphql entry (e.g. a subscription consumer with
+    /// no `request<T>` call site) would only orphan-noise the verdict run, so it
+    /// is dropped here. The #253 throw-guard lives in the matcher, which drops any
+    /// stray non-checkable entry defensively rather than crashing the run.
     #[test]
-    fn write_manifest_files_emits_http_and_socket_not_graphql() {
+    fn write_manifest_files_emits_http_socket_and_resolved_graphql() {
         use crate::cloud_storage::TypeEvidence;
         use crate::operation::{GraphqlOperationKind, OperationKey, SocketDirection};
         use crate::services::type_sidecar::InferKind;
 
-        fn entry(key: OperationKey, alias: &str) -> TypeManifestEntry {
+        fn entry_with_state(
+            key: OperationKey,
+            alias: &str,
+            type_state: ManifestTypeState,
+        ) -> TypeManifestEntry {
+            let is_explicit = type_state == ManifestTypeState::Explicit;
             TypeManifestEntry {
                 key,
                 role: ManifestRole::Producer,
@@ -4442,16 +4453,16 @@ mod tests {
                 type_alias: alias.to_string(),
                 file_path: "src/x.ts".to_string(),
                 line_number: 1,
-                is_explicit: true,
-                type_state: ManifestTypeState::Explicit,
+                is_explicit,
+                type_state,
                 evidence: TypeEvidence {
                     file_path: "src/x.ts".to_string(),
                     span_start: None,
                     span_end: None,
                     line_number: 1,
                     infer_kind: InferKind::ResponseBody,
-                    is_explicit: true,
-                    type_state: ManifestTypeState::Explicit,
+                    is_explicit,
+                    type_state,
                 },
                 resolved_definition: None,
                 expanded_definition: None,
@@ -4459,11 +4470,23 @@ mod tests {
             }
         }
 
+        fn entry(key: OperationKey, alias: &str) -> TypeManifestEntry {
+            entry_with_state(key, alias, ManifestTypeState::Explicit)
+        }
+
         let manifest = vec![
             entry(OperationKey::http("GET", "/orders/:id"), "OrderResponse"),
+            // Resolved graphql producer (anchor reached the bundle) → KEPT.
             entry(
                 OperationKey::graphql(GraphqlOperationKind::Query, "order"),
                 "OrderQueryResult",
+            ),
+            // Unresolved graphql producer (Unknown anchor) → DROPPED so it can't
+            // orphan-noise the verdict run (the subscription-consumer case).
+            entry_with_state(
+                OperationKey::graphql(GraphqlOperationKind::Subscription, "orderUpdated"),
+                "OrderUpdatedUnknown",
+                ManifestTypeState::Unknown,
             ),
             entry(
                 OperationKey::socket("order.created", SocketDirection::ServerToClient),
@@ -4513,11 +4536,13 @@ mod tests {
         )
         .unwrap();
 
-        // HTTP and socket producers survive; GraphQL is filtered out.
+        // HTTP, socket, and the RESOLVED graphql producer survive; the Unknown
+        // graphql producer is filtered out.
         assert_eq!(
             producer.entries.len(),
-            2,
-            "HTTP + socket entries reach the ts_check manifest; GraphQL is filtered"
+            3,
+            "HTTP + socket + resolved graphql reach the manifest; the Unknown \
+             graphql entry is dropped"
         );
         assert!(
             producer
@@ -4531,14 +4556,29 @@ mod tests {
                 .entries
                 .iter()
                 .any(|e| e.key.protocol() == crate::operation::Protocol::Websocket),
-            "the socket producer must now reach the manifest"
+            "the socket producer must reach the manifest"
+        );
+        let graphql_entries: Vec<_> = producer
+            .entries
+            .iter()
+            .filter(|e| e.key.protocol() == crate::operation::Protocol::Graphql)
+            .collect();
+        assert_eq!(
+            graphql_entries.len(),
+            1,
+            "exactly the resolved graphql producer reaches the manifest"
+        );
+        assert_eq!(
+            graphql_entries[0].type_alias, "OrderQueryResult",
+            "the kept graphql entry is the resolved one, not the Unknown one"
         );
         assert!(
             producer
                 .entries
                 .iter()
-                .all(|e| e.key.protocol() != crate::operation::Protocol::Graphql),
-            "GraphQL entries must not reach the ts_check manifest (#268)"
+                .all(|e| e.type_state != ManifestTypeState::Unknown
+                    || e.key.protocol() != crate::operation::Protocol::Graphql),
+            "no Unknown graphql entry may reach the ts_check manifest"
         );
     }
 

--- a/ts_check/lib/manifest-matcher.test.ts
+++ b/ts_check/lib/manifest-matcher.test.ts
@@ -238,7 +238,7 @@ describe('ManifestMatcher', () => {
 
     // --- #253 regression: non-HTTP entries must be skipped, not fatal ---
 
-    it('should keep HTTP and socket entries and drop GraphQL', () => {
+    it('should keep HTTP, socket, and graphql entries and drop a non-checkable protocol', () => {
       const httpEntry = createManifestEntry(
         'GET',
         '/orders/:id',
@@ -247,9 +247,9 @@ describe('ManifestMatcher', () => {
         'src/routes.ts',
         10
       );
-      // GraphQL serialises without a checkable identity for the matcher and is
-      // dropped; socket (event+direction) is now checked alongside HTTP. A
-      // non-checkable entry must never throw in validateEntry (#253).
+      // GraphQL (kind+field) is now checked alongside HTTP and socket. A truly
+      // non-checkable entry (an unrecognised protocol) is still dropped, and must
+      // never throw in validateEntry (#253).
       const graphqlEntry = {
         protocol: 'graphql',
         kind: 'query',
@@ -292,6 +292,26 @@ describe('ManifestMatcher', () => {
           type_state: 'explicit',
         },
       };
+      // Unrecognised protocol — not HTTP/socket/graphql — must be dropped (#253).
+      const nonCheckableEntry = {
+        protocol: 'grpc',
+        type_alias: 'SomeGrpcResult',
+        role: 'producer',
+        type_kind: 'response',
+        file_path: 'src/grpc.ts',
+        line_number: 9,
+        is_explicit: true,
+        type_state: 'explicit',
+        evidence: {
+          file_path: 'src/grpc.ts',
+          span_start: null,
+          span_end: null,
+          line_number: 9,
+          infer_kind: 'response_body',
+          is_explicit: true,
+          type_state: 'explicit',
+        },
+      };
 
       const filePath = path.join(tempDir, 'mixed-protocol.json');
       fs.writeFileSync(
@@ -299,13 +319,13 @@ describe('ManifestMatcher', () => {
         JSON.stringify({
           repo_name: 'orders-svc',
           commit_hash: 'abc123',
-          entries: [graphqlEntry, httpEntry, socketEntry],
+          entries: [graphqlEntry, httpEntry, socketEntry, nonCheckableEntry],
         })
       );
 
-      // Must NOT throw. Keeps the HTTP + socket entries, drops GraphQL.
+      // Must NOT throw. Keeps the HTTP + socket + graphql entries, drops grpc.
       const loaded = matcher.loadManifest(filePath);
-      assert.strictEqual(loaded.entries.length, 2);
+      assert.strictEqual(loaded.entries.length, 3);
       assert.ok(
         loaded.entries.some((e) => e.protocol === 'http' && e.path === '/orders/:id'),
         'HTTP entry must survive'
@@ -316,12 +336,17 @@ describe('ManifestMatcher', () => {
         ),
         'socket entry must survive'
       );
-      // Length 2 (from 3 inputs) with the http + socket survivors above proves
-      // the GraphQL entry was dropped. Assert the surviving protocols are only
-      // the two checkable ones.
+      assert.ok(
+        loaded.entries.some(
+          (e) => e.protocol === 'graphql' && e.kind === 'query' && e.field === 'order'
+        ),
+        'graphql entry must survive'
+      );
+      // Length 3 (from 4 inputs) with the survivors above proves the grpc entry
+      // was dropped. Assert the surviving protocols are exactly the checkable ones.
       assert.deepStrictEqual(
         loaded.entries.map((e) => e.protocol).sort(),
-        ['http', 'socket']
+        ['graphql', 'http', 'socket']
       );
     });
 
@@ -736,6 +761,98 @@ describe('ManifestMatcher', () => {
         repo_name: 'b',
         commit_hash: 'y',
         entries: [entry('client_to_server', 'consumer')],
+      };
+
+      const result = matcher.matchEndpoints(producers, consumers);
+
+      assert.strictEqual(result.matches.length, 0);
+      assert.strictEqual(result.orphanedProducers.length, 1);
+      assert.strictEqual(result.orphanedConsumers.length, 1);
+    });
+
+    it('should match a graphql producer and consumer on the canonical kind|field key', () => {
+      const graphqlEntry = (
+        typeAlias: string,
+        role: 'producer' | 'consumer'
+      ): ManifestEntry => ({
+        protocol: 'graphql',
+        kind: 'query',
+        field: 'order',
+        type_alias: typeAlias,
+        role,
+        type_kind: 'response',
+        file_path: role === 'producer' ? 'gateway/src/orders.resolver.ts' : 'lib/graphql.ts',
+        line_number: role === 'producer' ? 40 : 76,
+        is_explicit: true,
+        type_state: 'explicit',
+        evidence: {
+          file_path: role === 'producer' ? 'gateway/src/orders.resolver.ts' : 'lib/graphql.ts',
+          span_start: null,
+          span_end: null,
+          line_number: role === 'producer' ? 40 : 76,
+          infer_kind: 'response_body',
+          is_explicit: true,
+          type_state: 'explicit',
+        },
+      });
+
+      const producers: TypeManifest = {
+        repo_name: 'orders-monorepo',
+        commit_hash: 'abc123',
+        entries: [graphqlEntry('ProducerEnvelope', 'producer')],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def456',
+        entries: [graphqlEntry('OrderView', 'consumer')],
+      };
+
+      const result = matcher.matchEndpoints(producers, consumers);
+
+      assert.strictEqual(result.matches.length, 1);
+      assert.strictEqual(result.matches[0].method, 'GRAPHQL');
+      assert.strictEqual(result.matches[0].path, 'query|order');
+      assert.strictEqual(result.matches[0].producer.type_alias, 'ProducerEnvelope');
+      assert.strictEqual(result.matches[0].consumer.type_alias, 'OrderView');
+      assert.strictEqual(result.orphanedProducers.length, 0);
+      assert.strictEqual(result.orphanedConsumers.length, 0);
+    });
+
+    it('should not match graphql entries with different fields', () => {
+      const entry = (
+        field: string,
+        role: 'producer' | 'consumer'
+      ): ManifestEntry => ({
+        protocol: 'graphql',
+        kind: 'query',
+        field,
+        type_alias: 'OrderView',
+        role,
+        type_kind: 'response',
+        file_path: 'f.ts',
+        line_number: 1,
+        is_explicit: true,
+        type_state: 'explicit',
+        evidence: {
+          file_path: 'f.ts',
+          span_start: null,
+          span_end: null,
+          line_number: 1,
+          infer_kind: 'response_body',
+          is_explicit: true,
+          type_state: 'explicit',
+        },
+      });
+
+      const producers: TypeManifest = {
+        repo_name: 'a',
+        commit_hash: 'x',
+        entries: [entry('orders', 'producer')],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'b',
+        commit_hash: 'y',
+        entries: [entry('order', 'consumer')],
       };
 
       const result = matcher.matchEndpoints(producers, consumers);

--- a/ts_check/lib/manifest-matcher.ts
+++ b/ts_check/lib/manifest-matcher.ts
@@ -346,7 +346,7 @@ export class ManifestMatcher {
       // leave a trace rather than throwing.
       manifest.entries = this.retainCheckableEntries(manifest.entries, absolutePath);
 
-      // Validate the surviving (HTTP + socket) entries.
+      // Validate the surviving (HTTP + socket + graphql) entries.
       for (const entry of manifest.entries) {
         this.validateEntry(entry);
       }

--- a/ts_check/lib/manifest-matcher.ts
+++ b/ts_check/lib/manifest-matcher.ts
@@ -57,18 +57,30 @@ export interface ManifestEntry {
   /**
    * Protocol tag carried by the operation key. ts_check runs the same
    * `TypeCompatibilityChecker` assignability for every protocol it understands:
-   * "http" (matched by method/path) and "socket" (matched by event+direction).
-   * Other protocols are checked by their own pipelines and are dropped here.
+   * "http" (matched by method/path), "socket" (matched by event+direction), and
+   * "graphql" (matched by operation kind+field). Other protocols are checked by
+   * their own pipelines and are dropped here.
    */
-  protocol: 'http' | 'socket';
-  /** HTTP method (GET, POST, …). Present on HTTP entries; absent on socket. */
+  protocol: 'http' | 'socket' | 'graphql';
+  /** HTTP method (GET, POST, …). Present on HTTP entries; absent on socket/graphql. */
   method?: string;
-  /** API path (e.g., /api/users/:id). Present on HTTP entries; absent on socket. */
+  /** API path (e.g., /api/users/:id). Present on HTTP entries; absent on socket/graphql. */
   path?: string;
   /** Socket event name (e.g. `payment:settled`). Present on socket entries only. */
   event?: string;
   /** Socket message-flow direction. Present on socket entries only. */
   direction?: SocketDirection;
+  /**
+   * GraphQL root-operation kind (`query`/`mutation`/`subscription`). Present on
+   * graphql entries only; serialised lowercase by the Rust scanner
+   * (`GraphqlOperationKind::as_str`).
+   */
+  kind?: string;
+  /**
+   * GraphQL top-level field name (e.g. `order`). Present on graphql entries
+   * only; the field that, with `kind`, identifies the operation.
+   */
+  field?: string;
   /** The type alias for this endpoint */
   type_alias: string;
   /** Whether this is a producer or consumer */
@@ -241,13 +253,40 @@ export function socketKey(entry: ManifestEntry): string | null {
   return `${socketDirectionLabel(entry.direction)}|${entry.event}`;
 }
 
+// ============================================================================
+// GraphQL Identity
+// ============================================================================
+
+/** The pseudo-method graphql matches are keyed on, mirroring HTTP's method. */
+export const GRAPHQL_PSEUDO_METHOD = 'GRAPHQL';
+
+/**
+ * Stable identity for a graphql entry: `<kind>|<field>` (e.g. `query|order`).
+ * Two graphql entries match iff this string is equal (same root field of the
+ * same operation kind), the exact-key semantics the Rust side uses. The full
+ * canonical key on the Rust side is `graphql|<kind>|<field>`; this is its
+ * `<kind>|<field>` tail, which becomes the `path` of the graphql `MatchResult`
+ * so the assembled label `GRAPHQL <kind>|<field>` round-trips through the
+ * verdict-join (`parse_compat_endpoint` / `parse_producer_key`).
+ */
+export function graphqlKey(entry: ManifestEntry): string | null {
+  if (entry.protocol !== 'graphql' || !entry.kind || !entry.field) {
+    return null;
+  }
+  return `${entry.kind}|${entry.field}`;
+}
+
 /**
  * Human label for an entry in orphan/diagnostic strings: `<METHOD> <path>` for
- * HTTP, `socket <DIRECTION>|<event>` for socket.
+ * HTTP, `socket <DIRECTION>|<event>` for socket, `graphql <kind>|<field>` for
+ * graphql.
  */
 export function entryLabel(entry: ManifestEntry): string {
   if (entry.protocol === 'socket') {
     return `socket ${socketKey(entry) ?? entry.event ?? '<unknown>'}`;
+  }
+  if (entry.protocol === 'graphql') {
+    return `graphql ${graphqlKey(entry) ?? entry.field ?? '<unknown>'}`;
   }
   return `${entry.method} ${entry.path}`;
 }
@@ -298,13 +337,13 @@ export class ManifestMatcher {
         throw new Error('Manifest missing required field: entries (must be an array)');
       }
 
-      // ts_check checks HTTP (by method/path) and socket (by event+direction)
-      // entries with the same assignability checker. Any other protocol
-      // (GraphQL, which serialises without a checkable identity) is scored by
-      // its own pipeline and skipped here. The scanner already filters those out
-      // of the manifest files it writes (write_manifest_files), but a stray
-      // non-checkable entry must never crash the whole verdict run (#253), so we
-      // drop them defensively and leave a trace rather than throwing.
+      // ts_check checks HTTP (by method/path), socket (by event+direction), and
+      // graphql (by kind+field) entries with the same assignability checker. Any
+      // other protocol is scored by its own pipeline and skipped here. The
+      // scanner already filters non-checkable entries out of the manifest files
+      // it writes (write_manifest_files), but a stray non-checkable entry must
+      // never crash the whole verdict run (#253), so we drop them defensively and
+      // leave a trace rather than throwing.
       manifest.entries = this.retainCheckableEntries(manifest.entries, absolutePath);
 
       // Validate the surviving (HTTP + socket) entries.
@@ -323,12 +362,13 @@ export class ManifestMatcher {
 
   /**
    * Filter a manifest entry list down to the entries ts_check can check: HTTP
-   * (keyed by method/path) and socket (keyed by event+direction).
+   * (keyed by method/path), socket (keyed by event+direction), and graphql
+   * (keyed by kind+field).
    *
    * Any other protocol — or a malformed entry missing the identity its protocol
-   * needs — is skipped: it belongs to another pipeline (e.g. GraphQL, #268) or
-   * is junk. A single summary line is logged so the drop is never silent. A
-   * stray non-checkable entry can thus never zero out the verdict set (#253).
+   * needs — is skipped: it belongs to another pipeline or is junk. A single
+   * summary line is logged so the drop is never silent. A stray non-checkable
+   * entry can thus never zero out the verdict set (#253).
    */
   private retainCheckableEntries(entries: unknown[], source: string): ManifestEntry[] {
     const retained: ManifestEntry[] = [];
@@ -354,11 +394,11 @@ export class ManifestMatcher {
 
   /**
    * Shape guard for raw, possibly-malformed manifest JSON. A checkable entry is
-   * either an HTTP key (`protocol: "http"` with non-empty `method`+`path`) or a
-   * socket key (`protocol: "socket"` with non-empty `event`+`direction`).
-   * Everything else (GraphQL keys, junk) is filtered out here (#253). Full
-   * structural validation of the survivors is `validateEntry`'s job — a
-   * genuinely-malformed HTTP/socket entry still throws there.
+   * an HTTP key (`protocol: "http"` with non-empty `method`+`path`), a socket
+   * key (`protocol: "socket"` with non-empty `event`+`direction`), or a graphql
+   * key (`protocol: "graphql"` with non-empty `kind`+`field`). Everything else
+   * (junk) is filtered out here (#253). Full structural validation of the
+   * survivors is `validateEntry`'s job — a genuinely-malformed entry still throws.
    */
   private isCheckableManifestEntry(entry: unknown): entry is ManifestEntry {
     if (typeof entry !== 'object' || entry === null) {
@@ -378,6 +418,14 @@ export class ManifestMatcher {
         typeof e.event === 'string' &&
         e.event.length > 0 &&
         (e.direction === 'server_to_client' || e.direction === 'client_to_server')
+      );
+    }
+    if (e.protocol === 'graphql') {
+      return (
+        typeof e.kind === 'string' &&
+        e.kind.length > 0 &&
+        typeof e.field === 'string' &&
+        e.field.length > 0
       );
     }
     return false;
@@ -439,8 +487,15 @@ export class ManifestMatcher {
           'ManifestEntry missing or invalid field: direction (must be "server_to_client" or "client_to_server")'
         );
       }
+    } else if (entry.protocol === 'graphql') {
+      if (!entry.kind) {
+        throw new Error('ManifestEntry missing required field: kind');
+      }
+      if (!entry.field) {
+        throw new Error('ManifestEntry missing required field: field');
+      }
     } else {
-      throw new Error('ManifestEntry missing or invalid field: protocol (must be "http" or "socket")');
+      throw new Error('ManifestEntry missing or invalid field: protocol (must be "http", "socket", or "graphql")');
     }
     if (!entry.type_alias) {
       throw new Error('ManifestEntry missing required field: type_alias');
@@ -699,6 +754,52 @@ export class ManifestMatcher {
         orphanedConsumers.push({
           entry: consumer,
           reason: `No producer found for socket ${consumerKey} (${consumer.type_kind})`,
+        });
+      }
+    }
+
+    // GraphQL edges: exact-key match on `<kind>|<field>`, the same identity the
+    // Rust canonical key carries (`graphql|<kind>|<field>`). Like sockets there
+    // is no path/route to resolve, so a graphql consumer matches every producer
+    // carrying the same key. The assembled label `GRAPHQL <kind>|<field>`
+    // round-trips through the Rust verdict-join
+    // (`parse_compat_endpoint` / `parse_producer_key`). The producer/consumer
+    // type direction is handled in the type checker (`compareTypes`): the
+    // producer payload (SDL field type, structurally unwrapped from the resolver
+    // envelope) must satisfy what the consumer reads — `producer ⊑ consumer`,
+    // the same data-flow direction as HTTP (server → client), NOT the socket
+    // inversion.
+    for (let ci = 0; ci < consumerEntries.length; ci++) {
+      const consumer = consumerEntries[ci];
+      if (consumer.protocol !== 'graphql') continue;
+      const consumerKey = graphqlKey(consumer);
+      if (consumerKey === null) continue;
+
+      let matched = false;
+      for (let pi = 0; pi < producerEntries.length; pi++) {
+        const producer = producerEntries[pi];
+        if (producer.protocol !== 'graphql') continue;
+        if (graphqlKey(producer) !== consumerKey) continue;
+        if (producer.type_kind !== consumer.type_kind) continue;
+
+        matches.push({
+          method: GRAPHQL_PSEUDO_METHOD,
+          path: consumerKey,
+          type_kind: consumer.type_kind,
+          producer,
+          consumer,
+          match_score: 1.0,
+        });
+        matchedProducerIndices.add(pi);
+        matched = true;
+      }
+
+      if (matched) {
+        matchedConsumerIndices.add(ci);
+      } else {
+        orphanedConsumers.push({
+          entry: consumer,
+          reason: `No producer found for graphql ${consumerKey} (${consumer.type_kind})`,
         });
       }
     }

--- a/ts_check/lib/type-checker.test.ts
+++ b/ts_check/lib/type-checker.test.ts
@@ -766,6 +766,109 @@ describe('TypeCompatibilityChecker', () => {
       );
     });
 
+    it('reads a graphql edge whose consumer resolves to `any` as unverifiable, NOT compatible (subscription-orderUpdated false-positive)', async () => {
+      // The live `graphql|subscription|orderUpdated` false-positive: the PRODUCER
+      // resolves to a real `Order` envelope (Explicit), but the CONSUMER's
+      // synthetic dangling alias resolves to `any` in the bundle. The graphql
+      // direction is `producer ⊑ consumer`, so `Order ⊑ any` is trivially TRUE —
+      // the edge would read COMPATIBLE without the any/unknown guard, masking that
+      // the consumer type never reached the bundle. It MUST read unverifiable.
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        // Producer: real resolver return envelope unwrapping to a concrete Order.
+        export type ProducerEnvelope = {
+          data: { id: string; total: number; note?: string };
+          errors: string[];
+        };
+        // Consumer: synthetic alias referencing a type with no declaration in the
+        // bundle → resolves to \`any\` (the dangling-anchor shape).
+        export type OrderUpdateView = MissingShape;
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'orders-monorepo',
+        commit_hash: 'abc',
+        entries: [
+          graphqlEntry('ProducerEnvelope', 'producer', 'gateway/src/orders.resolver.ts', 75, 'subscription', 'orderUpdated'),
+        ],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def',
+        entries: [
+          graphqlEntry('OrderUpdateView', 'consumer', 'lib/graphql.ts', 80, 'subscription', 'orderUpdated'),
+        ],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.compatiblePairs, 0, 'must NOT read compatible');
+      assert.strictEqual(result.incompatiblePairs, 0);
+      assert.strictEqual(
+        result.unknownPairs.length,
+        1,
+        'a graphql consumer resolving to `any` must read unverifiable'
+      );
+      assert.ok(
+        result.unknownPairs[0].reason.includes('any'),
+        `the unverifiable reason must name the resolved \`any\`, got: ${result.unknownPairs[0].reason}`
+      );
+    });
+
+    it('reads a graphql edge whose consumer resolves to `unknown` as unverifiable, NOT compatible', async () => {
+      // The `unknown` twin of the subscription-orderUpdated trap: `Order ⊑ unknown`
+      // is also trivially TRUE, so an unguarded edge would read compatible.
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type ProducerEnvelope = {
+          data: { id: string; total: number };
+          errors: string[];
+        };
+        export type OrderUpdateView = unknown;
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'orders-monorepo',
+        commit_hash: 'abc',
+        entries: [
+          graphqlEntry('ProducerEnvelope', 'producer', 'gateway/src/orders.resolver.ts', 75, 'subscription', 'orderUpdated'),
+        ],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def',
+        entries: [
+          graphqlEntry('OrderUpdateView', 'consumer', 'lib/graphql.ts', 80, 'subscription', 'orderUpdated'),
+        ],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.compatiblePairs, 0, 'must NOT read compatible');
+      assert.strictEqual(result.incompatiblePairs, 0);
+      assert.strictEqual(result.unknownPairs.length, 1);
+    });
+
     it('reads a dangling consumer name as unverifiable but its structural shape as incompatible (#257)', async () => {
       // The #257 inference bug: a consumer like `res.json() as Promise<OrderView>`
       // wrote the bare NAME `= OrderView` into the cross-repo bundle. The bundle

--- a/ts_check/lib/type-checker.test.ts
+++ b/ts_check/lib/type-checker.test.ts
@@ -50,6 +50,41 @@ function socketEntry(
   };
 }
 
+/**
+ * Build a graphql `<kind> <field>` manifest entry. GraphQL entries carry
+ * `protocol: 'graphql'` + `kind` + `field` instead of HTTP method/path.
+ */
+function graphqlEntry(
+  typeAlias: string,
+  role: 'producer' | 'consumer',
+  filePath: string,
+  lineNumber: number,
+  kind: string = 'query',
+  field: string = 'order'
+): ManifestEntry {
+  return {
+    protocol: 'graphql',
+    kind,
+    field,
+    type_alias: typeAlias,
+    role,
+    type_kind: 'response',
+    file_path: filePath,
+    line_number: lineNumber,
+    is_explicit: true,
+    type_state: 'explicit',
+    evidence: {
+      file_path: filePath,
+      span_start: null,
+      span_end: null,
+      line_number: lineNumber,
+      infer_kind: 'response_body',
+      is_explicit: true,
+      type_state: 'explicit',
+    },
+  };
+}
+
 // ============================================================================
 // TypeCompatibilityChecker Tests
 // ============================================================================
@@ -597,6 +632,137 @@ describe('TypeCompatibilityChecker', () => {
       assert.ok(
         result.mismatches[0].endpoint.startsWith('SOCKET '),
         'the mismatch endpoint must carry the SOCKET label'
+      );
+    });
+
+    it('type-checks a graphql query|order edge end-to-end as compatible (consumer selects a subset of the producer payload)', async () => {
+      // The xrepo-corpus-1 `graphql|query|order` edge. The producer (gateway
+      // resolver) resolves to the return ENVELOPE `{ data: Order; errors }`; the
+      // SDL field payload is `Order`. The consumer document binds `OrderView`,
+      // which SELECTS a subset of the producer fields (`id`, `total`, optional
+      // `note`) and DROPS the producer's required `status` field — valid GraphQL
+      // field selection, so the edge is COMPATIBLE.
+      //
+      // PRE-FIX-FAILING: before the graphql arm in compareTypes, a graphql
+      // producer was never compared (entries were dropped), so this pair could
+      // not be checked at all. With a naive socket-style direction
+      // (`consumer ⊑ producer`) it would read INCOMPATIBLE (OrderView lacks the
+      // producer's required `status`). It only reads compatible once the producer
+      // envelope is structurally unwrapped to `Order` AND the data-flow direction
+      // `producer ⊑ consumer` (HTTP-like) is used.
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type Money = { amountCents: number; currency: string };
+        export type OrderStatus =
+          | { kind: "placed"; placedAt: string }
+          | { kind: "refunded"; refundedAt: string; reason?: string };
+        // Producer resolved type: the resolver RETURN ENVELOPE, not the payload.
+        export type ProducerEnvelope = {
+          data: { id: string; total: Money; status: OrderStatus; note?: string };
+          errors: string[];
+        };
+        export type MoneyView = { amountCents: number; currency: string };
+        // Consumer bound type: selects a subset, drops \`status\`.
+        export type OrderView = { id: string; total: MoneyView; note?: string };
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'orders-monorepo',
+        commit_hash: 'abc',
+        entries: [
+          graphqlEntry('ProducerEnvelope', 'producer', 'gateway/src/orders.resolver.ts', 40),
+        ],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def',
+        entries: [
+          graphqlEntry('OrderView', 'consumer', 'lib/graphql.ts', 76),
+        ],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.matchDetails?.length, 1, 'the graphql pair must match');
+      assert.strictEqual(
+        result.matchDetails?.[0].method,
+        'GRAPHQL',
+        'the match is keyed on the GRAPHQL pseudo-method'
+      );
+      assert.strictEqual(
+        result.matchDetails?.[0].path,
+        'query|order',
+        'the match path is the canonical graphql key tail'
+      );
+      assert.strictEqual(result.compatiblePairs, 1);
+      assert.strictEqual(result.incompatiblePairs, 0);
+      assert.strictEqual(result.unknownPairs.length, 0);
+    });
+
+    it('reads a graphql edge whose consumer requires a field the producer makes optional as incompatible (direction proof)', async () => {
+      // Direction/anchor proof, mirroring the corpus `subscription orderUpdated`
+      // trap: the producer payload makes `note` OPTIONAL, but the consumer makes
+      // it REQUIRED. Under `producer ⊑ consumer`, the producer payload
+      // `{ id; note?: string }` is NOT assignable to the consumer
+      // `{ id; note: string }` (optional can't satisfy required) → INCOMPATIBLE.
+      // This fails if the envelope is not unwrapped (the whole envelope is never
+      // assignable, but for the wrong reason) or if the direction is flipped
+      // (the consumer requiring more than the producer guarantees would wrongly
+      // read compatible).
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type ProducerEnvelope = {
+          data: { id: string; note?: string };
+          errors: string[];
+        };
+        // Consumer requires \`note\`; producer only optionally provides it.
+        export type OrderUpdate = { id: string; note: string };
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'orders-monorepo',
+        commit_hash: 'abc',
+        entries: [
+          graphqlEntry('ProducerEnvelope', 'producer', 'gateway/src/orders.resolver.ts', 75, 'subscription', 'orderUpdated'),
+        ],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def',
+        entries: [
+          graphqlEntry('OrderUpdate', 'consumer', 'lib/graphql.ts', 80, 'subscription', 'orderUpdated'),
+        ],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.incompatiblePairs, 1);
+      assert.strictEqual(result.compatiblePairs, 0);
+      assert.strictEqual(result.unknownPairs.length, 0);
+      assert.strictEqual(result.mismatches.length, 1);
+      assert.ok(
+        result.mismatches[0].endpoint.startsWith('GRAPHQL '),
+        'the mismatch endpoint must carry the GRAPHQL label'
       );
     });
 

--- a/ts_check/lib/type-checker.ts
+++ b/ts_check/lib/type-checker.ts
@@ -352,6 +352,17 @@ export class TypeCompatibilityChecker {
     // consumer (call) receives it, so the producer payload must satisfy the
     // consumer — `producer ⊑ consumer`.
     //
+    // GraphQL: same data-flow direction as HTTP. The producer (schema resolver,
+    // server) RETURNS the full object; the consumer (document, client) SELECTS a
+    // subset of its fields, so the producer payload must satisfy what the
+    // consumer reads — `producer ⊑ consumer`. (NOT the socket inversion: GraphQL
+    // is request/response server→client like HTTP, and a consumer that selects
+    // fewer fields than the producer provides is compatible — `OrderView`
+    // dropping the producer's `status` field is fine, whereas the socket
+    // direction would wrongly read it as incompatible because `Order` requires
+    // `status`.) The producer type is the SDL field PAYLOAD, structurally
+    // unwrapped from the resolver's return ENVELOPE below.
+    //
     // Socket: the role mapping is inverted relative to data flow. Carrick keys a
     // *listener* (`socket.on`) as the producer (endpoint) and an *emitter*
     // (`socket.emit`) as the consumer (call). The bytes flow emitter → listener,
@@ -363,8 +374,22 @@ export class TypeCompatibilityChecker {
     // "Socket producer/consumer direction".) The same `isAssignableTo` relation
     // and the same resolved Type objects are used either way.
     const socket = producer.protocol === "socket";
-    const sentType = socket ? consumerType : producerType;
-    const expectedType = socket ? producerType : consumerType;
+    const graphql = producer.protocol === "graphql";
+
+    // For GraphQL the producer's resolved type is the resolver's return ENVELOPE
+    // (e.g. `{ data: Order; errors: string[] }`), kept verbatim for the
+    // resolution metric. Compat must compare against the SDL field PAYLOAD
+    // (`Order`), so unwrap the envelope structurally — pick the single
+    // object/array-of-objects property among otherwise scalar/`string[]`
+    // siblings. Framework-agnostic: never matches the literal name `data`. If the
+    // shape is not a single-payload envelope (already bare, or ambiguous), the
+    // unwrap returns the type unchanged and logs a warning.
+    const producerComparand = graphql
+      ? this.unwrapGraphqlPayload(producerType, endpoint)
+      : producerType;
+
+    const sentType = socket ? consumerType : producerComparand;
+    const expectedType = socket ? producerComparand : consumerType;
     if (sentType.isAssignableTo(expectedType)) {
       return { kind: "compatible" };
     }
@@ -386,6 +411,82 @@ export class TypeCompatibilityChecker {
         consumerEvidence: consumer.evidence,
       },
     };
+  }
+
+  /**
+   * Unwrap a GraphQL resolver's return ENVELOPE to its SDL field PAYLOAD type.
+   *
+   * A GraphQL producer's resolved type is the resolver function's return type
+   * (e.g. `Promise<ApiResponse<Order>>` → `{ data: Order; errors: string[] }`),
+   * kept verbatim on the manifest entry for the resolution metric. For compat we
+   * must compare the consumer against the SDL field's payload (`Order`), not the
+   * transport envelope.
+   *
+   * The unwrap is STRUCTURAL and framework-agnostic — it never matches the
+   * literal property name `data`/`errors` or a wrapper symbol like `ApiResponse`.
+   * Among the envelope's own properties it keeps exactly those whose type is an
+   * object or an array-of-objects (the candidate payload), discarding scalar and
+   * scalar-array siblings (`errors: string[]`, status codes, flags). If exactly
+   * one payload candidate remains, that property's type is the payload. In every
+   * other case — the type is already a bare object that is not a single-payload
+   * envelope, has no payload candidate, or has several (ambiguous) — the original
+   * type is returned unchanged and a warning is logged, so an unrecognised
+   * envelope shape degrades to comparing the whole type rather than guessing.
+   */
+  private unwrapGraphqlPayload(producerType: Type, endpoint: string): Type {
+    // Only object-like types can be envelopes; a bare scalar/union is returned
+    // as-is (the producer already resolved to its payload, e.g. SDL `String`).
+    if (!producerType.isObject() || producerType.isArray()) {
+      return producerType;
+    }
+
+    const props = producerType.getProperties();
+    // A single-property wrapper whose property is itself the payload is the most
+    // common envelope shape, but we classify generally rather than assume arity.
+    const payloadCandidates: Type[] = [];
+    for (const prop of props) {
+      const decl = prop.getDeclarations()[0];
+      if (!decl) {
+        // No declaration to anchor the property type — can't classify, so this
+        // isn't a clean single-payload envelope. Bail out to whole-type compare.
+        return producerType;
+      }
+      const propType = prop.getTypeAtLocation(decl);
+      if (this.isPayloadShape(propType)) {
+        payloadCandidates.push(propType);
+      }
+    }
+
+    if (payloadCandidates.length === 1) {
+      return payloadCandidates[0];
+    }
+
+    // Zero candidates → the type may already BE the bare payload object (its own
+    // properties are scalars, e.g. `{ id; total }`); comparing it whole is
+    // correct, so this is the silent expected path, not a warning. More than one
+    // candidate → a genuinely ambiguous envelope; warn and compare whole.
+    if (payloadCandidates.length > 1) {
+      console.warn(
+        `[type-checker] GraphQL producer envelope for ${endpoint} has ${payloadCandidates.length} ` +
+          `object-typed properties; cannot pick a single SDL payload, comparing the whole type`
+      );
+    }
+    return producerType;
+  }
+
+  /**
+   * Whether a property type looks like a GraphQL SDL payload: an object, or an
+   * array whose element is an object (`Order` / `Order[]`). Scalars, unions of
+   * scalars, and scalar arrays (`string[]`, `number[]`) are NOT payloads — they
+   * are envelope metadata (`errors`, status flags). Kept deliberately structural
+   * so no property NAME is ever consulted.
+   */
+  private isPayloadShape(t: Type): boolean {
+    if (t.isArray()) {
+      const element = t.getArrayElementType();
+      return !!element && element.isObject() && !element.isArray();
+    }
+    return t.isObject();
   }
 
   /**

--- a/ts_check/lib/type-checker.ts
+++ b/ts_check/lib/type-checker.ts
@@ -390,6 +390,52 @@ export class TypeCompatibilityChecker {
 
     const sentType = socket ? consumerType : producerComparand;
     const expectedType = socket ? producerComparand : consumerType;
+
+    // Re-run the `any`/`unknown` → unverifiable guard on the COMPARANDS, not just
+    // the raw `producerType`/`consumerType` checked at the top. The GraphQL
+    // envelope unwrap (`unwrapGraphqlPayload`) can select a payload property that
+    // resolves to `any`/`unknown` even though the envelope object around it does
+    // not — e.g. `{ data: <unresolved>; errors }` whose `data` member dangles to
+    // `any`. Comparing a real producer against such a payload (or the inverse)
+    // would hit `isAssignableTo` with a top-ish side and read compatible: the
+    // exact `graphql|subscription|orderUpdated` false-positive. The raw-type
+    // guard never sees the unwrapped payload, so the comparands must be guarded
+    // again here, before `isAssignableTo`. (For HTTP/socket the comparands equal
+    // the raw types, so this is a redundant no-op that preserves their behavior.)
+    if (
+      sentType.isAny() ||
+      expectedType.isAny() ||
+      sentType.isUnknown() ||
+      expectedType.isUnknown()
+    ) {
+      const producerComparandIsTop = producerComparand.isAny() || producerComparand.isUnknown();
+      const consumerComparandIsTop = consumerType.isAny() || consumerType.isUnknown();
+      const reasonParts = [];
+      if (producerComparandIsTop) {
+        reasonParts.push(
+          `producer payload resolves to ${producerComparand.isAny() ? "any" : "unknown"} (type missing from bundled types?)`
+        );
+      }
+      if (consumerComparandIsTop) {
+        reasonParts.push(
+          `consumer type resolves to ${consumerType.isAny() ? "any" : "unknown"} (type missing from bundled types?)`
+        );
+      }
+      return {
+        kind: "unverifiable",
+        unknown: {
+          endpoint,
+          reason: reasonParts.join(", "),
+          producerTypeAlias: producer.type_alias,
+          consumerTypeAlias: consumer.type_alias,
+          producerLocation: this.formatEntryLocation(producer),
+          consumerLocation: this.formatEntryLocation(consumer),
+          producerEvidence: producer.evidence,
+          consumerEvidence: consumer.evidence,
+        },
+      };
+    }
+
     if (sentType.isAssignableTo(expectedType)) {
       return { kind: "compatible" };
     }


### PR DESCRIPTION
## What

Routes resolved cross-repo GraphQL edges through the ts_check compat engine (modeled on socket #273), so the `graphql|query|order` edge scores a real verdict instead of `None`.

- **edge4** `query|order` → `Some(true)` (consumer `OrderView` is a compatible subset of the producer `Order` payload). The intended win.
- **edge5** `subscription|orderUpdated` → `None` (honestly unverifiable). Its consumer is the synthetic `Endpoint_<hash> = unknown` missing-alias fallback (the subscription doc has no `client.request<T>` call site; resolving it to `OrderUpdate` is a separate, LLM-shaped lever). It is **not** a false `Some(true)`.

## How

- ts_check graphql compat: structural envelope-unwrap (pick the object/array payload among scalar siblings; no `data`/`errors` hardcode) + `producer ⊑ consumer` direction. HTTP/socket paths are provably untouched.
- **edge5 false-positive fix.** An unresolved graphql consumer must reach ts_check so the pair is reported as an `unknownPair` (→ `None`). The earlier attempt *dropped* it from the manifest, which removed the pair from ts_check's output entirely — and `apply_compat_verdicts` defaults an edge absent from both `mismatches` and `unknownPairs` to compatible, i.e. a false `Some(true)` (exactly the regression Copilot flagged). Fix: `write_manifest_files` no longer special-cases graphql; all graphql entries flow to ts_check like HTTP/socket, and the `any`/`unknown` comparand guard in `type-checker.ts` routes the unresolved pair to `unknownPairs`. This also closes the same-class footgun on unresolved graphql *producers*.
- Added `apply_compat_verdicts_graphql_unverifiable_edge_none` to prove the `GRAPHQL KIND|field` endpoint label joins the `graphql|KIND|field` producer key → `None` (a join the corpus's resolved graphql edges never exercise). The two `write_manifest_files` tests now assert unresolved graphql entries are **kept**. Fixed the stale `(HTTP + socket)` matcher comment to include graphql.

## Eval (xrepo-corpus-1, N=5, sha 20663b1)

OVERALL **85%** · compat **0.83 stable** (sd 0.00). All 6 edges now carry a correct or honestly-unverifiable verdict:

| edge | expected | actual |
|---|---|---|
| orders→payments `GET /orders` | true | `Some(true)` ✓ |
| orders→web `GET /orders` | false | `Some(false)` ✓ |
| payments→web `POST /payments` | true | `Some(true)` ✓ |
| gateway→web `query order` | true | `Some(true)` ✓ |
| gateway→web `subscription orderUpdated` | false | `None` (unverifiable — no false positive) |
| web→payments socket `payment:settled` | true | `Some(true)` ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
