### PR TITLE
feat(graphql): resolve resolver-less SDL producers via co-located backing type (#248)

### DIFF
--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -204,25 +204,34 @@ pub struct GraphqlOperation {
     pub kind: crate::operation::GraphqlOperationKind,
     /// The schema field name this resolver answers (e.g., "order").
     pub field: String,
-    /// Name of the resolver function (e.g., "resolveOrder"). `None` when no
-    /// function in this file resolves the field but a co-located type declares
-    /// its response shape (the #248 type-locate fallback), in which case
-    /// `primary_type_symbol` carries that type.
+    /// Name of the resolver function (e.g., "resolveOrder"). `None` only when no
+    /// function in this file resolves the field (the #248 type-locate fallback,
+    /// which carries `backing_type_symbol` instead).
     #[serde(default)]
     pub resolver_function: Option<String>,
     /// Line number where the resolver function is defined. `None` whenever
     /// `resolver_function` is `None`.
     #[serde(default)]
     pub resolver_line: Option<i32>,
-    /// The primary return type symbol without wrappers. When a resolver exists,
-    /// its return type (e.g. "ApiResponse" from "Promise<ApiResponse>"). When no
-    /// resolver exists, the co-located type declaring the field's response shape
-    /// (e.g. "Order" for a field returning `[Order!]!` backed by `interface
-    /// Order`). `None` for untyped or inline-object returns.
+    /// The primary return type symbol without wrappers (e.g. "ApiResponse" from
+    /// "Promise<ApiResponse>"). `None` for untyped or inline-object resolver
+    /// returns. Describes the RESOLVER's return type only — the resolver-less
+    /// fallback uses `backing_type_symbol`.
     pub primary_type_symbol: Option<String>,
-    /// Import path where the type is defined (e.g., "./types/order"), null if
-    /// inline or same file. Null whenever `primary_type_symbol` is null.
+    /// Import path where `primary_type_symbol` is defined (e.g., "./types/order"),
+    /// null if inline or same file. Null whenever `primary_type_symbol` is null.
     pub type_import_source: Option<String>,
+    /// #248 type-locate fallback: the co-located TS type describing a
+    /// resolver-less field's response shape (e.g. "Order" for `orders: [Order!]!`
+    /// with no `resolveOrders`). `None` whenever a resolver was linked — kept
+    /// separate from `primary_type_symbol` so the resolver-linking path stays
+    /// undisturbed.
+    #[serde(default)]
+    pub backing_type_symbol: Option<String>,
+    /// Import path where `backing_type_symbol` is defined, or `None` if declared
+    /// in this file. `None` whenever `backing_type_symbol` is `None`.
+    #[serde(default)]
+    pub backing_type_source: Option<String>,
 }
 
 /// A pub/sub operation the file-analyzer found: the topic it targets and which
@@ -737,13 +746,13 @@ impl FileAnalyzerAgent {
                 "\n### GRAPHQL SCHEMA PRODUCERS (from this repo's SDL)\n\
                  The fields below are this service's GraphQL schema root fields. If a function in \
                  this file resolves one of them, emit a `graphql_operations` entry linking the \
-                 resolver function (`resolver_function`/`resolver_line`) to its `kind`/`field` and \
-                 its return type (`primary_type_symbol`/`type_import_source`). If NO function in \
-                 this file resolves a listed field but a type declared or imported in this file \
-                 describes that field's response shape, still emit an entry with `kind`/`field`, \
-                 leave `resolver_function`/`resolver_line` null, and set \
-                 `primary_type_symbol`/`type_import_source` to that type (unwrap list/`[]` wrappers \
-                 to the bare element type, e.g. `Order` for `[Order!]!`).\n{}\n",
+                 resolver function to its `kind`/`field` and its return type. A function that \
+                 RETURNS a field's value is its resolver even when the return is wrapped (Promise, \
+                 a response envelope, an async iterator) — always link it. ONLY for a listed field \
+                 that NO function in this file returns, emit an entry with just `kind`/`field` and \
+                 set `backing_type_symbol` (+ `backing_type_source`) to a co-located type that \
+                 declares the field's response shape (leave `resolver_function` null; unwrap \
+                 list/`[]` wrappers to the bare element type, e.g. `Order` for `[Order!]!`).\n{}\n",
                 graphql_producer_hints
                     .iter()
                     .map(|line| format!("- {}", line))
@@ -1396,9 +1405,9 @@ mod tests {
     #[test]
     fn graphql_operations_deserialize_resolverless_type_locate() {
         // #248: a resolver-less field the LLM locates by its backing type omits
-        // resolver_function/resolver_line entirely and carries the type in
-        // primary_type_symbol. #[serde(default)] must yield None for the missing
-        // resolver locators rather than failing the parse.
+        // resolver_function/resolver_line entirely and carries the type in the
+        // dedicated backing_type_symbol. #[serde(default)] must yield None for the
+        // missing resolver locators rather than failing the parse.
         let json = r#"{
             "mounts": [],
             "endpoints": [],
@@ -1407,8 +1416,8 @@ mod tests {
                 {
                     "kind": "query",
                     "field": "orders",
-                    "primary_type_symbol": "Order",
-                    "type_import_source": null
+                    "backing_type_symbol": "Order",
+                    "backing_type_source": null
                 }
             ]
         }"#;
@@ -1418,7 +1427,8 @@ mod tests {
         assert_eq!(op.field, "orders");
         assert_eq!(op.resolver_function, None);
         assert_eq!(op.resolver_line, None);
-        assert_eq!(op.primary_type_symbol.as_deref(), Some("Order"));
+        assert_eq!(op.primary_type_symbol, None);
+        assert_eq!(op.backing_type_symbol.as_deref(), Some("Order"));
     }
 
     #[test]

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -204,12 +204,21 @@ pub struct GraphqlOperation {
     pub kind: crate::operation::GraphqlOperationKind,
     /// The schema field name this resolver answers (e.g., "order").
     pub field: String,
-    /// Name of the resolver function (e.g., "resolveOrder").
-    pub resolver_function: String,
-    /// Line number where the resolver function is defined.
-    pub resolver_line: i32,
-    /// The primary return type symbol without wrappers (e.g., "ApiResponse" from
-    /// "Promise<ApiResponse>"). `None` for untyped or inline-object returns.
+    /// Name of the resolver function (e.g., "resolveOrder"). `None` when no
+    /// function in this file resolves the field but a co-located type declares
+    /// its response shape (the #248 type-locate fallback), in which case
+    /// `primary_type_symbol` carries that type.
+    #[serde(default)]
+    pub resolver_function: Option<String>,
+    /// Line number where the resolver function is defined. `None` whenever
+    /// `resolver_function` is `None`.
+    #[serde(default)]
+    pub resolver_line: Option<i32>,
+    /// The primary return type symbol without wrappers. When a resolver exists,
+    /// its return type (e.g. "ApiResponse" from "Promise<ApiResponse>"). When no
+    /// resolver exists, the co-located type declaring the field's response shape
+    /// (e.g. "Order" for a field returning `[Order!]!` backed by `interface
+    /// Order`). `None` for untyped or inline-object returns.
     pub primary_type_symbol: Option<String>,
     /// Import path where the type is defined (e.g., "./types/order"), null if
     /// inline or same file. Null whenever `primary_type_symbol` is null.
@@ -728,7 +737,13 @@ impl FileAnalyzerAgent {
                 "\n### GRAPHQL SCHEMA PRODUCERS (from this repo's SDL)\n\
                  The fields below are this service's GraphQL schema root fields. If a function in \
                  this file resolves one of them, emit a `graphql_operations` entry linking the \
-                 resolver function to its `kind`/`field` and its return type.\n{}\n",
+                 resolver function (`resolver_function`/`resolver_line`) to its `kind`/`field` and \
+                 its return type (`primary_type_symbol`/`type_import_source`). If NO function in \
+                 this file resolves a listed field but a type declared or imported in this file \
+                 describes that field's response shape, still emit an entry with `kind`/`field`, \
+                 leave `resolver_function`/`resolver_line` null, and set \
+                 `primary_type_symbol`/`type_import_source` to that type (unwrap list/`[]` wrappers \
+                 to the bare element type, e.g. `Order` for `[Order!]!`).\n{}\n",
                 graphql_producer_hints
                     .iter()
                     .map(|line| format!("- {}", line))
@@ -1372,10 +1387,38 @@ mod tests {
         let op = &result.graphql_operations[0];
         assert_eq!(op.kind, crate::operation::GraphqlOperationKind::Query);
         assert_eq!(op.field, "order");
-        assert_eq!(op.resolver_function, "resolveOrder");
-        assert_eq!(op.resolver_line, 38);
+        assert_eq!(op.resolver_function.as_deref(), Some("resolveOrder"));
+        assert_eq!(op.resolver_line, Some(38));
         assert_eq!(op.primary_type_symbol.as_deref(), Some("ApiResponse"));
         assert_eq!(op.type_import_source, None);
+    }
+
+    #[test]
+    fn graphql_operations_deserialize_resolverless_type_locate() {
+        // #248: a resolver-less field the LLM locates by its backing type omits
+        // resolver_function/resolver_line entirely and carries the type in
+        // primary_type_symbol. #[serde(default)] must yield None for the missing
+        // resolver locators rather than failing the parse.
+        let json = r#"{
+            "mounts": [],
+            "endpoints": [],
+            "data_calls": [],
+            "graphql_operations": [
+                {
+                    "kind": "query",
+                    "field": "orders",
+                    "primary_type_symbol": "Order",
+                    "type_import_source": null
+                }
+            ]
+        }"#;
+
+        let result: FileAnalysisResult = serde_json::from_str(json).unwrap();
+        let op = &result.graphql_operations[0];
+        assert_eq!(op.field, "orders");
+        assert_eq!(op.resolver_function, None);
+        assert_eq!(op.resolver_line, None);
+        assert_eq!(op.primary_type_symbol.as_deref(), Some("Order"));
     }
 
     #[test]

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -639,6 +639,7 @@ impl FileOrchestrator {
                         symbol_name,
                         source_file,
                         alias,
+                        array_depth: None,
                     });
                 }
             };
@@ -1151,6 +1152,7 @@ impl FileOrchestrator {
                     symbol_name: symbol.clone(),
                     source_file,
                     alias: Some(alias),
+                    array_depth: None,
                 });
             }
         };
