### PR TITLE
fix(ts_check): correct HTTP request-body assignability direction (+ eval pins)

### DIFF
--- a/tests/eval_xrepo.rs
+++ b/tests/eval_xrepo.rs
@@ -2764,8 +2764,10 @@ mod scoring_tests {
         let repo_expected = load_repo_expected(&repos);
         let expected_output = load_expected_output(&corpus);
 
-        // 6 matched edges: 3 http + 2 graphql + 1 socket.
-        assert_eq!(expected_output.matches.len(), 6);
+        // 8 matched edges: 5 http + 2 graphql + 1 socket. The two extra HTTP
+        // edges are the request-body direction fixtures (POST /widgets widening,
+        // POST /invoices narrowing) that pin the confirmed request-direction bug.
+        assert_eq!(expected_output.matches.len(), 8);
         let n_proto = |p: &str| {
             expected_output
                 .matches
@@ -2773,17 +2775,18 @@ mod scoring_tests {
                 .filter(|m| m.producer_key.starts_with(&format!("{p}|")))
                 .count()
         };
-        assert_eq!(n_proto("http"), 3, "3 HTTP edges");
+        assert_eq!(n_proto("http"), 5, "5 HTTP edges");
         assert_eq!(n_proto("graphql"), 2, "2 GraphQL edges");
         assert_eq!(n_proto("socket"), 1, "1 socket edge");
 
-        // 2 incompatible edges (one REST, one GraphQL subscription).
+        // 3 incompatible edges: two REST (orders id string-vs-number, and the
+        // POST /invoices request-body narrowing) + one GraphQL subscription.
         let incompatible = expected_output
             .matches
             .iter()
             .filter(|m| m.type_compatible == Some(false))
             .count();
-        assert_eq!(incompatible, 2, "2 deliberately-incompatible edges");
+        assert_eq!(incompatible, 3, "3 deliberately-incompatible edges");
 
         // Every edge carries a non-null verdict → the §7 guard is live.
         assert!(

--- a/tests/fixtures/xrepo-corpus-1/README.md
+++ b/tests/fixtures/xrepo-corpus-1/README.md
@@ -69,6 +69,8 @@ connects to. So the GraphQL/socket connection URLs
 | http | orders-pkg `GET /orders/:param` | payments-svc | `http\|GET\|/orders/:param` | compatible |
 | http | orders-pkg `GET /orders/:param` | web-frontend | `http\|GET\|/orders/:param` | **incompatible** (`id` string vs number) |
 | http | payments-svc `POST /payments` | web-frontend | `http\|POST\|/payments` | compatible |
+| http | payments-svc `POST /widgets` | web-frontend | `http\|POST\|/widgets` | compatible (request-body **widening**) |
+| http | payments-svc `POST /invoices` | web-frontend | `http\|POST\|/invoices` | **incompatible** (request-body **narrowing**: caller omits required `amountCents`) |
 | graphql | gateway `query order` | web-frontend | `graphql\|query\|order` | compatible |
 | graphql | gateway `subscription orderUpdated` | web-frontend | `graphql\|subscription\|orderUpdated` | **incompatible** (optional-field widening: consumer `note` required, producer optional) |
 | socket | web-frontend (listener) | payments-svc (emitter) | `socket\|SERVER->CLIENT\|payment:settled` | compatible |
@@ -83,6 +85,18 @@ web-frontend client *listens*), the structured `matches` edge has
 `producer_repo: web-frontend` (the listener) and `consumer_repo: payments-svc`
 (the emitter), both on `socket|SERVER->CLIENT|payment:settled`. The *event*
 flows payments-svc → web-frontend; the *contract producer* is the listener.
+
+**HTTP request-body direction (`POST /widgets`, `POST /invoices`).** Request
+bodies flow the opposite way to responses: the caller (manifest consumer) sends
+the body the endpoint (manifest producer) must accept, so the assignability
+direction is `consumer ⊑ producer` — the inverse of the response direction. Both
+edges keep their response types byte-identical on each side, so the edge verdict
+is driven purely by the request pair. `POST /widgets` widens (caller sends a
+required superset `{ name, note }` the endpoint tolerates → compatible);
+`POST /invoices` narrows (caller omits the endpoint's required `amountCents` →
+incompatible). These pin the confirmed request-direction inversion — the old
+`compareTypes` keyed direction on protocol only and ran the response direction
+for every HTTP pair, so it read both verdicts inverted.
 
 Orphan producers: orders `GET /api/v1/status`, gateway `GET /users/:param`,
 `GET /users/recent`, `GET /gateway/health`, gateway `graphql query orders`,

--- a/tests/fixtures/xrepo-corpus-1/expected-output.json
+++ b/tests/fixtures/xrepo-corpus-1/expected-output.json
@@ -31,6 +31,26 @@
       "tier": "capability"
     },
     {
+      "producer_repo": "payments-svc",
+      "producer_key": "http|POST|/widgets",
+      "consumer_repo": "web-frontend",
+      "consumer_key": "http|POST|/widgets",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "http",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "payments-svc",
+      "producer_key": "http|POST|/invoices",
+      "consumer_repo": "web-frontend",
+      "consumer_key": "http|POST|/invoices",
+      "type_compatible": false,
+      "mismatch_reason": "consumer request body omits amountCents, which producer InvoiceRequest requires (request-body narrowing)",
+      "protocol": "http",
+      "tier": "capability"
+    },
+    {
       "producer_repo": "gateway",
       "producer_key": "graphql|query|order",
       "consumer_repo": "web-frontend",
@@ -82,13 +102,13 @@
   ],
   "summary": {
     "total_repos": 3,
-    "producers": 12,
-    "consumers": 8,
-    "matched_edges": 6,
-    "incompatible_edges": 2,
+    "producers": 14,
+    "consumers": 10,
+    "matched_edges": 8,
+    "incompatible_edges": 3,
     "orphan_producers": 6,
     "orphan_consumers": 2,
     "decoys_must_not_emit": 4,
-    "matched_edges_by_protocol": { "http": 3, "graphql": 2, "socket": 1 }
+    "matched_edges_by_protocol": { "http": 5, "graphql": 2, "socket": 1 }
   }
 }

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/expected.json
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/expected.json
@@ -17,6 +17,24 @@
       "resolved_type": "{ id: string; orderId: number; amountCents: number; status: \"pending\" | \"settled\"; }",
       "type_state": "Explicit",
       "tier": "capability"
