### PR TITLE
fix(pubsub): disambiguate fan-in publisher aliases by call site

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1176,11 +1176,14 @@ impl FileOrchestrator {
     /// producers, publishers are consumers; each resolves to the Response-kind
     /// alias.
     ///
-    /// The alias MUST be `build_manifest_type_alias(&key, role, Response)` —
-    /// byte-identical to the alias `add_protocol_manifest_entry` stamps on the
-    /// manifest entry in `append_pubsub_manifest_entries` (same `OperationKey`,
-    /// same role mapping, same kind) — or the resolved `.d.ts` never joins back
-    /// and the entry stays `Unknown`. This contract is guarded by a unit test.
+    /// The alias MUST be byte-identical to the one `add_protocol_manifest_entry`
+    /// stamps on the manifest entry in `append_pubsub_manifest_entries` — or the
+    /// resolved `.d.ts` never joins back and the entry stays `Unknown`. Producers
+    /// (subscribers) use the plain `build_manifest_type_alias(&key, role,
+    /// Response)`; consumers (publishers) append a `build_call_site_id(path, line,
+    /// &key)` suffix so fan-in publishers on one topic don't collide on a single
+    /// alias (see `append_pubsub_manifest_entries`). Both contracts are guarded by
+    /// unit tests.
     ///
     /// Only ops whose extractor captured a `primary_type_symbol` produce a
     /// request; a `None` symbol (untyped or inline-object payload) emits nothing,
@@ -1234,7 +1237,30 @@ impl FileOrchestrator {
                     None => file_abs,
                 };
                 let key = OperationKey::pubsub(op.topic.clone());
-                let alias = build_manifest_type_alias(&key, role, ManifestTypeKind::Response);
+                // Mirror the manifest side (`append_pubsub_manifest_entries`):
+                // publishers (consumers) disambiguate by call site so fan-in
+                // publishers don't collide on one alias; subscribers (producers)
+                // stay plain. `build_call_site_id` MUST see the same (path, line,
+                // key) the manifest side passes — `path` is the raw `file_results`
+                // key on both sides — or the alias diverges and the resolution
+                // enrich-join silently drops the resolved payload type.
+                let alias = match role {
+                    ManifestRole::Consumer => {
+                        // Same >= 1 clamp as the manifest side (see
+                        // `append_pubsub_manifest_entries`) so the call_id matches.
+                        let line = u32::try_from(op.line_number).unwrap_or(0).max(1);
+                        let call_id = build_call_site_id(path, line, &key);
+                        build_manifest_type_alias_with_call_id(
+                            &key,
+                            role,
+                            ManifestTypeKind::Response,
+                            Some(&call_id),
+                        )
+                    }
+                    ManifestRole::Producer => {
+                        build_manifest_type_alias(&key, role, ManifestTypeKind::Response)
+                    }
+                };
                 let dedup_key = format!("{}|{}|{}", source_file, symbol, alias);
                 if seen.insert(dedup_key) {
                     requests.push(SymbolRequest {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1351,7 +1351,23 @@ fn append_pubsub_manifest_entries(
                 None => continue,
             };
             let key = OperationKey::pubsub(op.topic.clone());
-            let line = u32::try_from(op.line_number).unwrap_or(0);
+            // Clamp to a valid 1-based line. A degenerate (<= 0) line must still
+            // hash identically here and on the SymbolRequest side, and 0 is an
+            // invalid anchor everywhere else (`parse_file_location` et al.).
+            let line = u32::try_from(op.line_number).unwrap_or(0).max(1);
+            // Publishers (consumers) disambiguate by call site. Two repos
+            // publishing to the same topic (fan-in — the common event-driven
+            // shape) otherwise hash to ONE consumer alias, and ts_check's bundled
+            // `cross-repo-consumers` types then declare that interface twice with
+            // different bodies — one publisher's payload masks the other's,
+            // yielding a spurious compat mismatch on whichever loses. Mirror the
+            // HTTP consumer path (`add_manifest_pair` + `build_call_site_id`).
+            // Subscribers (producers) keep the plain alias: one definition per
+            // topic per repo, exactly like an HTTP endpoint.
+            let call_id = match role {
+                ManifestRole::Consumer => Some(build_call_site_id(path, line, &key)),
+                ManifestRole::Producer => None,
+            };
             add_protocol_manifest_entry(
                 entries,
                 &key,
@@ -1359,6 +1375,7 @@ fn append_pubsub_manifest_entries(
                 path,
                 line,
                 op.primary_type_symbol.clone(),
+                call_id.as_deref(),
             );
         }
     }
@@ -1446,6 +1463,7 @@ fn append_protocol_manifest_entries(
             &op.file_path.to_string_lossy(),
             op.line,
             op.primary_type_symbol.clone(),
+            None,
         );
     }
     for op in &extractions.graphql.consumers {
@@ -1459,6 +1477,10 @@ fn append_protocol_manifest_entries(
             // the `request<T>(DOC)` call site (#248 consumer side), not the
             // SDL-derived `primary_type_symbol` (always `None` for documents).
             op.payload_type_symbol.clone(),
+            // Fan-in consumers (multiple repos reading the same field) carry the
+            // same latent alias-collision risk the pub/sub publisher path fixes,
+            // but neither corpus exercises it today; deferred to #291.
+            None,
         );
     }
     for op in &extractions.sockets.listeners {
@@ -1469,6 +1491,7 @@ fn append_protocol_manifest_entries(
             &op.file_path.to_string_lossy(),
             op.line,
             op.payload_type_symbol.clone(),
+            None,
         );
     }
     for op in &extractions.sockets.emitters {
@@ -1479,6 +1502,8 @@ fn append_protocol_manifest_entries(
             &op.file_path.to_string_lossy(),
             op.line,
             op.payload_type_symbol.clone(),
+            // Same deferred fan-in caveat as the graphql consumer above (#291).
+            None,
         );
     }
 }
@@ -1491,8 +1516,10 @@ fn append_protocol_manifest_entries(
 /// `primary_type_symbol` is threaded straight onto the entry at creation — the
 /// op carries its anchor deterministically, unlike HTTP where it is stamped
 /// later from the LLM result. The `type_alias` MUST be computed with the same
-/// `build_manifest_type_alias(key, role, Response)` the SymbolRequest side uses,
-/// or the enrich-join silently fails to flip `Unknown` → resolved.
+/// `build_manifest_type_alias_with_call_id(key, role, Response, call_id)` the
+/// SymbolRequest side uses — same key, same role, same kind, AND the same
+/// `call_id` (see the `call_id` param) — or the enrich-join silently fails to
+/// flip `Unknown` → resolved.
 fn add_protocol_manifest_entry(
     entries: &mut Vec<TypeManifestEntry>,
     key: &OperationKey,
@@ -1500,9 +1527,17 @@ fn add_protocol_manifest_entry(
     file_path: &str,
     line_number: u32,
     primary_type_symbol: Option<String>,
+    // Per-call-site disambiguator. `None` keeps the plain key-only alias (one
+    // definition per key per repo — correct for producers/endpoints). `Some`
+    // appends a `_Call<id>` suffix so multiple consumers of the same key in one
+    // bundle (fan-in) don't collide on a single alias; see the pub/sub publisher
+    // path in `append_pubsub_manifest_entries`. Must equal the `call_id` the
+    // SymbolRequest side computes for the same op, or the resolution join breaks.
+    call_id: Option<&str>,
 ) {
     let type_kind = ManifestTypeKind::Response;
-    let type_alias = crate::type_manifest::build_manifest_type_alias(key, role, type_kind);
+    let type_alias =
+        crate::type_manifest::build_manifest_type_alias_with_call_id(key, role, type_kind, call_id);
     let infer_kind = infer_kind_for_manifest(role, type_kind);
     let evidence = crate::cloud_storage::TypeEvidence {
         file_path: file_path.to_string(),
@@ -4498,6 +4533,74 @@ mod tests {
         );
         assert_eq!(manifest_alias, expected);
         assert_eq!(request.alias.as_deref(), Some(expected.as_str()));
+    }
+
+    /// Fan-in regression (the corpus-2 compat false-negative): two publishers on
+    /// the SAME topic but in different repos/files must get DISTINCT consumer
+    /// aliases. They previously hashed to one alias (`build_manifest_type_alias`
+    /// keys only on `topic|consumer|Response`), so ts_check's bundled
+    /// `cross-repo-consumers` declared that interface twice with different bodies
+    /// — one publisher's payload type masked the other's and the masked edge
+    /// reported a spurious compat mismatch. The publisher alias now disambiguates
+    /// by call site, and each publisher's SymbolRequest alias still byte-matches
+    /// its own manifest entry so the resolution join holds.
+    #[test]
+    fn pubsub_fan_in_publishers_get_distinct_consumer_aliases() {
+        use crate::operation::PubsubRole;
+
+        let mut file_results: HashMap<String, FileAnalysisResult> = HashMap::new();
+        // Two repos publishing `order.placed` with a same-named `OrderPlaced`
+        // symbol whose definition differs per repo — the exact corpus-2 shape.
+        file_results.insert(
+            "orders-engine/src/publish.ts".to_string(),
+            FileAnalysisResult {
+                pubsub_operations: vec![pubsub_op(
+                    "order.placed",
+                    PubsubRole::Publisher,
+                    Some("OrderPlaced"),
+                    Some("./types/order"),
+                )],
+                ..Default::default()
+            },
+        );
+        file_results.insert(
+            "billing-svc/src/emit.ts".to_string(),
+            FileAnalysisResult {
+                pubsub_operations: vec![pubsub_op(
+                    "order.placed",
+                    PubsubRole::Publisher,
+                    Some("OrderPlaced"),
+                    Some("./types/order"),
+                )],
+                ..Default::default()
+            },
+        );
+
+        let mut entries = Vec::new();
+        append_pubsub_manifest_entries(&mut entries, &file_results);
+        let manifest_aliases: HashSet<String> = entries
+            .iter()
+            .filter(|e| e.key.canonical() == "pubsub|order.placed")
+            .map(|e| e.type_alias.clone())
+            .collect();
+        assert_eq!(
+            manifest_aliases.len(),
+            2,
+            "two fan-in publishers must yield two DISTINCT consumer aliases, not \
+             one collided alias (which masks one payload type in ts_check)"
+        );
+
+        // Each publisher's SymbolRequest alias must byte-match its manifest alias
+        // (same call site → same call_id), so the resolution enrich-join holds.
+        let orchestrator = FileOrchestrator::new(AgentService::new());
+        let requests = orchestrator.collect_pubsub_type_requests(&file_results, ".");
+        let request_aliases: HashSet<String> =
+            requests.iter().filter_map(|r| r.alias.clone()).collect();
+        assert_eq!(
+            request_aliases, manifest_aliases,
+            "each publisher's SymbolRequest alias must byte-match its manifest \
+             entry's alias across the fan-in set"
+        );
     }
 
     /// PR-4: a subscriber pub/sub op carrying a decoded-payload


### PR DESCRIPTION
## What

Two repos publishing to the **same topic** (fan-in — the common event-driven shape) collided on a single consumer `type_alias`. `build_manifest_type_alias` keys only on `topic|consumer|Response`, with no per-call-site disambiguator, so both publishers hashed to the **identical** alias.

ts_check then bundles all consumers into one `cross-repo-consumers` compilation, which declared that interface **twice with different bodies** — one publisher's payload type masked the other's, producing a **spurious compat mismatch** on whichever lost.

This is the corpus-2 compat false-negative on `notifications-svc -> orders-engine|order.placed`. Confirmed from the eval's `ts_check-output` artifact:

```ts
// both in the bundled cross-repo-consumers types:
export interface Endpoint_3384da6baa7a45a6_Response { id: string; total: number; }                                  // billing-svc
export interface Endpoint_3384da6baa7a45a6_Response { id: string; total: { amountCents: number; currency: string; }; note?: string; } // orders-engine
```

orders-engine's `OrderPlaced` is structurally compatible with the subscriber's `OrderPlacedEvent`, but the collided alias made ts_check compare it against billing-svc's incompatible `{ total: number }` → `Some(false)`.

## Fix

Mirror the **HTTP consumer path** (`add_manifest_pair` + `build_call_site_id`): publisher (consumer) aliases now append a `build_call_site_id(path, line, &key)` suffix, computed **byte-identically** at:
- the manifest side — `append_pubsub_manifest_entries`
- the SymbolRequest side — `collect_pubsub_type_requests`

so the resolution enrich-join still holds (both sides see the same raw `file_results` key + line + key). Subscribers (producers) keep the **plain** alias — one definition per topic per repo, exactly like an HTTP endpoint.

An `Option<&str>` call_id is threaded through the shared `add_protocol_manifest_entry`; `None` preserves current graphql/socket behaviour. Those consumers carry the **same latent fan-in collision risk** but neither corpus exercises it today — deferred to a follow-up (noted inline).

## Tests

- New `pubsub_fan_in_publishers_get_distinct_consumer_aliases`: two publishers on one topic in different repos must get **distinct** aliases that **still byte-match** their own manifest entries.
- Existing `pubsub_symbol_request_alias_matches_manifest_alias` (subscriber/producer path) unchanged and passing.
- Full Rust suite (472 lib) + ts_check suite (85) green via pre-commit.

Deterministic scanner-only fix — no deploy. Corpus-1 has no pub/sub ops, so it is byte-identical (the graphql/socket `None` path is behaviour-preserving). Live corpus-2 eval running to confirm the edge flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)