@@ -1272,6 +1274,7 @@ impl FileOrchestrator {
                         symbol_name: symbol.clone(),
                         source_file,
                         alias: Some(alias),
+                        array_depth: None,
                     });
                 }
             }
@@ -1341,12 +1344,58 @@ impl FileOrchestrator {
                     symbol_name: symbol.clone(),
                     source_file,
                     alias: Some(alias),
+                    array_depth: None,
+                });
+            }
+        }
+        let consumer_count = requests.len();
+
+        // #248: SDL producer fields with no resolver but a co-located backing
+        // type. Unlike the resolver path (a `FunctionReturn` infer whose concrete
+        // return carries wrappers), this bundles the located element type and
+        // wraps it in the SDL list depth (`Order` + `[Order!]!` → `Order[]`). The
+        // symbol resolves against the file the entry came from (`resolver_file`),
+        // following `response_type_source` when the type is imported.
+        for op in &graphql.producers {
+            let Some(symbol) = op.response_type_symbol.as_ref() else {
+                continue;
+            };
+            let Some(entry_file) = op.resolver_file.as_ref() else {
+                continue;
+            };
+            let file_abs =
+                Self::to_absolute_path(&entry_file.to_string_lossy(), &repo_root_absolute);
+            let source_file = match op.response_type_source.as_ref() {
+                Some(import_source) => Self::resolve_import_path(&file_abs, import_source),
+                None => file_abs,
+            };
+            let alias = build_manifest_type_alias(
+                &op.key,
+                ManifestRole::Producer,
+                ManifestTypeKind::Response,
+            );
+            // SDL list depth carries the array-ness; the bundled element type
+            // carries the shape. `0` (a non-list field) bundles as-is.
+            let array_depth = op
+                .primary_type_symbol
+                .as_deref()
+                .map(crate::graphql::graphql_list_depth)
+                .filter(|&d| d > 0);
+            let dedup_key = format!("{}|{}|{}", source_file, symbol, alias);
+            if seen.insert(dedup_key) {
+                requests.push(SymbolRequest {
+                    symbol_name: symbol.clone(),
+                    source_file,
+                    alias: Some(alias),
+                    array_depth,
                 });
             }
         }
         debug!(
-            "[FileOrchestrator] Collected {} graphql consumer type requests",
-            requests.len()
+            "[FileOrchestrator] Collected {} graphql type requests ({} consumer, {} producer type-locate)",
+            requests.len(),
+            consumer_count,
+            requests.len() - consumer_count,
         );
         requests
     }

