### PR TITLE
feat(pubsub): resolve payload types via SymbolRequest bundle (resolution dim)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1137,6 +1137,90 @@ impl FileOrchestrator {
         requests
     }
 
+    /// Build `SymbolRequest`s for pub/sub decoded-payload anchors (#corpus-2
+    /// resolution dim).
+    ///
+    /// Sibling of `collect_socket_type_requests`, but reads the LLM-sourced
+    /// `pubsub_operations` out of `file_results` rather than the deterministic
+    /// `ProtocolExtractions` struct — pub/sub ops never go through the
+    /// deterministic protocol extractors, so this walks the exact same source
+    /// `append_pubsub_manifest_entries` walks. Each op carrying a
+    /// `primary_type_symbol` routes that decoded-payload type through the *same*
+    /// sidecar bundle path the Socket.IO and HTTP explicit-symbol cases use, so
+    /// the sidecar expands it into the entry's `resolved_type`. Subscribers are
+    /// producers, publishers are consumers; each resolves to the Response-kind
+    /// alias.
+    ///
+    /// The alias MUST be `build_manifest_type_alias(&key, role, Response)` —
+    /// byte-identical to the alias `add_protocol_manifest_entry` stamps on the
+    /// manifest entry in `append_pubsub_manifest_entries` (same `OperationKey`,
+    /// same role mapping, same kind) — or the resolved `.d.ts` never joins back
+    /// and the entry stays `Unknown`. This contract is guarded by a unit test.
+    ///
+    /// Only ops whose extractor captured a `primary_type_symbol` produce a
+    /// request; a `None` symbol (untyped or inline-object payload) emits nothing,
+    /// exactly like socket. A roleless op anchors nothing and is skipped (it was
+    /// already dropped from `cloud_data` and has no manifest entry to join to).
+    /// An absent `type_import_source` means the symbol is declared in the op's
+    /// own file, so it resolves against that file's absolute path.
+    pub fn collect_pubsub_type_requests(
+        &self,
+        file_results: &HashMap<String, FileAnalysisResult>,
+        repo_path: &str,
+    ) -> Vec<SymbolRequest> {
+        use crate::operation::{OperationKey, PubsubRole};
+
+        let repo_root = std::path::Path::new(repo_path);
+        let repo_root_absolute = if repo_root.is_absolute() {
+            repo_root.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(repo_root))
+                .unwrap_or_else(|_| repo_root.to_path_buf())
+                .canonicalize()
+                .unwrap_or_else(|_| repo_root.to_path_buf())
+        };
+
+        let mut requests: Vec<SymbolRequest> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        for (path, result) in file_results {
+            for op in &result.pubsub_operations {
+                // Mirror the manifest-side role mapping in
+                // `append_pubsub_manifest_entries`: subscriber = producer,
+                // publisher = consumer; a roleless op anchors nothing.
+                let role = match op.role {
+                    Some(PubsubRole::Subscriber) => ManifestRole::Producer,
+                    Some(PubsubRole::Publisher) => ManifestRole::Consumer,
+                    None => continue,
+                };
+                let Some(symbol) = op.primary_type_symbol.as_ref() else {
+                    continue;
+                };
+                let file_abs = Self::to_absolute_path(path, &repo_root_absolute);
+                let source_file = match op.type_import_source.as_ref() {
+                    Some(import_source) => Self::resolve_import_path(&file_abs, import_source),
+                    // No import → same-file declaration: resolve against the file.
+                    None => file_abs,
+                };
+                let key = OperationKey::pubsub(op.topic.clone());
+                let alias = build_manifest_type_alias(&key, role, ManifestTypeKind::Response);
+                let dedup_key = format!("{}|{}|{}", source_file, symbol, alias);
+                if seen.insert(dedup_key) {
+                    requests.push(SymbolRequest {
+                        symbol_name: symbol.clone(),
+                        source_file,
+                        alias: Some(alias),
+                    });
+                }
+            }
+        }
+        debug!(
+            "[FileOrchestrator] Collected {} pub/sub payload type requests",
+            requests.len()
+        );
+        requests
+    }
+
     /// Build `SymbolRequest`s for GraphQL consumer result-type anchors (#248
     /// consumer side).
     ///

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1025,6 +1025,12 @@ async fn analyze_current_repo_incremental(
                 file_orchestrator
                     .collect_graphql_type_requests(&protocol_extractions.graphql, repo_path),
             );
+            // Pub/sub ops are LLM-sourced in `merged_results`, not in the
+            // deterministic `protocol_extractions`, so their payload anchors
+            // bundle through the same path (#corpus-2 resolution dim).
+            protocol_requests.extend(
+                file_orchestrator.collect_pubsub_type_requests(&merged_results, repo_path),
+            );
 
             // GraphQL producers take the infer path, not the bundle path: their
             // response contract is the resolver's expanded RETURN type, so they
