### PR TITLE
feat(pubsub): cross-repo compat verdicts (ts_check inverted direction)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -228,12 +228,15 @@ pub fn filter_graphql_libraries(data_fetchers: &[String]) -> Vec<String> {
 
 /// Parse a ts_check compat `endpoint` string back into the verdict-join
 /// `(pseudo-method, identity)` pair. ts_check builds the string as
-/// `"<METHOD> <path> (<request|response>)"` for HTTP and
-/// `"SOCKET <DIRECTION>|<event> (response)"` for socket, so the same split —
-/// leading token off the front, trailing `" (type_kind)"` off the back — yields
-/// `("METHOD", "path")` or `("SOCKET", "DIRECTION|event")`, matching what
-/// `parse_producer_key` recovers from the edge's `producer_key`. Returns `None`
-/// for an unrecognized shape.
+/// `"<METHOD> <path> (<request|response>)"` for HTTP,
+/// `"SOCKET <DIRECTION>|<event> (response)"` for socket, and
+/// `"PUBSUB <topic> (response)"` for pub/sub, so the same split — leading token
+/// off the front, trailing `" (type_kind)"` off the back — yields
+/// `("METHOD", "path")`, `("SOCKET", "DIRECTION|event")`, or
+/// `("PUBSUB", "topic")`, matching what `parse_producer_key` recovers from the
+/// edge's `producer_key`. The pub/sub topic carries no path params (and no
+/// nested `|`), so the generic split needs no protocol-specific arm. Returns
+/// `None` for an unrecognized shape.
 fn parse_compat_endpoint(endpoint: &str) -> Option<(String, String)> {
     let (method, rest) = endpoint.split_once(' ')?;
     // Drop the trailing " (request)" / " (response)" annotation if present.
@@ -248,7 +251,8 @@ fn parse_compat_endpoint(endpoint: &str) -> Option<(String, String)> {
 }
 
 /// Recover the verdict-join `(pseudo-method, identity)` from a canonical
-/// producer key, for the protocols ts_check type-checks (HTTP + socket + graphql):
+/// producer key, for the protocols ts_check type-checks
+/// (HTTP + socket + graphql + pub/sub):
 ///
 /// - HTTP (`"http|METHOD|path"`) → `("METHOD", "path")`, the HTTP join key.
 /// - Socket (`"socket|DIRECTION|event"`) → `("SOCKET", "DIRECTION|event")`. The
@@ -261,6 +265,14 @@ fn parse_compat_endpoint(endpoint: &str) -> Option<(String, String)> {
 ///   joins its verdict exactly like socket. The `KIND` (`query`/`mutation`/
 ///   `subscription`) stays lowercase here AND in the ts_check label, so the two
 ///   sides agree without any case folding.
+/// - Pub/Sub (`"pubsub|topic"`) → `("PUBSUB", "topic")`. Unlike the other three
+///   this canonical is 2-segment (topic-only; the broker is not part of
+///   identity), so the third `splitn(3, '|')` field is `None`. The matching
+///   ts_check endpoint label is `"PUBSUB topic (response)"`, which
+///   `parse_compat_endpoint` reduces to the SAME pair, so a pub/sub edge joins
+///   its verdict exactly like socket. (A topic literally containing `|` would
+///   mis-split, but both sides split identically so the exact-topic match still
+///   holds; topics with `|` are pathological and left unguarded.)
 ///
 /// Returns `None` for any other protocol: ts_check produced no verdict for it,
 /// so its edge stays `None` rather than fabricating one.
@@ -277,6 +289,9 @@ fn parse_producer_key(key: &str) -> Option<(String, String)> {
         }
         (Some("graphql"), Some(kind), Some(field)) if !kind.is_empty() && !field.is_empty() => {
             Some(("GRAPHQL".to_string(), format!("{}|{}", kind, field)))
+        }
+        (Some("pubsub"), Some(topic), None) if !topic.is_empty() => {
+            Some(("PUBSUB".to_string(), topic.to_string()))
         }
         _ => None,
     }
@@ -3540,6 +3555,85 @@ mod tests {
         assert_eq!(
             matches[1].mismatch_reason.as_deref(),
             Some("note?: optional producer field is not assignable to required consumer field"),
+        );
+    }
+
+    /// Pub/sub canonical keys are 2-segment (`pubsub|<topic>`, broker excluded
+    /// from identity), so the third `splitn(3, '|')` field is `None`.
+    /// `parse_producer_key` must still recover `("PUBSUB", "<topic>")`, and a
+    /// round-trip through the ts_check endpoint label (`PUBSUB <topic>
+    /// (response)`) must yield the SAME pair so a pub/sub verdict joins its edge.
+    /// A topic carries no path params, so `normalize_compat_path` leaves it
+    /// unchanged — guarding a future param-collapse refactor from silently
+    /// breaking the pub/sub join.
+    #[test]
+    fn parse_producer_key_recovers_pubsub_pair() {
+        assert_eq!(
+            parse_producer_key("pubsub|order.placed"),
+            Some(("PUBSUB".to_string(), "order.placed".to_string())),
+        );
+        // Round-trip through the ts_check endpoint label yields the same pair.
+        assert_eq!(
+            parse_compat_endpoint("PUBSUB order.placed (response)"),
+            parse_producer_key("pubsub|order.placed"),
+        );
+        // Empty topic → no join key, edge stays None.
+        assert_eq!(parse_producer_key("pubsub|"), None);
+        // A topic with dots/no slashes is unaffected by the HTTP path-param
+        // collapse, so the two sides of the join still agree.
+        assert_eq!(normalize_compat_path("order.placed"), "order.placed");
+    }
+
+    /// The pub/sub cross-repo join. A `pubsub|<topic>` edge is type-checked by
+    /// ts_check on the Socket.IO inverted direction (subscriber=producer accepts
+    /// what publisher=consumer sends); ts_check emits its verdict under the
+    /// endpoint label `"PUBSUB <topic> (response)"`. `parse_producer_key`
+    /// recovers `("PUBSUB", "<topic>")` from the edge and `parse_compat_endpoint`
+    /// recovers the SAME pair from the label, so the verdict lands on the
+    /// pub/sub edge — `Some(true)` when compatible, `Some(false)` + reason on a
+    /// reported mismatch (the incompatible Kafka `order.placed` edge).
+    #[test]
+    fn apply_compat_verdicts_joins_pubsub_edge() {
+        let result = serde_json::json!({
+            "mismatches": [{
+                "endpoint": "PUBSUB order.placed (response)",
+                "consumerLocation": "orders-svc/src/publisher.ts:42",
+                "error": "Type 'WideOrder' is not assignable to type 'StrictOrder'"
+            }],
+            "unknownPairs": [],
+            "totalChecked": 2,
+            "compatibleCount": 1
+        });
+
+        let mut matches = vec![
+            edge_at(
+                "pubsub|metrics.page_view",
+                "analytics-svc",
+                "analytics-svc/src/track.ts:10",
+            ),
+            edge_at(
+                "pubsub|order.placed",
+                "orders-svc",
+                "orders-svc/src/publisher.ts:42",
+            ),
+        ];
+        apply_compat_verdicts(&result, &mut matches);
+
+        assert_eq!(
+            matches[0].type_compatible,
+            Some(true),
+            "the compatible pub/sub edge (absent from the mismatch list) reads Some(true)"
+        );
+        assert!(matches[0].mismatch_reason.is_none());
+
+        assert_eq!(
+            matches[1].type_compatible,
+            Some(false),
+            "the pub/sub edge in the mismatch list reads Some(false)"
+        );
+        assert_eq!(
+            matches[1].mismatch_reason.as_deref(),
+            Some("Type 'WideOrder' is not assignable to type 'StrictOrder'"),
         );
     }
 

--- a/ts_check/lib/manifest-matcher.ts
+++ b/ts_check/lib/manifest-matcher.ts
@@ -57,14 +57,15 @@ export interface ManifestEntry {
   /**
    * Protocol tag carried by the operation key. ts_check runs the same
    * `TypeCompatibilityChecker` assignability for every protocol it understands:
-   * "http" (matched by method/path), "socket" (matched by event+direction), and
-   * "graphql" (matched by operation kind+field). Other protocols are checked by
-   * their own pipelines and are dropped here.
+   * "http" (matched by method/path), "socket" (matched by event+direction),
+   * "graphql" (matched by operation kind+field), and "pubsub" (matched by
+   * topic). Other protocols are checked by their own pipelines and are dropped
+   * here.
    */
-  protocol: 'http' | 'socket' | 'graphql';
-  /** HTTP method (GET, POST, …). Present on HTTP entries; absent on socket/graphql. */
+  protocol: 'http' | 'socket' | 'graphql' | 'pubsub';
+  /** HTTP method (GET, POST, …). Present on HTTP entries; absent on socket/graphql/pubsub. */
   method?: string;
-  /** API path (e.g., /api/users/:id). Present on HTTP entries; absent on socket/graphql. */
+  /** API path (e.g., /api/users/:id). Present on HTTP entries; absent on socket/graphql/pubsub. */
   path?: string;
   /** Socket event name (e.g. `payment:settled`). Present on socket entries only. */
   event?: string;
@@ -81,6 +82,12 @@ export interface ManifestEntry {
    * only; the field that, with `kind`, identifies the operation.
    */
   field?: string;
+  /**
+   * Pub/sub topic/channel/subject (e.g. `order.placed`). Present on pubsub
+   * entries only; the sole cross-repo identity (the broker is intentionally NOT
+   * part of identity). The Rust canonical key is `pubsub|<topic>`.
+   */
+  topic?: string;
   /** The type alias for this endpoint */
   type_alias: string;
   /** Whether this is a producer or consumer */
@@ -105,15 +112,17 @@ export interface ManifestEntry {
 export interface MatchResult {
   /**
    * The pseudo-method this match is keyed on: the HTTP method for HTTP edges,
-   * or the literal `SOCKET` for socket edges. Combined with `path` it forms the
-   * `endpoint` label the Rust verdict-join parses back (`parse_compat_endpoint`).
+   * the literal `SOCKET` for socket edges, `GRAPHQL` for graphql edges, or
+   * `PUBSUB` for pub/sub edges. Combined with `path` it forms the `endpoint`
+   * label the Rust verdict-join parses back (`parse_compat_endpoint`).
    */
   method: string;
   /**
-   * The identity this match is keyed on: the normalized API path for HTTP, or
-   * the socket canonical `<DIRECTION>|<event>` tail for socket edges (so the
-   * full label `SOCKET <DIRECTION>|<event>` parses back into the same join key
-   * as the Rust `socket|<DIRECTION>|<event>` producer key).
+   * The identity this match is keyed on: the normalized API path for HTTP, the
+   * socket canonical `<DIRECTION>|<event>` tail for socket edges, the graphql
+   * `<kind>|<field>` tail for graphql edges, or the bare `<topic>` for pub/sub
+   * edges (so the full label `PUBSUB <topic>` parses back into the same join key
+   * as the Rust `pubsub|<topic>` producer key).
    */
   path: string;
   /** The type kind being matched */
@@ -276,10 +285,34 @@ export function graphqlKey(entry: ManifestEntry): string | null {
   return `${entry.kind}|${entry.field}`;
 }
 
+// ============================================================================
+// Pub/Sub Identity
+// ============================================================================
+
+/** The pseudo-method pub/sub matches are keyed on, mirroring HTTP's method. */
+export const PUBSUB_PSEUDO_METHOD = 'PUBSUB';
+
+/**
+ * Stable identity for a pub/sub entry: the bare `<topic>` string (e.g.
+ * `order.placed`). Two pub/sub entries match iff this string is equal (the same
+ * topic), the exact-key semantics the Rust side uses — the broker is NOT part
+ * of identity. The Rust canonical key is `pubsub|<topic>` (2-segment, unlike
+ * the 3-segment socket/graphql keys); this is its `<topic>` tail, which becomes
+ * the `path` of the pub/sub `MatchResult` so the assembled label
+ * `PUBSUB <topic>` round-trips through the Rust verdict-join
+ * (`parse_compat_endpoint` / `parse_producer_key`).
+ */
+export function pubsubKey(entry: ManifestEntry): string | null {
+  if (entry.protocol !== 'pubsub' || !entry.topic) {
+    return null;
+  }
+  return entry.topic;
+}
+
 /**
  * Human label for an entry in orphan/diagnostic strings: `<METHOD> <path>` for
  * HTTP, `socket <DIRECTION>|<event>` for socket, `graphql <kind>|<field>` for
- * graphql.
+ * graphql, `pubsub <topic>` for pub/sub.
  */
 export function entryLabel(entry: ManifestEntry): string {
   if (entry.protocol === 'socket') {
@@ -287,6 +320,9 @@ export function entryLabel(entry: ManifestEntry): string {
   }
   if (entry.protocol === 'graphql') {
     return `graphql ${graphqlKey(entry) ?? entry.field ?? '<unknown>'}`;
+  }
+  if (entry.protocol === 'pubsub') {
+    return `pubsub ${pubsubKey(entry) ?? entry.topic ?? '<unknown>'}`;
   }
   return `${entry.method} ${entry.path}`;
 }
@@ -337,16 +373,16 @@ export class ManifestMatcher {
         throw new Error('Manifest missing required field: entries (must be an array)');
       }
 
-      // ts_check checks HTTP (by method/path), socket (by event+direction), and
-      // graphql (by kind+field) entries with the same assignability checker. Any
-      // other protocol is scored by its own pipeline and skipped here. The
-      // scanner already filters non-checkable entries out of the manifest files
-      // it writes (write_manifest_files), but a stray non-checkable entry must
-      // never crash the whole verdict run (#253), so we drop them defensively and
-      // leave a trace rather than throwing.
+      // ts_check checks HTTP (by method/path), socket (by event+direction),
+      // graphql (by kind+field), and pubsub (by topic) entries with the same
+      // assignability checker. Any other protocol is scored by its own pipeline
+      // and skipped here. The scanner already filters non-checkable entries out
+      // of the manifest files it writes (write_manifest_files), but a stray
+      // non-checkable entry must never crash the whole verdict run (#253), so we
+      // drop them defensively and leave a trace rather than throwing.
       manifest.entries = this.retainCheckableEntries(manifest.entries, absolutePath);
 
-      // Validate the surviving (HTTP + socket + graphql) entries.
+      // Validate the surviving (HTTP + socket + graphql + pubsub) entries.
       for (const entry of manifest.entries) {
         this.validateEntry(entry);
       }
@@ -362,8 +398,8 @@ export class ManifestMatcher {
 
   /**
    * Filter a manifest entry list down to the entries ts_check can check: HTTP
-   * (keyed by method/path), socket (keyed by event+direction), and graphql
-   * (keyed by kind+field).
+   * (keyed by method/path), socket (keyed by event+direction), graphql (keyed
+   * by kind+field), and pubsub (keyed by topic).
    *
    * Any other protocol — or a malformed entry missing the identity its protocol
    * needs — is skipped: it belongs to another pipeline or is junk. A single
@@ -385,7 +421,7 @@ export class ManifestMatcher {
     if (skipped > 0) {
       console.warn(
         `[manifest] Skipped ${skipped} non-checkable entr${skipped === 1 ? 'y' : 'ies'} in ${source} ` +
-          `(not HTTP/socket, or missing its identity fields; other protocols are checked by their own pipelines)`
+          `(not HTTP/socket/graphql/pubsub, or missing its identity fields; other protocols are checked by their own pipelines)`
       );
     }
 
@@ -395,10 +431,11 @@ export class ManifestMatcher {
   /**
    * Shape guard for raw, possibly-malformed manifest JSON. A checkable entry is
    * an HTTP key (`protocol: "http"` with non-empty `method`+`path`), a socket
-   * key (`protocol: "socket"` with non-empty `event`+`direction`), or a graphql
-   * key (`protocol: "graphql"` with non-empty `kind`+`field`). Everything else
-   * (junk) is filtered out here (#253). Full structural validation of the
-   * survivors is `validateEntry`'s job — a genuinely-malformed entry still throws.
+   * key (`protocol: "socket"` with non-empty `event`+`direction`), a graphql
+   * key (`protocol: "graphql"` with non-empty `kind`+`field`), or a pubsub key
+   * (`protocol: "pubsub"` with non-empty `topic`). Everything else (junk) is
+   * filtered out here (#253). Full structural validation of the survivors is
+   * `validateEntry`'s job — a genuinely-malformed entry still throws.
    */
   private isCheckableManifestEntry(entry: unknown): entry is ManifestEntry {
     if (typeof entry !== 'object' || entry === null) {
@@ -427,6 +464,9 @@ export class ManifestMatcher {
         typeof e.field === 'string' &&
         e.field.length > 0
       );
+    }
+    if (e.protocol === 'pubsub') {
+      return typeof e.topic === 'string' && e.topic.length > 0;
     }
     return false;
   }
@@ -465,10 +505,11 @@ export class ManifestMatcher {
    * Validate a manifest entry has all required fields.
    *
    * Callers must drop non-checkable entries via `retainCheckableEntries` first;
-   * by the time an entry reaches here it is expected to be HTTP or socket. An
-   * HTTP entry missing `method`/`path`, or a socket entry missing
-   * `event`/`direction`, is a genuine data bug and still throws (the #253
-   * guard — a malformed entry must fail loud, not silently pass).
+   * by the time an entry reaches here it is expected to be HTTP, socket,
+   * graphql, or pubsub. An HTTP entry missing `method`/`path`, a socket entry
+   * missing `event`/`direction`, a graphql entry missing `kind`/`field`, or a
+   * pubsub entry missing `topic`, is a genuine data bug and still throws (the
+   * #253 guard — a malformed entry must fail loud, not silently pass).
    */
   private validateEntry(entry: ManifestEntry): void {
     if (entry.protocol === 'http') {
@@ -494,8 +535,12 @@ export class ManifestMatcher {
       if (!entry.field) {
         throw new Error('ManifestEntry missing required field: field');
       }
+    } else if (entry.protocol === 'pubsub') {
+      if (!entry.topic) {
+        throw new Error('ManifestEntry missing required field: topic');
+      }
     } else {
-      throw new Error('ManifestEntry missing or invalid field: protocol (must be "http", "socket", or "graphql")');
+      throw new Error('ManifestEntry missing or invalid field: protocol (must be "http", "socket", "graphql", or "pubsub")');
     }
     if (!entry.type_alias) {
       throw new Error('ManifestEntry missing required field: type_alias');
@@ -800,6 +845,53 @@ export class ManifestMatcher {
         orphanedConsumers.push({
           entry: consumer,
           reason: `No producer found for graphql ${consumerKey} (${consumer.type_kind})`,
+        });
+      }
+    }
+
+    // Pub/Sub edges: exact-key match on the bare `<topic>`, the same identity the
+    // Rust canonical key carries (`pubsub|<topic>`; the broker is NOT part of
+    // identity). Like sockets there is no path/route to resolve, so a pub/sub
+    // consumer matches every producer carrying the same topic. The assembled
+    // label `PUBSUB <topic>` round-trips through the Rust verdict-join
+    // (`parse_compat_endpoint` / `parse_producer_key`). The producer/consumer
+    // type direction is handled in the type checker (`compareTypes`): pub/sub
+    // shares the Socket.IO INVERTED direction — the subscriber (producer,
+    // endpoint) accepts the payload the publisher (consumer, call) sends, so the
+    // emitted payload must satisfy what the subscriber accepts —
+    // `consumer ⊑ producer`. A subscriber declaring a wider accepted type than
+    // the publisher sends is compatible.
+    for (let ci = 0; ci < consumerEntries.length; ci++) {
+      const consumer = consumerEntries[ci];
+      if (consumer.protocol !== 'pubsub') continue;
+      const consumerKey = pubsubKey(consumer);
+      if (consumerKey === null) continue;
+
+      let matched = false;
+      for (let pi = 0; pi < producerEntries.length; pi++) {
+        const producer = producerEntries[pi];
+        if (producer.protocol !== 'pubsub') continue;
+        if (pubsubKey(producer) !== consumerKey) continue;
+        if (producer.type_kind !== consumer.type_kind) continue;
+
+        matches.push({
+          method: PUBSUB_PSEUDO_METHOD,
+          path: consumerKey,
+          type_kind: consumer.type_kind,
+          producer,
+          consumer,
+          match_score: 1.0,
+        });
+        matchedProducerIndices.add(pi);
+        matched = true;
+      }
+
+      if (matched) {
+        matchedConsumerIndices.add(ci);
+      } else {
+        orphanedConsumers.push({
+          entry: consumer,
+          reason: `No producer found for pubsub ${consumerKey} (${consumer.type_kind})`,
         });
       }
     }

--- a/ts_check/lib/type-checker.test.ts
+++ b/ts_check/lib/type-checker.test.ts
@@ -85,6 +85,41 @@ function graphqlEntry(
   };
 }
 
+/**
+ * Build a pub/sub `order.placed` manifest entry. Pub/sub entries carry
+ * `protocol: 'pubsub'` + `topic` instead of HTTP method/path (the broker is NOT
+ * part of identity). The subscriber is keyed as the producer and the publisher
+ * as the consumer, so pub/sub shares the socket inverted direction.
+ */
+function pubsubEntry(
+  typeAlias: string,
+  role: 'producer' | 'consumer',
+  filePath: string,
+  lineNumber: number,
+  topic: string = 'order.placed'
+): ManifestEntry {
+  return {
+    protocol: 'pubsub',
+    topic,
+    type_alias: typeAlias,
+    role,
+    type_kind: 'response',
+    file_path: filePath,
+    line_number: lineNumber,
+    is_explicit: true,
+    type_state: 'explicit',
+    evidence: {
+      file_path: filePath,
+      span_start: null,
+      span_end: null,
+      line_number: lineNumber,
+      infer_kind: 'response_body',
+      is_explicit: true,
+      type_state: 'explicit',
+    },
+  };
+}
+
 // ============================================================================
 // TypeCompatibilityChecker Tests
 // ============================================================================
@@ -867,6 +902,105 @@ describe('TypeCompatibilityChecker', () => {
       assert.strictEqual(result.compatiblePairs, 0, 'must NOT read compatible');
       assert.strictEqual(result.incompatiblePairs, 0);
       assert.strictEqual(result.unknownPairs.length, 1);
+    });
+
+    it('type-checks a pub/sub edge end-to-end as compatible (subscriber accepts a wider payload than the publisher sends)', async () => {
+      // The corpus-2 `order.placed` edge. Carrick keys the *subscriber*
+      // (orders-svc handler, `WideOrder`) as the producer and the *publisher*
+      // (checkout-svc send, `StrictOrder`) as the consumer. The bytes flow
+      // publisher → subscriber, so the publisher payload must satisfy what the
+      // subscriber accepts: `StrictOrder.status: "placed" | "paid"` ⊑
+      // `WideOrder.status: string` → compatible. (Reusing the HTTP direction
+      // would wrongly read this as incompatible; this is the socket inversion.)
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type WideOrder = { id: string; totalCents: number; status: string };
+        export type StrictOrder = { id: string; totalCents: number; status: "placed" | "paid" };
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'orders-svc',
+        commit_hash: 'abc',
+        entries: [pubsubEntry('WideOrder', 'producer', 'src/consumer.ts', 14)],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'checkout-svc',
+        commit_hash: 'def',
+        entries: [pubsubEntry('StrictOrder', 'consumer', 'src/publisher.ts', 22)],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.matchDetails?.length, 1, 'the pub/sub pair must match');
+      assert.strictEqual(
+        result.matchDetails?.[0].method,
+        'PUBSUB',
+        'the match is keyed on the PUBSUB pseudo-method'
+      );
+      assert.strictEqual(
+        result.matchDetails?.[0].path,
+        'order.placed',
+        'the match path is the bare topic'
+      );
+      assert.strictEqual(result.compatiblePairs, 1);
+      assert.strictEqual(result.incompatiblePairs, 0);
+      assert.strictEqual(result.unknownPairs.length, 0);
+    });
+
+    it('reads a pub/sub edge whose published payload widens the subscriber type as incompatible (inverted-direction proof)', async () => {
+      // Direction proof (mirrors the socket widening test): if the publisher
+      // sends a *wider* type than the subscriber accepts, the edge is
+      // incompatible. Here the publisher sends `status: string` but the
+      // subscriber only accepts `"placed" | "paid"`, so `string` is NOT
+      // assignable → incompatible. This is the incompatible Kafka `order.placed`
+      // edge, and it fails if the assignability direction is not flipped for
+      // pub/sub (the same flip as socket).
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type StrictOrder = { id: string; status: "placed" | "paid" };
+        export type WideOrder = { id: string; status: string };
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'subscriber-repo',
+        commit_hash: 'abc',
+        entries: [pubsubEntry('StrictOrder', 'producer', 'src/consumer.ts', 14)],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'publisher-repo',
+        commit_hash: 'def',
+        entries: [pubsubEntry('WideOrder', 'consumer', 'src/publisher.ts', 22)],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.incompatiblePairs, 1);
+      assert.strictEqual(result.compatiblePairs, 0);
+      assert.strictEqual(result.mismatches.length, 1);
+      assert.ok(
+        result.mismatches[0].endpoint.startsWith('PUBSUB '),
+        'the mismatch endpoint must carry the PUBSUB label'
+      );
     });
 
     it('reads a dangling consumer name as unverifiable but its structural shape as incompatible (#257)', async () => {

--- a/ts_check/lib/type-checker.ts
+++ b/ts_check/lib/type-checker.ts
@@ -373,8 +373,20 @@ export class TypeCompatibilityChecker {
     // incompatible, the opposite of the truth. (See xrepo-corpus-1 README,
     // "Socket producer/consumer direction".) The same `isAssignableTo` relation
     // and the same resolved Type objects are used either way.
+    //
+    // Pub/Sub: shares the SAME inverted direction as socket. Carrick keys a
+    // *subscriber* (the handler registration) as the producer (endpoint) and a
+    // *publisher* (the send) as the consumer (call). The bytes flow publisher →
+    // subscriber, so the *publisher's* payload (manifest consumer) must satisfy
+    // what the *subscriber* accepts (manifest producer) — `consumer ⊑ producer`.
+    // A subscriber declaring a WIDER accepted payload than the publisher sends is
+    // compatible, identical to socket. Pub/sub payload types are already DECODED
+    // application types (the LLM emits `Order`, not the wire `Buffer`/`string`),
+    // so there is NO envelope/codec unwrap — pub/sub stays on the non-graphql
+    // `producerComparand` branch below.
     const socket = producer.protocol === "socket";
     const graphql = producer.protocol === "graphql";
+    const pubsub = producer.protocol === "pubsub";
 
     // For GraphQL the producer's resolved type is the resolver's return ENVELOPE
     // (e.g. `{ data: Order; errors: string[] }`), kept verbatim for the
@@ -388,8 +400,12 @@ export class TypeCompatibilityChecker {
       ? this.unwrapGraphqlPayload(producerType, endpoint)
       : producerType;
 
-    const sentType = socket ? consumerType : producerComparand;
-    const expectedType = socket ? producerComparand : consumerType;
+    // Socket AND pub/sub share the inverted direction: the consumer (emitter /
+    // publisher) sends, the producer (listener / subscriber) accepts. Pub/sub
+    // does NOT unwrap an envelope (its payload type is already decoded), so it
+    // rides the non-graphql `producerComparand` above.
+    const sentType = (socket || pubsub) ? consumerType : producerComparand;
+    const expectedType = (socket || pubsub) ? producerComparand : consumerType;
 
     // Re-run the `any`/`unknown` → unverifiable guard on the COMPARANDS, not just
     // the raw `producerType`/`consumerType` checked at the top. The GraphQL
@@ -400,8 +416,9 @@ export class TypeCompatibilityChecker {
     // would hit `isAssignableTo` with a top-ish side and read compatible: the
     // exact `graphql|subscription|orderUpdated` false-positive. The raw-type
     // guard never sees the unwrapped payload, so the comparands must be guarded
-    // again here, before `isAssignableTo`. (For HTTP/socket the comparands equal
-    // the raw types, so this is a redundant no-op that preserves their behavior.)
+    // again here, before `isAssignableTo`. (For HTTP/socket/pubsub the comparands
+    // equal the raw types, so this is a redundant no-op that preserves their
+    // behavior.)
     if (
       sentType.isAny() ||
       expectedType.isAny() ||


### PR DESCRIPTION
## What

Pub/sub edges now get a `type_compatible` verdict. `parse_producer_key` gains a pubsub arm (2-segment `pubsub|<topic>` → `("PUBSUB", topic)`); ts_check joins pub/sub to the **Socket.IO inverted-direction branch** (a subscriber accepting a wider payload than the publisher sends is compatible), on the non-graphql producer comparand (payloads are already decoded — **no envelope/codec unwrap**). manifest-matcher.ts threads pubsub entries (protocol union, `topic` field, `PUBSUB` pseudo-method, exact-topic match loop).

## Why

Every pub/sub edge was returning `compat=None` (no parse arm + no ts_check direction). This lands the verdict — including the deliberately **incompatible** Kafka `order.placed` edge (publisher `total: number` vs subscriber `{amountCents,currency}`).

## Verification

- ts_check **85 tests pass** incl. two new pubsub direction tests: a widening-compatible case AND the inverted-direction incompat proof (fails if the direction isn't flipped).
- `parse_producer_key`/`apply_compat_verdicts` unit tests pass (compatible→Some(true), mismatch→Some(false)+reason).
- Full debug suite green incl. cassette hard gate; no regressions.

Stacked on #286 → #285 → #284 → #283 → #282 → #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)