--- a/src/agents/schemas.rs
+++ b/src/agents/schemas.rs
@@ -418,7 +418,7 @@ impl AgentSchemas {
                             "resolver_function": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "Name of the resolver function implementing this field (e.g., 'resolveOrder'). Null when no function in this file resolves the field but a co-located type declares its response shape — in that case set primary_type_symbol/type_import_source to that type."
+                                "description": "Name of the resolver function implementing this field (e.g., 'resolveOrder'). A function that returns the field's value IS its resolver even when the return is wrapped (Promise, a response envelope, an async iterator) — always link it. Null only when no function in this file resolves the field."
                             },
                             "resolver_line": {
                                 "type": "INTEGER",
@@ -428,12 +428,22 @@ impl AgentSchemas {
                             "primary_type_symbol": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "The field's response type as a bare identifier. When a resolver_function exists, its return type (e.g., 'ApiResponse' from 'Promise<ApiResponse<Order>>'). When NO resolver exists but a type declared or imported in this file describes the field's response shape, that type (e.g., 'Order' for a field returning '[Order!]!' backed by 'interface Order'). Unwrap Promise<...>, arrays, and async-iterator wrappers down to the core identifier. Null for untyped, inline-object-literal, or otherwise un-annotated returns."
+                                "description": "The named return type of the resolver as a bare identifier (e.g., 'ApiResponse'). Unwrap Promise<...>, arrays, and async-iterator wrappers down to the core identifier. Null for untyped, inline-object-literal, or otherwise un-annotated resolver returns."
                             },
                             "type_import_source": {
                                 "type": "STRING",
                                 "nullable": true,
                                 "description": "Import path where the `primary_type_symbol` type is defined (e.g., './types/order'), or null if it is declared in the same file. Null whenever `primary_type_symbol` is null."
+                            },
+                            "backing_type_symbol": {
+                                "type": "STRING",
+                                "nullable": true,
+                                "description": "ONLY for a field that NO function in this file resolves: the co-located TS type (declared or imported in this file) that describes the field's response shape, as a bare identifier (e.g. 'Order' for a field returning '[Order!]!' backed by 'interface Order'; unwrap list/array wrappers to the element type). Leave null whenever resolver_function is set — a resolver's return type is richer, so link the resolver instead."
+                            },
+                            "backing_type_source": {
+                                "type": "STRING",
+                                "nullable": true,
+                                "description": "Import path where `backing_type_symbol` is defined (e.g., './types/order'), or null if it is declared in this file. Null whenever `backing_type_symbol` is null."
                             }
                         },
                         "required": ["kind", "field"]

--- a/src/agents/schemas.rs
+++ b/src/agents/schemas.rs
@@ -417,16 +417,18 @@ impl AgentSchemas {
                             },
                             "resolver_function": {
                                 "type": "STRING",
-                                "description": "Name of the resolver function implementing this field (e.g., 'resolveOrder')."
+                                "nullable": true,
+                                "description": "Name of the resolver function implementing this field (e.g., 'resolveOrder'). Null when no function in this file resolves the field but a co-located type declares its response shape — in that case set primary_type_symbol/type_import_source to that type."
                             },
                             "resolver_line": {
                                 "type": "INTEGER",
-                                "description": "Line number where the resolver function is defined (read from the line-number prefix in the source code)."
+                                "nullable": true,
+                                "description": "Line number where the resolver function is defined (read from the line-number prefix in the source code). Null whenever resolver_function is null."
                             },
                             "primary_type_symbol": {
                                 "type": "STRING",
                                 "nullable": true,
-                                "description": "The named return type of the resolver as a bare identifier (e.g., 'ApiResponse'). Unwrap Promise<...>, arrays, and async-iterator wrappers down to the core identifier. Null for untyped, inline-object-literal, or otherwise un-annotated resolver returns."
+                                "description": "The field's response type as a bare identifier. When a resolver_function exists, its return type (e.g., 'ApiResponse' from 'Promise<ApiResponse<Order>>'). When NO resolver exists but a type declared or imported in this file describes the field's response shape, that type (e.g., 'Order' for a field returning '[Order!]!' backed by 'interface Order'). Unwrap Promise<...>, arrays, and async-iterator wrappers down to the core identifier. Null for untyped, inline-object-literal, or otherwise un-annotated returns."
                             },
                             "type_import_source": {
                                 "type": "STRING",
@@ -434,7 +436,7 @@ impl AgentSchemas {
                                 "description": "Import path where the `primary_type_symbol` type is defined (e.g., './types/order'), or null if it is declared in the same file. Null whenever `primary_type_symbol` is null."
                             }
                         },
-                        "required": ["kind", "field", "resolver_function", "resolver_line"]
+                        "required": ["kind", "field"]
                     }
                 },
                 "pubsub_operations": {
@@ -793,15 +795,23 @@ mod tests {
 
         assert_eq!(schema_values, serde_values);
 
-        // The four locating fields must always be present; the type slots
-        // (primary_type_symbol / type_import_source) stay optional/nullable.
+        // Only the operation identity (kind/field) is required; the resolver
+        // locators (resolver_function / resolver_line) and the type slots
+        // (primary_type_symbol / type_import_source) stay optional/nullable so a
+        // resolver-less field can be located by its co-located backing type (#248).
         let required = schema["properties"]["graphql_operations"]["items"]["required"]
             .as_array()
             .expect("graphql_operations item required array must exist");
-        for field in ["kind", "field", "resolver_function", "resolver_line"] {
+        for field in ["kind", "field"] {
             assert!(
                 required.iter().any(|v| v == field),
                 "graphql_operations item required must contain {field}"
+            );
+        }
+        for field in ["resolver_function", "resolver_line"] {
+            assert!(
+                !required.iter().any(|v| v == field),
+                "graphql_operations item required must NOT contain {field} (resolver-less fields)"
             );
         }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1423,12 +1423,28 @@ fn merge_graphql_resolver_locations(
             };
             let producer = &mut graphql.producers[idx];
             producer.resolver_file = Some(PathBuf::from(path));
-            // The LLM line is a 1-based source line; clamp non-positive values to
-            // None rather than wrapping into a bogus u32 (the infer request's
-            // line_number is u32, and a 0/negative line can't anchor a function).
-            producer.resolver_line = u32::try_from(llm_op.resolver_line)
-                .ok()
-                .filter(|&line| line > 0);
+            if llm_op
+                .resolver_function
+                .as_deref()
+                .is_some_and(|f| !f.is_empty())
+            {
+                // Resolver located: its concrete return type carries the
+                // wrappers (Promise / ApiResponse envelope / async-iterator) the
+                // bare SDL-backed type can't, so the FunctionReturn path wins. The
+                // LLM line is a 1-based source line; clamp non-positive values to
+                // None rather than wrapping into a bogus u32 (the infer request's
+                // line_number is u32, and a 0/negative line can't anchor a fn).
+                producer.resolver_line = llm_op
+                    .resolver_line
+                    .and_then(|line| u32::try_from(line).ok())
+                    .filter(|&line| line > 0);
+            } else if let Some(symbol) = llm_op.primary_type_symbol.clone() {
+                // No resolver function: fall back to the co-located backing type
+                // the LLM located (#248). The sidecar bundles + structurally
+                // expands it and wraps it in the SDL list depth.
+                producer.response_type_symbol = Some(symbol);
+                producer.response_type_source = llm_op.type_import_source.clone();
+            }
         }
     }
 }
@@ -4221,6 +4237,8 @@ mod tests {
             payload_type_source: None,
             resolver_file: None,
             resolver_line: None,
+            response_type_symbol: None,
+            response_type_source: None,
         }
     }
 
@@ -4240,6 +4258,8 @@ mod tests {
             payload_type_source: payload_source.map(String::from),
             resolver_file: None,
             resolver_line: None,
+            response_type_symbol: None,
+            response_type_source: None,
         }
     }
 
