### PR TITLE
fix(extraction): force pubsub + data-call locator emission via schema required-ness (lever D)

### DIFF
--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -897,8 +897,8 @@ primary_type_symbol, type_import_source
   - Echo candidate_id from the candidate context
   - MUST emit call_expression_text: copy the EXACT text of the fetch/axios/HTTP call (e.g., 'fetch("/api/users")')
   - MUST emit call_expression_line: read the line number from the prefix
-  - For payload_expression_text: copy the EXACT payload argument text if detected
-  - For payload_expression_line: read the line number from the prefix
+  - For payload_expression_text: copy the EXACT payload argument text if detected; emit null when the call sends no payload
+  - For payload_expression_line: read the line number from the prefix; null whenever payload_expression_text is null
 
 For each pubsub_operation, include: topic, role, line_number, primary_type_symbol, type_import_source, broker
   - topic: the literal topic/channel/subject string (resolve a named const like TOPIC to its string literal)

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -878,6 +878,7 @@ Analyze this file and return a JSON object with:
 - "mounts": array of mount relationships found
 - "endpoints": array of HTTP endpoint definitions found
 - "data_calls": array of data fetching calls found
+- "pubsub_operations": array of pub/sub publish/subscribe operations found
 
 For each mount, include: line_number, parent_node, child_node, mount_path, import_source (null if local), pattern_matched
 
@@ -898,6 +899,14 @@ primary_type_symbol, type_import_source
   - MUST emit call_expression_line: read the line number from the prefix
   - For payload_expression_text: copy the EXACT payload argument text if detected
   - For payload_expression_line: read the line number from the prefix
+
+For each pubsub_operation, include: topic, role, line_number, primary_type_symbol, type_import_source, broker
+  - topic: the literal topic/channel/subject string (resolve a named const like TOPIC to its string literal)
+  - role: "publisher" if the code SENDS a payload to a topic, "subscriber" if it REGISTERS a handler for a topic
+  - line_number: read the line number from the prefix in the source code
+  - primary_type_symbol: the DECODED application payload type (unwrap envelope/transport wrappers and wire types down to the inner named type); null if untyped
+  - type_import_source: import path where primary_type_symbol is defined (from the import table), or null if local; null whenever primary_type_symbol is null
+  - broker: the messaging library/transport if evident (e.g. "kafka"), else null
 
 Return ONLY the JSON object, no explanations."#,
             // Section order is load-bearing for Vertex implicit prompt caching.
@@ -1718,6 +1727,29 @@ app.get('/health', (req, res) => res.json({ status: 'ok' }));
         assert!(message.contains("data_fetching_patterns"));
         assert!(message.contains("test.ts"));
         assert!(message.contains("express"));
+    }
+
+    #[test]
+    fn build_user_message_instructs_pubsub_operations() {
+        // The response schema requires `pubsub_operations`, so the message must
+        // also teach it: with no instruction (and nothing in the system prompt)
+        // the lite model omitted the array in 9/12 harness runs on the
+        // corpus-2 Kafka subscriber, silently dropping every pub/sub op in the
+        // file. Instruction and schema were each independently sufficient in
+        // the paired harness experiment (12/12 emission); both ship together.
+        let agent = FileAnalyzerAgent::new(AgentService::new());
+        let guidance = create_test_guidance();
+
+        let message = agent.build_user_message("test.ts", "const x = 1;", &guidance);
+
+        assert!(message.contains(
+            "- \"pubsub_operations\": array of pub/sub publish/subscribe operations found"
+        ));
+        assert!(message.contains("For each pubsub_operation, include: topic, role, line_number"));
+        assert!(
+            message.contains("resolve a named const like TOPIC to its string literal"),
+            "topic instruction must teach const-reference resolution"
+        );
     }
 
     fn named(local: &str, source: &str) -> ImportedSymbol {

--- a/src/agents/schemas.rs
+++ b/src/agents/schemas.rs
@@ -398,7 +398,17 @@ impl AgentSchemas {
                                 "description": "Import path where the `primary_type_symbol` type is defined (e.g., './types/user'), or null if it is declared in the same file. Read the import statements at the top of the file."
                             }
                         },
-                        "required": ["candidate_id", "line_number", "target", "pattern_matched"]
+                        // The four locator fields are required-but-nullable: the
+                        // lite model OMITS optional fields entirely (~8/12 runs
+                        // dropped payload_expression_line on the corpus-1 POST
+                        // /payments consumer), which starves the sidecar and
+                        // collapses the compat verdict to None. Requiring them
+                        // forces an explicit null instead — measured 12/12
+                        // emission with no hallucinated payload on GET calls.
+                        // Locator fields only; judgment fields (primary_type_symbol)
+                        // must stay optional — requiring them borrows the request
+                        // type when null is correct.
+                        "required": ["candidate_id", "line_number", "target", "pattern_matched", "call_expression_text", "call_expression_line", "payload_expression_text", "payload_expression_line"]
                     }
                 },
                 "graphql_operations": {
@@ -514,7 +524,17 @@ impl AgentSchemas {
                     }
                 }
             },
