### PR TITLE
fix: semver-incompatible dep conflicts + drop synthetic anchor fallback (eval 85%→91%)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -2319,9 +2319,13 @@ mod tests {
         ));
 
         // typescript 5.3 vs 5.4 — same-major minor drift → suppressed.
-        assert!(!Analyzer::is_reportable_conflict(&infos(&["5.3.0", "5.4.0"])));
+        assert!(!Analyzer::is_reportable_conflict(&infos(&[
+            "5.3.0", "5.4.0"
+        ])));
         // patch-only drift → also suppressed.
-        assert!(!Analyzer::is_reportable_conflict(&infos(&["1.1.1", "1.1.2"])));
+        assert!(!Analyzer::is_reportable_conflict(&infos(&[
+            "1.1.1", "1.1.2"
+        ])));
         // three same-major versions → suppressed.
         assert!(!Analyzer::is_reportable_conflict(&infos(&[
             "18.2.0", "18.3.0", "18.3.1"

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -603,7 +603,7 @@ impl Analyzer {
                 let first_version = &repo_infos[0].version;
                 let has_conflicts = repo_infos.iter().any(|info| info.version != *first_version);
 
-                if has_conflicts {
+                if has_conflicts && Self::is_reportable_conflict(&repo_infos) {
                     let severity = Self::determine_conflict_severity(&repo_infos);
                     conflicts.push(DependencyConflict {
                         package_name,
@@ -615,6 +615,34 @@ impl Analyzer {
         }
 
         conflicts
+    }
+
+    /// A cross-service version difference is only worth reporting when the
+    /// versions are semver-INCOMPATIBLE — i.e. they span more than one MAJOR
+    /// version (`zod` 3.x vs 4.x). Differences confined to minor/patch within a
+    /// single major (`typescript` 5.3 vs 5.4) are semver-compatible by
+    /// construction and would be false positives: they don't cause the
+    /// cross-service type/runtime breakage this report exists to surface, and on
+    /// real org-wide installs they are pervasive noise that buries the genuine
+    /// major-version conflicts. Versions that don't parse as semver fall back to
+    /// "report it" — `has_conflicts` already established the raw strings differ,
+    /// and a genuinely divergent non-semver pin (`workspace:*` vs a tag, a git
+    /// URL) must never be silently dropped.
+    fn is_reportable_conflict(repo_infos: &[RepoPackageInfo]) -> bool {
+        use semver::Version;
+
+        let parsed: Vec<Version> = repo_infos
+            .iter()
+            .filter_map(|info| Version::parse(&info.version).ok())
+            .collect();
+
+        // At least one version is not valid semver: report conservatively.
+        if parsed.len() != repo_infos.len() {
+            return true;
+        }
+
+        let first_major = parsed[0].major;
+        parsed.iter().any(|v| v.major != first_major)
     }
 
     fn determine_conflict_severity(repo_infos: &[RepoPackageInfo]) -> ConflictSeverity {
@@ -2261,6 +2289,51 @@ impl Analyzer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Cross-service dependency conflicts are reported only when semver-
+    /// INCOMPATIBLE (a major-version spread). `zod` 3.22.0 vs 4.0.0 is a real
+    /// conflict (Critical); `typescript` 5.3.0 vs 5.4.0 is a compatible same-major
+    /// drift and must be suppressed — it was the false positive that pinned the
+    /// xrepo-corpus-1 dependency F1 to 0.667 (precision 0.5). Non-semver pins that
+    /// differ as raw strings are reported conservatively.
+    #[test]
+    fn dependency_conflict_reported_only_when_major_incompatible() {
+        fn infos(versions: &[&str]) -> Vec<RepoPackageInfo> {
+            versions
+                .iter()
+                .enumerate()
+                .map(|(i, v)| RepoPackageInfo {
+                    repo_name: format!("repo-{i}"),
+                    version: (*v).to_string(),
+                    source_path: PathBuf::from("package.json"),
+                })
+                .collect()
+        }
+
+        // zod 3.x vs 4.x — major spread → reported, Critical.
+        let zod = infos(&["3.22.0", "4.0.0"]);
+        assert!(Analyzer::is_reportable_conflict(&zod));
+        assert!(matches!(
+            Analyzer::determine_conflict_severity(&zod),
+            ConflictSeverity::Critical
+        ));
+
+        // typescript 5.3 vs 5.4 — same-major minor drift → suppressed.
+        assert!(!Analyzer::is_reportable_conflict(&infos(&["5.3.0", "5.4.0"])));
+        // patch-only drift → also suppressed.
+        assert!(!Analyzer::is_reportable_conflict(&infos(&["1.1.1", "1.1.2"])));
+        // three same-major versions → suppressed.
+        assert!(!Analyzer::is_reportable_conflict(&infos(&[
+            "18.2.0", "18.3.0", "18.3.1"
+        ])));
+
+        // A non-semver pin that differs as a raw string → reported conservatively
+        // (has_conflicts upstream already established the strings differ).
+        assert!(Analyzer::is_reportable_conflict(&infos(&[
+            "workspace:*",
+            "1.0.0"
+        ])));
+    }
 
     #[test]
     fn route_shape_drops_non_route_values() {

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -276,13 +276,13 @@ impl EvalOp {
             expanded_definition: fields.and_then(|f| f.expanded_definition.clone()),
             is_explicit: fields.and_then(|f| f.is_explicit),
             // The real LLM type anchor (#233): the symbol threaded onto the
-            // manifest entry, falling back to the hashed `type_alias` only when
-            // no real symbol was extracted for this op.
-            primary_type_symbol: fields.and_then(|f| {
-                f.primary_type_symbol
-                    .clone()
-                    .or_else(|| f.type_alias.clone())
-            }),
+            // manifest entry. NO fallback to the hashed `type_alias` — an op whose
+            // response is an inline/anonymous type (e.g. `GET /users/recent`
+            // returning a bare `{ count; ids }`) has no named symbol, so its anchor
+            // is genuinely `None`. Substituting the synthetic `Endpoint_<hash>`
+            // alias there fabricates an anchor the source never declared and mis-
+            // scores against an expected `None`.
+            primary_type_symbol: fields.and_then(|f| f.primary_type_symbol.clone()),
         }
     }
 }

--- a/tests/dependency_analysis_test.rs
+++ b/tests/dependency_analysis_test.rs
@@ -193,13 +193,17 @@ async fn test_no_conflicts_for_unique_packages() {
 }
 
 #[tokio::test]
-async fn test_severity_levels() {
+async fn test_only_major_incompatible_conflicts_reported() {
     // Create analyzer
     let config = Config::default();
     let cm: Lrc<SourceMap> = Default::default();
     let mut analyzer = Analyzer::new(config, cm);
 
-    // Create packages with different severity conflicts
+    // Create packages spanning a major (critical), minor (warning), and patch
+    // (info) difference. Only the semver-INCOMPATIBLE major spread is reported as
+    // a cross-service conflict; the same-major minor/patch drifts are compatible
+    // and suppressed (they were the false-positive noise that pinned dependency
+    // F1 on xrepo-corpus-1).
     let mut deps_a = HashMap::new();
     deps_a.insert("critical_pkg".to_string(), "2.0.0".to_string()); // Major diff
     deps_a.insert("warning_pkg".to_string(), "1.2.0".to_string()); // Minor diff
@@ -247,16 +251,20 @@ async fn test_severity_levels() {
     // Run dependency analysis
     let conflicts = analyzer.analyze_dependencies();
 
-    // Should find 3 conflicts with different severities
-    assert_eq!(conflicts.len(), 3);
-
-    // Check severities
-    for conflict in &conflicts {
-        match conflict.package_name.as_str() {
-            "critical_pkg" => assert!(matches!(conflict.severity, ConflictSeverity::Critical)),
-            "warning_pkg" => assert!(matches!(conflict.severity, ConflictSeverity::Warning)),
-            "info_pkg" => assert!(matches!(conflict.severity, ConflictSeverity::Info)),
-            _ => panic!("Unexpected package: {}", conflict.package_name),
-        }
-    }
+    // Only the major-incompatible conflict is reported; the minor and patch
+    // drifts are compatible and suppressed.
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "only the major-version (semver-incompatible) conflict is reported"
+    );
+    let conflict = &conflicts[0];
+    assert_eq!(conflict.package_name, "critical_pkg");
+    assert!(matches!(conflict.severity, ConflictSeverity::Critical));
+    assert!(
+        !conflicts
+            .iter()
+            .any(|c| matches!(c.package_name.as_str(), "warning_pkg" | "info_pkg")),
+        "same-major minor/patch drift must not be reported as a conflict"
+    );
 }

--- a/tests/fixtures/llm-mocked-api/__golden__.json
+++ b/tests/fixtures/llm-mocked-api/__golden__.json
@@ -29,8 +29,7 @@
       "line": 9,
       "type_alias": "Endpoint_1732d2237f37ec97_Response",
       "type_state": "Unknown",
-      "is_explicit": false,
-      "primary_type_symbol": "Endpoint_1732d2237f37ec97_Response"
+      "is_explicit": false
     },
     {
       "key": "http|GET|/health",
@@ -46,8 +45,7 @@
       "type_state": "Implicit",
       "resolved_definition": "export type Endpoint_2a10f0dfd8c3cde7_Response = { status: string; };",
       "expanded_definition": "{ status: string; }",
-      "is_explicit": false,
-      "primary_type_symbol": "Endpoint_2a10f0dfd8c3cde7_Response"
+      "is_explicit": false
     },
     {
       "key": "http|GET|/summary",
@@ -63,8 +61,7 @@
       "type_state": "Implicit",
       "resolved_definition": "export type Endpoint_97b757a2c4112fad_Response = { total: number; };",
       "expanded_definition": "{ total: number; }",
-      "is_explicit": false,
-      "primary_type_symbol": "Endpoint_97b757a2c4112fad_Response"
+      "is_explicit": false
     },
     {
       "key": "http|POST|/api/users",
@@ -106,22 +103,6 @@
         "5.0.0"
       ],
       "severity": "critical"
-    },
-    {
-      "package": "lodash",
-      "versions": [
-        "4.17.21",
-        "4.17.22"
-      ],
-      "severity": "info"
-    },
-    {
-      "package": "react",
-      "versions": [
-        "18.2.0",
-        "18.3.0"
-      ],
-      "severity": "warning"
     }
   ]
 }

--- a/tests/fixtures/scenario-1-dependency-conflicts/expected-output.json
+++ b/tests/fixtures/scenario-1-dependency-conflicts/expected-output.json
@@ -13,34 +13,6 @@
         }
       ],
       "severity": "Critical"
-    },
-    {
-      "package_name": "react",
-      "versions": [
-        {
-          "repo": "repo-a",
-          "version": "18.3.0"
-        },
-        {
-          "repo": "repo-b",
-          "version": "18.2.0"
-        }
-      ],
-      "severity": "Warning"
-    },
-    {
-      "package_name": "lodash",
-      "versions": [
-        {
-          "repo": "repo-a",
-          "version": "4.17.22"
-        },
-        {
-          "repo": "repo-b",
-          "version": "4.17.21"
-        }
-      ],
-      "severity": "Info"
     }
   ]
 }