@@ -4296,16 +4316,16 @@ mod tests {
                     GraphqlOperation {
                         kind: GraphqlOperationKind::Query,
                         field: "order".to_string(),
-                        resolver_function: "resolveOrder".to_string(),
-                        resolver_line: 38,
+                        resolver_function: Some("resolveOrder".to_string()),
+                        resolver_line: Some(38),
                         primary_type_symbol: Some("ApiResponse".to_string()),
                         type_import_source: None,
                     },
                     GraphqlOperation {
                         kind: GraphqlOperationKind::Mutation,
                         field: "createOrder".to_string(),
-                        resolver_function: "createOrder".to_string(),
-                        resolver_line: 7,
+                        resolver_function: Some("createOrder".to_string()),
+                        resolver_line: Some(7),
                         primary_type_symbol: None,
                         type_import_source: None,
                     },
@@ -4329,8 +4349,13 @@ mod tests {
         assert_eq!(order.resolver_line, Some(38));
         // The SDL anchor is untouched by the merge.
         assert_eq!(order.primary_type_symbol.as_deref(), Some("Order"));
+        // A resolver was matched, so the FunctionReturn path wins: the LLM's
+        // `primary_type_symbol` ("ApiResponse") must NOT become a type-locate
+        // fallback (bundling the bare generic would drop the envelope).
+        assert_eq!(order.response_type_symbol, None);
 
-        // The producer with no matching LLM op keeps both resolver fields None.
+        // The producer with no matching LLM op keeps both resolver fields None
+        // and gains no type-locate fallback.
         let orders = graphql
             .producers
             .iter()
@@ -4338,6 +4363,7 @@ mod tests {
             .expect("orders producer");
         assert_eq!(orders.resolver_file, None);
         assert_eq!(orders.resolver_line, None);
+        assert_eq!(orders.response_type_symbol, None);
 
         // The LLM op with no SDL producer (`mutation createOrder`) created no
         // new producer — it was ignored.
@@ -4348,6 +4374,67 @@ mod tests {
                 .any(|op| op.key.canonical() == "graphql|mutation|createOrder"),
             "an LLM op with no matching SDL producer must not create a producer"
         );
+    }
+
+    /// #248: an SDL producer field with NO resolver function but a co-located
+    /// backing type (the LLM emits `primary_type_symbol` with a null
+    /// `resolver_function`) picks up the type-locate fallback — the scanner
+    /// records the backing type so the sidecar can bundle + list-wrap it. The
+    /// resolver locators stay `None` (no FunctionReturn), and `resolver_file` is
+    /// still stamped with the file the entry came from.
+    #[test]
+    fn merge_graphql_type_locate_for_resolverless_field() {
+        use crate::agents::file_analyzer_agent::GraphqlOperation;
+        use crate::operation::GraphqlOperationKind;
+
+        let mut graphql = crate::graphql::GraphqlExtraction {
+            producers: vec![graphql_op(
+                GraphqlOperationKind::Query,
+                "orders",
+                Some("[Order!]!"),
+            )],
+            consumers: vec![],
+        };
+
+        let mut file_results: HashMap<String, FileAnalysisResult> = HashMap::new();
+        file_results.insert(
+            "packages/gateway/src/orders.resolver.ts".to_string(),
+            FileAnalysisResult {
+                mounts: vec![],
+                endpoints: vec![],
+                data_calls: vec![],
+                graphql_operations: vec![GraphqlOperation {
+                    kind: GraphqlOperationKind::Query,
+                    field: "orders".to_string(),
+                    // No resolver — the field is backed only by a co-located type.
+                    resolver_function: None,
+                    resolver_line: None,
+                    primary_type_symbol: Some("Order".to_string()),
+                    type_import_source: None,
+                }],
+                pubsub_operations: vec![],
+            },
+        );
+
+        merge_graphql_resolver_locations(&mut graphql, &file_results);
+
+        let orders = graphql
+            .producers
+            .iter()
+            .find(|op| op.key.canonical() == "graphql|query|orders")
+            .expect("orders producer");
+        assert_eq!(
+            orders.resolver_file,
+            Some(PathBuf::from("packages/gateway/src/orders.resolver.ts")),
+            "the file the entry came from is still recorded"
+        );
+        // No FunctionReturn: the resolver locators stay unset.
+        assert_eq!(orders.resolver_line, None);
+        // The type-locate fallback carries the backing type for the sidecar.
+        assert_eq!(orders.response_type_symbol.as_deref(), Some("Order"));
+        assert_eq!(orders.response_type_source, None);
+        // The SDL anchor is untouched.
+        assert_eq!(orders.primary_type_symbol.as_deref(), Some("[Order!]!"));
     }
 
     /// A typed socket emitter produces a Response-kind manifest entry keyed by

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1423,10 +1423,15 @@ fn merge_graphql_resolver_locations(
             };
             let producer = &mut graphql.producers[idx];
             producer.resolver_file = Some(PathBuf::from(path));
+            // Trim before the emptiness check: a whitespace-only string (e.g.
+            // " ") from the model is not a resolver function name, and letting
+            // it through here would wrongly take the FunctionReturn path and
+            // block the type-locate fallback below, leaving the producer
+            // unanchored.
             if llm_op
                 .resolver_function
                 .as_deref()
-                .is_some_and(|f| !f.is_empty())
+                .is_some_and(|f| !f.trim().is_empty())
             {
                 // Resolver located: its concrete return type carries the
                 // wrappers (Promise / ApiResponse envelope / async-iterator) the
@@ -4449,6 +4454,59 @@ mod tests {
         assert_eq!(orders.response_type_source, None);
         // The SDL anchor is untouched.
         assert_eq!(orders.primary_type_symbol.as_deref(), Some("[Order!]!"));
+    }
+
+    /// A whitespace-only `resolver_function` (e.g. `" "`) must be treated the
+    /// same as `None`/empty: it is not a real function name, so it must not
+    /// take the FunctionReturn path, and the type-locate fallback (backing
+    /// type) must still fire.
+    #[test]
+    fn merge_graphql_whitespace_only_resolver_function_is_treated_as_absent() {
+        use crate::agents::file_analyzer_agent::GraphqlOperation;
+        use crate::operation::GraphqlOperationKind;
+
+        let mut graphql = crate::graphql::GraphqlExtraction {
+            producers: vec![graphql_op(
+                GraphqlOperationKind::Query,
+                "orders",
+                Some("[Order!]!"),
+            )],
+            consumers: vec![],
+        };
+
+        let mut file_results: HashMap<String, FileAnalysisResult> = HashMap::new();
+        file_results.insert(
+            "packages/gateway/src/orders.resolver.ts".to_string(),
+            FileAnalysisResult {
+                mounts: vec![],
+                endpoints: vec![],
+                data_calls: vec![],
+                graphql_operations: vec![GraphqlOperation {
+                    kind: GraphqlOperationKind::Query,
+                    field: "orders".to_string(),
+                    // Whitespace only, not a real resolver name.
+                    resolver_function: Some("  ".to_string()),
+                    resolver_line: Some(38),
+                    primary_type_symbol: None,
+                    type_import_source: None,
+                    backing_type_symbol: Some("Order".to_string()),
+                    backing_type_source: None,
+                }],
+                pubsub_operations: vec![],
+            },
+        );
+
+        merge_graphql_resolver_locations(&mut graphql, &file_results);
+
+        let orders = graphql
+            .producers
+            .iter()
+            .find(|op| op.key.canonical() == "graphql|query|orders")
+            .expect("orders producer");
+        // No FunctionReturn: a whitespace-only name must not anchor a resolver.
+        assert_eq!(orders.resolver_line, None);
+        // The type-locate fallback still fires (the producer stays anchored).
+        assert_eq!(orders.response_type_symbol.as_deref(), Some("Order"));
     }
 
     /// A typed socket emitter produces a Response-kind manifest entry keyed by

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1438,12 +1438,15 @@ fn merge_graphql_resolver_locations(
                     .resolver_line
                     .and_then(|line| u32::try_from(line).ok())
                     .filter(|&line| line > 0);
-            } else if let Some(symbol) = llm_op.primary_type_symbol.clone() {
+            } else if let Some(symbol) = llm_op.backing_type_symbol.clone() {
                 // No resolver function: fall back to the co-located backing type
-                // the LLM located (#248). The sidecar bundles + structurally
+                // the LLM located (#248). Keyed on the dedicated
+                // `backing_type_symbol` (never `primary_type_symbol`, which
+                // describes a resolver's return type) so this can only fire for a
+                // genuinely resolver-less field. The sidecar bundles + structurally
                 // expands it and wraps it in the SDL list depth.
                 producer.response_type_symbol = Some(symbol);
-                producer.response_type_source = llm_op.type_import_source.clone();
+                producer.response_type_source = llm_op.backing_type_source.clone();
             }
         }
     }
@@ -4320,6 +4323,11 @@ mod tests {
                         resolver_line: Some(38),
                         primary_type_symbol: Some("ApiResponse".to_string()),
                         type_import_source: None,
+                        // Even if the model ALSO emits a backing type here, the
+                        // resolver path must win (regression guard: bundling the
+                        // bare `Order` would drop the ApiResponse envelope).
+                        backing_type_symbol: Some("Order".to_string()),
+                        backing_type_source: None,
                     },
                     GraphqlOperation {
                         kind: GraphqlOperationKind::Mutation,
@@ -4328,6 +4336,8 @@ mod tests {
                         resolver_line: Some(7),
                         primary_type_symbol: None,
                         type_import_source: None,
+                        backing_type_symbol: None,
+                        backing_type_source: None,
                     },
                 ],
                 pubsub_operations: vec![],
@@ -4349,9 +4359,10 @@ mod tests {
         assert_eq!(order.resolver_line, Some(38));
         // The SDL anchor is untouched by the merge.
         assert_eq!(order.primary_type_symbol.as_deref(), Some("Order"));
-        // A resolver was matched, so the FunctionReturn path wins: the LLM's
-        // `primary_type_symbol` ("ApiResponse") must NOT become a type-locate
-        // fallback (bundling the bare generic would drop the envelope).
+        // A resolver was matched, so the FunctionReturn path wins even though the
+        // op also carries a `backing_type_symbol`: the type-locate fallback must
+        // NOT fire (bundling the bare `Order` would drop the ApiResponse
+        // envelope — the exact live-eval regression this guards against).
         assert_eq!(order.response_type_symbol, None);
 
         // The producer with no matching LLM op keeps both resolver fields None
@@ -4406,11 +4417,14 @@ mod tests {
                 graphql_operations: vec![GraphqlOperation {
                     kind: GraphqlOperationKind::Query,
                     field: "orders".to_string(),
-                    // No resolver — the field is backed only by a co-located type.
+                    // No resolver — the field is backed only by a co-located type,
+                    // carried on the dedicated backing_type_symbol.
                     resolver_function: None,
                     resolver_line: None,
-                    primary_type_symbol: Some("Order".to_string()),
+                    primary_type_symbol: None,
                     type_import_source: None,
+                    backing_type_symbol: Some("Order".to_string()),
+                    backing_type_source: None,
                 }],
                 pubsub_operations: vec![],
             },

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -66,6 +66,21 @@ pub struct GraphqlOp {
     /// paired with `resolver_file`. Anchors the `FunctionReturn` infer request.
     /// `None` whenever `resolver_file` is `None`.
     pub resolver_line: Option<u32>,
+    /// PRODUCER-only fallback (#248): the co-located TS type that declares this
+    /// field's response shape when NO resolver function exists (e.g. an SDL
+    /// `orders: [Order!]!` field backed by `interface Order`, with no
+    /// `resolveOrders`). Located by the file-analyzer (`graphql_operations`
+    /// `primary_type_symbol`), it is bundled + structurally expanded + wrapped in
+    /// the SDL list depth by the type sidecar — the deterministic half of the
+    /// LLM-locate/scanner-expand split. `None` when a resolver was matched (the
+    /// `FunctionReturn` path wins) or nothing was located. Paired with
+    /// `resolver_file`, which is set to the analyzed file the entry came from.
+    pub response_type_symbol: Option<String>,
+    /// PRODUCER-only: import specifier the `response_type_symbol` is declared in
+    /// (`./types/order`), resolved against `resolver_file`. `None` when the type
+    /// is declared in `resolver_file` itself. Null whenever
+    /// `response_type_symbol` is null.
+    pub response_type_source: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -300,6 +315,10 @@ pub fn extract_from_document_text(
                     // graphql_operations fill these in the engine merge (Stage B1).
                     resolver_file: None,
                     resolver_line: None,
+                    // Populated in the engine merge only when the LLM located a
+                    // co-located backing type for a resolver-less field (#248).
+                    response_type_symbol: None,
+                    response_type_source: None,
                 });
             }
         }
