### PR TITLE
fix(http): normalize internal consumer call keys in the cloud_data projection (#292)

### DIFF
--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     operation::OperationKey,
     packages::Packages,
     services::type_sidecar::InferKind,
+    url_normalizer::UrlNormalizer,
     visitor::{FunctionDefinition, Mount, OwnerType},
 };
 use async_trait::async_trait;
@@ -182,6 +183,16 @@ impl CloudRepoData {
         });
         let mount_graph = &analysis_result.mount_graph;
 
+        // Normalizer built from this repo's carrick.json (internalEnvVars etc.)
+        // so consumer call keys strip a declared-internal host base. Absent/
+        // unparseable config → empty Config (only relative paths normalize; env-
+        // var targets stay raw — matches the prior raw behavior, never over-strips).
+        let url_normalizer = config_json
+            .as_ref()
+            .and_then(|json| serde_json::from_str::<crate::config::Config>(json).ok())
+            .map(|cfg| UrlNormalizer::new(&cfg))
+            .unwrap_or_else(|| UrlNormalizer::new(&crate::config::Config::default()));
+
         // Convert ResolvedEndpoints to ApiEndpointDetails
         let endpoints: Vec<ApiEndpointDetails> = mount_graph
             .get_resolved_endpoints()
@@ -207,7 +218,10 @@ impl CloudRepoData {
             .iter()
             .map(|call| ApiEndpointDetails {
                 owner: None,
-                key: OperationKey::http(&call.method, call.target_url.clone()),
+                key: OperationKey::http(
+                    &call.method,
+                    url_normalizer.consumer_call_path(&call.target_url),
+                ),
                 params: vec![],
                 request_body: None,
                 response_body: None,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1602,12 +1602,18 @@ fn build_cloud_data_from_mount_graph(
         })
         .collect();
 
+    // Strip a declared-internal host base from consumer call keys (see
+    // `UrlNormalizer::consumer_call_path`) so they match their producer endpoints.
+    let url_normalizer = UrlNormalizer::new(config);
     let calls: Vec<ApiEndpointDetails> = mount_graph
         .get_data_calls()
         .iter()
         .map(|call| ApiEndpointDetails {
             owner: None,
-            key: OperationKey::http(&call.method, call.target_url.clone()),
+            key: OperationKey::http(
+                &call.method,
+                url_normalizer.consumer_call_path(&call.target_url),
+            ),
             params: vec![],
             request_body: None,
             response_body: None,

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -490,6 +490,43 @@ impl UrlNormalizer {
         self.normalize(url).path
     }
 
+    /// Path to key a CONSUMER data call on in the cloud_data projection.
+    ///
+    /// Like `extract_path`, but conservative about WHICH targets get their host
+    /// stripped: only a declared-internal env-var base (e.g. `internalEnvVars`
+    /// in `carrick.json`) or a plain relative path (no host at all) is reduced
+    /// to its bare route. A target whose host was stripped but is NOT internal —
+    /// an external or unknown base like `${process.env.STRIPE_URL}/charges` — is
+    /// returned verbatim, so a third-party call can never collide with an
+    /// internal producer's `/charges`.
+    ///
+    /// This exists because the LLM `data_calls` path stores the raw target on
+    /// the `DataFetchingCall` (`file_orchestrator.rs` fifth pass), and only the
+    /// cross-repo *matcher* normalized it; the per-op cloud_data CALL key stayed
+    /// un-normalized, so a consumer call like `${process.env.ANALYTICS_URL}/track`
+    /// never keyed as `/track` and so never matched its producer or got a compat
+    /// verdict.
+    pub fn consumer_call_path(&self, url: &str) -> String {
+        // A plain relative path (`/track`, `/users/${id}`) has no host to strip —
+        // always safe to clean. NOT protocol-relative (`//host/...`), which has a
+        // host. Checked on the raw target (minus literal quote/backtick wrappers).
+        let trimmed = url.trim_matches(|c| c == '`' || c == '"' || c == '\'');
+        let is_relative_path = trimmed.starts_with('/') && !trimmed.starts_with("//");
+
+        let normalized = self.normalize(url);
+        if normalized.is_internal || is_relative_path {
+            normalized.path
+        } else {
+            // External / unknown / full-URL targets are kept VERBATIM. A
+            // declared-external or unknown env-var base must not collide with an
+            // internal producer's path; and a full URL with an interpolation in
+            // its query (`https://h/p?u=${id}`) dispatches to the template-literal
+            // branch, which would mangle the scheme — keep it raw rather than
+            // emit `/https:/h/p`.
+            url.to_string()
+        }
+    }
+
     /// Heuristic check for URL-like inputs to avoid matching variable names as paths.
     pub fn is_probable_url(&self, url: &str) -> bool {
         let trimmed = url.trim();
@@ -554,6 +591,50 @@ mod tests {
                 .collect(),
             ..Default::default()
         }
+    }
+
+    /// The corpus-2 HTTP regression: a consumer call whose base is a declared-
+    /// internal env var must key on the BARE route (so it matches its producer),
+    /// while an unknown/external base must be kept VERBATIM (so a third-party
+    /// call can't collide with an internal producer's path). `consumer_call_path`
+    /// is what the cloud_data CALL projection uses; before it, the projection
+    /// keyed on the raw LLM `target_url` and these edges never matched.
+    #[test]
+    fn consumer_call_path_strips_internal_base_keeps_external_raw() {
+        let n = UrlNormalizer::new(&create_test_config());
+
+        // Internal env-var base (process.env form, and the const-resolved form) →
+        // bare route. This is the exact corpus-2 miss.
+        assert_eq!(
+            n.consumer_call_path("${process.env.API_URL}/users"),
+            "/users"
+        );
+        assert_eq!(n.consumer_call_path("${API_URL}/users"), "/users");
+
+        // Internal base + a path param: base stripped, param preserved.
+        let with_param = n.consumer_call_path("${process.env.API_URL}/users/${id}");
+        assert!(
+            with_param.starts_with("/users/:") && !with_param.contains("process.env"),
+            "expected /users/:param, got {with_param}"
+        );
+
+        // A relative path (no host) is returned cleaned, shape unchanged.
+        assert_eq!(n.consumer_call_path("/track"), "/track");
+
+        // An UNKNOWN base (NOT in internalEnvVars) is returned VERBATIM — never
+        // normalized into something that could match an internal producer.
+        assert_eq!(
+            n.consumer_call_path("${process.env.STRIPE_URL}/charges"),
+            "${process.env.STRIPE_URL}/charges"
+        );
+
+        // A full URL — even with an interpolation in its query string, which
+        // dispatches to the template-literal branch — is kept VERBATIM, never
+        // mangled to `/https:/orders.internal/...` by `clean_path`.
+        assert_eq!(
+            n.consumer_call_path("https://orders.internal/api/orders?user=${userId}"),
+            "https://orders.internal/api/orders?user=${userId}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

The LLM `data_calls` path stores the raw call target on `DataFetchingCall` (`file_orchestrator.rs` fifth pass), and only the cross-repo **matcher** normalized it. The per-op cloud_data **CALL projection** (`cloud_storage::from_multi_agent_results` — the live full-scan path — and the incremental `build_cloud_data_from_mount_graph`) keyed on that raw `target_url`. So a consumer call like:

```
fetch(`${ANALYTICS_BASE}/track`)   // ANALYTICS_BASE = process.env.ANALYTICS_URL ?? ""
```

projected as `http|POST|${process.env.ANALYTICS_URL}/track` instead of `http|POST|/track` — never matching its producer endpoint, never getting a compat verdict.

This is the dominant **non-LLM** drag on xrepo-corpus-2 (84% mean / 90% peak): two HTTP consumer edges (`/track`, `/notifications/:param`) miss match + compat. It is **not** the const-indirection — corpus-1 uses the identical `const BASE = process.env.X ?? ""` pattern at 91%; it is the projection keying on the un-normalized target. Closes #292.

## Fix

`UrlNormalizer::consumer_call_path`: strip the host **only** for
- a declared-**internal** env-var base (carrick.json `internalEnvVars`), or
- a plain relative path (`/track`).

Everything else — external/unknown env-var bases, **and full URLs** (incl. `https://h/p?u=${id}`, which dispatch to the template-literal branch and would otherwise mangle to `/https:/h/p`) — is returned **verbatim**, so a third-party call can never collide with an internal producer's path. Applied at both projection sites.

## Tests

- `consumer_call_path_strips_internal_base_keeps_external_raw` — internal base → bare route (process.env + const-resolved forms), param preserved, relative path unchanged, unknown base + full URL kept verbatim.
- Full Rust suite (473 lib) + the **cassette hard gate** (frozen-golden) green — the gate's full-URL-with-query-interpolation consumer keeps its raw key, so **no golden re-record** was needed (proof the fix is surgical).

Deterministic, scanner-only, no deploy. Live evals running: corpus-2 (confirm gain) + corpus-1 (confirm no regression on its shared `internalEnvVars` HTTP edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)