+    },
+    {
+      "method": "POST",
+      "path": "/widgets",
+      "owner": "createWidget",
+      "primary_type_symbol": "WidgetCreated",
+      "resolved_type": "{ id: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "POST",
+      "path": "/invoices",
+      "owner": "createInvoice",
+      "primary_type_symbol": "InvoiceCreated",
+      "resolved_type": "{ id: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
     }
   ],
   "calls": [

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/index.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/index.ts
@@ -1,6 +1,13 @@
 import express from "express";
 import type { Request, Response } from "express";
-import type { Payment, CreatePayment } from "./src/types";
+import type {
+  Payment,
+  CreatePayment,
+  WidgetRequest,
+  WidgetCreated,
+  InvoiceRequest,
+  InvoiceCreated,
+} from "./src/types";
 
 const app = express();
 
@@ -27,8 +34,24 @@ async function getPayment(req: Request, res: Response): Promise<void> {
   res.json(payment);
 }
 
+// POST /widgets — request body { name }; the caller may send a required superset.
+async function createWidget(req: Request, res: Response): Promise<void> {
+  const body = req.body as WidgetRequest;
+  const widget: WidgetCreated = { id: `wid_${body.name}` };
+  res.status(201).json(widget);
+}
+
+// POST /invoices — request body requires { invoiceId, amountCents }.
+async function createInvoice(req: Request, res: Response): Promise<void> {
+  const body = req.body as InvoiceRequest;
+  const invoice: InvoiceCreated = { id: `inv_${body.invoiceId}_${body.amountCents}` };
+  res.status(201).json(invoice);
+}
+
 app.post("/payments", createPayment);
 app.get("/payments/:paymentId", getPayment);
+app.post("/widgets", createWidget);
+app.post("/invoices", createInvoice);
 
 app.listen(3002, () => {
   console.log("payments-svc running on :3002");

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/src/types/index.ts
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/src/types/index.ts
@@ -11,3 +11,29 @@ export interface CreatePayment {
   orderId: number;
   amountCents: number;
 }
+
+// POST /widgets — request-body direction fixture (widening). The endpoint accepts
+// just { name }; the web-frontend caller sends a REQUIRED superset { name, note }.
+// Request bodies flow caller → endpoint (consumer ⊑ producer), so a widening body
+// is compatible. Response is byte-identical on both sides so the edge verdict is
+// driven purely by the request pair.
+export interface WidgetRequest {
+  name: string;
+}
+
+export interface WidgetCreated {
+  id: string;
+}
+
+// POST /invoices — request-body direction fixture (narrowing). The endpoint
+// REQUIRES both invoiceId and amountCents; the caller omits the required
+// amountCents. In the request direction (consumer ⊑ producer) this narrowing body
+// is incompatible.
+export interface InvoiceRequest {
+  invoiceId: string;
+  amountCents: number;
+}
+
+export interface InvoiceCreated {
+  id: string;
+}

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/expected.json
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/expected.json
@@ -20,6 +20,26 @@
       "resolved_type": "{ id: string; orderId: number; amountCents: number; status: string; }",
       "type_state": "Explicit",
       "tier": "capability"
+    },
+    {
+      "method": "POST",
+      "path": "/widgets",
+      "path_contains": "/widgets",
+      "import_source": null,
+      "primary_type_symbol": "WidgetCreated",
+      "resolved_type": "{ id: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "POST",
+      "path": "/invoices",
+      "path_contains": "/invoices",
+      "import_source": null,
+      "primary_type_symbol": "InvoiceCreated",
+      "resolved_type": "{ id: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
     }
   ],
   "graphql_operations": [

--- a/tests/fixtures/xrepo-corpus-1/web-frontend/lib/api.ts
+++ b/tests/fixtures/xrepo-corpus-1/web-frontend/lib/api.ts
@@ -30,6 +30,29 @@ export interface CreatePaymentRequest {
   amountCents: number;
 }
 
+// POST /widgets request body — a REQUIRED superset of what the endpoint accepts
+// ({ name, note } vs the producer's { name }). In the request direction
+// (consumer ⊑ producer) this widening body is compatible.
+export interface CreateWidgetBody {
+  name: string;
+  note: string;
+}
+
+export interface WidgetCreated {
+  id: string;
+}
+
+// POST /invoices request body — OMITS the endpoint's required amountCents
+// ({ invoiceId } vs the producer's { invoiceId, amountCents }). In the request
+// direction this narrowing body is incompatible.
+export interface CreateInvoiceBody {
+  invoiceId: string;
+}
+
+export interface InvoiceCreated {
+  id: string;
+}
+
 // GET /orders/:id — fetches a single order by id.
 // NOTE: id is typed as string here; the producer emits id as number (incompatible edge).
 export async function fetchOrder(id: string): Promise<OrderView> {
@@ -54,4 +77,38 @@ export async function createPayment(
     throw new Error(`Failed to create payment: ${res.status}`);
   }
   return res.json() as Promise<Payment>;
+}
+
+// POST /widgets — creates a widget via payments-svc. The request body is a
+// required superset of what the endpoint accepts, so the request pair is
+// compatible; the response is byte-identical, so the edge reads compatible.
+export async function createWidget(
+  body: CreateWidgetBody
+): Promise<WidgetCreated> {
+  const res = await fetch(`${PAYMENTS_BASE}/widgets`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to create widget: ${res.status}`);
+  }
+  return res.json() as Promise<WidgetCreated>;
+}
+
+// POST /invoices — creates an invoice via payments-svc. The request body omits
+// the endpoint's required amountCents, so the request pair is incompatible and
+// the edge reads incompatible even though the response is byte-identical.
+export async function createInvoice(
+  body: CreateInvoiceBody
+): Promise<InvoiceCreated> {
+  const res = await fetch(`${PAYMENTS_BASE}/invoices`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to create invoice: ${res.status}`);
+  }
+  return res.json() as Promise<InvoiceCreated>;
 }

--- a/ts_check/lib/type-checker.test.ts
+++ b/ts_check/lib/type-checker.test.ts
@@ -1003,6 +1003,117 @@ describe('TypeCompatibilityChecker', () => {
       );
     });
 