@@ -356,6 +375,9 @@ pub fn extract_from_document_text(
                     // Consumers never carry a resolver location.
                     resolver_file: None,
                     resolver_line: None,
+                    // Producer-only fallback; never set on consumers.
+                    response_type_symbol: None,
+                    response_type_source: None,
                 });
             }
         }
@@ -375,6 +397,15 @@ fn render_sdl_type(ty: &graphql_parser::schema::Type<'_, String>) -> String {
         Type::ListType(inner) => format!("[{}]", render_sdl_type(inner)),
         Type::NonNullType(inner) => format!("{}!", render_sdl_type(inner)),
     }
+}
+
+/// List-nesting depth of a rendered SDL type expression (#248): `[Order!]!` → 1,
+/// `[[Order!]!]!` → 2, `Order`/`Order!` → 0. Non-null (`!`) markers do not add
+/// depth. Used to wrap a resolver-less field's bundled element type in the right
+/// number of TS array levels (`Order` → `Order[]` for `[Order!]!`) so the
+/// producer's response contract matches the SDL list shape.
+pub fn graphql_list_depth(rendered_sdl_type: &str) -> u32 {
+    rendered_sdl_type.chars().take_while(|c| *c == '[').count() as u32
 }
 
 /// Join a `gql`/`graphql` tagged template's literal parts, dropping