### PR DESCRIPTION
## What

Two deterministic, scanner-side accuracy fixes that take eval-xrepo (xrepo-corpus-1) from **85% → 91%** OVERALL, clearing the ≥90% goal. Both are independent of the LLM and validated live.

## Fixes

### 1. Report cross-service version conflicts only when semver-incompatible
`find_dependency_conflicts` flagged *any* differing version string across services as a conflict — including same-major minor/patch drift that is semver-compatible by construction. On the corpus that surfaced a false-positive `typescript` ^5.3.0 vs ^5.4.0 conflict alongside the genuine `zod` 3.x vs 4.x one (dependency F1 0.667, precision 0.5). On real org-wide installs the same noise buries the major-version conflicts that actually break cross-service contracts.

A conflict is now reported only when the versions span more than one **major** version (`is_reportable_conflict`). Same-major drift is suppressed; non-semver pins that differ as raw strings are still reported (conservative fallback). `dependency F1 0.667 → 1.00`.

### 2. Drop the synthetic anchor fallback for inline/unresolved types
The eval projection fell back `primary_type_symbol` to the hashed `type_alias` (`Endpoint_<hash>_Response`) when no real named symbol was extracted. An op whose response is an inline/anonymous type — e.g. `GET /users/recent` returning a bare `{ count; ids }` — has no named anchor, so its expected symbol is `None`; the hash fabricated an anchor the source never declared. Now emits the real symbol or `None`. `type-anchor 0.80 → 0.87` (12/15 → 13/15).

## Eval (xrepo-corpus-1, N=5, base = #278)

OVERALL **91%** (stable: runs 91/90/91/91/91). `endpoint 1.00 · call 0.93 · match 1.00 · anchor 0.87 · resolution 0.73 · compat 0.83 · dep 1.00`.

## Tests

- `dependency_conflict_reported_only_when_major_incompatible` (unit, grounded in the zod/typescript corpus shapes).
- Updated `test_only_major_incompatible_conflicts_reported` and the `scenario-1` output-contract fixture to the corrected behavior.
- Re-recorded the cassette golden; verified the diff is **exactly** the two intended changes and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
