### PR TITLE
fix(ts_check): abstain instead of false-compatible on dangling library types (MVP safety)

### DIFF
--- a/ts_check/lib/type-checker.test.ts
+++ b/ts_check/lib/type-checker.test.ts
@@ -1297,6 +1297,78 @@ describe('TypeCompatibilityChecker', () => {
       );
     });
 
+    it('abstains (unverifiable) when a NESTED field dangles to any via a kept-by-name library type (version-conflict safety)', async () => {
+      // The measured false-compatible: a library/version type (e.g. bson ObjectId,
+      // a zod-inferred class across majors) is serialized BY NAME with no import,
+      // so at check time the field dangles. Here producer/consumer both read
+      // `{ token: Token; amount: number }` with `Token` undeclared. The top-level
+      // any/unknown guard MISSES it (the object type is not itself any; only the
+      // nested `token` field is), so `isAssignableTo` compares any-vs-any on
+      // `token` and reads COMPATIBLE — masking a real wire mismatch. It must
+      // instead read unverifiable: a dangling reference means the shape never
+      // reached the bundle and the verdict cannot be trusted.
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        // \`Token\` is a library class kept by name with no declaration in the
+        // bundle (imports are stripped in the flat cross-repo project).
+        export interface Endpoint_vc_Response { token: Token; amount: number; }
+        export interface Endpoint_vc_Response_Call1 { token: Token; amount: number; }
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'producer-svc', commit_hash: 'p',
+        entries: [createManifestEntry('POST', '/x', 'Endpoint_vc_Response', 'producer', 'p.ts', 1)],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'consumer-svc', commit_hash: 'c',
+        entries: [createManifestEntry('POST', '/x', 'Endpoint_vc_Response_Call1', 'consumer', 'c.ts', 1)],
+      };
+
+      const result = await typeChecker.checkCompatibility(producers, consumers, typesProject);
+
+      assert.strictEqual(result.compatiblePairs, 0, 'must NOT read compatible (would be a false-compatible)');
+      assert.strictEqual(result.incompatiblePairs, 0);
+      assert.strictEqual(result.unknownPairs.length, 1, 'a dangling nested reference must read unverifiable');
+      assert.ok(
+        /unresolved|dangl|not in the bundle|cannot verify/i.test(result.unknownPairs[0].reason),
+        `the reason must name the dangling reference, got: ${result.unknownPairs[0].reason}`
+      );
+    });
+
+    it('does NOT over-abstain: a cleanly-resolved pair with a genuine field type stays a definite verdict', async () => {
+      // Guard against the fix over-firing: identical, cleanly-resolving inlined
+      // shapes (e.g. a nominal class inlined to its wire shape) must keep their
+      // definite verdict, not get swept into unverifiable. No dangling refs here.
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        export interface Endpoint_ok_Response { cents: number; toJSON: () => { cents: number } }
+        export interface Endpoint_ok_Response_Call1 { cents: number; toJSON: () => { cents: number } }
+        `,
+        { overwrite: true }
+      );
+      const producers: TypeManifest = {
+        repo_name: 'p', commit_hash: 'p',
+        entries: [createManifestEntry('POST', '/x', 'Endpoint_ok_Response', 'producer', 'p.ts', 1)],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'c', commit_hash: 'c',
+        entries: [createManifestEntry('POST', '/x', 'Endpoint_ok_Response_Call1', 'consumer', 'c.ts', 1)],
+      };
+      const result = await typeChecker.checkCompatibility(producers, consumers, typesProject);
+      assert.strictEqual(result.compatiblePairs, 1, 'cleanly-resolving identical shapes stay compatible');
+      assert.strictEqual(result.unknownPairs.length, 0);
+    });
+
     it('should match with path parameter normalization', async () => {
       const producers: TypeManifest = {
         repo_name: 'producer-api',

--- a/ts_check/lib/type-checker.ts
+++ b/ts_check/lib/type-checker.ts
@@ -138,6 +138,13 @@ export class TypeCompatibilityChecker {
     // Use provided project or fall back to instance project
     const project = typesProject || this.project;
 
+    // Aliases whose declaration references an unresolved symbol (a library type
+    // kept by name with no declaration in the flat bundle — imports are stripped
+    // cross-repo). Such a reference makes a NESTED field dangle to `any`, which
+    // the top-level any/unknown guard in compareTypes cannot see, so a definite
+    // verdict over it would be a false-compatible. Used as a safety net below.
+    const danglingAliases = this.computeDanglingAliases(project);
+
     // Match endpoints using the manifest matcher
     const { matches, orphanedProducers, orphanedConsumers } =
       this.manifestMatcher.matchEndpoints(producerManifest, consumerManifest);
@@ -224,7 +231,26 @@ export class TypeCompatibilityChecker {
           consumerTypeInfo?.type ?? this.findTypeInProject(project, match.consumer.type_alias)
         );
 
-        if (outcome.kind === "incompatible") {
+        const producerDangling = danglingAliases.has(match.producer.type_alias);
+        const consumerDangling = danglingAliases.has(match.consumer.type_alias);
+        if (outcome.kind !== "unverifiable" && (producerDangling || consumerDangling)) {
+          // Dangling-reference safety net (version-conflict / kept-by-name library
+          // types). compareTypes returned a definite verdict, but one side references
+          // an unresolved symbol so a nested field dangled to `any` — the verdict is
+          // untrustworthy (the false-compatible measured on the hard-types fixture).
+          // Abstain instead of asserting compatible/incompatible.
+          const which = producerDangling ? "producer" : "consumer";
+          result.unknownPairs.push({
+            endpoint,
+            reason: `${which} type references an unresolved symbol (a library type kept by name with no declaration in the bundle) — cannot verify`,
+            producerTypeAlias: match.producer.type_alias,
+            consumerTypeAlias: match.consumer.type_alias,
+            producerLocation: this.formatEntryLocation(match.producer),
+            consumerLocation: this.formatEntryLocation(match.consumer),
+            producerEvidence: match.producer.evidence,
+            consumerEvidence: match.consumer.evidence,
+          });
+        } else if (outcome.kind === "incompatible") {
           result.mismatches.push(outcome.mismatch);
           result.incompatiblePairs++;
         } else if (outcome.kind === "unverifiable") {
@@ -580,6 +606,43 @@ export class TypeCompatibilityChecker {
    * @param typeName - The name of the type to find
    * @returns The Type if found, null otherwise
    */
+  /**
+   * Aliases whose declaration references an unresolved symbol — a library type
+   * kept by name whose declaration never made it into the flat cross-repo bundle
+   * (imports are stripped), or a renamed/missing surface export. Such a reference
+   * makes a NESTED field dangle to `any`, which the top-level any/unknown guard in
+   * compareTypes cannot see, so `isAssignableTo` would compare `any`-vs-`any` at
+   * that position and yield a false verdict (the version-conflict false-compatible
+   * measured on the hard-types fixture). Detected via the compiler's own
+   * unresolved-reference diagnostics — a genuine `any` field produces no such
+   * reference (or a declared-but-`any` alias) is swept in, so genuine concrete
+   * fields keep their verdict. Detected via the AST rather than diagnostics
+   * because the bundle is a `.d.ts` and the check runs `skipLibCheck` (which
+   * suppresses declaration-file diagnostics), so the type checker is queried
+   * directly: an unresolved type name has no symbol and resolves to `any`.
+   */
+  private computeDanglingAliases(project: Project): Set<string> {
+    const dangling = new Set<string>();
+    for (const sf of project.getSourceFiles()) {
+      for (const decl of [...sf.getTypeAliases(), ...sf.getInterfaces()]) {
+        const refs = decl.getDescendantsOfKind(SyntaxKind.TypeReference);
+        for (const ref of refs) {
+          // An unresolved type name (a library type kept by name with no
+          // declaration in the bundle) resolves to `any`, and its symbol — if
+          // ts-morph synthesises one — carries ZERO declarations. A genuine
+          // declared-but-`any` alias has a declaration, so it is not swept in.
+          const sym = ref.getTypeName().getSymbol();
+          const unresolved = !sym || sym.getDeclarations().length === 0;
+          if (unresolved && ref.getType().isAny()) {
+            dangling.add(decl.getName());
+            break;
+          }
+        }
+      }
+    }
+    return dangling;
+  }
+
   private findTypeInProject(project: Project, typeName: string): Type | null {
     for (const sourceFile of project.getSourceFiles()) {
       // Check type aliases

--- a/ts_check/lib/type-checker.ts
+++ b/ts_check/lib/type-checker.ts
@@ -239,10 +239,15 @@ export class TypeCompatibilityChecker {
           // an unresolved symbol so a nested field dangled to `any` — the verdict is
           // untrustworthy (the false-compatible measured on the hard-types fixture).
           // Abstain instead of asserting compatible/incompatible.
-          const which = producerDangling ? "producer" : "consumer";
+          const which =
+            producerDangling && consumerDangling
+              ? "producer and consumer types reference"
+              : producerDangling
+                ? "producer type references"
+                : "consumer type references";
           result.unknownPairs.push({
             endpoint,
-            reason: `${which} type references an unresolved symbol (a library type kept by name with no declaration in the bundle) — cannot verify`,
+            reason: `${which} an unresolved symbol (a library type kept by name with no declaration in the bundle) — cannot verify`,
             producerTypeAlias: match.producer.type_alias,
             consumerTypeAlias: match.consumer.type_alias,
             producerLocation: this.formatEntryLocation(match.producer),
@@ -600,26 +605,17 @@ export class TypeCompatibilityChecker {
   }
 
   /**
-   * Find a type alias or interface in the project by name
-   *
-   * @param project - The ts-morph project to search
-   * @param typeName - The name of the type to find
-   * @returns The Type if found, null otherwise
-   */
-  /**
    * Aliases whose declaration references an unresolved symbol — a library type
    * kept by name whose declaration never made it into the flat cross-repo bundle
    * (imports are stripped), or a renamed/missing surface export. Such a reference
    * makes a NESTED field dangle to `any`, which the top-level any/unknown guard in
    * compareTypes cannot see, so `isAssignableTo` would compare `any`-vs-`any` at
    * that position and yield a false verdict (the version-conflict false-compatible
-   * measured on the hard-types fixture). Detected via the compiler's own
-   * unresolved-reference diagnostics — a genuine `any` field produces no such
-   * reference (or a declared-but-`any` alias) is swept in, so genuine concrete
-   * fields keep their verdict. Detected via the AST rather than diagnostics
-   * because the bundle is a `.d.ts` and the check runs `skipLibCheck` (which
-   * suppresses declaration-file diagnostics), so the type checker is queried
-   * directly: an unresolved type name has no symbol and resolves to `any`.
+   * measured on the hard-types fixture). Detection queries the type checker via
+   * the AST rather than reading diagnostics, because the bundle is a `.d.ts` and
+   * the check runs `skipLibCheck` (which suppresses declaration-file diagnostics):
+   * an unresolved type name has no symbol and resolves to `any`, while a genuine
+   * declared-but-`any` alias has a declaration and is not swept in.
    */
   private computeDanglingAliases(project: Project): Set<string> {
     const dangling = new Set<string>();
@@ -643,6 +639,13 @@ export class TypeCompatibilityChecker {
     return dangling;
   }
 
+  /**
+   * Find a type alias or interface in the project by name
+   *
+   * @param project - The ts-morph project to search
+   * @param typeName - The name of the type to find
+   * @returns The Type if found, null otherwise
+   */
   private findTypeInProject(project: Project, typeName: string): Type | null {
     for (const sourceFile of project.getSourceFiles()) {
       // Check type aliases


### PR DESCRIPTION
## What & why

Closes the one **wire-real false-compatible** in the type-compatibility checker — the drift-detector's most dangerous error (silently reports "compatible" when payloads actually differ).

Measured on a hard-types fixture (raw tsc as oracle): when a payload field is typed by a **library class kept by name** (e.g. an `ObjectId`/`Decimal`/branded class, especially across conflicting major versions), the flat cross-repo bundle strips the import, so the field dangles to `any`. The `any`/`unknown` guard in `compareTypes` inspects only the **top-level** type, not nested fields — so `isAssignableTo` compares `any`-vs-`any` on that field and reads **compatible**, masking real drift (`id: string` vs `id: number` went undetected).

## Fix (check-side only — no sidecar or cloud change)

`computeDanglingAliases` walks each bundled alias's type-reference nodes and flags any that resolves to `any` with a declaration-less symbol (an unresolved reference). Detection is via the AST, not diagnostics, because the bundle is a `.d.ts` checked under `skipLibCheck` (which suppresses declaration-file diagnostics). Any pair touching a dangling alias **abstains (unverifiable)** with a distinct reason, instead of asserting a verdict it can't trust.

- Two deterministic tests (red→green): nested-dangling → unverifiable; cleanly-resolving → keeps its verdict (guards against over-abstaining).
- The distinct abstention reason doubles as **telemetry** — the per-reason count from real scans is what later decides whether the full v2 rebuild is worth it.

## Scope (deliberately narrow)

This is the **MVP safety patch**, not the full type-compat v2 migration. It flips the dangerous silent false-compatible into an honest "can't verify." The **nominal class-identity** case is intentionally left alone: its "compatible" is *wire-correct* (private members don't cross the JSON wire), so abstaining there would only cost coverage. Full accuracy on hard types (turning these abstentions into real verdicts) remains the deferred v2 play, triggered by the abstention telemetry.

## Verification
`cd ts_check && npm test` → 87/87 green. No Rust/sidecar changes. Follow-up (issue): route "same library, conflicting majors" to the existing dependency-conflict finding for an even better verdict than a bare abstain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)