--- a/src/services/type_sidecar.rs
+++ b/src/services/type_sidecar.rs
@@ -121,6 +121,13 @@ pub struct SymbolRequest {
     /// Optional alias for the exported type
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
+    /// Wrap the bundled symbol in this many TS array levels (#248): a GraphQL
+    /// SDL producer field `[Order!]!` backed by `interface Order` bundles `Order`
+    /// with `array_depth: 1` so the sidecar emits `Order[]` — the element type
+    /// carries the shape, the SDL list marker carries the depth. Omitted/`0`
+    /// bundles the symbol as-is (the HTTP/socket/consumer default).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub array_depth: Option<u32>,
 }
 
 /// Request for type inference at a specific location
@@ -1009,9 +1016,12 @@ mod tests {
             symbol_name: "User".to_string(),
             source_file: "src/types.ts".to_string(),
             alias: Some("UserResponse".to_string()),
+            array_depth: None,
         };
         let json = serde_json::to_string(&request).unwrap();
         assert!(json.contains(r#""symbol_name":"User""#));
+        // array_depth defaults to None and is skipped on the wire.
+        assert!(!json.contains("array_depth"));
         assert!(json.contains(r#""alias":"UserResponse""#));
     }
 
@@ -1058,6 +1068,7 @@ mod tests {
                 symbol_name: "User".to_string(),
                 source_file: "src/types.ts".to_string(),
                 alias: None,
+                array_depth: None,
             }],
         };
         let json = serde_json::to_string(&request).unwrap();
@@ -1146,6 +1157,7 @@ mod tests {
             symbol_name: "SomeInterface".to_string(),
             source_file: "src/types.ts".to_string(),
             alias: Some("Endpoint_abc_Response".to_string()),
+            array_depth: None,
         }];
 
         if had_explicit_dts {

--- a/src/sidecar/src/bundler.ts
+++ b/src/sidecar/src/bundler.ts
@@ -584,6 +584,25 @@ export class TypeBundler {
   private extractTypeDefinition(
     symbol: SymbolRequest
   ): { definition: string; typeString: string } | null {
+    const base = this.extractTypeDefinitionBase(symbol);
+    if (!base) return null;
+
+    // #248: wrap the resolved element type in the SDL list depth. A GraphQL
+    // producer field `[Order!]!` backed by `interface Order` bundles `Order`
+    // with `array_depth: 1`; the alias becomes `Order[]` (arrays can't be
+    // interfaces, so it is always emitted as a type alias). The element's
+    // structurally-expanded body carries the shape, so downstream resolution
+    // and the eval's whitespace-collapsed `{...}[]` comparison both hold.
+    const depth = symbol.array_depth ?? 0;
+    if (depth <= 0) return base;
+    const alias = symbol.alias || symbol.symbol_name;
+    const typeString = `${base.typeString}${'[]'.repeat(depth)}`;
+    return { definition: `export type ${alias} = ${typeString};`, typeString };
+  }
+
+  private extractTypeDefinitionBase(
+    symbol: SymbolRequest
+  ): { definition: string; typeString: string } | null {
     const absolutePath = path.isAbsolute(symbol.source_file)
       ? symbol.source_file
       : path.resolve(this.repoRoot, symbol.source_file);

--- a/src/sidecar/src/bundler.ts
+++ b/src/sidecar/src/bundler.ts
@@ -37,6 +37,17 @@ import type {
 import { expandTypeStructural } from './type-structural-expander.js';
 
 /**
+ * #248: upper bound on `SymbolRequest.array_depth`. SDL list nesting is
+ * realistically 1-3 levels (`[Order!]!`, at most `[[Order!]!]!`); this is a
+ * generous ceiling, not a realistic value. `array_depth` wraps via string
+ * repetition (`'[]'.repeat(depth)`), so an unbounded value from the model
+ * would let a single symbol blow up the emitted `.d.ts` (and the memory/CPU
+ * spent producing it). Depths above this are treated as unresolvable, same
+ * as any other symbol the bundler can't extract a type for.
+ */
+const MAX_ARRAY_DEPTH = 10;
+
+/**
  * Options for SurfaceEmitter construction
  */
 export interface SurfaceEmitterOptions {
@@ -595,6 +606,12 @@ export class TypeBundler {
     // and the eval's whitespace-collapsed `{...}[]` comparison both hold.
     const depth = symbol.array_depth ?? 0;
     if (depth <= 0) return base;
+    // Reject rather than clamp: silently clamping would emit a type at a
+    // depth the model never asked for, which is wrong in a different way.
+    // Falling through to the symbol's normal "could not extract" failure
+    // keeps this on the existing per-symbol failure path (`symbol_failures`)
+    // instead of rejecting the whole batch.
+    if (depth > MAX_ARRAY_DEPTH) return null;
     const alias = symbol.alias || symbol.symbol_name;
     // Parenthesise a union/intersection/function element so `(A | B)[]` doesn't
     // misparse as `A | B[]` and `(() => T)[]` as `() => T[]`. Decide from the

--- a/src/sidecar/src/bundler.ts
+++ b/src/sidecar/src/bundler.ts
@@ -596,8 +596,39 @@ export class TypeBundler {
     const depth = symbol.array_depth ?? 0;
     if (depth <= 0) return base;
     const alias = symbol.alias || symbol.symbol_name;
-    const typeString = `${base.typeString}${'[]'.repeat(depth)}`;
+    // Parenthesise a union/intersection/function element so `(A | B)[]` doesn't
+    // misparse as `A | B[]` and `(() => T)[]` as `() => T[]`. Decide from the
+    // TYPE (not the string): a single object literal `{ a: A | B }` is NOT a
+    // top-level union and must stay unparenthesised (`{ a: A | B }[]`).
+    const element = this.elementNeedsArrayParens(symbol)
+      ? `(${base.typeString})`
+      : base.typeString;
+    const typeString = `${element}${'[]'.repeat(depth)}`;
     return { definition: `export type ${alias} = ${typeString};`, typeString };
+  }
+
+  /// Whether the element type must be parenthesised before an `[]` suffix.
+  /// Interfaces/classes/enums are always object/nominal (never a top-level
+  /// union), so only type aliases and typed variables can carry a bare
+  /// union/intersection/function that would misparse; those are re-resolved
+  /// from the source Type here (this runs only on the rare array_depth path).
+  private elementNeedsArrayParens(symbol: SymbolRequest): boolean {
+    const absolutePath = path.isAbsolute(symbol.source_file)
+      ? symbol.source_file
+      : path.resolve(this.repoRoot, symbol.source_file);
+    const sourceFile = this.project.getSourceFile(absolutePath);
+    if (!sourceFile) return false;
+    const name = symbol.symbol_name;
+    const decl =
+      sourceFile.getTypeAlias(name) ?? sourceFile.getVariableDeclaration(name);
+    if (!decl) return false;
+    const t = decl.getType();
+    return (
+      t.isUnion() ||
+      t.isIntersection() ||
+      t.getCallSignatures().length > 0 ||
+      t.getConstructSignatures().length > 0
+    );
   }
 
   private extractTypeDefinitionBase(

--- a/src/sidecar/src/types.ts
+++ b/src/sidecar/src/types.ts
@@ -313,6 +313,14 @@ export interface SymbolRequest {
   source_file: string;
   /** Optional alias for the exported type */
   alias?: string;
+  /**
+   * Wrap the bundled symbol in this many TS array levels (#248). A GraphQL SDL
+   * producer field `[Order!]!` backed by `interface Order` bundles `Order` with
+   * `array_depth: 1`, so the sidecar emits `Order[]`: the element type carries
+   * the shape, the SDL list marker carries the depth. Omitted/`0` bundles the
+   * symbol as-is (the HTTP/socket/consumer default).
+   */
+  array_depth?: number;
 }
 
 /**

--- a/src/sidecar/src/validators.ts
+++ b/src/sidecar/src/validators.ts
@@ -96,6 +96,8 @@ export const SymbolRequestSchema = z.object({
   symbol_name: z.string().min(1, 'Symbol name cannot be empty'),
   source_file: z.string().min(1, 'Source file cannot be empty'),
   alias: z.string().optional(),
+  // #248: SDL list depth to wrap the bundled element type in (`Order` → `Order[]`).
+  array_depth: z.number().int().nonnegative().optional(),
 });
 
 // ============================================================================

--- a/src/sidecar/src/validators.ts
+++ b/src/sidecar/src/validators.ts
@@ -97,6 +97,12 @@ export const SymbolRequestSchema = z.object({
   source_file: z.string().min(1, 'Source file cannot be empty'),
   alias: z.string().optional(),
   // #248: SDL list depth to wrap the bundled element type in (`Order` → `Order[]`).
+  // No upper bound here deliberately: a batch invalid at this schema layer
+  // fails the *whole* bundle request (see the `maxDepth` note above), which
+  // is worse than one bad symbol. The bundler enforces MAX_ARRAY_DEPTH
+  // per-symbol instead, so an over-bound depth becomes a normal
+  // `symbol_failures` entry rather than sinking every other symbol in the
+  // batch.
   array_depth: z.number().int().nonnegative().optional(),
 });
 

--- a/src/sidecar/test/bundle-array-depth.test.ts
+++ b/src/sidecar/test/bundle-array-depth.test.ts
@@ -24,6 +24,7 @@ interface BundleResponseShape {
   status: string;
   dts_content?: string;
   errors?: string[];
+  symbol_failures?: Array<{ symbol_name: string; source_file: string; reason: string }>;
 }
 
 interface ResolveResponseShape {
@@ -123,6 +124,35 @@ describe('array_depth wraps a bundled symbol in TS array levels (#248)', () => {
     assert.ok(
       !/"guest"\[\]/.test(noWs(dts)),
       `must NOT misparse the last union member as an array, got:\n${dts}`,
+    );
+  });
+
+  it('treats an array_depth above the sane ceiling as an unresolvable symbol, not a huge type', async () => {
+    const ALIAS = 'Endpoint_arr4_Response';
+    const bundle = await client.send<BundleResponseShape>({
+      action: 'bundle',
+      request_id: 'arr-bundle-4',
+      symbols: [
+        // Well past MAX_ARRAY_DEPTH (10): must fail this symbol rather than
+        // emit `'[]'.repeat(depth)` worth of array levels.
+        { symbol_name: 'UserProfile', source_file: TYPES_FIXTURE, alias: ALIAS, array_depth: 1000 },
+      ],
+    });
+
+    // The batch itself still succeeds (other symbols in a real batch must
+    // not be sunk by one bad depth): this symbol is reported as a
+    // `symbol_failures` entry instead, same as any other unresolvable
+    // symbol, and never makes it into the emitted .d.ts.
+    assert.strictEqual(
+      bundle.status,
+      'success',
+      `expected the batch to still succeed with a per-symbol failure, got: ${JSON.stringify(bundle)}`,
+    );
+    const dts = bundle.dts_content ?? '';
+    assert.ok(!dts.includes(ALIAS), `over-depth alias must not be emitted, got:\n${dts}`);
+    assert.ok(
+      bundle.symbol_failures?.some((f) => f.symbol_name === 'UserProfile'),
+      `expected a symbol_failures entry for the over-depth symbol, got: ${JSON.stringify(bundle.symbol_failures)}`,
     );
   });
 });

--- a/src/sidecar/test/bundle-array-depth.test.ts
+++ b/src/sidecar/test/bundle-array-depth.test.ts
@@ -1,0 +1,103 @@
+/**
+ * #248: a `SymbolRequest.array_depth > 0` wraps the bundled element type in that
+ * many TS array levels. This is the GraphQL producer type-locate path: an SDL
+ * field `orders: [Order!]!` backed by `interface Order` (with no resolver) is
+ * bundled as `Order` with `array_depth: 1`, so the alias must resolve to the
+ * element's fully-inlined body followed by `[]` — the shape from the element
+ * type, the list depth from the SDL marker.
+ *
+ * Reuses UserProfile (test/fixtures/sample-repo/src/types.ts), the same nested
+ * shape the explicit-symbol bundle test exercises, so we also confirm the wrap
+ * does not break the structural inlining of nested named members.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const TYPES_FIXTURE = path.join(FIXTURES_PATH, 'src/types.ts');
+const noWs = (s: string) => s.replace(/\s/g, '');
+
+interface BundleResponseShape {
+  request_id: string;
+  status: string;
+  dts_content?: string;
+  errors?: string[];
+}
+
+interface ResolveResponseShape {
+  request_id: string;
+  status: string;
+  definitions?: Array<{ type_alias: string; definition: string; expanded: string }>;
+  errors?: string[];
+}
+
+describe('array_depth wraps a bundled symbol in TS array levels (#248)', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({ action: 'init', request_id: 'arr-init', repo_root: FIXTURES_PATH });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('emits `= {...}[];` (a type alias, not an interface) and keeps nested inlining', async () => {
+    const ALIAS = 'Endpoint_arr1_Response';
+    const bundle = await client.send<BundleResponseShape>({
+      action: 'bundle',
+      request_id: 'arr-bundle',
+      symbols: [
+        { symbol_name: 'UserProfile', source_file: TYPES_FIXTURE, alias: ALIAS, array_depth: 1 },
+      ],
+    });
+    assert.strictEqual(bundle.status, 'success', `bundle failed: ${JSON.stringify(bundle.errors)}`);
+    const dts = bundle.dts_content ?? '';
+
+    // Arrays can't be interfaces: the alias must be a type alias, not `interface`.
+    assert.ok(
+      new RegExp(`type\\s+${ALIAS}\\s*=`).test(dts) && !dts.includes(`interface ${ALIAS}`),
+      `array-wrapped alias must be a type alias, got:\n${dts}`,
+    );
+    // The RHS ends in `[]` and the element body is still structurally inlined.
+    assert.ok(noWs(dts).includes('}[]'), `expected a trailing []-wrapped body, got:\n${dts}`);
+    assert.ok(
+      noWs(dts).includes('settings:{') && !/settings\s*:\s*UserSettings/.test(dts),
+      `nested member must still be inlined under the wrap, got:\n${dts}`,
+    );
+  });
+
+  it('resolves the wrapped alias to `{...}[]` end-to-end', async () => {
+    const ALIAS = 'Endpoint_arr2_Response';
+    const bundle = await client.send<BundleResponseShape>({
+      action: 'bundle',
+      request_id: 'arr-bundle-2',
+      symbols: [
+        { symbol_name: 'UserProfile', source_file: TYPES_FIXTURE, alias: ALIAS, array_depth: 1 },
+      ],
+    });
+    assert.strictEqual(bundle.status, 'success');
+
+    const resolved = await client.send<ResolveResponseShape>({
+      action: 'resolve_definitions',
+      request_id: 'arr-resolve',
+      bundled_dts: bundle.dts_content ?? '',
+      aliases: [ALIAS],
+    });
+    assert.strictEqual(resolved.status, 'success', `resolve failed: ${JSON.stringify(resolved.errors)}`);
+    const def = resolved.definitions?.find((d) => d.type_alias === ALIAS);
+    assert.ok(def, `expected a resolved definition for ${ALIAS}`);
+
+    // The end-to-end expanded string (what the scorer compares) is the inlined
+    // element body wrapped in a single array level.
+    assert.ok(noWs(def.expanded).endsWith('[]'), `expanded must end in [], got: ${def.expanded}`);
+    assert.ok(
+      noWs(def.expanded).includes('settings:{') && !def.expanded.includes('UserSettings'),
+      `expanded must inline nested members under the wrap, got: ${def.expanded}`,
+    );
+  });
+});

--- a/src/sidecar/test/bundle-array-depth.test.ts
+++ b/src/sidecar/test/bundle-array-depth.test.ts
@@ -100,4 +100,29 @@ describe('array_depth wraps a bundled symbol in TS array levels (#248)', () => {
       `expanded must inline nested members under the wrap, got: ${def.expanded}`,
     );
   });
+
+  it('parenthesises a union element so `(A | B)[]` does not misparse as `A | B[]`', async () => {
+    const ALIAS = 'Endpoint_arr3_Response';
+    const bundle = await client.send<BundleResponseShape>({
+      action: 'bundle',
+      request_id: 'arr-bundle-3',
+      // UserRole = 'admin' | 'user' | 'guest' (a top-level union type alias).
+      symbols: [
+        { symbol_name: 'UserRole', source_file: TYPES_FIXTURE, alias: ALIAS, array_depth: 1 },
+      ],
+    });
+    assert.strictEqual(bundle.status, 'success', `bundle failed: ${JSON.stringify(bundle.errors)}`);
+    const dts = bundle.dts_content ?? '';
+
+    // The union must be parenthesised before the `[]`, never `... | "guest"[]`.
+    // (ts-morph normalises string-literal members to double quotes.)
+    assert.ok(
+      noWs(dts).includes('("admin"|"user"|"guest")[]'),
+      `union element must be parenthesised under the array wrap, got:\n${dts}`,
+    );
+    assert.ok(
+      !/"guest"\[\]/.test(noWs(dts)),
+      `must NOT misparse the last union member as an array, got:\n${dts}`,
+    );
+  });
 });


### PR DESCRIPTION
## What

A GraphQL SDL producer field with **no resolver function** (corpus-1 `orders: [Order!]!`, no `resolveOrders`) previously stayed `type_state=Unknown` — the `FunctionReturn` resolver path had nothing to anchor on. This adds a **type-locate fallback**: the file-analyzer locates the field's co-located backing type, and the scanner bundles + structurally-expands it, wrapping it in the SDL list depth (`Order` → `Order[]`).

## The scanner/cloud split (why this is the design)

Follows the standing line (`feedback_prefer_llm_pipeline_over_brittle_scanner`): resolution has two steps, drawn on different sides.

- **LOCATE** (which TS type is this field's response contract?) → **LLM**. This is the convention-sensitive step — a real repo names the backing type `Order`/`OrderModel`/`OrderDTO` or inlines it, so a scanner name-match would pass *this* corpus while overstating real coverage. Steered entirely by the scanner-side **response-schema descriptions + user message** (the file-analyzer system prompt is a generic Pattern Matcher) → **no deploy**.
- **RESOLVE + EXPAND** (turn the located type into its structural shape + apply the SDL list depth) → **scanner**, deterministic, reuses the existing consumer-bundle machinery.

A matched resolver still **wins** (its concrete return carries the `Promise`/`ApiResponse` envelope wrappers the bare SDL-backed type can't), so `order`/`refundOrder`/`orderUpdated` are untouched.

## Changes

- `schemas.rs`: `graphql_operations` `resolver_function`/`resolver_line` now optional (only `kind`/`field` required); `primary_type_symbol` description broadened to the no-resolver backing-type case.
- `file_analyzer_agent.rs`: `GraphqlOperation` resolver fields → `Option`; user-message GRAPHQL PRODUCERS section instructs the type-locate emission.
- `graphql.rs`: `GraphqlOp` gains producer-only `response_type_symbol`/`response_type_source` + a `graphql_list_depth` helper.
- `engine/mod.rs`: the merge routes a matched resolver to `FunctionReturn`, else records the located backing type.
- `file_orchestrator.rs`: `collect_graphql_type_requests` emits a `Producer/Response` `SymbolRequest` for the located type with `array_depth` from the SDL list depth.
- sidecar (`bundler.ts`/`types.ts`/`validators.ts`): `SymbolRequest.array_depth` wraps the bundled element type in TS array levels, emitted as a type alias.

## Verification

- Cargo lib + integration suites, sidecar `npm test` (+ new `bundle-array-depth` test), ts_check suite, clippy, fmt — all green.
- Deterministic cassette + xrepo-harness goldens **unchanged** (the type-locate path only fires on a resolver-less LLM entry, absent from the cassette).
- Live eval running on both corpora (runs=3). Expected: corpus-1 `graphql|query|orders` producer `Unknown → Explicit {Order}[]`, resolution 0.80 → 0.90; corpus-2 no regression. Per-edge results to follow.

Scanner-only, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)