+    it('type-checks an HTTP request-body edge as compatible when the caller sends a superset the endpoint tolerates (request-direction proof)', async () => {
+      // HTTP REQUEST bodies flow consumer → producer: the CALLER (manifest
+      // consumer) sends the body the ENDPOINT (manifest producer) must accept,
+      // so the direction is `consumer ⊑ producer` — the inverse of the HTTP
+      // RESPONSE direction. Here the caller sends an extra REQUIRED field `note`
+      // the endpoint does not require; `{ name; note }` IS assignable to
+      // `{ name }`, so a widening request body is COMPATIBLE.
+      //
+      // PRE-FIX-FAILING: the old compareTypes keyed direction on protocol only
+      // and ran the RESPONSE direction `producer ⊑ consumer` for every HTTP pair.
+      // That asks whether `{ name }` is assignable to `{ name; note }` — it is
+      // NOT (the target requires `note`) — so this pair read INCOMPATIBLE. It
+      // only reads compatible once request `type_kind` selects `consumer ⊑ producer`.
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        // Endpoint accepts just { name }.
+        export type CreateWidgetRequest = { name: string };
+        // Caller sends { name, note } — a required superset.
+        export type CreateWidgetBody = { name: string; note: string };
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'widgets-svc',
+        commit_hash: 'abc',
+        entries: [
+          createManifestEntry('POST', '/widgets', 'CreateWidgetRequest', 'producer', 'routes.ts', 10, 'request'),
+        ],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def',
+        entries: [
+          createManifestEntry('POST', '/widgets', 'CreateWidgetBody', 'consumer', 'api.ts', 5, 'request'),
+        ],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.matchDetails?.length, 1, 'the request pair must match');
+      assert.strictEqual(result.compatiblePairs, 1);
+      assert.strictEqual(result.incompatiblePairs, 0);
+      assert.strictEqual(result.unknownPairs.length, 0);
+    });
+
+    it('reads an HTTP request-body edge as incompatible when the caller omits a field the endpoint requires (request-direction proof)', async () => {
+      // Mirror of the widening case. The endpoint REQUIRES both `orderId` and
+      // `amountCents`; the caller sends only `{ orderId }`. In the request
+      // direction `consumer ⊑ producer`, `{ orderId }` is NOT assignable to
+      // `{ orderId; amountCents }` (missing required `amountCents`) → INCOMPATIBLE.
+      //
+      // PRE-FIX-FAILING: the old protocol-only direction ran `producer ⊑ consumer`,
+      // asking whether `{ orderId; amountCents }` is assignable to `{ orderId }` —
+      // it IS (a superset satisfies a subset target) — so this genuine drift read
+      // COMPATIBLE, the inverted verdict. It only reads incompatible once request
+      // `type_kind` selects `consumer ⊑ producer`.
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        // Endpoint requires both fields.
+        export type CreatePaymentRequest = { orderId: number; amountCents: number };
+        // Caller omits the required amountCents.
+        export type CreatePaymentBody = { orderId: number };
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'payments-svc',
+        commit_hash: 'abc',
+        entries: [
+          createManifestEntry('POST', '/payments', 'CreatePaymentRequest', 'producer', 'index.ts', 8, 'request'),
+        ],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def',
+        entries: [
+          createManifestEntry('POST', '/payments', 'CreatePaymentBody', 'consumer', 'api.ts', 45, 'request'),
+        ],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.incompatiblePairs, 1);
+      assert.strictEqual(result.compatiblePairs, 0);
+      assert.strictEqual(result.unknownPairs.length, 0);
+      assert.strictEqual(result.mismatches.length, 1);
+      assert.ok(
+        result.mismatches[0].endpoint.includes('POST') &&
+          result.mismatches[0].endpoint.includes('request'),
+        `the mismatch endpoint must carry the POST request label, got: ${result.mismatches[0].endpoint}`
+      );
+    });
+
     it('reads a dangling consumer name as unverifiable but its structural shape as incompatible (#257)', async () => {
       // The #257 inference bug: a consumer like `res.json() as Promise<OrderView>`
       // wrote the bare NAME `= OrderView` into the cross-repo bundle. The bundle

--- a/ts_check/lib/type-checker.ts
+++ b/ts_check/lib/type-checker.ts
@@ -348,9 +348,11 @@ export class TypeCompatibilityChecker {
     // Assignability runs in the DATA-flow direction: the value that is sent
     // must satisfy the type the receiver expects.
     //
-    // HTTP: the manifest producer (endpoint) emits the response and the manifest
-    // consumer (call) receives it, so the producer payload must satisfy the
-    // consumer — `producer ⊑ consumer`.
+    // HTTP responses: the manifest producer (endpoint) emits the response and the
+    // manifest consumer (call) receives it, so the producer payload must satisfy
+    // the consumer — `producer ⊑ consumer`. HTTP REQUEST bodies invert this: the
+    // consumer (caller) sends the body the producer (endpoint) must accept, so
+    // `consumer ⊑ producer` (keyed on `type_kind` via `httpRequest` below).
     //
     // GraphQL: same data-flow direction as HTTP. The producer (schema resolver,
     // server) RETURNS the full object; the consumer (document, client) SELECTS a
@@ -387,6 +389,11 @@ export class TypeCompatibilityChecker {
     const socket = producer.protocol === "socket";
     const graphql = producer.protocol === "graphql";
     const pubsub = producer.protocol === "pubsub";
+    // HTTP request bodies flow consumer → producer (the caller sends the body the
+    // endpoint must accept), the inverse of the HTTP response direction. The
+    // matcher pairs strictly per `type_kind`, so producer and consumer agree here.
+    const httpRequest =
+      producer.protocol === "http" && producer.type_kind === "request";
 
     // For GraphQL the producer's resolved type is the resolver's return ENVELOPE
     // (e.g. `{ data: Order; errors: string[] }`), kept verbatim for the
@@ -400,12 +407,15 @@ export class TypeCompatibilityChecker {
       ? this.unwrapGraphqlPayload(producerType, endpoint)
       : producerType;
 
-    // Socket AND pub/sub share the inverted direction: the consumer (emitter /
-    // publisher) sends, the producer (listener / subscriber) accepts. Pub/sub
-    // does NOT unwrap an envelope (its payload type is already decoded), so it
-    // rides the non-graphql `producerComparand` above.
-    const sentType = (socket || pubsub) ? consumerType : producerComparand;
-    const expectedType = (socket || pubsub) ? producerComparand : consumerType;
+    // Socket, pub/sub, AND HTTP request bodies share the inverted direction: the
+    // consumer (emitter / publisher / caller) sends, the producer (listener /
+    // subscriber / endpoint) accepts — `consumer ⊑ producer`. HTTP responses and
+    // GraphQL keep the data-flow-forward `producer ⊑ consumer`. Pub/sub and HTTP
+    // requests do NOT unwrap an envelope (only graphql does), so they ride the
+    // non-graphql `producerComparand` above.
+    const inverted = socket || pubsub || httpRequest;
+    const sentType = inverted ? consumerType : producerComparand;
+    const expectedType = inverted ? producerComparand : consumerType;
 
     // Re-run the `any`/`unknown` → unverifiable guard on the COMPARANDS, not just
     // the raw `producerType`/`consumerType` checked at the top. The GraphQL


### PR DESCRIPTION
## What

Fixes the **confirmed HTTP request-body direction inversion** in `ts_check`
`compareTypes`, and pins it with deterministic unit tests + xrepo-corpus-1 eval
fixtures. This is step 1 of the type-compat v2 migration plan
(`docs/research/type-compat-synthetic-monorepo.md`) — a real bug today,
independent of the migration ("Failure classes" last bullet + "Eval leverage").

## The bug

`compareTypes` selected the assignability direction from **protocol only**, so
every HTTP pair ran the response direction `producer ⊑ consumer`. That is correct
for **response** bodies (endpoint sends → caller receives) but inverted for
**request** bodies: the caller sends the body the endpoint must accept, so data
flows consumer → producer and the check must be `consumer ⊑ producer`. `type_kind`
(Request|Response) was already on the matched entries but never consulted for
direction, so widening/narrowing verdicts on request bodies were inverted.

## The fix

One flag added to the existing inversion set: `httpRequest = protocol http &&
type_kind request` joins `socket`/`pubsub` (which already run `consumer ⊑
producer`). GraphQL and HTTP responses are unchanged. The matcher pairs strictly
per `type_kind`, so producer/consumer `type_kind` agree.

The migration's later `(protocol, type_kind)` direction table (doc Check-phase 8)
subsumes this once `compareTypes` is deleted; until then this stops shipping
inverted request-body verdicts.

## Pins (pre-fix-failing → green)

- **`ts_check/lib/type-checker.test.ts`** — two deterministic direction-proof unit
  tests (widening request → compatible; narrowing request → incompatible). Both
  FAIL against the old protocol-only direction and pass after the fix. These are
  the CI merge gate (they run in `ci.yml`'s ts_check step); commit order carries
  the red→green evidence (tests first, fix second).
- **`tests/fixtures/xrepo-corpus-1`** — two new POST endpoints on `payments-svc`
  (producer) consumed by `web-frontend`, mirroring the proven `POST /payments`
  express pattern. Responses are **byte-identical** both sides so the edge verdict
  is driven purely by the request pair: `POST /widgets` widens (compatible),
  `POST /invoices` narrows (incompatible). Per-repo `expected.json`,
  `expected-output.json` matches, the corpus README, and the `eval_xrepo` shape
  guard updated to match.

## Safety on existing edges

The direction flip is a **no-op** on the two existing corpus HTTP request pairs:
`POST /payments` and `POST /track` carry structurally identical request types on
both sides, so `producer ⊑ consumer ≡ consumer ⊑ producer` for them. Today's green
does not ride the bug.

## Verification

- `cargo test` (full suite incl. cassette hard gate), `cargo clippy --all-targets`,
  `cargo fmt --check`, `cd ts_check && npm test` (87 pass), `cd src/sidecar && npm run build && npm test` — all green locally.
- Live per-edge eval (`eval-xrepo.yml`) on corpus-1 and corpus-2 triggered
  separately; results posted in a follow-up comment. Ground truth encodes the
  CORRECT verdicts — no answer key was edited to match buggy output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)