### PR TITLE
test(eval): add xrepo-corpus-2 — authored event-driven cross-repo corpus

### DIFF
--- a/tests/eval_xrepo.rs
+++ b/tests/eval_xrepo.rs
@@ -192,6 +192,12 @@ struct ExpectedRepo {
     /// is the producer (endpoint) and an *emitter* the consumer (call).
     #[serde(default)]
     socket_events: Vec<ExpNonHttpOp>,
+    /// Non-HTTP pub/sub ops (Kafka/Redis/NATS). Same role/key convention as
+    /// graphql/socket: a *subscriber* is the producer (endpoint), a *publisher*
+    /// the consumer (call); `key` is `pubsub|<topic>`. The topic/broker/side/source
+    /// fields in the JSON are diagnostic and ignored by serde (unknown-field drop).
+    #[serde(default)]
+    pubsub_operations: Vec<ExpNonHttpOp>,
     #[serde(default, rename = "_must_not_emit")]
     must_not_emit: Vec<ExpMustNotEmit>,
 }
@@ -408,6 +414,7 @@ fn expected_endpoint_set(
             .graphql_operations
             .iter()
             .chain(exp.socket_events.iter())
+            .chain(exp.pubsub_operations.iter())
         {
             if op.role == "producer" && op.tier == tier {
                 set.insert(nonhttp_op_key(&op.key));
@@ -534,7 +541,12 @@ fn score_call_set(
     let nonhttp_expected = |t: &str| -> HashSet<OpSetKey> {
         repo_expected
             .iter()
-            .flat_map(|(_r, e)| e.graphql_operations.iter().chain(e.socket_events.iter()))
+            .flat_map(|(_r, e)| {
+                e.graphql_operations
+                    .iter()
+                    .chain(e.socket_events.iter())
+                    .chain(e.pubsub_operations.iter())
+            })
             .filter(|op| op.role == "consumer" && op.tier == t)
             .map(|op| nonhttp_op_key(&op.key))
             .collect()
@@ -792,6 +804,7 @@ fn for_each_expected_typed_op(
             .graphql_operations
             .iter()
             .chain(exp.socket_events.iter())
+            .chain(exp.pubsub_operations.iter())
         {
             if op.tier == tier {
                 let is_producer = op.role == "producer";
@@ -2007,7 +2020,48 @@ mod scoring_tests {
             norm_key("socket|SERVER->CLIENT|payment:settled"),
             "socket|SERVER->CLIENT|payment:settled"
         );
+        // Pub/sub keys are 2-segment (`pubsub|<topic>`) → the splitn(3,'|')
+        // never matches the 3-tuple HTTP arm, so they fall through unchanged.
+        assert_eq!(norm_key("pubsub|order.placed"), "pubsub|order.placed");
         assert_eq!(norm_key("not-a-key"), "not-a-key");
+    }
+
+    /// Ungated parse smoke for whatever corpus is selected (`CARRICK_EVAL_CORPUS`).
+    /// Verifies every `<repo>/expected.json` deserializes to `ExpectedRepo` and the
+    /// corpus `expected-output.json` to `ExpectedOutput`, with a message naming the
+    /// offending file on failure. Runs for ANY corpus (not gated on the default),
+    /// so it offline-validates corpus-2's additive `pubsub_operations` arrays.
+    #[test]
+    fn corpus_expected_files_parse() {
+        let corpus = corpus_dir();
+        if !corpus.is_dir() {
+            eprintln!("[eval] corpus dir missing — skipping");
+            return;
+        }
+        let repos = discover_repos(&corpus);
+        for repo in &repos {
+            let path = repo.join("expected.json");
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            let parsed: Result<ExpectedRepo, _> = serde_json::from_str(&text);
+            assert!(
+                parsed.is_ok(),
+                "parse {} into ExpectedRepo failed: {}",
+                path.display(),
+                parsed.unwrap_err()
+            );
+        }
+
+        let out_path = corpus.join("expected-output.json");
+        let out_text = std::fs::read_to_string(&out_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", out_path.display()));
+        let out_parsed: Result<ExpectedOutput, _> = serde_json::from_str(&out_text);
+        assert!(
+            out_parsed.is_ok(),
+            "parse {} into ExpectedOutput failed: {}",
+            out_path.display(),
+            out_parsed.unwrap_err()
+        );
     }
 
     #[test]
@@ -2471,6 +2525,7 @@ mod scoring_tests {
                 .graphql_operations
                 .iter()
                 .chain(exp.socket_events.iter())
+                .chain(exp.pubsub_operations.iter())
             {
                 let proto = op.key.split('|').next().unwrap_or("");
                 let mut eo = nonhttp_op(proto, &op.key);

--- a/tests/fixtures/xrepo-corpus-2/README.md
+++ b/tests/fixtures/xrepo-corpus-2/README.md
@@ -1,0 +1,130 @@
+# xrepo-corpus-2 — authored event-driven cross-repo accuracy corpus
+
+Five statically-analyzable (not runnable) repos with an owned answer key, for the
+cross-repo accuracy eval. The deliberate **dual of corpus-1**: where corpus-1 is a
+request/response topology, corpus-2 is **event-driven**, centered on a new
+**pub/sub family** protocol (Kafka + Redis pub/sub + NATS) with typed payloads, so
+each broker carries a real cross-repo type-compat edge. Labels are
+**spec-of-record**: authored first, code built to match, never derived from a scan.
+Change a label only by hand, in a separate commit, reviewed against the spec.
+
+Selected via `CARRICK_EVAL_CORPUS=xrepo-corpus-2` through the same two-phase scorer
+(`tests/eval_xrepo.rs`); default (`xrepo-corpus-1`) is unaffected.
+
+## Why this corpus exists
+1. **Validate the pub/sub family** as ONE topic-keyed abstraction across three
+   brokers from the start (anti-overfit: no single-broker hack). Subscriber = the
+   contract **producer** (endpoint); publisher = the **consumer** (call). Cross-repo
+   key is `pubsub|<topic>` — the broker is detection metadata, **not** part of
+   identity (a publisher and subscriber on the same topic string match regardless of
+   broker; corpus-2 gives each topic a single broker, so the cross-broker case is a
+   future-corpus + unit-test concern, not exercised here).
+2. **Stress generalization of existing scanner features** with mechanisms tagged
+   `roadmap` (scored separately, see Tiers): code-first GraphQL (Pothos),
+   TypedDocumentNode / graphql-ws consumers (no `gql` tag), a real GraphQL
+   subscription (async-generator resolver), async iterators.
+3. **Framework-agnostic proof** via three HTTP frameworks: Fastify, Hono, Express
+   (alongside corpus-1's Express/NestJS), tagged `capability`.
+
+## Repos
+- `notifications-svc/` (Fastify + kafkajs + nats.js) — pub/sub **subscriber** (=
+  producer) of Kafka `order.placed` and NATS `user.registered` (async iterator),
+  plus a Fastify HTTP producer (`GET /notifications/:id`, `GET /health` orphan).
+- `orders-engine/` (NestJS + Pothos + kafkajs) — Kafka `order.placed` **publisher**
+  (= consumer; payload wrapped in `Envelope<T>`), and a **code-first Pothos** schema:
+  `query order`, `mutation cancelOrder` (orphan), `subscription orderEvents`
+  (async-generator). Hosts the `__dlq.retry` intra-repo self-loop (see Decoys).
+- `analytics-worker/` (Hono + ioredis + nats.js) — **mixed-broker publisher**: Redis
+  `metrics.page_view` and NATS `user.registered`; Hono HTTP producer (`POST /track`).
+- `web-dashboard/` (Next-ish + @graphql-typed-document-node/core + graphql-ws +
+  ioredis) — GraphQL **consumer** via TypedDocumentNode (`query order`) and graphql-ws
+  (`subscription orderEvents`); Redis `metrics.page_view` **subscriber** (= producer);
+  HTTP consumer of `/notifications/:id` + `/track`.
+- `billing-svc/` (Express + kafkajs + nats.js) — Kafka `order.placed` publisher with
+  an **incompatible** payload; NATS `payment.captured` publisher (orphan); HTTP
+  consumer of `${LEDGER_URL}/ledger/append` (orphan).
+
+## Configuration
+Consumer repos with `${ENV}`-based **HTTP** calls carry a `carrick.json` with
+`internalEnvVars` (web-dashboard: `NOTIFICATIONS_URL`, `ANALYTICS_URL`; billing-svc:
+`LEDGER_URL`) — the same internal-classification gate as corpus-1 (without it the
+HTTP edges never form). **Pub/sub (like GraphQL/Socket.IO) needs no
+connection-classification config**: it keys on the topic literal, not a URL.
+
+## Tiers
+`capability` = scored in the headline `overall_correctness`. `roadmap` = tracked but
+partitioned out. The 2 code-first-GraphQL edges (Pothos producer + TypedDocumentNode /
+graphql-ws consumer) are **`roadmap`**: the scanner is schema-first/SDL+`gql`-tag only
+(`src/graphql.rs`), so scoring them `capability` would crater the headline for work the
+pub/sub program does not ship. They are next-program headroom, flipped to `capability`
+only when their detection lands — never to inflate the score.
+
+## Cross-repo edges
+| # | Protocol | Producer (subscriber) | Consumer (publisher) | Key | Compat | Tier |
+|---|---|---|---|---|---|---|
+| 1 | pubsub/kafka | notifications-svc `order.placed` | orders-engine | `pubsub\|order.placed` | compatible | capability |
+| 2 | pubsub/kafka | notifications-svc `order.placed` | billing-svc | `pubsub\|order.placed` | **incompatible** (`total` `number` vs `{amountCents,currency}`) | capability |
+| 3 | pubsub/nats | notifications-svc `user.registered` | analytics-worker | `pubsub\|user.registered` | compatible | capability |
+| 4 | pubsub/redis | web-dashboard `metrics.page_view` | analytics-worker | `pubsub\|metrics.page_view` | compatible | capability |
+| 5 | graphql | orders-engine `query order` | web-dashboard | `graphql\|query\|order` | compatible | roadmap |
+| 6 | graphql | orders-engine `subscription orderEvents` | web-dashboard | `graphql\|subscription\|orderEvents` | **incompatible** (consumer adds `"cancelled"` union member) | roadmap |
+| 7 | http | notifications-svc `GET /notifications/:id` | web-dashboard | `http\|GET\|/notifications/:param` | compatible | capability |
+| 8 | http | analytics-worker `POST /track` | web-dashboard | `http\|POST\|/track` | compatible | capability |
+
+**Pub/sub producer/consumer direction (read before "fixing" the labels).** Mirroring
+the socket model: a *subscriber* (`consumer.subscribe` / `sub.on('message')` /
+`nc.subscribe`) is the **producer (endpoint)** of the topic it receives; a *publisher*
+(`producer.send` / `redis.publish` / `nc.publish`) is the **consumer (call)**. So for
+`order.placed` (orders-engine + billing-svc *publish* → notifications-svc *subscribes*),
+the `matches` edge has `producer_repo: notifications-svc` (subscriber) and
+`consumer_repo:` the publisher. The *event* flows publisher → subscriber; the *contract
+producer* is the subscriber.
+
+Orphan producers: orders-engine `graphql mutation cancelOrder` (roadmap),
+notifications-svc `http GET /health`. Orphan consumers: billing-svc
+`pubsub payment.captured`, billing-svc `http POST /ledger/append`.
+
+`dependency_conflicts` carries one deliberate cross-repo conflict: `ioredis` 4.28.0
+(web-dashboard) vs 5.3.0 (analytics-worker) — major-incompatible → `critical`,
+exercising the semver-major gate. Kept in-model (a pub/sub dep).
+
+## Decoys (anti-overfit traps that must extract nothing as a cross-repo edge)
+1. `analytics-worker/src/redis/publisher.ts` — `redis.set('metrics.page_view', …)` /
+   `redis.get(…)`: ioredis **key-value cache** on a string that happens to equal a
+   topic. NOT pub/sub. The "don't hallucinate a topic from a cache key" trap.
+2. `orders-engine/src/kafka/dlq.ts` — `__dlq.retry` is **published AND subscribed
+   within the same repo** (dead-letter self-loop). It is real pub/sub but an
+   intra-repo self-edge; it must NOT surface as a cross-repo match.
+3. `billing-svc/src/http/client.ts` — `kafka.admin().createTopics(…)`: topic
+   **administration**, not publish/subscribe.
+
+### Decoy-scoring limitation (logged, not silent)
+`score_decoy_leak` (`tests/eval_xrepo.rs`) currently matches `_must_not_emit` entries
+only against HTTP `(method, path)` projections; it skips non-HTTP ops. The three
+pub/sub decoys above are therefore **documented but not yet counted** by the decoy
+metric, and decoys 1/2 additionally collide on topic-key with a legit op on the same
+topic (so set-precision can't distinguish them either). Extending decoy scoring to
+non-HTTP ops (source-location-keyed, to survive the topic-key collision) is a deliberate
+follow-up of the pub/sub slice; until then these traps are validated only by manual
+projection inspection. Pre-slice the scanner cannot emit pub/sub ops at all, so the
+decoy count is trivially 0.
+
+## Phasing (what scores when — do not mistake a low pre-slice run for a corpus bug)
+- **Pass immediately** (existing machinery, `capability`): the `ioredis` dep conflict;
+  the 2 HTTP edges (Fastify/Hono — Hono is medium-confidence, real framework-agnostic
+  headroom if it misses); the HTTP orphans.
+- **Start near 0 → climb as the pub/sub slice + extraction land**: all 4 pub/sub edges
+  (ep/call/match/anchor/resolution), then pub/sub compat **last** (needs the ts_check
+  direction + codec-unwrap path; until then pub/sub matches return `None` and the
+  compat dimension reads as absent, exactly the corpus-1 graphql/socket arc).
+- **`roadmap`, partitioned out**: the 2 code-first-GraphQL edges (Pothos detection +
+  TypedDocumentNode/graphql-ws consumer are detection cliffs).
+
+## Ground truth
+- Per-repo `<repo>/expected.json` — HTTP `endpoints`/`calls` + the non-HTTP
+  `graphql_operations` and additive `pubsub_operations` arrays (each op carries
+  `role`/`key`/`primary_type_symbol`/`resolved_type`/`type_state`/`tier`; for pub/sub
+  the `topic`/`broker`/`side`/`source` fields are diagnostic and ignored by the scorer).
+  `_must_not_emit` lists the decoys.
+- Corpus `expected-output.json` — cross-repo `matches` (with `protocol`/`tier`/compat),
+  `orphans`, `dependency_conflicts`, and a `summary`.

--- a/tests/fixtures/xrepo-corpus-2/analytics-worker/expected.json
+++ b/tests/fixtures/xrepo-corpus-2/analytics-worker/expected.json
@@ -1,0 +1,50 @@
+{
+  "endpoints": [
+    {
+      "method": "POST",
+      "path": "/track",
+      "owner": "app.post",
+      "primary_type_symbol": "TrackResult",
+      "resolved_type": "{ ok: boolean; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "calls": [],
+  "pubsub_operations": [
+    {
+      "role": "consumer",
+      "service": "analytics-worker",
+      "key": "pubsub|metrics.page_view",
+      "topic": "metrics.page_view",
+      "broker": "redis",
+      "side": "publisher",
+      "source": "src/redis/publisher.ts",
+      "primary_type_symbol": "PageView",
+      "resolved_type": "{ path: string; userId: string; ts: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "consumer",
+      "service": "analytics-worker",
+      "key": "pubsub|user.registered",
+      "topic": "user.registered",
+      "broker": "nats",
+      "side": "publisher",
+      "source": "src/nats/publisher.ts",
+      "primary_type_symbol": "UserRegisteredEvent",
+      "resolved_type": "{ userId: string; email: string; registeredAt: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "_must_not_emit": [
+    {
+      "kind": "pubsub",
+      "method": "*",
+      "path": "pubsub|metrics.page_view",
+      "evidence": "src/redis/publisher.ts: redis.set('metrics.page_view', ...) and redis.get('metrics.page_view') are ioredis KEY-VALUE cache ops, not publish/subscribe. The shared string is a cache key, not a topic. Must not be extracted as a second pub/sub consumer (the genuine publish on the same string is the only metrics.page_view op)."
+    }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-2/analytics-worker/package.json
+++ b/tests/fixtures/xrepo-corpus-2/analytics-worker/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "analytics-worker",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "hono": "^4.4.0",
+    "ioredis": "5.3.0",
+    "nats": "^2.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-2/analytics-worker/src/http/app.ts
+++ b/tests/fixtures/xrepo-corpus-2/analytics-worker/src/http/app.ts
@@ -1,0 +1,31 @@
+// Hono HTTP PRODUCER — edge 8 (third framework, after Fastify + Express).
+//
+// `app.post('/track', c => c.json<TrackResult>(...))` registers POST /track.
+// Request body is { path: string; userId: string }; response anchors on
+// TrackResult. The matching consumer is web-dashboard's `fetch POST /track`.
+// Cross-repo key: http|POST|/track. Capability tier (Hono producer is a real
+// HTTP framework, framework-agnostic proof).
+
+import { Hono } from "hono";
+
+const app = new Hono();
+
+// Request body shape for POST /track.
+export interface TrackRequest {
+  path: string;
+  userId: string;
+}
+
+// Response contract for POST /track — the producer anchor type.
+export interface TrackResult {
+  ok: boolean;
+}
+
+// POST /track — record a tracked event, return { ok }.
+app.post("/track", async (c) => {
+  const body = await c.req.json<TrackRequest>();
+  const result: TrackResult = { ok: Boolean(body.path && body.userId) };
+  return c.json<TrackResult>(result);
+});
+
+export { app };

--- a/tests/fixtures/xrepo-corpus-2/analytics-worker/src/nats/publisher.ts
+++ b/tests/fixtures/xrepo-corpus-2/analytics-worker/src/nats/publisher.ts
@@ -1,0 +1,25 @@
+// NATS pub/sub PUBLISHER — edge 3 CONSUMER (publisher = consumer of the topic).
+//
+// `nc.publish(SUBJECT, JSONCodec.encode(userRegistered))` emits the
+// UserRegisteredEvent contract on the NATS subject `user.registered`. Publisher
+// = consumer of the key; the matching producer (endpoint) is the SUBSCRIBER —
+// notifications-svc `nc.subscribe('user.registered')`. Structured edge:
+//   { producer_repo: notifications-svc (subscriber), consumer_repo: analytics-worker (publisher) }
+// both on `pubsub|user.registered`. Broker (nats) is metadata, not key.
+//
+// Topic-literal variation: this site references a `const SUBJECT` (the Redis
+// publisher uses an inline literal) — stresses the call-site literal resolver.
+
+import { connect, JSONCodec } from "nats";
+import type { UserRegisteredEvent } from "../types/metrics";
+
+const SUBJECT = "user.registered";
+const codec = JSONCodec<UserRegisteredEvent>();
+
+export async function publishUserRegistered(
+  userRegistered: UserRegisteredEvent
+): Promise<void> {
+  const nc = await connect({ servers: process.env.NATS_URL });
+  // edge 3 consumer: const-subject reference, JSONCodec encode.
+  nc.publish(SUBJECT, codec.encode(userRegistered));
+}

--- a/tests/fixtures/xrepo-corpus-2/analytics-worker/src/redis/publisher.ts
+++ b/tests/fixtures/xrepo-corpus-2/analytics-worker/src/redis/publisher.ts
@@ -1,0 +1,35 @@
+// Redis pub/sub PUBLISHER — edge 4 CONSUMER (publisher = consumer of the topic).
+//
+// `redis.publish('metrics.page_view', JSON.stringify(pageView))` emits the
+// PageView contract on the Redis channel `metrics.page_view`. In Carrick's
+// pub/sub model a PUBLISHER is the CONSUMER (call) of the key it sends; the
+// matching producer (endpoint) is the SUBSCRIBER on the other side — the
+// web-dashboard `sub.subscribe('metrics.page_view')`. So the structured edge is
+//   { producer_repo: web-dashboard (subscriber), consumer_repo: analytics-worker (publisher) }
+// both on `pubsub|metrics.page_view`. Broker (redis) is detection metadata, not key.
+//
+// Topic-literal variation: this site uses an INLINE string literal
+// ('metrics.page_view'); the NATS publisher uses a `const SUBJECT` reference.
+
+import Redis from "ioredis";
+import type { PageView } from "../types/metrics";
+
+const redis = new Redis(process.env.REDIS_URL);
+
+export async function publishPageView(pageView: PageView): Promise<void> {
+  // edge 4 consumer: inline topic literal, JSON.stringify codec.
+  await redis.publish("metrics.page_view", JSON.stringify(pageView));
+}
+
+// DECOY: ioredis is dual-use. These are key-value cache ops on a key that
+// happens to share the string 'metrics.page_view' — NOT a pub/sub publish.
+// The scanner must NOT hallucinate a topic from a cache key. Emits nothing.
+export async function cacheLastView(pageView: PageView): Promise<void> {
+  // DECOY — redis.set is key-value, not publish.
+  await redis.set("metrics.page_view", JSON.stringify(pageView));
+}
+
+export async function readLastView(): Promise<string | null> {
+  // DECOY — redis.get is key-value, not subscribe.
+  return redis.get("metrics.page_view");
+}

--- a/tests/fixtures/xrepo-corpus-2/analytics-worker/src/types/metrics.ts
+++ b/tests/fixtures/xrepo-corpus-2/analytics-worker/src/types/metrics.ts
@@ -1,0 +1,17 @@
+// Publisher payload types for analytics-worker.
+// These are the CONSUMER-side contract shapes (publisher = consumer of the topic).
+// They must stay byte-compatible with the subscriber/producer answer key:
+//   - PageView           → web-dashboard subscriber (Redis metrics.page_view)
+//   - UserRegisteredEvent → notifications-svc subscriber (NATS user.registered)
+
+export interface PageView {
+  path: string;
+  userId: string;
+  ts: number;
+}
+
+export interface UserRegisteredEvent {
+  userId: string;
+  email: string;
+  registeredAt: number;
+}

--- a/tests/fixtures/xrepo-corpus-2/analytics-worker/src/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-2/analytics-worker/src/types/stubs.d.ts
@@ -1,0 +1,39 @@
+// Ambient stubs — keep types resolvable without npm install.
+
+// ioredis stub — dual-use client: pub/sub (publish) AND key-value (set/get).
+// The KV surface exists only so the DECOY in redis/publisher.ts type-checks.
+declare module "ioredis" {
+  export default class Redis {
+    constructor(url?: string);
+    publish(channel: string, message: string): Promise<number>;
+    set(key: string, value: string): Promise<"OK">;
+    get(key: string): Promise<string | null>;
+  }
+}
+
+// nats.js stub — connection + JSONCodec for the publish path.
+declare module "nats" {
+  export interface Codec<T> {
+    encode(value: T): Uint8Array;
+    decode(data: Uint8Array): T;
+  }
+  export function JSONCodec<T = unknown>(): Codec<T>;
+  export interface NatsConnection {
+    publish(subject: string, payload: Uint8Array): void;
+  }
+  export function connect(opts?: { servers?: string }): Promise<NatsConnection>;
+}
+
+// Hono stub — minimal context with a generic json() response helper.
+declare module "hono" {
+  export interface Context {
+    req: {
+      json<T = unknown>(): Promise<T>;
+    };
+    json<T = unknown>(body: T, status?: number): T;
+  }
+  export class Hono {
+    post(path: string, handler: (c: Context) => unknown): Hono;
+    get(path: string, handler: (c: Context) => unknown): Hono;
+  }
+}

--- a/tests/fixtures/xrepo-corpus-2/analytics-worker/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-2/analytics-worker/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-2/billing-svc/carrick.json
+++ b/tests/fixtures/xrepo-corpus-2/billing-svc/carrick.json
@@ -1,0 +1,3 @@
+{
+  "internalEnvVars": ["LEDGER_URL"]
+}

--- a/tests/fixtures/xrepo-corpus-2/billing-svc/expected.json
+++ b/tests/fixtures/xrepo-corpus-2/billing-svc/expected.json
@@ -1,0 +1,52 @@
+{
+  "endpoints": [],
+  "calls": [
+    {
+      "method": "POST",
+      "path": "/ledger/append",
+      "host_contains": "LEDGER_URL",
+      "path_contains": "/ledger/append",
+      "import_source": "axios",
+      "primary_type_symbol": "LedgerEntry",
+      "resolved_type": "{ orderId: string; amountCents: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "pubsub_operations": [
+    {
+      "role": "consumer",
+      "service": "billing-svc",
+      "key": "pubsub|order.placed",
+      "topic": "order.placed",
+      "broker": "kafka",
+      "side": "publisher",
+      "source": "src/kafka/producer.ts",
+      "primary_type_symbol": "OrderPlaced",
+      "resolved_type": "{ id: string; total: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "consumer",
+      "service": "billing-svc",
+      "key": "pubsub|payment.captured",
+      "topic": "payment.captured",
+      "broker": "nats",
+      "side": "publisher",
+      "source": "src/nats/publisher.ts",
+      "primary_type_symbol": "PaymentCaptured",
+      "resolved_type": "{ orderId: string; amountCents: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "_must_not_emit": [
+    {
+      "kind": "call",
+      "method": "*",
+      "path": "pubsub|order.placed",
+      "evidence": "src/http/client.ts: kafka.admin().createTopics({ topics: [{ topic: 'order.placed' }] }) is topic MANAGEMENT (admin API), not a publish or subscribe. It must not be extracted as a pub/sub producer or consumer op despite naming the same topic literal."
+    }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-2/billing-svc/package.json
+++ b/tests/fixtures/xrepo-corpus-2/billing-svc/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "billing-svc",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "axios": "^1.6.0",
+    "kafkajs": "^2.2.4",
+    "nats": "^2.19.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-2/billing-svc/src/http/client.ts
+++ b/tests/fixtures/xrepo-corpus-2/billing-svc/src/http/client.ts
@@ -1,0 +1,27 @@
+import axios from "axios";
+import { Kafka } from "kafkajs";
+
+export interface LedgerEntry {
+  orderId: string;
+  amountCents: number;
+}
+
+const LEDGER_BASE = process.env.LEDGER_URL ?? "http://localhost:4000";
+
+// ORPHAN consumer: POST ${LEDGER_URL}/ledger/append. No producer in the corpus
+// serves this route, so the call stays unmatched. LEDGER_URL is declared in
+// carrick.json `internalEnvVars` so the env-var-base HTTP call is classified
+// internal and can be considered for cross-repo matching at all.
+export async function appendToLedger(entry: LedgerEntry): Promise<void> {
+  await axios.post(`${LEDGER_BASE}/ledger/append`, entry);
+}
+
+const kafka = new Kafka({ clientId: "billing-svc", brokers: ["localhost:9092"] });
+
+// DECOY: kafka.admin().createTopics(...) is topic MANAGEMENT, not a
+// publish/subscribe data flow. It must emit NOTHING — no pub/sub op, no edge.
+export async function ensureTopics(): Promise<void> {
+  const admin = kafka.admin();
+  await admin.connect();
+  await admin.createTopics({ topics: [{ topic: "order.placed" }] });
+}

--- a/tests/fixtures/xrepo-corpus-2/billing-svc/src/kafka/producer.ts
+++ b/tests/fixtures/xrepo-corpus-2/billing-svc/src/kafka/producer.ts
@@ -1,0 +1,18 @@
+import { Kafka } from "kafkajs";
+import type { OrderPlaced } from "../types/billing";
+
+const kafka = new Kafka({ clientId: "billing-svc", brokers: ["localhost:9092"] });
+const producer = kafka.producer();
+
+// EDGE 2 (consumer = publisher): publishes Kafka `order.placed`.
+// Topic supplied as an INLINE string literal (the other pub/sub site,
+// nats/publisher.ts, uses a `const TOPIC` reference — stresses the literal
+// resolver). Payload is INCOMPATIBLE with the subscriber contract: OrderPlaced
+// here carries `total: number`, the subscriber expects a nested Money object.
+export async function publishOrderPlaced(order: OrderPlaced): Promise<void> {
+  await producer.connect();
+  await producer.send({
+    topic: "order.placed",
+    messages: [{ key: order.id, value: JSON.stringify(order) }],
+  });
+}

--- a/tests/fixtures/xrepo-corpus-2/billing-svc/src/nats/publisher.ts
+++ b/tests/fixtures/xrepo-corpus-2/billing-svc/src/nats/publisher.ts
@@ -1,0 +1,17 @@
+import { connect, JSONCodec } from "nats";
+import type { PaymentCaptured } from "../types/billing";
+
+// Topic supplied via a `const` reference (the kafka producer site uses an
+// inline literal — together they stress the scanner's topic-literal resolver).
+const TOPIC = "payment.captured";
+
+const codec = JSONCodec<PaymentCaptured>();
+
+// ORPHAN consumer (publisher = consumer): publishes NATS `payment.captured`.
+// No subscriber exists anywhere in the corpus, so this edge must remain
+// unmatched (orphan consumer on `pubsub|payment.captured`).
+export async function publishPaymentCaptured(event: PaymentCaptured): Promise<void> {
+  const nc = await connect({ servers: "nats://localhost:4222" });
+  nc.publish(TOPIC, codec.encode(event));
+  await nc.drain();
+}

--- a/tests/fixtures/xrepo-corpus-2/billing-svc/src/types/billing.ts
+++ b/tests/fixtures/xrepo-corpus-2/billing-svc/src/types/billing.ts
@@ -1,0 +1,16 @@
+// Publisher payload types for billing-svc's pub/sub call sites.
+
+// Kafka `order.placed` publisher payload — DELIBERATELY INCOMPATIBLE with the
+// notifications-svc subscriber contract: `total` here is a bare cents `number`,
+// whereas OrderPlacedEvent.total is `{ amountCents: number; currency: string }`.
+// This is edge 2 (payload-shape mismatch).
+export interface OrderPlaced {
+  id: string;
+  total: number;
+}
+
+// NATS `payment.captured` publisher payload — ORPHAN (no subscriber in corpus).
+export interface PaymentCaptured {
+  orderId: string;
+  amountCents: number;
+}

--- a/tests/fixtures/xrepo-corpus-2/billing-svc/src/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-2/billing-svc/src/types/stubs.d.ts
@@ -1,0 +1,77 @@
+// Ambient stubs — keep types resolvable without npm install
+
+declare module "express" {
+  export interface Request {
+    params: Record<string, string>;
+    body: unknown;
+    query: Record<string, string>;
+  }
+  export interface Response {
+    status(code: number): Response;
+    json(body: unknown): Response;
+    send(body: unknown): Response;
+  }
+  export interface NextFunction {
+    (err?: unknown): void;
+  }
+  export interface Application {
+    get(path: string, handler: (req: Request, res: Response) => void): Application;
+    post(path: string, handler: (req: Request, res: Response) => void): Application;
+    listen(port: number, callback?: () => void): void;
+  }
+  function express(): Application;
+  export default express;
+}
+
+declare module "axios" {
+  export interface AxiosResponse<T = unknown> {
+    data: T;
+    status: number;
+    statusText: string;
+  }
+  export interface AxiosInstance {
+    get<T = unknown>(url: string, config?: unknown): Promise<AxiosResponse<T>>;
+    post<T = unknown>(url: string, data?: unknown, config?: unknown): Promise<AxiosResponse<T>>;
+  }
+  const axios: AxiosInstance;
+  export default axios;
+}
+
+// kafkajs stub — producer.send (publish, edge 2) + admin().createTopics (DECOY).
+declare module "kafkajs" {
+  export interface Message {
+    key?: string;
+    value: string | Buffer;
+  }
+  export interface ProducerRecord {
+    topic: string;
+    messages: Message[];
+  }
+  export interface Producer {
+    connect(): Promise<void>;
+    send(record: ProducerRecord): Promise<void>;
+  }
+  export interface Admin {
+    connect(): Promise<void>;
+    createTopics(config: { topics: { topic: string }[] }): Promise<boolean>;
+  }
+  export class Kafka {
+    constructor(config: { clientId: string; brokers: string[] });
+    producer(): Producer;
+    admin(): Admin;
+  }
+}
+
+// nats.js stub — nc.publish (publish, orphan) + JSONCodec encode.
+declare module "nats" {
+  export interface Codec<T> {
+    encode(value: T): Uint8Array;
+    decode(data: Uint8Array): T;
+  }
+  export function JSONCodec<T = unknown>(): Codec<T>;
+  export interface NatsConnection {
+    publish(subject: string, payload: Uint8Array): void;
+    drain(): Promise<void>;
+  }
+  export function connect(opts: { servers: string }): Promise<NatsConnection>;
+}

--- a/tests/fixtures/xrepo-corpus-2/billing-svc/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-2/billing-svc/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-2/expected-output.json
+++ b/tests/fixtures/xrepo-corpus-2/expected-output.json
@@ -1,0 +1,109 @@
+{
+  "matches": [
+    {
+      "producer_repo": "notifications-svc",
+      "producer_key": "pubsub|order.placed",
+      "consumer_repo": "orders-engine",
+      "consumer_key": "pubsub|order.placed",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "pubsub",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "notifications-svc",
+      "producer_key": "pubsub|order.placed",
+      "consumer_repo": "billing-svc",
+      "consumer_key": "pubsub|order.placed",
+      "type_compatible": false,
+      "mismatch_reason": "publisher billing OrderPlaced.total is number but subscriber OrderPlacedEvent.total is { amountCents: number; currency: string } (payload-shape mismatch)",
+      "protocol": "pubsub",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "notifications-svc",
+      "producer_key": "pubsub|user.registered",
+      "consumer_repo": "analytics-worker",
+      "consumer_key": "pubsub|user.registered",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "pubsub",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "web-dashboard",
+      "producer_key": "pubsub|metrics.page_view",
+      "consumer_repo": "analytics-worker",
+      "consumer_key": "pubsub|metrics.page_view",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "pubsub",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "orders-engine",
+      "producer_key": "graphql|query|order",
+      "consumer_repo": "web-dashboard",
+      "consumer_key": "graphql|query|order",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "graphql",
+      "tier": "roadmap"
+    },
+    {
+      "producer_repo": "orders-engine",
+      "producer_key": "graphql|subscription|orderEvents",
+      "consumer_repo": "web-dashboard",
+      "consumer_key": "graphql|subscription|orderEvents",
+      "type_compatible": false,
+      "mismatch_reason": "consumer OrderEvent.kind allows \"cancelled\" but producer only emits \"placed\" | \"shipped\" (missing union member)",
+      "protocol": "graphql",
+      "tier": "roadmap"
+    },
+    {
+      "producer_repo": "notifications-svc",
+      "producer_key": "http|GET|/notifications/:param",
+      "consumer_repo": "web-dashboard",
+      "consumer_key": "http|GET|/notifications/:param",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "http",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "analytics-worker",
+      "producer_key": "http|POST|/track",
+      "consumer_repo": "web-dashboard",
+      "consumer_key": "http|POST|/track",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "http",
+      "tier": "capability"
+    }
+  ],
+  "orphans": [
+    { "repo": "orders-engine", "side": "producer", "key": "graphql|mutation|cancelOrder", "tier": "roadmap" },
+    { "repo": "notifications-svc", "side": "producer", "key": "http|GET|/health", "tier": "capability" },
+    { "repo": "billing-svc", "side": "consumer", "key": "pubsub|payment.captured", "tier": "capability" },
+    { "repo": "billing-svc", "side": "consumer", "key": "http|POST|/ledger/append", "tier": "capability" }
+  ],
+  "dependency_conflicts": [
+    {
+      "package": "ioredis",
+      "versions": ["4.28.0", "5.3.0"],
+      "severity": "critical",
+      "tier": "capability"
+    }
+  ],
+  "summary": {
+    "total_repos": 5,
+    "producers": 9,
+    "consumers": 10,
+    "matched_edges": 8,
+    "incompatible_edges": 2,
+    "orphan_producers": 2,
+    "orphan_consumers": 2,
+    "decoys_must_not_emit": 3,
+    "matched_edges_by_protocol": { "pubsub": 4, "graphql": 2, "http": 2 }
+  }
+}

--- a/tests/fixtures/xrepo-corpus-2/notifications-svc/carrick.json
+++ b/tests/fixtures/xrepo-corpus-2/notifications-svc/carrick.json
@@ -1,0 +1,3 @@
+{
+  "internalEnvVars": []
+}

--- a/tests/fixtures/xrepo-corpus-2/notifications-svc/expected.json
+++ b/tests/fixtures/xrepo-corpus-2/notifications-svc/expected.json
@@ -1,0 +1,52 @@
+{
+  "endpoints": [
+    {
+      "method": "GET",
+      "path": "/notifications/:id",
+      "owner": "routes",
+      "primary_type_symbol": "Notification",
+      "resolved_type": "{ id: string; message: string; read: boolean; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "GET",
+      "path": "/health",
+      "owner": "routes",
+      "primary_type_symbol": null,
+      "resolved_type": "{ status: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "calls": [],
+  "pubsub_operations": [
+    {
+      "role": "producer",
+      "service": "notifications-svc",
+      "key": "pubsub|order.placed",
+      "topic": "order.placed",
+      "broker": "kafka",
+      "side": "subscriber",
+      "source": "src/kafka/consumer.ts",
+      "primary_type_symbol": "OrderPlacedEvent",
+      "resolved_type": "{ id: string; total: { amountCents: number; currency: string; }; note?: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "producer",
+      "service": "notifications-svc",
+      "key": "pubsub|user.registered",
+      "topic": "user.registered",
+      "broker": "nats",
+      "side": "subscriber",
+      "source": "src/nats/subscriber.ts",
+      "primary_type_symbol": "UserRegisteredEvent",
+      "resolved_type": "{ userId: string; email: string; registeredAt: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "_must_not_emit": []
+}

--- a/tests/fixtures/xrepo-corpus-2/notifications-svc/package.json
+++ b/tests/fixtures/xrepo-corpus-2/notifications-svc/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "notifications-svc",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "fastify": "^4.26.0",
+    "kafkajs": "^2.2.4",
+    "nats": "^2.19.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-2/notifications-svc/src/http/routes.ts
+++ b/tests/fixtures/xrepo-corpus-2/notifications-svc/src/http/routes.ts
@@ -1,0 +1,30 @@
+import fastify from "fastify";
+
+const app = fastify();
+
+// HTTP PRODUCER. Fastify is the framework-agnostic proof point for this corpus
+// (corpus-1 covered Express/NestJS; corpus-2 adds Fastify/Hono).
+
+// Cross-repo contract type for edge 7.
+// Producer here -> web-dashboard consumer expects this same Notification shape.
+export interface Notification {
+  id: string;
+  message: string;
+  read: boolean;
+}
+
+// GET /notifications/:id  — producer for edge 7 (consumer: web-dashboard).
+// Cross-repo key normalises to http|GET|/notifications/:param.
+app.get<Notification>("/notifications/:id", async (request, reply): Promise<Notification> => {
+  const { id } = request.params;
+  return { id, message: "your order shipped", read: false };
+});
+
+// GET /health  — ORPHAN PRODUCER (no consumer in corpus).
+// Inline return-type literal `{ status: string }` — the anchor is the inline
+// object type, not a named symbol (primary_type_symbol = null in ground truth).
+app.get<{ status: string }>("/health", async (_request, _reply): Promise<{ status: string }> => {
+  return { status: "ok" };
+});
+
+export default app;

--- a/tests/fixtures/xrepo-corpus-2/notifications-svc/src/kafka/consumer.ts
+++ b/tests/fixtures/xrepo-corpus-2/notifications-svc/src/kafka/consumer.ts
@@ -1,0 +1,31 @@
+import { Kafka } from "kafkajs";
+import type { OrderPlacedEvent } from "../types/events";
+
+// Pub/sub SUBSCRIBER = contract PRODUCER for `pubsub|order.placed`.
+// Edges 1 (orders-engine, compatible) + 2 (billing-svc, INCOMPATIBLE) both
+// publish this topic; this is the single producer endpoint they join to.
+//
+// Topic-literal-via-const variation (one of the two required call sites):
+// the topic is a `const TOPIC` reference, NOT an inline string literal — it
+// stresses the scanner's const topic-literal resolver. The NATS subscriber
+// (src/nats/subscriber.ts) uses the inline-literal form for contrast.
+const TOPIC = "order.placed";
+
+const kafka = new Kafka({ clientId: "notifications-svc", brokers: ["localhost:9092"] });
+const consumer = kafka.consumer({ groupId: "notifications" });
+
+export async function startOrderConsumer(): Promise<void> {
+  await consumer.connect();
+  // subscribe via the const reference — the topic-literal resolver must follow it.
+  await consumer.subscribe({ topic: TOPIC, fromBeginning: false });
+
+  await consumer.run({
+    eachMessage: async ({ message }) => {
+      // Codec unwrap: Kafka delivers a Buffer; decode to text then JSON.parse
+      // into the subscriber contract type OrderPlacedEvent.
+      const raw = message.value ? message.value.toString("utf8") : "{}";
+      const event = JSON.parse(raw) as OrderPlacedEvent;
+      console.log("order.placed", event.id, event.total.amountCents);
+    },
+  });
+}

--- a/tests/fixtures/xrepo-corpus-2/notifications-svc/src/nats/subscriber.ts
+++ b/tests/fixtures/xrepo-corpus-2/notifications-svc/src/nats/subscriber.ts
@@ -1,0 +1,25 @@
+import { connect, StringCodec } from "nats";
+import type { UserRegisteredEvent } from "../types/events";
+
+// Pub/sub SUBSCRIBER = contract PRODUCER for `pubsub|user.registered`.
+// Edge 3: analytics-worker publishes this topic (compatible). This is the
+// producer endpoint it joins to.
+//
+// Topic-literal INLINE-LITERAL variation (the second of the two required call
+// sites): the subject is passed as a bare string literal `"user.registered"`
+// directly to nc.subscribe(...) — contrast with the const-ref Kafka subscriber.
+//
+// Async-iterator subscribe: `for await (const m of sub)` drains the
+// Subscription's AsyncIterable; NATS delivers a Uint8Array (m.data) decoded
+// via StringCodec then JSON.parse into the contract type.
+export async function startUserConsumer(): Promise<void> {
+  const nc = await connect({ servers: "localhost:4222" });
+  const sc = StringCodec();
+
+  const sub = nc.subscribe("user.registered");
+
+  for await (const m of sub) {
+    const event = JSON.parse(sc.decode(m.data)) as UserRegisteredEvent;
+    console.log("user.registered", event.userId, event.email, event.registeredAt);
+  }
+}

--- a/tests/fixtures/xrepo-corpus-2/notifications-svc/src/types/events.ts
+++ b/tests/fixtures/xrepo-corpus-2/notifications-svc/src/types/events.ts
@@ -1,0 +1,25 @@
+// Subscriber payload contract types — this repo is the CONTRACT PRODUCER
+// for the topics it subscribes to (pub/sub direction rule: subscriber = producer).
+// The cross-repo eval expects these EXACT shapes; they are the join-key answer.
+
+// Nested money object — stresses the codec-unwrap + nested-field compat path.
+// Compatible publisher: orders-engine OrderPlaced.total = { amountCents; currency }.
+// Incompatible publisher: billing-svc OrderPlaced.total = bare number.
+export interface Money {
+  amountCents: number;
+  currency: string;
+}
+
+// Kafka "order.placed" subscriber payload (edges 1 + 2 producer side).
+export interface OrderPlacedEvent {
+  id: string;
+  total: Money;
+  note?: string;
+}
+
+// NATS "user.registered" subscriber payload (edge 3 producer side).
+export interface UserRegisteredEvent {
+  userId: string;
+  email: string;
+  registeredAt: number;
+}

--- a/tests/fixtures/xrepo-corpus-2/notifications-svc/src/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-2/notifications-svc/src/types/stubs.d.ts
@@ -1,0 +1,75 @@
+// Ambient stubs — keep types resolvable without npm install.
+// Just enough surface for the call sites; the scanner reads AST structure.
+
+declare module "kafkajs" {
+  export interface KafkaMessage {
+    // value arrives as a Buffer; subscriber Buffer->JSON.parse unwrap.
+    value: Buffer | null;
+  }
+  export interface EachMessagePayload {
+    topic: string;
+    partition: number;
+    message: KafkaMessage;
+  }
+  export interface ConsumerSubscribeTopic {
+    topic: string;
+    fromBeginning?: boolean;
+  }
+  export interface ConsumerRunConfig {
+    eachMessage: (payload: EachMessagePayload) => Promise<void>;
+  }
+  export interface Consumer {
+    connect(): Promise<void>;
+    subscribe(subscription: ConsumerSubscribeTopic): Promise<void>;
+    run(config: ConsumerRunConfig): Promise<void>;
+  }
+  export interface ConsumerConfig {
+    groupId: string;
+  }
+  export class Kafka {
+    constructor(config: { clientId: string; brokers: string[] });
+    consumer(config: ConsumerConfig): Consumer;
+  }
+}
+
+declare module "nats" {
+  // Subscription is an async-iterable of messages; m.data is a Uint8Array.
+  export interface Msg {
+    subject: string;
+    data: Uint8Array;
+  }
+  export interface Subscription extends AsyncIterable<Msg> {}
+  export interface NatsConnection {
+    subscribe(subject: string): Subscription;
+    close(): Promise<void>;
+  }
+  export function connect(opts?: { servers?: string | string[] }): Promise<NatsConnection>;
+  export interface Codec<T> {
+    encode(d: T): Uint8Array;
+    decode(a: Uint8Array): T;
+  }
+  export function StringCodec(): Codec<string>;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    params: Record<string, string>;
+    query: Record<string, string>;
+    body: unknown;
+  }
+  interface FastifyReply {
+    send(payload?: unknown): FastifyReply;
+    status(code: number): FastifyReply;
+  }
+  type RouteHandler<TReply = unknown> = (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ) => Promise<TReply> | TReply;
+  interface FastifyInstance {
+    get<TReply = unknown>(path: string, handler: RouteHandler<TReply>): this;
+    post<TReply = unknown>(path: string, handler: RouteHandler<TReply>): this;
+    listen(opts: { port: number }): Promise<void>;
+  }
+  function fastify(): FastifyInstance;
+  export = fastify;
+}

--- a/tests/fixtures/xrepo-corpus-2/notifications-svc/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-2/notifications-svc/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-2/orders-engine/expected.json
+++ b/tests/fixtures/xrepo-corpus-2/orders-engine/expected.json
@@ -1,0 +1,65 @@
+{
+  "endpoints": [],
+  "calls": [],
+  "pubsub_operations": [
+    {
+      "role": "consumer",
+      "service": "orders-engine",
+      "key": "pubsub|order.placed",
+      "topic": "order.placed",
+      "broker": "kafka",
+      "side": "publisher",
+      "source": "src/kafka/producer.ts",
+      "primary_type_symbol": "OrderPlaced",
+      "resolved_type": "{ id: string; total: { amountCents: number; currency: string; }; note?: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "graphql_operations": [
+    {
+      "role": "producer",
+      "service": "orders-engine",
+      "key": "graphql|query|order",
+      "kind": "query",
+      "field": "order",
+      "source": "src/schema.builder.ts",
+      "primary_type_symbol": "OrderView",
+      "resolved_type": "{ id: string; total: { amountCents: number; currency: string; }; }",
+      "type_state": "Explicit",
+      "tier": "roadmap"
+    },
+    {
+      "role": "producer",
+      "service": "orders-engine",
+      "key": "graphql|mutation|cancelOrder",
+      "kind": "mutation",
+      "field": "cancelOrder",
+      "source": "src/schema.builder.ts",
+      "primary_type_symbol": "CancelResult",
+      "resolved_type": "{ id: string; cancelled: boolean; }",
+      "type_state": "Explicit",
+      "tier": "roadmap"
+    },
+    {
+      "role": "producer",
+      "service": "orders-engine",
+      "key": "graphql|subscription|orderEvents",
+      "kind": "subscription",
+      "field": "orderEvents",
+      "source": "src/schema.builder.ts",
+      "primary_type_symbol": "OrderEvent",
+      "resolved_type": "{ orderId: string; kind: \"placed\" | \"shipped\"; }",
+      "type_state": "Explicit",
+      "tier": "roadmap"
+    }
+  ],
+  "_must_not_emit": [
+    {
+      "kind": "pubsub",
+      "method": "*",
+      "path": "pubsub|__dlq.retry",
+      "evidence": "src/kafka/dlq.ts: `__dlq.retry` is published AND subscribed within orders-engine (intra-repo dead-letter self-loop). It must not surface as a cross-repo match — no other repo is on this topic and an intra-repo publisher↔subscriber pair is a self-edge, not a contract edge."
+    }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-2/orders-engine/package.json
+++ b/tests/fixtures/xrepo-corpus-2/orders-engine/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "orders-engine",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/main.js"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@pothos/core": "^3.41.0",
+    "graphql": "^16.8.0",
+    "kafkajs": "^2.2.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-2/orders-engine/src/kafka/dlq.ts
+++ b/tests/fixtures/xrepo-corpus-2/orders-engine/src/kafka/dlq.ts
@@ -1,0 +1,35 @@
+// DECOY — intra-repo dead-letter retry loop on `__dlq.retry`.
+//
+// This file BOTH publishes and subscribes to `__dlq.retry` within orders-engine
+// (an internal self-edge). It must NOT surface as a cross-repo match: there is
+// no other repo on this topic, and an intra-repo publisher↔subscriber pair is a
+// self-loop, not a contract edge. Listed in expected.json `_must_not_emit`.
+//
+// Topic-literal variation: inline string literals here (producer.ts uses a
+// `const TOPIC` reference).
+
+import { Kafka } from "kafkajs";
+
+const kafka = new Kafka({ clientId: "orders-engine-dlq", brokers: ["kafka:9092"] });
+
+const dlqProducer = kafka.producer();
+const dlqConsumer = kafka.consumer({ groupId: "orders-engine-dlq" });
+
+// Publish a retry message back onto the internal DLQ topic (inline literal).
+export async function requeue(raw: string): Promise<void> {
+  await dlqProducer.send({
+    topic: "__dlq.retry",
+    messages: [{ value: raw }],
+  });
+}
+
+// Subscribe to the SAME internal topic (inline literal) — intra-repo self-edge.
+export async function drainDlq(): Promise<void> {
+  await dlqConsumer.subscribe({ topic: "__dlq.retry", fromBeginning: true });
+  await dlqConsumer.run({
+    eachMessage: async ({ message }) => {
+      const raw = message.value ? message.value.toString() : "";
+      void raw;
+    },
+  });
+}

--- a/tests/fixtures/xrepo-corpus-2/orders-engine/src/kafka/producer.ts
+++ b/tests/fixtures/xrepo-corpus-2/orders-engine/src/kafka/producer.ts
@@ -1,0 +1,33 @@
+// Kafka PUBLISHER of `order.placed` (edge 1). A publisher is the cross-repo
+// CONSUMER (call) of the topic; the subscriber (notifications-svc) is the
+// contract producer. Cross-repo key = `pubsub|order.placed` (no broker).
+//
+// The payload is wrapped in Envelope<OrderPlaced> at the call site (unwrap
+// stress), but the contract type is the INNER OrderPlaced — that is the
+// resolved_type in expected.json, not the envelope.
+//
+// Topic-literal variation: this site uses a `const TOPIC` reference (the DLQ
+// decoy in dlq.ts uses inline string literals) to stress the literal resolver.
+
+import { Kafka } from "kafkajs";
+import type { OrderPlaced, Envelope } from "../types/order";
+
+const TOPIC = "order.placed";
+
+const kafka = new Kafka({ clientId: "orders-engine", brokers: ["kafka:9092"] });
+const producer = kafka.producer();
+
+export async function publishOrderPlaced(order: OrderPlaced): Promise<void> {
+  const envelope: Envelope<OrderPlaced> = { v: 1, data: order };
+  await producer.send({
+    topic: TOPIC,
+    messages: [{ value: JSON.stringify(envelope) }],
+  });
+}
+
+// Static example payload (analyzable, not run).
+void publishOrderPlaced({
+  id: "ord_1",
+  total: { amountCents: 4999, currency: "EUR" },
+  note: "gift wrap",
+});

--- a/tests/fixtures/xrepo-corpus-2/orders-engine/src/main.ts
+++ b/tests/fixtures/xrepo-corpus-2/orders-engine/src/main.ts
@@ -1,0 +1,24 @@
+// NestJS host bootstrap — runtime host only, carries NO cross-repo edge.
+// Exists so the repo is a believable NestJS application around the Pothos
+// schema (src/schema.builder.ts) and the Kafka publisher (src/kafka/producer.ts).
+// No HTTP routes are registered here, so nothing is extracted from this file.
+
+import { Module } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { schema } from "./schema.builder";
+import { publishOrderPlaced } from "./kafka/producer";
+
+@Module({
+  providers: [],
+})
+class OrdersModule {}
+
+async function bootstrap(): Promise<void> {
+  // Reference the schema + publisher so they are part of the program graph.
+  void schema;
+  void publishOrderPlaced;
+  const app = await NestFactory.create(OrdersModule);
+  await app.listen(3000);
+}
+
+void bootstrap();

--- a/tests/fixtures/xrepo-corpus-2/orders-engine/src/schema.builder.ts
+++ b/tests/fixtures/xrepo-corpus-2/orders-engine/src/schema.builder.ts
@@ -1,0 +1,58 @@
+// Pothos CODE-FIRST GraphQL schema (no SDL file). Root operations:
+//   query order          -> OrderView      (edge 5 PRODUCER, compatible)
+//   mutation cancelOrder -> CancelResult   (ORPHAN producer — no consumer doc)
+//   subscription orderEvents -> OrderEvent (edge 6 PRODUCER, async-generator;
+//                                           INCOMPATIBLE: producer union omits
+//                                           "cancelled" that the consumer expects)
+//
+// Cross-repo keys: graphql|query|order, graphql|mutation|cancelOrder,
+// graphql|subscription|orderEvents. Tagged `roadmap` — code-first Pothos
+// detection is a scanner gap (src/graphql.rs is SDL-/gql-tag-only).
+
+import SchemaBuilder from "@pothos/core";
+import type { OrderView, OrderEvent, CancelResult } from "./types/order";
+
+const builder = new SchemaBuilder();
+
+const OrderViewRef = builder.objectRef<OrderView>("OrderView");
+const OrderEventRef = builder.objectRef<OrderEvent>("OrderEvent");
+const CancelResultRef = builder.objectRef<CancelResult>("CancelResult");
+
+// query order -> OrderView
+builder.queryType({
+  fields: (t) => ({
+    order: t.field({
+      type: OrderViewRef,
+      resolve: (): OrderView => ({
+        id: "ord_1",
+        total: { amountCents: 4999, currency: "EUR" },
+      }),
+    }),
+  }),
+});
+
+// mutation cancelOrder -> CancelResult (ORPHAN producer)
+builder.mutationType({
+  fields: (t) => ({
+    cancelOrder: t.field({
+      type: CancelResultRef,
+      resolve: (): CancelResult => ({ id: "ord_1", cancelled: true }),
+    }),
+  }),
+});
+
+// subscription orderEvents -> OrderEvent (async-generator resolver, edge 6)
+builder.subscriptionType({
+  fields: (t) => ({
+    orderEvents: t.field({
+      type: OrderEventRef,
+      subscribe: async function* (): AsyncIterable<OrderEvent> {
+        yield { orderId: "ord_1", kind: "placed" };
+        yield { orderId: "ord_1", kind: "shipped" };
+      },
+      resolve: (parent: OrderEvent): OrderEvent => parent,
+    }),
+  }),
+});
+
+export const schema = builder.toSchema();

--- a/tests/fixtures/xrepo-corpus-2/orders-engine/src/types/order.ts
+++ b/tests/fixtures/xrepo-corpus-2/orders-engine/src/types/order.ts
@@ -1,0 +1,45 @@
+// Owned domain types for orders-engine — the spec-of-record payload shapes.
+// These EXACT field names are the cross-repo answer key; do not rename.
+
+// Nested money object — shared shape across the order.placed contract.
+export interface Money {
+  amountCents: number;
+  currency: string;
+}
+
+// Kafka `order.placed` publisher payload (edge 1, compatible with the
+// notifications-svc subscriber's OrderPlacedEvent). `note?` is optional.
+export interface OrderPlaced {
+  id: string;
+  total: Money;
+  note?: string;
+}
+
+// Generic transport wrapper around the Kafka payload. The publisher sends an
+// Envelope<OrderPlaced>; the INNER OrderPlaced is the contract type (unwrap
+// stress at the call site — the expected resolved_type is OrderPlaced, not this).
+export interface Envelope<T> {
+  v: number;
+  data: T;
+}
+
+// GraphQL `query order` producer result (edge 5, compatible with web-dashboard).
+export interface OrderView {
+  id: string;
+  total: Money;
+}
+
+// GraphQL `subscription orderEvents` producer payload (edge 6). Discriminated
+// union; producer only emits "placed" | "shipped" (the web-dashboard consumer
+// widens this to include "cancelled" → INCOMPATIBLE, missing-union-member).
+export interface OrderEvent {
+  orderId: string;
+  kind: "placed" | "shipped";
+}
+
+// GraphQL `mutation cancelOrder` producer result (ORPHAN — no consumer doc
+// references it in the corpus).
+export interface CancelResult {
+  id: string;
+  cancelled: boolean;
+}

--- a/tests/fixtures/xrepo-corpus-2/orders-engine/src/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-2/orders-engine/src/types/stubs.d.ts
@@ -1,0 +1,82 @@
+// Ambient stubs — keep types resolvable without npm install.
+// Just enough surface for the call sites in this repo; no node_modules.
+
+// kafkajs — producer.send (publisher) + consumer.subscribe/run (DLQ decoy).
+declare module "kafkajs" {
+  export interface Message {
+    key?: string;
+    value: string | Buffer | null;
+  }
+  export interface ProducerRecord {
+    topic: string;
+    messages: Message[];
+  }
+  export interface Producer {
+    connect(): Promise<void>;
+    send(record: ProducerRecord): Promise<void>;
+  }
+  export interface KafkaMessage {
+    value: Buffer | null;
+  }
+  export interface EachMessagePayload {
+    topic: string;
+    partition: number;
+    message: KafkaMessage;
+  }
+  export interface Consumer {
+    connect(): Promise<void>;
+    subscribe(opts: { topic: string; fromBeginning?: boolean }): Promise<void>;
+    run(opts: {
+      eachMessage: (payload: EachMessagePayload) => Promise<void>;
+    }): Promise<void>;
+  }
+  export class Kafka {
+    constructor(config: { clientId?: string; brokers: string[] });
+    producer(): Producer;
+    consumer(opts: { groupId: string }): Consumer;
+  }
+}
+
+// @pothos/core — code-first schema builder (objectRef + queryType/mutationType/
+// subscriptionType + t.field). Generic params kept loose; resolvers carry the types.
+declare module "@pothos/core" {
+  export interface FieldRef<T> {
+    __type: T;
+  }
+  export interface FieldBuilder<TParent> {
+    field<T>(opts: {
+      type?: unknown;
+      resolve?: (parent: TParent, args: unknown) => T | Promise<T>;
+      subscribe?: (parent: TParent, args: unknown) => AsyncIterable<T>;
+    }): FieldRef<T>;
+  }
+  export interface ObjectRef<T> {
+    implement(opts: {
+      fields: (t: FieldBuilder<T>) => Record<string, unknown>;
+    }): ObjectRef<T>;
+  }
+  export default class SchemaBuilder<Types = unknown> {
+    objectRef<T>(name: string): ObjectRef<T>;
+    queryType(opts: {
+      fields: (t: FieldBuilder<unknown>) => Record<string, unknown>;
+    }): void;
+    mutationType(opts: {
+      fields: (t: FieldBuilder<unknown>) => Record<string, unknown>;
+    }): void;
+    subscriptionType(opts: {
+      fields: (t: FieldBuilder<unknown>) => Record<string, unknown>;
+    }): void;
+    toSchema(): unknown;
+  }
+}
+
+// @nestjs/* — host module/injectable decorators (orders-engine runtime host).
+declare module "@nestjs/common" {
+  export function Module(meta: Record<string, unknown>): ClassDecorator;
+  export function Injectable(): ClassDecorator;
+}
+declare module "@nestjs/core" {
+  export class NestFactory {
+    static create(module: unknown): Promise<{ listen(port: number): Promise<void> }>;
+  }
+}

--- a/tests/fixtures/xrepo-corpus-2/orders-engine/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-2/orders-engine/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-2/web-dashboard/carrick.json
+++ b/tests/fixtures/xrepo-corpus-2/web-dashboard/carrick.json
@@ -1,0 +1,3 @@
+{
+  "internalEnvVars": ["NOTIFICATIONS_URL", "ANALYTICS_URL"]
+}

--- a/tests/fixtures/xrepo-corpus-2/web-dashboard/expected.json
+++ b/tests/fixtures/xrepo-corpus-2/web-dashboard/expected.json
@@ -1,0 +1,68 @@
+{
+  "endpoints": [],
+  "calls": [
+    {
+      "method": "GET",
+      "path": "/notifications/:param",
+      "host_contains": "NOTIFICATIONS_URL",
+      "path_contains": "/notifications/",
+      "import_source": null,
+      "primary_type_symbol": "Notification",
+      "resolved_type": "{ id: string; message: string; read: boolean; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "POST",
+      "path": "/track",
+      "host_contains": "ANALYTICS_URL",
+      "path_contains": "/track",
+      "import_source": null,
+      "primary_type_symbol": "TrackResult",
+      "resolved_type": "{ ok: boolean; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "pubsub_operations": [
+    {
+      "role": "producer",
+      "service": "web-dashboard",
+      "key": "pubsub|metrics.page_view",
+      "topic": "metrics.page_view",
+      "broker": "redis",
+      "side": "subscriber",
+      "source": "lib/realtime.ts",
+      "primary_type_symbol": "PageView",
+      "resolved_type": "{ path: string; userId: string; ts: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "graphql_operations": [
+    {
+      "role": "consumer",
+      "service": "web-dashboard",
+      "key": "graphql|query|order",
+      "kind": "query",
+      "field": "order",
+      "source": "graphql/generated.ts",
+      "primary_type_symbol": "OrderView",
+      "resolved_type": "{ id: string; total: { amountCents: number; currency: string; }; }",
+      "type_state": "Explicit",
+      "tier": "roadmap"
+    },
+    {
+      "role": "consumer",
+      "service": "web-dashboard",
+      "key": "graphql|subscription|orderEvents",
+      "kind": "subscription",
+      "field": "orderEvents",
+      "source": "graphql/generated.ts",
+      "primary_type_symbol": "OrderEvent",
+      "resolved_type": "{ orderId: string; kind: \"placed\" | \"shipped\" | \"cancelled\"; }",
+      "type_state": "Explicit",
+      "tier": "roadmap"
+    }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-2/web-dashboard/graphql/generated.ts
+++ b/tests/fixtures/xrepo-corpus-2/web-dashboard/graphql/generated.ts
@@ -1,0 +1,47 @@
+// Codegen artifact (graphql-codegen TypedDocumentNode preset). NO gql tag — the
+// operations are pre-compiled DocumentNode values carrying their result/variable
+// types in TypedDocumentNode<R, V>. The scanner's gql-tag consumer path
+// (src/graphql.rs) does NOT key on these → edges 5,6 consumer-side are roadmap.
+//
+// The top-level field of each operation is the consumer key:
+//   query GetOrder        -> order       -> graphql|query|order        [edge 5]
+//   subscription OrderEvts -> orderEvents -> graphql|subscription|orderEvents [edge 6]
+
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+
+// Nested money object — compatible with the orders-engine Pothos producer.
+export interface MoneyView {
+  amountCents: number;
+  currency: string;
+}
+
+// Consumer view returned by `query order`. Compatible with the producer
+// OrderView { id; total: { amountCents; currency } }.
+export interface OrderView {
+  id: string;
+  total: MoneyView;
+}
+
+// Consumer view delivered by `subscription orderEvents`. INCOMPATIBLE with the
+// producer: the consumer union admits an EXTRA member "cancelled" that the
+// producer never emits ("placed" | "shipped" only) — missing-union-member
+// widening, a subtler mismatch than a string-vs-number swap.
+export interface OrderEvent {
+  orderId: string;
+  kind: "placed" | "shipped" | "cancelled";
+}
+
+// query order — TypedDocumentNode<{ order: OrderView }, {}> (no variables shape).
+export const OrderDocument: TypedDocumentNode<{ order: OrderView }, {}> = {
+  __resultType: undefined,
+  __variablesType: undefined,
+};
+
+// subscription orderEvents — TypedDocumentNode<{ orderEvents: OrderEvent }, {}>.
+export const OrderEventsDocument: TypedDocumentNode<
+  { orderEvents: OrderEvent },
+  {}
+> = {
+  __resultType: undefined,
+  __variablesType: undefined,
+};

--- a/tests/fixtures/xrepo-corpus-2/web-dashboard/lib/api.ts
+++ b/tests/fixtures/xrepo-corpus-2/web-dashboard/lib/api.ts
@@ -1,0 +1,48 @@
+// HTTP consumer for the dashboard. Both calls use ${process.env.*_URL} bases
+// declared internal in carrick.json, so the cross-repo HTTP matcher fires.
+//
+//   GET  ${NOTIFICATIONS_URL}/notifications/:id -> Notification  [edge 7 CONSUMER]
+//   POST ${ANALYTICS_URL}/track                 -> TrackResult   [edge 8 CONSUMER]
+
+const NOTIFICATIONS_BASE = process.env.NOTIFICATIONS_URL ?? "";
+const ANALYTICS_BASE = process.env.ANALYTICS_URL ?? "";
+
+// Compatible with the notifications-svc Fastify producer Notification type.
+export interface Notification {
+  id: string;
+  message: string;
+  read: boolean;
+}
+
+// Request body for POST /track (compatible with the analytics-worker producer).
+export interface TrackRequest {
+  path: string;
+  userId: string;
+}
+
+// Compatible with the analytics-worker Hono producer TrackResult type.
+export interface TrackResult {
+  ok: boolean;
+}
+
+// GET /notifications/:id — fetch one notification from notifications-svc.
+export async function fetchNotification(id: string): Promise<Notification> {
+  const res = await fetch(`${NOTIFICATIONS_BASE}/notifications/${id}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch notification ${id}: ${res.status}`);
+  }
+  return res.json() as Promise<Notification>;
+}
+
+// POST /track — record a page view via analytics-worker.
+export async function track(body: TrackRequest): Promise<TrackResult> {
+  const res = await fetch(`${ANALYTICS_BASE}/track`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to track: ${res.status}`);
+  }
+  return res.json() as Promise<TrackResult>;
+}

--- a/tests/fixtures/xrepo-corpus-2/web-dashboard/lib/gqlClient.ts
+++ b/tests/fixtures/xrepo-corpus-2/web-dashboard/lib/gqlClient.ts
@@ -1,0 +1,38 @@
+// GraphQL consumer over graphql-ws using TypedDocumentNode codegen documents.
+//
+// Both edges are CONSUMER side (web-dashboard consumes the orders-engine Pothos
+// schema). They are tagged `roadmap`: the scanner detects gql-tagged templates,
+// not TypedDocumentNode exports + wsClient.subscribe(payload, sink), so neither
+// the document detection nor the result-type anchor join fires today (#268-class
+// gap generalized to graphql-ws).
+//
+//   client.query({ query: OrderDocument })            -> graphql|query|order        [edge 5]
+//   wsClient.subscribe({ query: OrderEventsDocument }) -> graphql|subscription|orderEvents [edge 6]
+
+import { createClient } from "graphql-ws";
+import { OrderDocument, OrderEventsDocument } from "../graphql/generated";
+import type { OrderView, OrderEvent } from "../graphql/generated";
+
+const GQL_WS_URL = process.env.GATEWAY_GQL_WS_URL ?? "";
+const wsClient = createClient({ url: GQL_WS_URL });
+
+// query order — one-shot over the ws client; result type rides on OrderDocument.
+export async function fetchOrder(): Promise<OrderView> {
+  const res = await wsClient.query<{ order: OrderView }>({
+    query: OrderDocument,
+  });
+  return res.data.order;
+}
+
+// subscription orderEvents — streaming consumer. The sink receives OrderEvent,
+// whose `kind` union includes "cancelled" (the incompatible extra member).
+export function onOrderEvents(handler: (e: OrderEvent) => void): () => void {
+  return wsClient.subscribe<{ orderEvents: OrderEvent }>(
+    { query: OrderEventsDocument },
+    {
+      next: (value) => handler(value.orderEvents),
+      error: () => {},
+      complete: () => {},
+    }
+  );
+}

--- a/tests/fixtures/xrepo-corpus-2/web-dashboard/lib/realtime.ts
+++ b/tests/fixtures/xrepo-corpus-2/web-dashboard/lib/realtime.ts
@@ -1,0 +1,31 @@
+// Redis pub/sub SUBSCRIBER (ioredis). In Carrick's pub/sub model a subscriber is
+// the contract PRODUCER (endpoint) of the topic it receives, mirroring the
+// socket-listener-as-producer rule. So web-dashboard owns the producer side of
+// `pubsub|metrics.page_view`; the matching consumer (call) is analytics-worker's
+// redis.publish. Both meet on the topic literal, NOT on a connection URL — so no
+// internalEnvVars entry is needed for this edge.
+//
+//   sub.subscribe('metrics.page_view') + sub.on('message', JSON.parse) -> pubsub|metrics.page_view [edge 4 PRODUCER]
+
+import Redis from "ioredis";
+
+const REDIS_URL = process.env.REDIS_URL ?? "";
+const sub = new Redis(REDIS_URL);
+
+// Subscriber payload — compatible with the analytics-worker publisher PageView.
+export interface PageView {
+  path: string;
+  userId: string;
+  ts: number;
+}
+
+// Subscribe to the page-view stream and decode each message body.
+// inline topic literal 'metrics.page_view' (web-dashboard's single pub/sub site;
+// the const-vs-inline literal variation is exercised on the broker repos).
+export function onPageView(handler: (view: PageView) => void): void {
+  sub.subscribe("metrics.page_view");
+  sub.on("message", (_channel: string, message: string) => {
+    const view = JSON.parse(message) as PageView;
+    handler(view);
+  });
+}

--- a/tests/fixtures/xrepo-corpus-2/web-dashboard/package.json
+++ b/tests/fixtures/xrepo-corpus-2/web-dashboard/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "web-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@graphql-typed-document-node/core": "^3.2.0",
+    "graphql": "^16.8.0",
+    "graphql-ws": "^5.16.0",
+    "ioredis": "4.28.0",
+    "next": "14.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.4.0"
+  },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-2/web-dashboard/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-2/web-dashboard/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/tests/fixtures/xrepo-corpus-2/web-dashboard/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-2/web-dashboard/types/stubs.d.ts
@@ -1,0 +1,45 @@
+// Ambient stubs — keep the TypedDocumentNode + graphql-ws + ioredis consumer
+// types resolvable without npm install (mirrors corpus-1's *.d.ts convention).
+
+// @graphql-typed-document-node/core: a codegen artifact carries the operation's
+// result (R) and variables (V) types in the document's phantom type parameters.
+// No gql tag is involved — generated.ts exports plain TypedDocumentNode values.
+declare module "@graphql-typed-document-node/core" {
+  export interface TypedDocumentNode<Result = unknown, Variables = unknown> {
+    readonly __resultType?: Result;
+    readonly __variablesType?: Variables;
+  }
+}
+
+// graphql-ws: the WebSocket subscription client used by lib/gqlClient.ts.
+declare module "graphql-ws" {
+  export interface Sink<T = unknown> {
+    next(value: T): void;
+    error(err: unknown): void;
+    complete(): void;
+  }
+  export interface SubscribePayload {
+    query: unknown;
+    variables?: unknown;
+  }
+  export interface Client {
+    // Non-graphql-request shape: a document object + a sink callback.
+    subscribe<T = unknown>(payload: SubscribePayload, sink: Sink<T>): () => void;
+    // A request-style query helper used for one-shot operations.
+    query<T = unknown>(payload: SubscribePayload): Promise<{ data: T }>;
+  }
+  export function createClient(options: { url: string }): Client;
+}
+
+// ioredis: dual-use client — pub/sub (subscribe/on 'message') AND key-value
+// (set/get). lib/realtime.ts uses the pub/sub path; only that is a contract.
+declare module "ioredis" {
+  export default class Redis {
+    constructor(url?: string);
+    subscribe(...channels: string[]): Promise<number>;
+    on(event: "message", handler: (channel: string, message: string) => void): this;
+    publish(channel: string, message: string): Promise<number>;
+    set(key: string, value: string): Promise<"OK">;
+    get(key: string): Promise<string | null>;
+  }
+}


### PR DESCRIPTION
## What

A second authored accuracy corpus — the **event-driven dual** of corpus-1 — centered on a new **pub/sub family** protocol (Kafka + Redis pub/sub + NATS), keyed on topic (subscriber = contract producer, publisher = consumer).

**5 stubbed repos:** notifications-svc (Fastify), orders-engine (NestJS + Pothos), analytics-worker (Hono), web-dashboard (TypedDocumentNode + graphql-ws), billing-svc (Express).

**Constellation:** 8 matched edges (4 pubsub, 2 graphql, 2 http), 2 incompatible (Kafka payload-shape + graphql union-member), 4 orphans, 3 decoys, and an `ioredis` 4.x-vs-5.x major-incompatible dep conflict. Fan-in (2 publishers → 1 subscriber on `order.placed`) + fan-out proves TOPIC is the join key independent of repo count.

**Tiers:** code-first Pothos producer + TypedDocumentNode/graphql-ws consumer are `roadmap` (partitioned out of the headline — they're detection cliffs for a separate program). Fastify/Hono HTTP stay `capability` as framework-agnostic proof.

## Scorer delta (additive only)

`ExpectedRepo` gains a `pubsub_operations` array (`Vec<ExpNonHttpOp>`, same role/key convention as graphql/socket), chained into the producer/consumer/anchor folds exactly like `socket_events`. `norm_key` pins the 2-segment `pubsub|<topic>` contract. New ungated `corpus_expected_files_parse` test verifies every corpus's `expected.json` deserializes.

## Phasing

Pre-slice the pub/sub dims score **0** (no `pubsub` protocol yet) — this corpus is the forward-looking validation surface the pub/sub family slice drives to 90%. HTTP + dep + orphans pass on existing machinery.

**Logged limitation:** `score_decoy_leak` is HTTP-only, so the 3 pub/sub decoys are documented in the README but not yet counted (non-HTTP decoy scoring is a slice follow-up).

## Verification

Full debug suite green incl. cassette hard gate; `corpus_expected_files_parse` passes for both corpus-1 (default) and `CARRICK_EVAL_CORPUS=xrepo-corpus-2` (all 5 expected.json + expected-output.json deserialize). Stacked on #281 (harness parameterization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)