### PR TITLE
ci: run the ts_check test suite in CI (close graphql-compat CI coverage gap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
             tests/fixtures/fastify-api/package.json
             tests/fixtures/koa-api/package.json
             src/sidecar/package-lock.json
+            ts_check/package-lock.json
 
       - name: Install test dependencies
         run: |
@@ -90,6 +91,9 @@ jobs:
 
       - name: Run sidecar unit tests
         run: cd src/sidecar && npm test
+
+      - name: Run ts_check unit tests
+        run: cd ts_check && npm ci && npm test
 
       - name: Run library tests
         run: cargo test --lib --verbose


### PR DESCRIPTION
## What

Run the `ts_check` test suite in CI. It currently runs **only in the local pre-commit hook**, so the `ts_check` half of the #278 graphql cross-repo compat machinery had **zero CI coverage**.

`ts_check/lib/*.test.ts` covers, among others:
- the `any`/`unknown` comparand guard that turns the unresolved `subscription|orderUpdated` consumer into `unverifiable` → `None` (the edge5 false-positive fix),
- the optional-field-widening **direction proof** (consumer-requires / producer-optional → incompatible),
- the `query|order` compatible case,
- the graphql producer/consumer matcher.

A regression in any of these would have gone green in CI and only surfaced in a manual eval run. The Rust half of the machinery is already gated via `cargo test --lib`; this closes the TypeScript half.

## How

- New Test Suite step `cd ts_check && npm ci && npm test`, placed between the sidecar and library test steps (same `npm ci` invocation the eval-xrepo workflow already uses).
- Added `ts_check/package-lock.json` to the Node `cache-dependency-path` so installs are cached.

Verified locally: **83 pass, 0 fail**.

## Context

Found while auditing regression coverage for the 91% xrepo-eval gains (#278/#279) before shifting attention to a second eval corpus. The companion gap — a deterministic end-to-end cassette for the cross-repo corpus — turned out to need scanner + harness changes (basename cassette-key collisions, two-phase fixture-dir wiring) and a live LLM capture, so it's tracked as a separate follow-up rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
