### PR TITLE
fix(eval): projection type-slot correctness + sidecar request-body locator convergence

### DIFF
--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -16,7 +16,7 @@ use crate::analyzer::{
     ApiAnalysisResult, ApiEndpointDetails, ConflictSeverity,
     CrossRepoMatch as AnalyzerCrossRepoMatch, DependencyConflict,
 };
-use crate::cloud_storage::{ManifestRole, TypeManifestEntry};
+use crate::cloud_storage::{ManifestRole, ManifestTypeKind, TypeManifestEntry};
 use crate::operation::OperationKey;
 
 /// The full eval projection of a single scan: the producer endpoints, the
@@ -162,8 +162,9 @@ impl EvalProjection {
     }
 }
 
-/// The manifest fields an op carries, collapsed from the request/response
-/// manifest entries for a single operation key.
+/// The manifest fields an op carries, selected from the request/response
+/// manifest entries for a single operation key at the op's own call/handler
+/// site.
 #[derive(Default)]
 struct ManifestFields {
     type_alias: Option<String>,
@@ -177,59 +178,146 @@ struct ManifestFields {
     primary_type_symbol: Option<String>,
 }
 
-/// Lookup from `(canonical operation key, role)` → manifest fields. The manifest
-/// carries up to two entries per op-and-role (request + response); we prefer the
-/// entry that has resolved-type detail so the projection surfaces the richest
-/// available type.
+/// One manifest entry, kept whole (kind + site discriminators intact) so the
+/// per-op join can pick the right entry instead of collapsing them.
+struct ManifestRecord {
+    type_kind: ManifestTypeKind,
+    file_path: String,
+    line_number: u32,
+    type_alias: String,
+    type_state: String,
+    resolved_definition: Option<String>,
+    expanded_definition: Option<String>,
+    is_explicit: bool,
+    primary_type_symbol: Option<String>,
+}
+
+impl ManifestRecord {
+    fn has_definition(&self) -> bool {
+        self.resolved_definition.is_some() || self.expanded_definition.is_some()
+    }
+}
+
+/// Lookup from `(canonical operation key, role)` → the manifest entries for
+/// that op-and-role.
 ///
 /// Keying on role as well as the canonical key is load-bearing (#207): a single
 /// canonical key (e.g. `http|GET|/orders/:param`) can be both a producer in one
 /// repo and a consumer in another. Keying by canonical alone collapsed the two
 /// roles' entries into one slot, so the last writer's anchor /
-/// resolved-definition / type-state clobbered the other role's — surfacing, for
-/// instance, the consumer's `OrderView` against the producer's op. Splitting by
-/// role keeps each side's manifest fields distinct.
+/// resolved-definition / type-state clobbered the other role's.
+///
+/// Within a `(key, role)` slot the entries are NOT interchangeable either, on
+/// two axes the previous first-definition-wins collapse got wrong:
+/// - **kind**: an op has up to a request and a response entry. The eval's
+///   per-op resolved-type labels are the op's response contract, so a request
+///   entry that happened to resolve first must not displace the response
+///   (`POST /payments` / `POST /track` surfaced their request shapes).
+/// - **site**: fan-in — several call sites on the same key (two repos
+///   publishing one pub/sub topic, #290) — carries one entry per site. All
+///   sites shared whichever entry won, so one publisher's payload masked the
+///   other's. Each op joins the records at its own file/line.
 struct ManifestIndex {
-    by_key: HashMap<(String, ManifestRole), ManifestFields>,
+    by_key: HashMap<(String, ManifestRole), Vec<ManifestRecord>>,
 }
 
 impl ManifestIndex {
     fn build(entries: &[TypeManifestEntry]) -> Self {
-        let mut by_key: HashMap<(String, ManifestRole), ManifestFields> = HashMap::new();
+        let mut by_key: HashMap<(String, ManifestRole), Vec<ManifestRecord>> = HashMap::new();
         for entry in entries {
-            let key = (entry.key.canonical(), entry.role);
-            let slot = by_key.entry(key).or_default();
-            // Prefer an entry that resolved a concrete definition; otherwise
-            // keep the first-seen alias/state so the field is at least present.
-            let entry_has_definition =
-                entry.resolved_definition.is_some() || entry.expanded_definition.is_some();
-            let slot_has_definition =
-                slot.resolved_definition.is_some() || slot.expanded_definition.is_some();
-            if slot.type_alias.is_none() || (entry_has_definition && !slot_has_definition) {
-                slot.type_alias = Some(entry.type_alias.clone());
-                slot.type_state = Some(manifest_type_state_string(entry.type_state));
-                slot.resolved_definition = entry.resolved_definition.clone();
-                slot.expanded_definition = entry.expanded_definition.clone();
-                slot.is_explicit = Some(entry.is_explicit);
-            }
-            // The anchor symbol is independent of the definition-richness race
-            // above: keep the first non-None symbol seen for this op so a
-            // response entry that wins on definition but carries no symbol does
-            // not erase a request entry's symbol.
-            if slot.primary_type_symbol.is_none() {
-                slot.primary_type_symbol = entry.primary_type_symbol.clone();
-            }
+            by_key
+                .entry((entry.key.canonical(), entry.role))
+                .or_default()
+                .push(ManifestRecord {
+                    type_kind: entry.type_kind,
+                    file_path: entry.file_path.clone(),
+                    line_number: entry.line_number,
+                    type_alias: entry.type_alias.clone(),
+                    type_state: manifest_type_state_string(entry.type_state),
+                    resolved_definition: entry.resolved_definition.clone(),
+                    expanded_definition: entry.expanded_definition.clone(),
+                    is_explicit: entry.is_explicit,
+                    primary_type_symbol: entry.primary_type_symbol.clone(),
+                });
         }
         Self { by_key }
     }
 
-    /// Look up the manifest fields for an op's canonical `key` in the given
-    /// `role`. A producer EvalOp (endpoint) joins the Producer slot, a consumer
-    /// EvalOp (call) the Consumer slot, so a shared canonical key never crosses
-    /// the two roles' manifest fields (#207).
-    fn get(&self, key: &str, role: ManifestRole) -> Option<&ManifestFields> {
-        self.by_key.get(&(key.to_string(), role))
+    /// Join one op to its manifest fields.
+    ///
+    /// 1. **Site filter**: keep the records in the op's own file (suffix-aligned
+    ///    so a repo-relative manifest path matches an absolute op path). When
+    ///    nothing matches — single-site slots, or a path convention drift — all
+    ///    records stay in play, which is exactly the pre-site-aware behavior.
+    /// 2. **Kind preference**: the op-level fields carry the RESPONSE entry
+    ///    (the contract the per-op eval labels are written against), falling
+    ///    back to a request entry only when no response entry resolved a
+    ///    definition, so request-only ops (`POST /billing/charge`) still
+    ///    surface their one known type.
+    /// 3. **Line proximity**: same-kind records left after (1)+(2) are same-file
+    ///    fan-in; the record nearest the op's line is the op's own.
+    fn get(
+        &self,
+        key: &str,
+        role: ManifestRole,
+        op_file: &str,
+        op_line: u32,
+    ) -> Option<ManifestFields> {
+        let records = self.by_key.get(&(key.to_string(), role))?;
+        let site: Vec<&ManifestRecord> = {
+            let in_file: Vec<&ManifestRecord> = records
+                .iter()
+                .filter(|r| same_source_file(&r.file_path, op_file))
+                .collect();
+            if in_file.is_empty() {
+                records.iter().collect()
+            } else {
+                in_file
+            }
+        };
+        let nearest = |kind: ManifestTypeKind, need_definition: bool| {
+            site.iter()
+                .filter(|r| r.type_kind == kind && (!need_definition || r.has_definition()))
+                .min_by_key(|r| r.line_number.abs_diff(op_line))
+                .copied()
+        };
+        let definition_record = nearest(ManifestTypeKind::Response, true)
+            .or_else(|| nearest(ManifestTypeKind::Request, true))
+            .or_else(|| {
+                site.iter()
+                    .min_by_key(|r| r.line_number.abs_diff(op_line))
+                    .copied()
+            })?;
+        // The anchor symbol is independent of the definition-richness pick: a
+        // response entry that wins on definition but carries no symbol must not
+        // erase a request entry's symbol.
+        let primary_type_symbol = definition_record
+            .primary_type_symbol
+            .clone()
+            .or_else(|| site.iter().find_map(|r| r.primary_type_symbol.clone()));
+        Some(ManifestFields {
+            type_alias: Some(definition_record.type_alias.clone()),
+            type_state: Some(definition_record.type_state.clone()),
+            resolved_definition: definition_record.resolved_definition.clone(),
+            expanded_definition: definition_record.expanded_definition.clone(),
+            is_explicit: Some(definition_record.is_explicit),
+            primary_type_symbol,
+        })
     }
+}
+
+/// Whether two source paths name the same file across the repo-relative vs
+/// absolute conventions the manifest and op details mix: equal, or one is a
+/// path-component-aligned suffix of the other.
+fn same_source_file(a: &str, b: &str) -> bool {
+    if a.is_empty() || b.is_empty() {
+        return false;
+    }
+    if a == b {
+        return true;
+    }
+    let (long, short) = if a.len() >= b.len() { (a, b) } else { (b, a) };
+    long.ends_with(short) && long.as_bytes()[long.len() - short.len() - 1] == b'/'
 }
 
 /// `ManifestTypeState` → its String form, matching the manifest's serde naming
@@ -253,7 +341,7 @@ impl EvalOp {
         let (protocol, method, path) = project_key(&d.key);
         let (file, line) = split_location(&d.file_path);
         let canonical = d.key.canonical();
-        let fields = manifest.get(&canonical, role);
+        let fields = manifest.get(&canonical, role, &file, line);
         EvalOp {
             key: canonical,
             protocol,
@@ -270,11 +358,11 @@ impl EvalOp {
                 .map(|t| t.composite_type_string.clone()),
             file,
             line,
-            type_alias: fields.and_then(|f| f.type_alias.clone()),
-            type_state: fields.and_then(|f| f.type_state.clone()),
-            resolved_definition: fields.and_then(|f| f.resolved_definition.clone()),
-            expanded_definition: fields.and_then(|f| f.expanded_definition.clone()),
-            is_explicit: fields.and_then(|f| f.is_explicit),
+            type_alias: fields.as_ref().and_then(|f| f.type_alias.clone()),
+            type_state: fields.as_ref().and_then(|f| f.type_state.clone()),
+            resolved_definition: fields.as_ref().and_then(|f| f.resolved_definition.clone()),
+            expanded_definition: fields.as_ref().and_then(|f| f.expanded_definition.clone()),
+            is_explicit: fields.as_ref().and_then(|f| f.is_explicit),
             // The real LLM type anchor (#233): the symbol threaded onto the
             // manifest entry. NO fallback to the hashed `type_alias` — an op whose
             // response is an inline/anonymous type (e.g. `GET /users/recent`
@@ -374,21 +462,51 @@ mod tests {
         resolved: Option<&str>,
         primary_type_symbol: Option<&str>,
     ) -> TypeManifestEntry {
+        manifest_entry_at(
+            key,
+            role,
+            ManifestTypeKind::Response,
+            "Endpoint_abc_Response",
+            "src/orders.ts",
+            12,
+            type_state,
+            is_explicit,
+            resolved,
+            primary_type_symbol,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn manifest_entry_at(
+        key: OperationKey,
+        role: ManifestRole,
+        type_kind: ManifestTypeKind,
+        type_alias: &str,
+        file_path: &str,
+        line_number: u32,
+        type_state: ManifestTypeState,
+        is_explicit: bool,
+        resolved: Option<&str>,
+        primary_type_symbol: Option<&str>,
+    ) -> TypeManifestEntry {
         TypeManifestEntry {
             key,
             role,
-            type_kind: ManifestTypeKind::Response,
-            type_alias: "Endpoint_abc_Response".to_string(),
-            file_path: "src/orders.ts".to_string(),
-            line_number: 12,
+            type_kind,
+            type_alias: type_alias.to_string(),
+            file_path: file_path.to_string(),
+            line_number,
             is_explicit,
             type_state,
             evidence: TypeEvidence {
-                file_path: "src/orders.ts".to_string(),
+                file_path: file_path.to_string(),
                 span_start: None,
                 span_end: None,
-                line_number: 12,
-                infer_kind: InferKind::ResponseBody,
+                line_number,
+                infer_kind: match type_kind {
+                    ManifestTypeKind::Request => InferKind::RequestBody,
+                    ManifestTypeKind::Response => InferKind::ResponseBody,
+                },
                 is_explicit,
                 type_state,
             },
@@ -749,5 +867,198 @@ mod tests {
         assert_eq!(call_op["resolved_definition"], "{ id: number }");
         assert_eq!(call_op["type_state"], "Implicit");
         assert_eq!(call_op["is_explicit"], false);
+    }
+
+    /// The per-op eval labels are written against the op's RESPONSE contract,
+    /// so when an op carries both a request and a response manifest entry, the
+    /// response entry's fields must surface — even when the request entry
+    /// resolved first. Before the kind-aware join, first-definition-wins let the
+    /// request shape displace the response (`POST /payments` / `POST /track`
+    /// surfaced `{ orderId; amountCents }` where the eval expected `Payment`).
+    #[test]
+    fn response_entry_wins_over_request_entry_for_op_fields() {
+        let key = OperationKey::http("POST", "/payments");
+        let result = ApiAnalysisResult {
+            endpoints: vec![endpoint("POST", "/payments", "src/payments.ts:30")],
+            calls: vec![],
+            issues: empty_issues_with_deps(vec![]),
+            verified_endpoints: vec![],
+            detected_graphql_libraries: vec![],
+            graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
+        };
+        // Request entry FIRST (the manifest order that used to win).
+        let manifest = vec![
+            manifest_entry_at(
+                key.clone(),
+                ManifestRole::Producer,
+                ManifestTypeKind::Request,
+                "Endpoint_req_Request",
+                "src/payments.ts",
+                30,
+                ManifestTypeState::Explicit,
+                true,
+                Some("{ orderId: number; amountCents: number }"),
+                None,
+            ),
+            manifest_entry_at(
+                key,
+                ManifestRole::Producer,
+                ManifestTypeKind::Response,
+                "Endpoint_res_Response",
+                "src/payments.ts",
+                35,
+                ManifestTypeState::Explicit,
+                true,
+                Some("{ id: string; orderId: number; status: string }"),
+                Some("Payment"),
+            ),
+        ];
+
+        let projection = EvalProjection::from_results(&result, &manifest);
+        let json: Value =
+            serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
+        let op = &json["endpoints"].as_array().unwrap()[0];
+
+        assert_eq!(op["type_alias"], "Endpoint_res_Response");
+        assert_eq!(
+            op["resolved_definition"],
+            "{ id: string; orderId: number; status: string }"
+        );
+        assert_eq!(op["primary_type_symbol"], "Payment");
+    }
+
+    /// An op whose only resolved entry is request-kind (`POST /billing/charge`,
+    /// a fire-and-forget consumer with no read response) must keep surfacing
+    /// that request definition — the response preference is a preference, not a
+    /// filter.
+    #[test]
+    fn request_only_op_still_surfaces_request_definition() {
+        let key = OperationKey::http("POST", "/billing/charge");
+        let call = ApiEndpointDetails {
+            owner: None,
+            key: key.clone(),
+            params: vec![],
+            request_body: None,
+            response_body: None,
+            handler_name: None,
+            request_type: None,
+            response_type: None,
+            file_path: PathBuf::from("src/billing.client.ts:19"),
+            repo_name: None,
+            service_name: None,
+        };
+        let result = ApiAnalysisResult {
+            endpoints: vec![],
+            calls: vec![call],
+            issues: empty_issues_with_deps(vec![]),
+            verified_endpoints: vec![],
+            detected_graphql_libraries: vec![],
+            graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
+        };
+        let manifest = vec![manifest_entry_at(
+            key,
+            ManifestRole::Consumer,
+            ManifestTypeKind::Request,
+            "Endpoint_req_Request_Callabc",
+            "src/billing.client.ts",
+            19,
+            ManifestTypeState::Implicit,
+            false,
+            Some("{ paymentId: string; amountCents: number }"),
+            None,
+        )];
+
+        let projection = EvalProjection::from_results(&result, &manifest);
+        let json: Value =
+            serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
+        let op = &json["calls"].as_array().unwrap()[0];
+
+        assert_eq!(
+            op["resolved_definition"],
+            "{ paymentId: string; amountCents: number }"
+        );
+        assert_eq!(op["type_state"], "Implicit");
+    }
+
+    /// Fan-in (#290/#291): two consumer call sites on ONE canonical key — two
+    /// repos publishing the same pub/sub topic with deliberately different
+    /// payloads — carry one manifest entry per site. Each call op must join the
+    /// records at ITS OWN file, not whichever site's entry happened to be
+    /// indexed first (which masked orders-engine's nested payload behind
+    /// billing's flat one and mis-scored its resolution). The manifest path is
+    /// repo-relative while the op path is absolute, mirroring the live mixed
+    /// conventions, so this also pins the suffix-aligned site match.
+    #[test]
+    fn fan_in_consumer_calls_join_their_own_site_records() {
+        let key = OperationKey::pubsub("order.placed");
+        let call_at = |file_line: &str| ApiEndpointDetails {
+            owner: None,
+            key: key.clone(),
+            params: vec![],
+            request_body: None,
+            response_body: None,
+            handler_name: None,
+            request_type: None,
+            response_type: None,
+            file_path: PathBuf::from(file_line),
+            repo_name: None,
+            service_name: None,
+        };
+        let result = ApiAnalysisResult {
+            endpoints: vec![],
+            calls: vec![
+                call_at("/scan/billing-svc/src/kafka/producer.ts:15"),
+                call_at("/scan/orders-engine/src/kafka/producer.ts:22"),
+            ],
+            issues: empty_issues_with_deps(vec![]),
+            verified_endpoints: vec![],
+            detected_graphql_libraries: vec![],
+            graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
+        };
+        let manifest = vec![
+            manifest_entry_at(
+                key.clone(),
+                ManifestRole::Consumer,
+                ManifestTypeKind::Response,
+                "Endpoint_x_Response_Callbilling",
+                "billing-svc/src/kafka/producer.ts",
+                15,
+                ManifestTypeState::Explicit,
+                true,
+                Some("{ id: string; total: number }"),
+                Some("OrderPlaced"),
+            ),
+            manifest_entry_at(
+                key,
+                ManifestRole::Consumer,
+                ManifestTypeKind::Response,
+                "Endpoint_x_Response_Callorders",
+                "orders-engine/src/kafka/producer.ts",
+                22,
+                ManifestTypeState::Explicit,
+                true,
+                Some("{ id: string; total: { amountCents: number } }"),
+                Some("OrderPlaced"),
+            ),
+        ];
+
+        let projection = EvalProjection::from_results(&result, &manifest);
+        let json: Value =
+            serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
+        let calls = json["calls"].as_array().unwrap();
+
+        assert_eq!(calls[0]["type_alias"], "Endpoint_x_Response_Callbilling");
+        assert_eq!(
+            calls[0]["resolved_definition"],
+            "{ id: string; total: number }"
+        );
+        assert_eq!(calls[1]["type_alias"], "Endpoint_x_Response_Callorders");
+        assert_eq!(
+            calls[1]["resolved_definition"],
+            "{ id: string; total: { amountCents: number } }"
+        );
     }
 }

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -308,7 +308,9 @@ impl ManifestIndex {
 
 /// Whether two source paths name the same file across the repo-relative vs
 /// absolute conventions the manifest and op details mix: equal, or one is a
-/// path-component-aligned suffix of the other.
+/// path-component-aligned suffix of the other. Both separator styles count as
+/// a component boundary so a Windows-style absolute path still aligns against
+/// a repo-relative one.
 fn same_source_file(a: &str, b: &str) -> bool {
     if a.is_empty() || b.is_empty() {
         return false;
@@ -317,7 +319,7 @@ fn same_source_file(a: &str, b: &str) -> bool {
         return true;
     }
     let (long, short) = if a.len() >= b.len() { (a, b) } else { (b, a) };
-    long.ends_with(short) && long.as_bytes()[long.len() - short.len() - 1] == b'/'
+    long.ends_with(short) && matches!(long.as_bytes()[long.len() - short.len() - 1], b'/' | b'\\')
 }
 
 /// `ManifestTypeState` → its String form, matching the manifest's serde naming

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -28,6 +28,7 @@ import {
   type FunctionExpression,
   type MethodDeclaration,
   type CallExpression,
+  type PropertyAssignment,
   type Type,
   type Symbol as TsSymbol,
   ts,
@@ -692,7 +693,7 @@ export class TypeInferrer {
     request: InferRequestItem,
     extractionConfig?: ExtractionConfig
   ): InferredType | null {
-    const located = this.resolveTargetNode(sourceFile, request);
+    let located = this.resolveTargetNode(sourceFile, request);
 
     if (!located) {
       // Line-only anchor: the scanner points a request infer at the route
@@ -747,6 +748,27 @@ export class TypeInferrer {
       return null;
     }
 
+    // A text locator (Gemini `expression_text` + `expression_line`, as opposed
+    // to a byte span) can land on the property itself in `{ body:
+    // JSON.stringify(body) }` — either the whole PropertyAssignment (locator
+    // text is the full `key: value` source) or the property NAME identifier
+    // (locator text is a bare word that exact-matches the name over the
+    // value). Both type as the assigned value's own type — here the useless
+    // `string` result of `JSON.stringify` — not the payload. A property name
+    // is a label, not the contract expression: redirect to the value so the
+    // unwraps below read the real request body. Shorthand (`{ body }`) is
+    // left alone — its identifier already IS the value.
+    if (Node.isPropertyAssignment(located)) {
+      located = located.getInitializer() ?? located;
+    } else if (
+      Node.isIdentifier(located) &&
+      Node.isPropertyAssignment(located.getParent()) &&
+      (located.getParent() as PropertyAssignment).getNameNode() === located
+    ) {
+      const parent = located.getParent() as PropertyAssignment;
+      located = parent.getInitializer() ?? located;
+    }
+
     // Mirror inferCallResult: strip `await`/`as`/parens/`!` so the inner
     // expression's type (not the surrounding `Promise<any>`) is read.
     const unwrapped = this.unwrapExpressionNode(located);
@@ -755,7 +777,31 @@ export class TypeInferrer {
     // is the useless `string`. Drill to the serialized argument so the consumer
     // request shape is the payload's type, not `string`. General: any
     // `JSON.stringify(x)` resolves to the type of `x`.
-    const node = this.unwrapJsonStringifyArg(unwrapped);
+    let node = this.unwrapJsonStringifyArg(unwrapped);
+
+    // A locator can also land on a serialized IDENTIFIER one value-hop from
+    // the payload — `const body = JSON.stringify(payload); sendBeacon(url,
+    // body)` — whose own declared type is `string`, the same useless result
+    // the direct-call unwrap above already handles. Follow the identifier to
+    // its declaration and, only when that declaration's initializer is itself
+    // a `JSON.stringify(...)` call, resolve through to the serialized
+    // argument. One hop only: an identifier declared from anything else
+    // already carries its own correct type and must not be rewritten.
+    if (Node.isIdentifier(node)) {
+      for (const def of node.getDefinitionNodes()) {
+        const varDecl = Node.isVariableDeclaration(def)
+          ? def
+          : def.getFirstAncestorByKind(SyntaxKind.VariableDeclaration);
+        const initializer = varDecl?.getInitializer();
+        if (!initializer) continue;
+        const unwrappedInit = this.unwrapExpressionNode(initializer);
+        const stringifyArg = this.unwrapJsonStringifyArg(unwrappedInit);
+        if (stringifyArg !== unwrappedInit) {
+          node = stringifyArg;
+          break;
+        }
+      }
+    }
 
     const payloadType = node.getType();
     let typeString = typeText(payloadType, node);

--- a/src/sidecar/test/fixtures/sample-repo/src/request-body-locator-convergence.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/request-body-locator-convergence.ts
@@ -1,0 +1,60 @@
+/**
+ * Fixture for the request_body TEXT-LOCATOR convergence regression.
+ *
+ * Mirrors two cross-repo corpus shapes where a Gemini `expression_text` +
+ * `expression_line` locator (not a byte span) lands on a PROPERTY NAME, a
+ * whole PropertyAssignment, or a declared-through-`JSON.stringify` IDENTIFIER
+ * rather than the payload expression itself, and used to resolve the useless
+ * `string` result instead of the payload shape:
+ *
+ *  (a) `fetch(url, { ..., body: <serialized param> })` — a locator text
+ *      anchored on the property (a bare `"body"`, or the whole `key: value`
+ *      property source) at the property's line resolves the property NAME /
+ *      PropertyAssignment,
+ *      which types as the assigned value (`string`), not the payload. The
+ *      param/property/argument names deliberately COLLIDE (`body`) — that
+ *      collision is what made `matchByText`'s exact match land on the wrong
+ *      node in practice.
+ *  (b) `const body = JSON.stringify(payload); sendBeacon(url, body)` — a
+ *      locator text `"body"` at the call line resolves the argument
+ *      IDENTIFIER, whose own declared type is `string` — the payload is one
+ *      value-hop away through the declaration initializer.
+ */
+
+export interface CreatePaymentRequest {
+  orderId: number;
+  amountCents: number;
+}
+
+export interface MetricPayload {
+  event: string;
+  paymentId: string;
+  durationMs: number;
+}
+
+// (a) createPayment-like: param, property name, and argument all named `body`.
+export async function createPayment(body: CreatePaymentRequest): Promise<Response> {
+  return fetch('/payments', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// (b) beacon-like: a serialized identifier one hop from a typed param.
+export function reportMetric(payload: MetricPayload): boolean {
+  const body = JSON.stringify(payload);
+  return navigator.sendBeacon('/metrics/ingest', body);
+}
+
+function getRawPayload(): string {
+  return 'raw-payload';
+}
+
+// Control: an identifier declared from a NON-stringify initializer must not
+// be rewritten by the one-hop declaration follow — it resolves whatever its
+// own type is (here, faithfully `string`).
+export function reportRaw(): boolean {
+  const raw = getRawPayload();
+  return navigator.sendBeacon('/metrics/raw', raw);
+}

--- a/src/sidecar/test/infer-request-body-locator-convergence.test.ts
+++ b/src/sidecar/test/infer-request-body-locator-convergence.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression for `inferRequestBody` TEXT-LOCATOR convergence.
+ *
+ * The scanner sends the LLM's `expression_text` + `expression_line` locator
+ * (not a byte span) for cross-repo consumer request bodies. Two locator
+ * shapes used to resolve the WRONG node and surface the useless `string`
+ * result of `JSON.stringify` instead of the payload:
+ *
+ *  1. A bare property-name locator (`text="body"`) on a `{ body:
+ *     JSON.stringify(body) }` property line exact-matches the property NAME
+ *     identifier — which types as the assigned value (`string`), not the
+ *     payload.
+ *  2. A whole-property locator (`text="body: JSON.stringify(body)"`)
+ *     resolves the PropertyAssignment node itself, which also types as its
+ *     value.
+ *  3. A locator on a serialized IDENTIFIER one value-hop from the payload
+ *     (`const body = JSON.stringify(payload); sendBeacon(url, body)`)
+ *     resolves the argument identifier, whose own declared type is `string`.
+ *
+ * The fix adds two structural redirects in `inferRequestBody`: (1) a
+ * PropertyAssignment / property-name-identifier locator redirects to the
+ * property's value; (2) a serialized identifier follows ONE hop to its
+ * declaration and, only when that declaration's initializer is itself a
+ * `JSON.stringify(...)` call, resolves through to the serialized argument.
+ * Cases 4 and 5 are controls: case 4 proves the pre-existing direct-call path
+ * still works; case 5 proves the one-hop follow does not fire on a
+ * non-stringify initializer.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const FIXTURE = path.join(FIXTURES_PATH, 'src/request-body-locator-convergence.ts');
+const FIXTURE_SOURCE = fs.readFileSync(FIXTURE, 'utf-8');
+
+/** Structural form of `interface CreatePaymentRequest { orderId; amountCents }`. */
+const CREATE_PAYMENT_STRUCTURAL = '{ orderId: number; amountCents: number; }';
+
+/** Structural form of `interface MetricPayload { event; paymentId; durationMs }`. */
+const METRIC_PAYLOAD_STRUCTURAL = '{ event: string; paymentId: string; durationMs: number; }';
+
+/**
+ * 1-based line number of the (unique) line containing `anchorText`. Used to
+ * build `expression_line` the same way the scanner's LLM locator does — a
+ * line number alongside `expression_text`, not a byte span.
+ */
+function lineOf(anchorText: string): number {
+  const idx = FIXTURE_SOURCE.indexOf(anchorText);
+  assert.ok(idx >= 0, `fixture must contain: ${anchorText}`);
+  assert.strictEqual(
+    FIXTURE_SOURCE.indexOf(anchorText, idx + 1),
+    -1,
+    `fixture must contain exactly one occurrence of: ${anchorText}`
+  );
+  return FIXTURE_SOURCE.slice(0, idx).split('\n').length;
+}
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    infer_kind: string;
+    is_explicit: boolean;
+  }>;
+  errors?: string[];
+}
+
+describe('request_body TEXT-LOCATOR convergence (property-name / serialized-identifier)', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'reqbody-locator-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  async function inferOne(
+    alias: string,
+    expressionText: string,
+    expressionLine: number
+  ): Promise<{ type_string: string; is_explicit: boolean } | undefined> {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: `reqbody-locator-${alias}`,
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: expressionLine,
+          expression_text: expressionText,
+          expression_line: expressionLine,
+          infer_kind: 'request_body',
+          alias,
+        },
+      ],
+    });
+    assert.ok(
+      response.inferred_types?.length || response.errors?.length,
+      `expected either an inferred type or an error, got neither: ${JSON.stringify(response)}`
+    );
+    return response.inferred_types?.find((t) => t.alias === alias);
+  }
+
+  it('1. bare property-name locator ("body" on the property line) resolves the payload shape, not `string`', async () => {
+    const line = lineOf('body: JSON.stringify(body)');
+    const inferred = await inferOne('PropertyNameLocator', 'body', line);
+    assert.ok(inferred, 'expected an inferred type');
+    assert.notStrictEqual(
+      inferred.type_string,
+      'string',
+      'must not surface the property NAME identifier\'s type (JSON.stringify\'s `string` result)'
+    );
+    assert.strictEqual(inferred.type_string, CREATE_PAYMENT_STRUCTURAL);
+  });
+
+  it('2. whole-property locator ("body: JSON.stringify(body)") resolves the payload shape, not `string`', async () => {
+    const line = lineOf('body: JSON.stringify(body)');
+    const inferred = await inferOne(
+      'PropertyAssignmentLocator',
+      'body: JSON.stringify(body)',
+      line
+    );
+    assert.ok(inferred, 'expected an inferred type');
+    assert.notStrictEqual(
+      inferred.type_string,
+      'string',
+      'must not surface the PropertyAssignment node\'s own type (its value\'s `string`)'
+    );
+    assert.strictEqual(inferred.type_string, CREATE_PAYMENT_STRUCTURAL);
+  });
+
+  it('3. serialized-identifier locator ("body" at the sendBeacon call line) resolves the payload shape, not `string`', async () => {
+    const line = lineOf("navigator.sendBeacon('/metrics/ingest', body)");
+    const inferred = await inferOne('SerializedIdentifierLocator', 'body', line);
+    assert.ok(inferred, 'expected an inferred type');
+    assert.notStrictEqual(
+      inferred.type_string,
+      'string',
+      'must not surface the argument identifier\'s own declared type (`string`) — follow one hop to the JSON.stringify argument'
+    );
+    assert.strictEqual(inferred.type_string, METRIC_PAYLOAD_STRUCTURAL);
+  });
+
+  it('4. control: direct `JSON.stringify(body)` call locator keeps resolving the payload shape', async () => {
+    const line = lineOf('body: JSON.stringify(body)');
+    const inferred = await inferOne('DirectStringifyControl', 'JSON.stringify(body)', line);
+    assert.ok(inferred, 'expected an inferred type');
+    assert.strictEqual(inferred.type_string, CREATE_PAYMENT_STRUCTURAL);
+  });
+
+  it('5. control: an identifier declared from a NON-stringify initializer is not rewritten by the one-hop follow', async () => {
+    const line = lineOf("navigator.sendBeacon('/metrics/raw', raw)");
+    const inferred = await inferOne('NonStringifyIdentifierControl', 'raw', line);
+    assert.ok(inferred, 'expected an inferred type');
+    // `raw` is declared `const raw = getRawPayload()` — a non-stringify call.
+    // The one-hop follow must not fire; the identifier's own type (`string`)
+    // is correct here and must be preserved faithfully.
+    assert.strictEqual(inferred.type_string, 'string');
+  });
+});

--- a/tests/eval_xrepo.rs
+++ b/tests/eval_xrepo.rs
@@ -668,16 +668,42 @@ fn index_proj_endpoints(proj: &EvalProjection) -> std::collections::HashMap<OpSe
     idx
 }
 
-/// Index the projection's consumer calls by key, for the consumer-side type
-/// metrics (GraphQL/socket consumers + HTTP calls carry anchors/resolved types).
-fn index_proj_calls(proj: &EvalProjection) -> std::collections::HashMap<OpSetKey, &EvalOp> {
-    let mut idx = std::collections::HashMap::new();
-    for o in &proj.calls {
+/// Group ALL projection ops per key instead of keeping only the first. Fan-in
+/// (two repos publishing one pub/sub topic) puts several ops — with genuinely
+/// different resolved types — on one key; the type metrics 1:1-claim within the
+/// group so each expected slot scores against a distinct actual op rather than
+/// whichever op the old `or_insert` happened to keep.
+fn group_proj_ops(ops: &[EvalOp]) -> std::collections::HashMap<OpSetKey, Vec<&EvalOp>> {
+    let mut idx: std::collections::HashMap<OpSetKey, Vec<&EvalOp>> =
+        std::collections::HashMap::new();
+    for o in ops {
         if let Some(k) = op_to_set_key(o) {
-            idx.entry(k).or_insert(o);
+            idx.entry(k).or_default().push(o);
         }
     }
     idx
+}
+
+/// 1:1 claiming join between the expected typed ops of one key and the actual
+/// ops grouped on that key. Each expected slot claims the first UNCLAIMED op
+/// satisfying `matches`; a claimed op can't satisfy a second slot, so a
+/// duplicate projection entry can no longer double-count (and a genuinely
+/// missing fan-in op scores as the miss it is). Single-op keys — everything but
+/// fan-in — behave exactly as the old first-op join. Returns whether a claim
+/// was made.
+fn claim_matching_op(
+    group: &[&EvalOp],
+    claimed: &mut [bool],
+    matches: impl Fn(&EvalOp) -> bool,
+) -> bool {
+    debug_assert_eq!(group.len(), claimed.len());
+    for (i, op) in group.iter().enumerate() {
+        if !claimed[i] && matches(op) {
+            claimed[i] = true;
+            return true;
+        }
+    }
+    false
 }
 
 /// `(correct, total)` fraction with the convention `(0,0) -> 1.0` (nothing to
@@ -726,15 +752,22 @@ fn score_type_anchor_accuracy(
     proj: &EvalProjection,
     tier: &str,
 ) -> f64 {
-    let ep_idx = index_proj_endpoints(proj);
-    let call_idx = index_proj_calls(proj);
+    let ep_idx = group_proj_ops(&proj.endpoints);
+    let call_idx = group_proj_ops(&proj.calls);
+    let mut claimed: std::collections::HashMap<(bool, OpSetKey), Vec<bool>> =
+        std::collections::HashMap::new();
     let mut correct = 0usize;
     let mut total = 0usize;
     for_each_expected_typed_op(repo_expected, tier, |key, is_producer, anchor, _rt, _ts| {
         let idx = if is_producer { &ep_idx } else { &call_idx };
-        if let Some(actual) = idx.get(&key) {
+        if let Some(group) = idx.get(&key) {
             total += 1;
-            if anchor == actual.primary_type_symbol.as_deref() {
+            let flags = claimed
+                .entry((is_producer, key))
+                .or_insert_with(|| vec![false; group.len()]);
+            if claim_matching_op(group, flags, |op| {
+                anchor == op.primary_type_symbol.as_deref()
+            }) {
                 correct += 1;
             }
         }
@@ -754,8 +787,10 @@ fn score_type_resolution_accuracy(
     proj: &EvalProjection,
     tier: &str,
 ) -> f64 {
-    let ep_idx = index_proj_endpoints(proj);
-    let call_idx = index_proj_calls(proj);
+    let ep_idx = group_proj_ops(&proj.endpoints);
+    let call_idx = group_proj_ops(&proj.calls);
+    let mut claimed: std::collections::HashMap<(bool, OpSetKey), Vec<bool>> =
+        std::collections::HashMap::new();
     let mut correct = 0usize;
     let mut total = 0usize;
     for_each_expected_typed_op(repo_expected, tier, |key, is_producer, _anchor, rt, ts| {
@@ -763,15 +798,20 @@ fn score_type_resolution_accuracy(
             return; // only score ops with an expected resolved type
         };
         let idx = if is_producer { &ep_idx } else { &call_idx };
-        if let Some(actual) = idx.get(&key) {
+        if let Some(group) = idx.get(&key) {
             total += 1;
-            let actual_rt = actual
-                .expanded_definition
-                .as_deref()
-                .or(actual.resolved_definition.as_deref());
-            let state_ok = ts == actual.type_state.as_deref();
-            let rt_ok = actual_rt.map(collapse_ws) == Some(collapse_ws(expected_rt));
-            if state_ok && rt_ok {
+            let flags = claimed
+                .entry((is_producer, key))
+                .or_insert_with(|| vec![false; group.len()]);
+            if claim_matching_op(group, flags, |actual| {
+                let actual_rt = actual
+                    .expanded_definition
+                    .as_deref()
+                    .or(actual.resolved_definition.as_deref());
+                let state_ok = ts == actual.type_state.as_deref();
+                let rt_ok = actual_rt.map(collapse_ws) == Some(collapse_ws(expected_rt));
+                state_ok && rt_ok
+            }) {
                 correct += 1;
             }
         }
@@ -1722,25 +1762,45 @@ fn xrepo_live_scorer() {
             // hashed `type_alias` / a different symbol (`MISS` with the actual
             // value), or has no projection entry at all (`actual=None`, the
             // non-HTTP type-pipeline gap, #245).
-            let ep_idx = index_proj_endpoints(&proj);
-            let call_idx = index_proj_calls(&proj);
+            let ep_idx = group_proj_ops(&proj.endpoints);
+            let call_idx = group_proj_ops(&proj.calls);
+            let mut diag_claimed: std::collections::HashMap<(bool, OpSetKey), Vec<bool>> =
+                std::collections::HashMap::new();
             eprintln!("[diag] anchor (expected primary_type_symbol vs actual):");
             for_each_expected_typed_op(
                 &repo_expected,
                 TIER_CAPABILITY,
                 |key, is_producer, anchor, _rt, _ts| {
                     let idx = if is_producer { &ep_idx } else { &call_idx };
-                    let entry = idx.get(&key);
-                    let actual = entry.and_then(|a| a.primary_type_symbol.as_deref());
-                    // Distinguish "no projection entry at all" (the #245 non-HTTP
-                    // type-pipeline gap) from "entry present but anchor null/wrong"
-                    // so a miss is attributable rather than conflated. `NOENT` =
-                    // the op isn't in the projection; `MISS` = it is, but the
-                    // anchor differs from expected.
-                    let mark = match entry {
-                        None => "NOENT",
-                        Some(_) if anchor == actual => "ok   ",
-                        Some(_) => "MISS ",
+                    let group = idx.get(&key);
+                    // Mirror the metric's 1:1 claiming so the diag shows what the
+                    // score saw. Distinguish "no projection entry at all" (the
+                    // #245 non-HTTP type-pipeline gap) from "entry present but
+                    // anchor null/wrong" so a miss is attributable rather than
+                    // conflated. `NOENT` = the op isn't in the projection;
+                    // `MISS` = it is, but no unclaimed op carries the expected
+                    // anchor.
+                    let (mark, actual) = match group {
+                        None => ("NOENT", None),
+                        Some(group) => {
+                            let flags = diag_claimed
+                                .entry((is_producer, key.clone()))
+                                .or_insert_with(|| vec![false; group.len()]);
+                            if claim_matching_op(group, flags, |op| {
+                                anchor == op.primary_type_symbol.as_deref()
+                            }) {
+                                ("ok   ", anchor)
+                            } else {
+                                // Show the first unclaimed op's anchor as the
+                                // nearest-actual for the report.
+                                let nearest = group
+                                    .iter()
+                                    .zip(flags.iter())
+                                    .find(|(_, claimed)| !**claimed)
+                                    .and_then(|(op, _)| op.primary_type_symbol.as_deref());
+                                ("MISS ", nearest)
+                            }
+                        }
                     };
                     eprintln!(
                         "[diag]   anchor[{mark}] {key:?} expected={anchor:?} actual={actual:?}"
@@ -2278,6 +2338,93 @@ mod scoring_tests {
         proj.endpoints.push(a);
         proj.endpoints.push(b);
         // a correct, b wrong (state mismatch) → 0.5.
+        assert!(
+            (score_type_resolution_accuracy(&repos, &proj, TIER_CAPABILITY) - 0.5).abs() < 1e-9
+        );
+    }
+
+    /// Fan-in (#290/#291): two expected consumer slots on ONE key (two repos
+    /// publishing the same pub/sub topic with different payloads) must each
+    /// claim a DISTINCT actual op. The old first-op join scored both slots
+    /// against whichever op the index kept — the flat-payload slot passed and
+    /// the nested-payload slot could never match.
+    #[test]
+    fn type_resolution_fan_in_slots_claim_distinct_ops() {
+        let repos = vec![
+            (
+                "billing-svc".to_string(),
+                serde_json::from_value::<ExpectedRepo>(serde_json::json!({
+                    "pubsub_operations": [
+                        { "key": "pubsub|order.placed", "role": "consumer",
+                          "resolved_type": "{ id: string; total: number; }",
+                          "type_state": "Explicit", "tier": "capability" }
+                    ]
+                }))
+                .unwrap(),
+            ),
+            (
+                "orders-engine".to_string(),
+                serde_json::from_value::<ExpectedRepo>(serde_json::json!({
+                    "pubsub_operations": [
+                        { "key": "pubsub|order.placed", "role": "consumer",
+                          "resolved_type": "{ id: string; total: { amountCents: number; }; }",
+                          "type_state": "Explicit", "tier": "capability" }
+                    ]
+                }))
+                .unwrap(),
+            ),
+        ];
+        let mut proj = empty_proj();
+        let mut flat = nonhttp_op("pubsub", "pubsub|order.placed");
+        flat.resolved_definition = Some("{ id: string; total: number; }".to_string());
+        flat.type_state = Some("Explicit".to_string());
+        let mut nested = nonhttp_op("pubsub", "pubsub|order.placed");
+        nested.resolved_definition =
+            Some("{ id: string; total: { amountCents: number; }; }".to_string());
+        nested.type_state = Some("Explicit".to_string());
+        proj.calls.push(flat);
+        proj.calls.push(nested);
+        // Both slots find their own op → 1.0 (was 0.5 under the first-op join).
+        assert!(
+            (score_type_resolution_accuracy(&repos, &proj, TIER_CAPABILITY) - 1.0).abs() < 1e-9
+        );
+    }
+
+    /// The claiming join is 1:1: when the projection carries only ONE op for a
+    /// fan-in key (the other site's op is genuinely missing), a single actual
+    /// op must not double-count against both expected slots.
+    #[test]
+    fn type_resolution_single_op_cannot_satisfy_two_slots() {
+        let repos = vec![
+            (
+                "billing-svc".to_string(),
+                serde_json::from_value::<ExpectedRepo>(serde_json::json!({
+                    "pubsub_operations": [
+                        { "key": "pubsub|order.placed", "role": "consumer",
+                          "resolved_type": "{ id: string; total: number; }",
+                          "type_state": "Explicit", "tier": "capability" }
+                    ]
+                }))
+                .unwrap(),
+            ),
+            (
+                "orders-engine".to_string(),
+                serde_json::from_value::<ExpectedRepo>(serde_json::json!({
+                    "pubsub_operations": [
+                        { "key": "pubsub|order.placed", "role": "consumer",
+                          "resolved_type": "{ id: string; total: number; }",
+                          "type_state": "Explicit", "tier": "capability" }
+                    ]
+                }))
+                .unwrap(),
+            ),
+        ];
+        let mut proj = empty_proj();
+        let mut only = nonhttp_op("pubsub", "pubsub|order.placed");
+        only.resolved_definition = Some("{ id: string; total: number; }".to_string());
+        only.type_state = Some("Explicit".to_string());
+        proj.calls.push(only);
+        // Two slots joined (key present), one distinct op to claim → 0.5.
         assert!(
             (score_type_resolution_accuracy(&repos, &proj, TIER_CAPABILITY) - 0.5).abs() < 1e-9
         );

--- a/tests/fixtures/llm-mocked-api/__golden__.json
+++ b/tests/fixtures/llm-mocked-api/__golden__.json
@@ -73,10 +73,10 @@
       "response_type": null,
       "file": "tests/fixtures/llm-mocked-api/src/routes/users.ts",
       "line": 11,
-      "type_alias": "Endpoint_7624e36e7268b452_Request",
+      "type_alias": "Endpoint_e8e423d0a20a7bde_Response",
       "type_state": "Implicit",
-      "resolved_definition": "export type Endpoint_7624e36e7268b452_Request = { name: string; email: string; };",
-      "expanded_definition": "{ name: string; email: string; }",
+      "resolved_definition": "export type Endpoint_e8e423d0a20a7bde_Response = User;",
+      "expanded_definition": "User",
       "is_explicit": false,
       "primary_type_symbol": "User"
     }


### PR DESCRIPTION
Two deterministic fixes from the per-edge diagnosis of both corpora (full miss map + reproduction in the session's analysis doc). Both scanner-only, no deploy.

## 1. Kind- and site-aware manifest join for the eval projection (`a2b9b46`)

The eval projection's `ManifestIndex` collapsed every manifest entry for a `(canonical key, role)` into one slot, first-definition-wins:

- **kind collapse**: a request entry that resolved first displaced the response entry, so the op surfaced its request shape where the eval's per-op `resolved_type` labels are the response contract. Corpus-1 `POST /payments` and corpus-2 `POST /track` producers both surfaced `_Request` shapes; the correct `_Response` entries were present in the manifests all along.
- **site collapse (fan-in)**: two call sites on one key — billing-svc and orders-engine both publishing `pubsub|order.placed` (#290) — shared whichever site's entry won, masking orders-engine's nested payload behind billing's flat one. The scorer's `or_insert` first-op-wins join had the matching bug, so the two expected slots joined the same op.

The index now keeps every entry whole and joins per op (suffix-aligned site filter → response-kind preference with request-only fallback → nearest-line tiebreak), and the scorer's type metrics group per key and 1:1-claim within the group (a duplicate op can no longer double-count; single-op keys behave exactly as before). Cassette golden re-recorded: the frozen-LLM corpus flips exactly one op (`POST /api/users` request→response), proving the change surgical.

## 2. Sidecar request-body text-locator convergence (`ad32ba6`)

Root cause of the corpus-1 compat flake (0.83↔0.67): the LLM's optional expression locator sometimes lands on the property NAME in `body: JSON.stringify(body)` (or the whole property assignment), which types as the property — `string` — producing a wrong incompatible verdict on `POST /payments`. Reproduced offline by driving the sidecar with every plausible locator variant. Second variant: a serialized identifier one hop from the payload (`const body = JSON.stringify(payload); sendBeacon(url, body)`, the stable `/metrics/ingest` miss).

Two structural guards in `inferRequestBody` converge all variants to the payload type: property-name/PropertyAssignment anchors redirect to the initializer; an identifier whose declaration initializer is a `JSON.stringify` call resolves one hop to the serialized argument (anything else is never rewritten). Pre-fix-failing tests + controls included.

## Expected eval movement

| dim | corpus-1 | corpus-2 |
|---|---|---|
| resolution | 0.87 → 0.93 | 0.81 → 1.00 |
| compat | 0.72±0.10 → 0.83 stable | 1.00 (unchanged) |

Live eval runs (runs=3, both corpora) dispatched from this branch — results to be verified per-edge before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)