@@ -2393,6 +2399,13 @@ async fn analyze_current_repo(
         file_orchestrator.collect_socket_type_requests(&protocol_extractions.sockets, repo_path);
     protocol_requests.extend(
         file_orchestrator.collect_graphql_type_requests(&protocol_extractions.graphql, repo_path),
+    );
+    // Pub/sub ops are LLM-sourced in `analysis_result.file_results`, not in the
+    // deterministic `protocol_extractions`, so their payload anchors bundle
+    // through the same path (#corpus-2 resolution dim).
+    protocol_requests.extend(
+        file_orchestrator
+            .collect_pubsub_type_requests(&analysis_result.file_results, repo_path),
     );
 
     // GraphQL producers take the infer path, not the bundle path: their response
@@ -4420,6 +4433,61 @@ mod tests {
         let expected = crate::type_manifest::build_manifest_type_alias(
             &emitter.key,
             ManifestRole::Consumer,
+            ManifestTypeKind::Response,
+        );
+        assert_eq!(manifest_alias, expected);
+        assert_eq!(request.alias.as_deref(), Some(expected.as_str()));
+    }
+
+    /// The same fragile alias contract for pub/sub (PR-6, corpus-2 resolution dim):
+    /// the SymbolRequest alias produced by `collect_pubsub_type_requests` MUST
+    /// byte-match the manifest entry's alias from `append_pubsub_manifest_entries`,
+    /// or the resolved payload `.d.ts` never joins back and the op stays
+    /// `Unknown` — silently. A subscriber is the producer side.
+    #[test]
+    fn pubsub_symbol_request_alias_matches_manifest_alias() {
+        use crate::operation::PubsubRole;
+
+        let mut file_results: HashMap<String, FileAnalysisResult> = HashMap::new();
+        file_results.insert(
+            "web-dashboard/lib/realtime.ts".to_string(),
+            FileAnalysisResult {
+                pubsub_operations: vec![pubsub_op(
+                    "metrics.page_view",
+                    PubsubRole::Subscriber,
+                    Some("PageView"),
+                    Some("./types/metrics"),
+                )],
+                ..Default::default()
+            },
+        );
+
+        let mut entries = Vec::new();
+        append_pubsub_manifest_entries(&mut entries, &file_results);
+        let manifest_alias = entries
+            .iter()
+            .find(|e| e.key.canonical() == "pubsub|metrics.page_view")
+            .map(|e| e.type_alias.clone())
+            .expect("pubsub manifest entry");
+
+        let orchestrator = FileOrchestrator::new(AgentService::new());
+        let requests = orchestrator.collect_pubsub_type_requests(&file_results, ".");
+        let request = requests
+            .iter()
+            .find(|r| r.symbol_name == "PageView")
+            .expect("pubsub SymbolRequest");
+
+        assert_eq!(
+            request.alias.as_deref(),
+            Some(manifest_alias.as_str()),
+            "pubsub SymbolRequest.alias must byte-match the manifest entry's alias \
+             or the resolution enrich-join silently breaks"
+        );
+        // Independently confirm both equal the canonical builder output
+        // (subscriber = producer side).
+        let expected = crate::type_manifest::build_manifest_type_alias(
+            &OperationKey::pubsub("metrics.page_view"),
+            ManifestRole::Producer,
             ManifestTypeKind::Response,
         );
         assert_eq!(manifest_alias, expected);


### PR DESCRIPTION
## What

Add `collect_pubsub_type_requests`, mirroring the Socket.IO resolution path: each pub/sub op emits a `SymbolRequest` whose `alias` **byte-matches its manifest entry's alias**, so the sidecar expands the decoded-payload type into the full `resolved_type` and the **resolution** dimension scores pub/sub ops (instead of leaving them anchored-but-unexpanded). Wired at both the incremental and full-analysis sites.

## Why

After PR #284 (anchor) the pub/sub anchor recovered to 1.00 but `resolution` stayed stuck at ~0.32 on the live eval — the payload symbol was present but the sidecar wasn't expanding it because no SymbolRequest fed it through the bundle path. This closes that gap.

## Verification

- **Deterministic contract test** `pubsub_symbol_request_alias_matches_manifest_alias`: asserts the SymbolRequest alias byte-matches the manifest entry alias (both = `build_manifest_type_alias(key, Producer, Response)`) — the fragile invariant the whole resolution join hinges on. This is the offline proof.
- Full debug suite green incl. cassette hard gate; no regressions; only `engine/mod.rs` + `file_orchestrator.rs` changed.
- Resolution-dimension recovery is **live-eval-measurable** (offline mock can't emit `pubsub_operations` + the sidecar needs real type files); run dispatched.

Stacked on #285 → #284 → #283 → #282 → #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)