### PR TITLE
feat(pubsub): structural multi-broker idiom-teaching + sanitize pubsub ops

### DIFF
--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -609,6 +609,25 @@ impl FileAnalyzerAgent {
             }
         }
 
+        // Sanitize pub/sub operations (#283): trim/normalize the topic, payload
+        // type symbol, and its import source the same way data_calls are handled.
+        for op in &mut result.pubsub_operations {
+            let trimmed_topic = op.topic.trim();
+            if trimmed_topic != op.topic.as_str() {
+                op.topic = trimmed_topic.to_string();
+            }
+            normalize_optional_string(&mut op.primary_type_symbol);
+            if normalize_import_source(&mut op.type_import_source) {
+                needs_retry = true;
+            }
+            if let Some(ref symbol) = op.primary_type_symbol
+                && !is_valid_identifier(symbol)
+            {
+                op.primary_type_symbol = None;
+            }
+            normalize_optional_string(&mut op.broker);
+        }
+
         needs_retry
     }
 

--- a/src/agents/schemas.rs
+++ b/src/agents/schemas.rs
@@ -444,12 +444,12 @@ impl AgentSchemas {
                         "properties": {
                             "topic": {
                                 "type": "STRING",
-                                "description": "The exact topic or channel name the operation targets, as a literal string (e.g., 'metrics.page_view'). Copy it verbatim from the source; skip operations whose topic is a runtime variable with no literal value."
+                                "description": "The named topic, channel, or subject the message flows over, as a literal string (e.g., 'metrics.page_view'). This is the first string argument to a publish/subscribe call or the `topic` property in its options object. Copy it verbatim from the source; skip operations whose topic is a runtime variable with no literal value."
                             },
                             "role": {
                                 "type": "STRING",
                                 "enum": ["subscriber", "publisher"],
-                                "description": "subscriber when the code registers a handler that receives messages on the topic; publisher when the code sends a message to the topic."
+                                "description": "A pub/sub operation moves a payload over a named topic/channel/subject. Use `publisher` when the code SENDS a payload to a named topic — for example `producer.send({ topic, messages: [{ value }] })`, `redis.publish(channel, payload)`, or `nc.publish(subject, data)`. Use `subscriber` when the code REGISTERS a handler for (or iterates messages on) a named topic — for example `consumer.subscribe({ topic })` paired with `consumer.run({ eachMessage })`, `sub.subscribe(channel)` paired with `sub.on('message', ...)`, or `nc.subscribe(subject)` consumed with `for await`. These three libraries are only examples of the shape; recognize the same send-to-topic / handle-from-topic shape for any messaging client. Ignore non-pub/sub calls on the same libraries (a key-value `get`/`set`, an admin `createTopics`, or a `request`/reply round-trip are not publish or subscribe)."
                             },
                             "line_number": {
                                 "type": "INTEGER",
@@ -458,7 +458,7 @@ impl AgentSchemas {
                             "primary_type_symbol": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "The named type of the message payload as a bare identifier (e.g., 'PageViewEvent'). Unwrap arrays and promise wrappers down to the core identifier. Null for untyped or inline-object payloads."
+                                "description": "The named type of the DECODED application payload as a bare identifier (e.g., 'PageViewEvent') — the `T` the subscriber parses each message into, or the type of the value handed to a publish call. Use the decoded application type, NOT the wire type (`Buffer`, `string`, `Uint8Array`) and NOT an envelope/wrapper around it. Unwrap arrays and promise wrappers down to the core identifier. Null for untyped or inline-object payloads."
                             },
                             "type_import_source": {
                                 "type": "STRING",


### PR DESCRIPTION
## What

Strengthen the `pubsub_operations` idiom-teaching so the file-analyzer reliably recognizes publish/subscribe across **Kafka + Redis + NATS** — all in the **public** schema descriptions (zero cloud deploy), taught by **call shape, not a broker-name allowlist** (framework-agnostic):
- PUBLISH = sends a payload to a named topic/channel/subject → `publisher`; SUBSCRIBE = registers a handler / iterates messages for a topic → `subscriber`. The three brokers are examples of the shape; the model is told to generalize.
- `primary_type_symbol` = the **decoded application payload** type (not Buffer/string/Uint8Array, not the envelope).
- Explicitly ignore non-pub/sub uses of the same libs (Redis `get`/`set`, Kafka `admin().createTopics`, NATS `request`/reply).

Also routes `pubsub_operations` through `sanitize_result` (addresses Copilot #283: trims topic, identifier-guards the symbol, normalizes the import source).

## Why

The PR-3 idiom-teaching was too sparse: the live eval showed Redis extracted *inconsistently* and Kafka/NATS *never* (match recall stuck at 0.33–0.50). This targets that dominant gap.

## Note

The user-message idiom block (the stronger lever, per the graphql precedent) was **deliberately not added**: an unconditional block breaks the Vertex prefix-cache byte-identity invariant, and gating it would need a broker-name allowlist the anti-overfit guardrail forbids. If the live eval shows Kafka/NATS still underdeliver, the follow-up is a deploy-gated `system_prompt.txt` block in carrick-cloud (owner-deployed) — flagged, not built.

## Verification

Full debug suite green incl. cassette hard gate; lib 464 tests; prompt-leak-guard count unchanged; only the two extraction-path files changed. Extraction improvement is live-eval-measurable; run dispatched.

Stacked on #284 → #283 → #282 → #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)