-            "required": ["mounts", "endpoints", "data_calls"]
+            // `pubsub_operations` is required so the model must always emit the
+            // array (empty when a file has none). As an optional property the
+            // lite model omitted it in 9/12 harness runs on the corpus-2 Kafka
+            // subscriber — the schema is pub/sub extraction's ONLY signal (the
+            // system prompt says nothing about it), so omission silently drops
+            // every pub/sub op in the file. An empty array is always
+            // groundable, so requiring it cannot force hallucination.
+            // `graphql_consumer_locates` stays optional deliberately: its
+            // instruction is "omit the entry rather than guess" — judgment,
+            // not location.
+            "required": ["mounts", "endpoints", "data_calls", "pubsub_operations"]
         })
     }
 
@@ -899,9 +919,46 @@ mod tests {
             );
         }
 
-        // pubsub_operations is optional at the top level: a model may omit it.
+        // pubsub_operations is REQUIRED at the top level. The schema is pub/sub
+        // extraction's only signal, and an optional array is one the lite model
+        // omits (measured 9/12 dropped ops on the corpus-2 Kafka subscriber);
+        // requiring it forces an explicit (possibly empty) array every response.
         let top_required = schema["required"].as_array().unwrap();
-        assert!(!top_required.iter().any(|v| v == "pubsub_operations"));
+        assert!(
+            top_required.iter().any(|v| v == "pubsub_operations"),
+            "pubsub_operations must be top-level required — optional emission drops pub/sub ops"
+        );
+    }
+
+    #[test]
+    fn data_call_locator_fields_are_required_but_type_judgment_stays_optional() {
+        // Locator fields (verbatim text + line) are required-but-nullable so the
+        // model must emit an explicit null instead of omitting them — omission
+        // starves the sidecar and collapses compat verdicts to None (corpus-1
+        // POST /payments consumer, 8/12 runs dropped payload_expression_line).
+        // Judgment fields (primary_type_symbol / type_import_source) must stay
+        // optional: requiring them borrows the request type when null is correct.
+        let schema = AgentSchemas::file_analysis_schema();
+        let required = schema["properties"]["data_calls"]["items"]["required"]
+            .as_array()
+            .expect("data_calls item required array must exist");
+        for field in [
+            "call_expression_text",
+            "call_expression_line",
+            "payload_expression_text",
+            "payload_expression_line",
+        ] {
+            assert!(
+                required.iter().any(|v| v == field),
+                "data_calls item required must contain locator field {field}"
+            );
+        }
+        for field in ["primary_type_symbol", "type_import_source"] {
+            assert!(
+                !required.iter().any(|v| v == field),
+                "judgment field {field} must NOT be required on data_calls"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Two schema `required`-list changes plus the missing pub/sub instruction block in the file-analyzer user message. Scanner-only — the scanner sends both the schema and the message per request, so nothing is deploy-gated.

1. **`pubsub_operations` is now top-level required**, and the user-message template teaches it (bullet + per-op field instructions). Until now the schema was pub/sub extraction's *only* signal — the system prompt and user message never mention it — and an optional array is one the lite model can legally omit.
2. **The four `data_calls` locator fields** (`call_expression_text/line`, `payload_expression_text/line`) **are now required-but-nullable**, forcing an explicit `null` instead of omission. Judgment fields (`primary_type_symbol`, `type_import_source`) deliberately stay optional.

## Why

This is lever D of the 95% program: both corpora's residual run-to-run variance is the file-analyzer omitting optional fields, measured on production-faithful messages in the prompt harness (gemini-3.1-flash-lite, temp 0, thinking low, real system prompt + schema, 12 runs per variant):

| experiment | today | schema-required | prompt-instructions | both |
|---|---|---|---|---|
| corpus-2 Kafka subscriber op emitted | 3/12 | 12/12 | 12/12 | 12/12 |
| corpus-1 POST /payments locator usable | 4/12 | 12/12 | — | — |

- The subscriber drop is corpus-2's catastrophic-extraction runs (main verification pair: 91/91/**80**, bad run ep F1 0.73 with anchor/resolution/compat all 1.00).
- The locator drop is corpus-1's `compat=None` flake (main verification pair run 1: both HTTP edges lost their verdict; web-frontend consumer side unresolved).
- Framework-detect was exonerated first: 12/12 identical `messaging_clients=["kafkajs","nats"]` on the notifications-svc input, and the deployed lambda zip was verified to contain the field.
- No hallucination backfire: required locators still come back `null` on payload-less GET calls (12/12), and every emitted locator variant (`body@46`, `JSON.stringify(body)@51`) is one the post-#297 sidecar resolves correctly.

## Tests

- `data_call_locator_fields_are_required_but_type_judgment_stays_optional` (new)
- `build_user_message_instructs_pubsub_operations` (new)
- The old "pubsub_operations is optional at top level" assertion flipped to pin the new invariant.
- Full `cargo test` (incl. cassette hard gate) green; sidecar untouched.

Live eval pair (runs=3 per corpus) on this branch to follow as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)