### PR TITLE
feat(eval): xrepo-corpus-3 — messy-realism cross-repo corpus + kind-aware decoy scoring

### DIFF
--- a/tests/eval_xrepo.rs
+++ b/tests/eval_xrepo.rs
@@ -251,8 +251,12 @@ struct ExpNonHttpOp {
 
 #[derive(Debug, Deserialize)]
 struct ExpMustNotEmit {
-    /// `"endpoint"` or `"call"` — which projection set this decoy would leak into.
-    #[allow(dead_code)]
+    /// `"endpoint"` or `"call"` — which projection set this decoy would leak
+    /// into. The set matters when a decoy shares `(method, path)` with a legit
+    /// op on the OTHER side (corpus-3's intra-repo self-call decoy is a `call`
+    /// whose path is also a labelled endpoint). Other values (corpus-2's
+    /// non-HTTP `"pubsub"` decoys) match neither HTTP set — documented, not
+    /// yet scoreable.
     kind: String,
     /// `"*"` matches any method.
     method: String,
@@ -627,16 +631,24 @@ fn fuzzy_call_match(ec: &ExpCall, ac: &EvalOp) -> bool {
 }
 
 /// Decoy leakage (contract §6 row 3): the count of actual ops (endpoints +
-/// calls) whose normalized `(method, path)` equals a `_must_not_emit` entry.
-/// `method: "*"` matches any method. Reported separately, not tier-partitioned
-/// (a leak is a leak regardless of which tier the surrounding labels are).
+/// calls) whose normalized `(method, path)` equals a `_must_not_emit` entry
+/// of the SAME projection set (`kind: "endpoint"` matches only endpoints,
+/// `kind: "call"` only calls) — so a call-decoy sharing a path with a legit
+/// endpoint never flags the endpoint. `method: "*"` matches any method.
+/// Reported separately, not tier-partitioned (a leak is a leak regardless of
+/// which tier the surrounding labels are).
 fn score_decoy_leak(repo_expected: &[(String, ExpectedRepo)], proj: &EvalProjection) -> usize {
     let decoys: Vec<&ExpMustNotEmit> = repo_expected
         .iter()
         .flat_map(|(_r, e)| e.must_not_emit.iter())
         .collect();
     let mut leaks = 0usize;
-    for op in proj.endpoints.iter().chain(proj.calls.iter()) {
+    for (op, set_kind) in proj
+        .endpoints
+        .iter()
+        .map(|o| (o, "endpoint"))
+        .chain(proj.calls.iter().map(|o| (o, "call")))
+    {
         let (Some(m), Some(p)) = (op.method.as_deref(), op.path.as_deref()) else {
             // Non-HTTP ops have no (method, path); the corpus decoys are all
             // HTTP-keyed, so a non-HTTP op can never match one.
@@ -645,8 +657,9 @@ fn score_decoy_leak(repo_expected: &[(String, ExpectedRepo)], proj: &EvalProject
         let m_up = m.to_uppercase();
         let p_norm = norm_path(p);
         let is_leak = decoys.iter().any(|d| {
+            let kind_ok = d.kind == set_kind;
             let method_ok = d.method == "*" || d.method.eq_ignore_ascii_case(&m_up);
-            method_ok && norm_path(&d.path) == p_norm
+            kind_ok && method_ok && norm_path(&d.path) == p_norm
         });
         if is_leak {
             leaks += 1;
@@ -2813,6 +2826,123 @@ mod scoring_tests {
         assert_eq!(n_decoys, 4, "4 _must_not_emit decoys across the corpus");
 
         // Dependency conflict: one cross-repo zod 3.x vs 4.x, critical.
+        assert_eq!(expected_output.dependency_conflicts.len(), 1);
+        let dc = &expected_output.dependency_conflicts[0];
+        assert_eq!(dc.package, "zod");
+        assert_eq!(dc.severity, "critical");
+    }
+
+    #[test]
+    fn decoy_leak_respects_projection_set_kind() {
+        // Corpus-3's intra-repo self-call decoy shares (method, path) with the
+        // repo's legit endpoint. The `kind: "call"` label must flag only a
+        // call-set emission — never the endpoint-set one.
+        let repos = vec![(
+            "inventory-svc".to_string(),
+            serde_json::from_value::<ExpectedRepo>(serde_json::json!({
+                "_must_not_emit": [
+                    { "kind": "call", "method": "GET", "path": "/warehouses/:warehouseId/stock/:sku" }
+                ]
+            }))
+            .unwrap(),
+        )];
+        let mut proj = empty_proj();
+        // The legit producer endpoint on the same (method, path): clean.
+        proj.endpoints
+            .push(http_ep("GET", "/warehouses/:warehouseId/stock/:sku"));
+        assert_eq!(score_decoy_leak(&repos, &proj), 0);
+        // The self-call emitted into the call set: a leak.
+        proj.calls
+            .push(http_ep("GET", "/warehouses/:wid/stock/:sku"));
+        assert_eq!(score_decoy_leak(&repos, &proj), 1);
+    }
+
+    #[test]
+    fn corpus3_has_the_expected_protocol_and_edge_shape() {
+        // Answer-key-drift guard for xrepo-corpus-3; skip for other corpora.
+        if corpus_name() != "xrepo-corpus-3" {
+            return;
+        }
+        let corpus = corpus_dir();
+        let repos = discover_repos(&corpus);
+        assert_eq!(repos.len(), 7, "the 7 top-level corpus repos");
+        let repo_expected = load_repo_expected(&repos);
+        let expected_output = load_expected_output(&corpus);
+
+        // 12 matched edges: 4 http + 5 pubsub + 2 graphql + 1 socket, all capability.
+        assert_eq!(expected_output.matches.len(), 12);
+        let n_proto = |p: &str| {
+            expected_output
+                .matches
+                .iter()
+                .filter(|m| m.producer_key.starts_with(&format!("{p}|")))
+                .count()
+        };
+        assert_eq!(n_proto("http"), 4, "4 HTTP edges");
+        assert_eq!(n_proto("pubsub"), 5, "5 pub/sub edges");
+        assert_eq!(n_proto("graphql"), 2, "2 GraphQL edges");
+        assert_eq!(n_proto("socket"), 1, "1 socket edge");
+        assert!(
+            expected_output
+                .matches
+                .iter()
+                .all(|m| m.tier == TIER_CAPABILITY),
+            "every corpus-3 edge is capability tier"
+        );
+
+        // 4 incompatible edges (null-vs-optional, array-vs-scalar, Date-vs-string,
+        // missing-required-field) and a live §7 guard on every edge.
+        let incompatible = expected_output
+            .matches
+            .iter()
+            .filter(|m| m.type_compatible == Some(false))
+            .count();
+        assert_eq!(incompatible, 4, "4 deliberately-incompatible edges");
+        assert!(
+            expected_output
+                .matches
+                .iter()
+                .all(|m| m.type_compatible.is_some()),
+            "every corpus edge labels a compat verdict"
+        );
+
+        // Fan-out: two producers (subscriber repos) on one pubsub key.
+        let fanout = expected_output
+            .matches
+            .iter()
+            .filter(|m| m.producer_key == "pubsub|catalog.price.updated")
+            .count();
+        assert_eq!(
+            fanout, 2,
+            "catalog.price.updated fans out to two subscribers"
+        );
+
+        // 7 orphans: 5 producers + 2 consumers; exactly one roadmap (SQS digest).
+        assert_eq!(expected_output.orphans.len(), 7);
+        let roadmap_orphans: Vec<_> = expected_output
+            .orphans
+            .iter()
+            .filter(|o| o.tier == TIER_ROADMAP)
+            .collect();
+        assert_eq!(roadmap_orphans.len(), 1);
+        assert_eq!(roadmap_orphans[0].key, "pubsub|notifications.digest");
+
+        // The Implicit inference case (support-desk GET /tickets/:id).
+        let any_implicit = repo_expected.iter().any(|(_r, e)| {
+            e.endpoints
+                .iter()
+                .any(|ep| ep.type_state.as_deref() == Some("Implicit"))
+        });
+        assert!(any_implicit, "corpus-3 keeps an Implicit type_state case");
+
+        // 3 formal HTTP-keyed decoys (supertest, msw, self-call).
+        let n_decoys: usize = repo_expected
+            .iter()
+            .map(|(_r, e)| e.must_not_emit.len())
+            .sum();
+        assert_eq!(n_decoys, 3, "3 _must_not_emit decoys across the corpus");
+
+        // Dependency conflict: zod 3.23.0 vs 4.0.0, critical, used in code.
         assert_eq!(expected_output.dependency_conflicts.len(), 1);
         let dc = &expected_output.dependency_conflicts[0];
         assert_eq!(dc.package, "zod");

--- a/tests/fixtures/xrepo-corpus-3/README.md
+++ b/tests/fixtures/xrepo-corpus-3/README.md
@@ -1,0 +1,173 @@
+# xrepo-corpus-3 — messy-realism cross-repo accuracy corpus
+
+Seven statically-analyzable (not runnable) repos with an owned answer key, for the
+cross-repo accuracy eval. Corpus-1 is the request/response corpus, corpus-2 the
+event-driven dual; corpus-3 is the **messy-realism** corpus: breadth, indirection
+and type depth **within the four shipped protocol families** (HTTP / GraphQL /
+socket / pubsub), on the axes neither earlier corpus exercises. No new protocol
+family is introduced (gRPC/tRPC are deliberately out of scope — new-machinery
+programs of their own). Labels are **spec-of-record**: authored first, code built
+to match, never derived from a scan. Change a label only by hand, in a separate
+commit, reviewed against the spec — never to match scanner output.
+
+Selected via `CARRICK_EVAL_CORPUS=xrepo-corpus-3` through the same two-phase scorer
+(`tests/eval_xrepo.rs`); default (`xrepo-corpus-1`) is unaffected.
+
+## Why this corpus exists (the gap list it covers)
+
+1. **Broker-agnostic pub/sub, proven** — two brokers never seen by corpus-2
+   (RabbitMQ via `amqplib`, BullMQ) plus the first **cross-broker edge** (NATS
+   publisher → Kafka subscriber on one topic; the `pubsub|<topic>` key is
+   broker-agnostic by design, until now untested) and the first **fan-out**
+   (one publisher, two subscriber repos on `catalog.price.updated`).
+2. **Consumer indirection** — a hand-rolled `apiClient` wrapper over `fetch`
+   (base URL applied inside the wrapper, call sites carry only relative paths +
+   a call-site generic), env bases read through a **config object**
+   (`config.ordersApiUrl`) instead of inline `process.env`, and two client
+   libraries new to the corpora (`got`, `ky`).
+3. **Type depth** — contract types derived with **`zod` `z.infer`** (zod was a
+   phantom dep in corpus-1; here it is used in code, and is also the dep-conflict
+   vehicle: 3.23.0 vs 4.0.0, both sides real usage), a **shared workspace types
+   package** (`@meridian/contracts`) imported across monorepo package boundaries,
+   an HTTP **array response** (`TimelineEvent[]`), and a `DELETE` → 204 no-body
+   endpoint (anchor must stay null).
+4. **New compat-mismatch axes** — `Date` vs ISO-string, array-vs-scalar,
+   `T | null` vs optional (`?: T`), and missing-required-field; plus two subtle
+   **compatible** true negatives (producer-extra-fields narrowing; required →
+   optional narrowing on the subscriber side).
+5. **New HTTP shapes** — Koa (`@koa/router`, incl. the `router.del` alias),
+   `PATCH`, versioned paths with a **version-drift negative** (consumer on
+   `/api/v1/...`, producer serves only `/api/v2/...` — must NOT match),
+   multi-segment nested params (`/products/:id/variants/:variantId`), first
+   **matched** GraphQL mutation, first **CLIENT->SERVER** socket edge, first
+   `gql`-tag consumer with **no call-site generic** (exercises the #298
+   file-analyzer hint path).
+6. **New decoy families** — supertest test-client calls, msw mock handlers,
+   an intra-repo HTTP self-call, `amqplib` `assertQueue` topology setup.
+
+## Repos
+
+| Repo | Stack | Role in the graph |
+|---|---|---|
+| `platform-monorepo/` | npm workspaces: `@meridian/contracts` (zod schemas + shared types) + `catalog-api` (Koa + `@koa/router` + nats) | HTTP producer (v2 products/variants; PATCH; DELETE-204), NATS fan-out publisher `catalog.price.updated`, supertest decoy |
+| `orders-api/` | Fastify + amqplib + bullmq + kafkajs + @aws-sdk/client-sqs | HTTP producer (`POST /orders`, `GET /orders/:orderId/timeline`), RabbitMQ publisher `inventory.stock.adjust`, BullMQ publisher `shipments.dispatch`, Kafka subscriber `orders.status.changed` (cross-broker), SQS publisher (roadmap) |
+| `inventory-svc/` | Express + amqplib + nats + zod@3 | RabbitMQ subscriber `inventory.stock.adjust` (payload type via `z.infer`), NATS subscriber `catalog.price.updated` (fan-out A), HTTP orphan producer, self-call + assertQueue decoys |
+| `fulfillment-worker/` | bullmq + nats + got (no HTTP framework) | BullMQ Worker `shipments.dispatch` (subscriber=producer), NATS publisher `orders.status.changed`, `got` consumer of catalog variants |
+| `storefront-web/` | Next-ish + ky + graphql-tag + socket.io-client + msw + zod@4 | `ky` consumer `POST /orders`, v1 drift consumer, gql query consumer (no generic → #298), socket emitter `support:message`, msw decoy |
+| `ops-console/` | plain node BFF: fetch-wrapper + graphql-request + nats | wrapper consumers (PATCH products, GET timeline) through config-object env bases, gql mutation consumer (with generic), NATS subscriber `catalog.price.updated` (fan-out B) |
+| `support-desk/` | NestJS + SDL GraphQL + socket.io | SDL producer (query/mutation/subscription), socket listener `support:message` (CLIENT->SERVER), Implicit-inference HTTP orphan |
+
+## Configuration
+
+Consumer repos with `${ENV}`-based HTTP calls carry `carrick.json` `internalEnvVars`:
+`fulfillment-worker` (`CATALOG_URL`), `storefront-web` (`NEXT_PUBLIC_ORDERS_API_URL`,
+`NEXT_PUBLIC_CATALOG_URL`), `ops-console` (`ORDERS_API_URL`, `CATALOG_URL` — note
+these are read through `src/config.ts`'s config object, not inline at the call
+site). `platform-monorepo/carrick.json` is the multi-service descriptor (only
+`catalog-api` is a service; `contracts` is a library resolved via tsconfig paths).
+Pub/sub, GraphQL and socket edges need no connection-classification config (they
+key on topic/operation/event identity, not URLs).
+
+## Cross-repo edges
+
+Producer/consumer direction follows the standing model: HTTP/GraphQL producer =
+the server; socket **listener** = producer; pub/sub **subscriber** = producer
+(publisher/emitter = consumer). All tiers `capability` unless marked.
+
+| # | Protocol | Producer | Consumer | Key | Compat |
+|---|---|---|---|---|---|
+| 1 | http | catalog-api `GET /api/v2/products/:id/variants/:variantId` | fulfillment-worker (got) | `http\|GET\|/api/v2/products/:param/variants/:param` | compatible (consumer omits `productId` — producer-extra-fields narrowing) |
+| 2 | http | catalog-api `PATCH /api/v2/products/:id` | ops-console (wrapper) | `http\|PATCH\|/api/v2/products/:param` | **incompatible** (producer `price: {…} \| null` vs consumer `price?: {…}` — null is not undefined) |
+| 3 | http | orders-api `POST /orders` | storefront-web (ky) | `http\|POST\|/orders` | compatible |
+| 4 | http | orders-api `GET /orders/:orderId/timeline` | ops-console (wrapper) | `http\|GET\|/orders/:param/timeline` | **incompatible** (producer `TimelineEvent[]` vs consumer scalar `TimelineEntry` — array-vs-scalar) |
+| 5 | pubsub/rabbitmq | inventory-svc (amqplib consume) | orders-api (sendToQueue) | `pubsub\|inventory.stock.adjust` | compatible |
+| 6 | pubsub/bullmq | fulfillment-worker (Worker) | orders-api (Queue.add) | `pubsub\|shipments.dispatch` | **incompatible** (subscriber `dispatchAfter: Date` vs publisher ISO `string` — date serialization) |
+| 7 | pubsub/**cross-broker** | orders-api (kafkajs subscribe) | fulfillment-worker (nats publish) | `pubsub\|orders.status.changed` | compatible |
+| 8 | pubsub/nats | inventory-svc (subscribe) | catalog-api (publish) | `pubsub\|catalog.price.updated` | compatible |
+| 9 | pubsub/nats | ops-console (subscribe) | catalog-api (publish) | `pubsub\|catalog.price.updated` | compatible (subscriber `effectiveAt?` optional vs publisher required — safe narrowing) |
+| 10 | graphql | support-desk `query ticket` | storefront-web (gql tag, **no generic**) | `graphql\|query\|ticket` | compatible |
+| 11 | graphql | support-desk `mutation escalateTicket` | ops-console (`request<T>`) | `graphql\|mutation\|escalateTicket` | **incompatible** (consumer requires `assignee: string`; producer `EscalationResult` lacks it) |
+| 12 | socket | support-desk (server `socket.on`) | storefront-web (client emit) | `socket\|CLIENT->SERVER\|support:message` | compatible |
+
+**Edges 8/9 are the fan-out**: one publisher (catalog-api), two subscriber repos —
+two producers on one key (`pubsub|catalog.price.updated`), so two match edges
+sharing a consumer. **Edge 7 is the cross-broker edge**: the publisher moved to
+NATS mid-migration while the subscriber still reads the mirrored Kafka topic; the
+key is broker-agnostic so they must match.
+
+### Version-drift negative (must NOT match)
+storefront-web calls `GET ${NEXT_PUBLIC_CATALOG_URL}/api/v1/products/:id`;
+catalog-api serves only `/api/v2/products/:id`. Both sides are labelled orphans.
+A match between them is a false positive.
+
+## Orphans
+
+Producers: catalog-api `GET /api/v2/products/:id` (drift counterpart) and
+`DELETE /api/v2/products/:id` (204, no body → null anchor, null resolved type);
+inventory-svc `GET /warehouses/:warehouseId/stock/:sku`; support-desk
+`GET /tickets/:id` (**Implicit**: no return annotation, inferred
+`{ id: string; subject: string; ageDays: number; }`) and
+`graphql subscription ticketUpdated`.
+Consumers: storefront-web `GET /api/v1/products/:id` (drift);
+orders-api `pubsub|notifications.digest` (**roadmap**, see Tiers).
+
+## Tiers
+
+Everything is `capability` except the SQS digest publisher
+(`orders-api/src/mq/digest.publisher.ts`): its queue identity lives in a URL
+template (`${SQS_BASE_URL}/notifications.digest`), i.e. an **env-templated
+topic** — extraction of these is deferred (`src/engine/mod.rs` env-template
+note). It is tracked as a `roadmap` orphan consumer with key
+`pubsub|notifications.digest`, flipped to `capability` only when that extraction
+lands — never to inflate the score.
+
+## Decoys (anti-overfit traps)
+
+Formal `_must_not_emit` entries (HTTP-keyed, scoreable — paths chosen to collide
+with NO legit op corpus-wide, since the decoy pool is matched against every
+repo's emissions):
+1. `platform-monorepo/packages/catalog-api/test/products.test.ts` — supertest
+   `request(app).get("/api/v2/health")`: a **test-client call**, not a runtime
+   consumer. `{kind: "call", GET /api/v2/health}`.
+2. `storefront-web/mocks/handlers.ts` — msw `http.get("/api/v2/promotions/:id")`:
+   a **mock route registration**, not a producer. `{kind: "endpoint", GET
+   /api/v2/promotions/:id}`.
+3. `inventory-svc/src/jobs/reindex.ts` — `fetch("http://localhost:4002/warehouses/…")`:
+   an **intra-repo self-call**; must not surface as a consumer call (and never as
+   a cross-repo edge). `{kind: "call", GET /warehouses/:warehouseId/stock/:sku}` —
+   this entry shares (method, path) with the repo's legit *endpoint*, so the
+   decoy scorer distinguishes on `kind` (endpoint-set vs call-set).
+4. Documented, not formally scoreable (non-HTTP; same limitation corpus-2 logs):
+   `inventory-svc/src/mq/setup.ts` `ch.assertQueue("inventory.stock.adjust")` —
+   queue **topology setup**, not subscribe; and the SQS `sqs.send(…)` must not be
+   emitted as an HTTP call.
+
+## Type-inference cases
+
+- **`z.infer` contracts**: `@meridian/contracts` (`Price`, `VariantDetail`) and
+  inventory-svc's `StockAdjustCommand` are zod-schema-derived; the sidecar must
+  expand through the zod stub's mapped type.
+- **Shared workspace package**: catalog-api imports `Product`/`VariantDetail`
+  from `@meridian/contracts` via tsconfig paths across the package boundary.
+- **Array response**: `GET /orders/:orderId/timeline` resolves to an inlined
+  array form (`{ … }[]`).
+- **No-body response**: `DELETE /api/v2/products/:id` → anchor null, resolved null.
+- **Implicit**: support-desk `GET /tickets/:id` has no return annotation.
+- **Explicit everywhere else.**
+
+## Dependency conflict
+
+One deliberate cross-repo conflict: `zod` **3.23.0** (platform-monorepo +
+inventory-svc) vs **4.0.0** (storefront-web) → major-incompatible → `critical`.
+Unlike corpus-1's phantom zod, both sides use zod in code.
+
+## Protocol detectability notes
+
+- RabbitMQ/BullMQ have no scanner-side adapter — extraction rides the
+  broker-agnostic `pubsub_operations` file-analyzer schema (shape-based, "any
+  messaging client"). BullMQ trap: the topic is the **queue name**
+  (`shipments.dispatch`), not the `Queue.add` job-name argument (`"dispatch"`).
+- The socket edge uses ESM `socket.io`/`socket.io-client` imports (the CJS
+  `require` form is a known blind spot, deliberately not used).
+- The wrapper-client call sites (`ops-console`) carry only relative paths; the
+  post-#294 canonical key (host-free) is what makes them matchable.

--- a/tests/fixtures/xrepo-corpus-3/expected-output.json
+++ b/tests/fixtures/xrepo-corpus-3/expected-output.json
@@ -1,0 +1,152 @@
+{
+  "matches": [
+    {
+      "producer_repo": "catalog-api",
+      "producer_key": "http|GET|/api/v2/products/:param/variants/:param",
+      "consumer_repo": "fulfillment-worker",
+      "consumer_key": "http|GET|/api/v2/products/:param/variants/:param",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "http",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "catalog-api",
+      "producer_key": "http|PATCH|/api/v2/products/:param",
+      "consumer_repo": "ops-console",
+      "consumer_key": "http|PATCH|/api/v2/products/:param",
+      "type_compatible": false,
+      "mismatch_reason": "producer Product.price is `{ amount; currency } | null` but consumer ProductRecord.price is optional `?: { amount; currency }` (null is not undefined)",
+      "protocol": "http",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "orders-api",
+      "producer_key": "http|POST|/orders",
+      "consumer_repo": "storefront-web",
+      "consumer_key": "http|POST|/orders",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "http",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "orders-api",
+      "producer_key": "http|GET|/orders/:param/timeline",
+      "consumer_repo": "ops-console",
+      "consumer_key": "http|GET|/orders/:param/timeline",
+      "type_compatible": false,
+      "mismatch_reason": "producer returns TimelineEvent[] but consumer TimelineEntry types a single object (array vs scalar)",
+      "protocol": "http",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "inventory-svc",
+      "producer_key": "pubsub|inventory.stock.adjust",
+      "consumer_repo": "orders-api",
+      "consumer_key": "pubsub|inventory.stock.adjust",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "pubsub",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "fulfillment-worker",
+      "producer_key": "pubsub|shipments.dispatch",
+      "consumer_repo": "orders-api",
+      "consumer_key": "pubsub|shipments.dispatch",
+      "type_compatible": false,
+      "mismatch_reason": "subscriber DispatchJob.dispatchAfter is Date but publisher DispatchRequest sends an ISO string (date serialization)",
+      "protocol": "pubsub",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "orders-api",
+      "producer_key": "pubsub|orders.status.changed",
+      "consumer_repo": "fulfillment-worker",
+      "consumer_key": "pubsub|orders.status.changed",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "pubsub",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "inventory-svc",
+      "producer_key": "pubsub|catalog.price.updated",
+      "consumer_repo": "catalog-api",
+      "consumer_key": "pubsub|catalog.price.updated",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "pubsub",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "ops-console",
+      "producer_key": "pubsub|catalog.price.updated",
+      "consumer_repo": "catalog-api",
+      "consumer_key": "pubsub|catalog.price.updated",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "pubsub",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "support-desk",
+      "producer_key": "graphql|query|ticket",
+      "consumer_repo": "storefront-web",
+      "consumer_key": "graphql|query|ticket",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "graphql",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "support-desk",
+      "producer_key": "graphql|mutation|escalateTicket",
+      "consumer_repo": "ops-console",
+      "consumer_key": "graphql|mutation|escalateTicket",
+      "type_compatible": false,
+      "mismatch_reason": "consumer EscalationReceipt requires assignee: string; producer EscalationResult has no such field (missing required field)",
+      "protocol": "graphql",
+      "tier": "capability"
+    },
+    {
+      "producer_repo": "support-desk",
+      "producer_key": "socket|CLIENT->SERVER|support:message",
+      "consumer_repo": "storefront-web",
+      "consumer_key": "socket|CLIENT->SERVER|support:message",
+      "type_compatible": true,
+      "mismatch_reason": null,
+      "protocol": "socket",
+      "tier": "capability"
+    }
+  ],
+  "orphans": [
+    { "repo": "catalog-api", "side": "producer", "key": "http|GET|/api/v2/products/:param", "tier": "capability" },
+    { "repo": "catalog-api", "side": "producer", "key": "http|DELETE|/api/v2/products/:param", "tier": "capability" },
+    { "repo": "inventory-svc", "side": "producer", "key": "http|GET|/warehouses/:param/stock/:param", "tier": "capability" },
+    { "repo": "support-desk", "side": "producer", "key": "http|GET|/tickets/:param", "tier": "capability" },
+    { "repo": "support-desk", "side": "producer", "key": "graphql|subscription|ticketUpdated", "tier": "capability" },
+    { "repo": "storefront-web", "side": "consumer", "key": "http|GET|/api/v1/products/:param", "tier": "capability" },
+    { "repo": "orders-api", "side": "consumer", "key": "pubsub|notifications.digest", "tier": "roadmap" }
+  ],
+  "dependency_conflicts": [
+    {
+      "package": "zod",
+      "versions": ["3.23.0", "4.0.0"],
+      "severity": "critical",
+      "tier": "capability"
+    }
+  ],
+  "summary": {
+    "total_repos": 7,
+    "producers": 17,
+    "consumers": 13,
+    "matched_edges": 12,
+    "incompatible_edges": 4,
+    "orphan_producers": 5,
+    "orphan_consumers": 2,
+    "decoys_must_not_emit": 3,
+    "matched_edges_by_protocol": { "http": 4, "pubsub": 5, "graphql": 2, "socket": 1 }
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/fulfillment-worker/carrick.json
+++ b/tests/fixtures/xrepo-corpus-3/fulfillment-worker/carrick.json
@@ -1,0 +1,3 @@
+{
+  "internalEnvVars": ["CATALOG_URL"]
+}

--- a/tests/fixtures/xrepo-corpus-3/fulfillment-worker/expected.json
+++ b/tests/fixtures/xrepo-corpus-3/fulfillment-worker/expected.json
@@ -1,0 +1,44 @@
+{
+  "endpoints": [],
+  "calls": [
+    {
+      "method": "GET",
+      "path": "/api/v2/products/:param/variants/:param",
+      "path_contains": "/variants/",
+      "import_source": null,
+      "primary_type_symbol": "VariantView",
+      "resolved_type": "{ id: string; sku: string; price: { amount: number; currency: string; }; inStock: boolean; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "pubsub_operations": [
+    {
+      "role": "producer",
+      "service": "fulfillment-worker",
+      "key": "pubsub|shipments.dispatch",
+      "topic": "shipments.dispatch",
+      "broker": "bullmq",
+      "side": "subscriber",
+      "source": "src/worker.ts",
+      "primary_type_symbol": "DispatchJob",
+      "resolved_type": "{ orderId: string; warehouseId: string; dispatchAfter: Date; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "consumer",
+      "service": "fulfillment-worker",
+      "key": "pubsub|orders.status.changed",
+      "topic": "orders.status.changed",
+      "broker": "nats",
+      "side": "publisher",
+      "source": "src/status.publisher.ts",
+      "primary_type_symbol": "OrderStatusChanged",
+      "resolved_type": "{ orderId: string; status: \"picked\" | \"dispatched\" | \"delivered\"; occurredAt: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "_must_not_emit": []
+}

--- a/tests/fixtures/xrepo-corpus-3/fulfillment-worker/package.json
+++ b/tests/fixtures/xrepo-corpus-3/fulfillment-worker/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fulfillment-worker",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "bullmq": "5.12.0",
+    "got": "14.4.0",
+    "nats": "2.28.2"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/fulfillment-worker/src/catalog.client.ts
+++ b/tests/fixtures/xrepo-corpus-3/fulfillment-worker/src/catalog.client.ts
@@ -1,0 +1,8 @@
+import got from "got";
+import { VariantView } from "./types/fulfillment";
+
+const CATALOG_BASE = process.env.CATALOG_URL ?? "http://localhost:4001";
+
+export async function fetchVariant(productId: string, variantId: string): Promise<VariantView> {
+  return got.get(`${CATALOG_BASE}/api/v2/products/${productId}/variants/${variantId}`).json<VariantView>();
+}

--- a/tests/fixtures/xrepo-corpus-3/fulfillment-worker/src/status.publisher.ts
+++ b/tests/fixtures/xrepo-corpus-3/fulfillment-worker/src/status.publisher.ts
@@ -1,0 +1,12 @@
+import { connect, JSONCodec } from "nats";
+import { OrderStatusChanged } from "./types/fulfillment";
+
+const jc = JSONCodec<OrderStatusChanged>();
+
+// Publishes on NATS; orders-api still reads the mirrored Kafka topic during
+// the broker migration. Same topic string, different broker.
+export async function publishStatusChanged(evt: OrderStatusChanged): Promise<void> {
+  const nc = await connect({ servers: process.env.NATS_URL });
+  nc.publish("orders.status.changed", jc.encode(evt));
+  await nc.close();
+}

--- a/tests/fixtures/xrepo-corpus-3/fulfillment-worker/src/types/fulfillment.ts
+++ b/tests/fixtures/xrepo-corpus-3/fulfillment-worker/src/types/fulfillment.ts
@@ -1,0 +1,22 @@
+// What the worker believes arrives on the dispatch queue. dispatchAfter is
+// typed Date, but the publisher sends an ISO string — the deliberate mismatch.
+export interface DispatchJob {
+  orderId: string;
+  warehouseId: string;
+  dispatchAfter: Date;
+}
+
+export interface OrderStatusChanged {
+  orderId: string;
+  status: "picked" | "dispatched" | "delivered";
+  occurredAt: string;
+}
+
+// Narrower view of the catalog's VariantDetail (productId deliberately
+// omitted — safe producer-extra-fields narrowing).
+export interface VariantView {
+  id: string;
+  sku: string;
+  price: { amount: number; currency: string };
+  inStock: boolean;
+}

--- a/tests/fixtures/xrepo-corpus-3/fulfillment-worker/src/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-3/fulfillment-worker/src/types/stubs.d.ts
@@ -1,0 +1,44 @@
+// Ambient stubs — keep types resolvable without npm install.
+// Just enough surface for the call sites; the scanner reads AST structure.
+
+declare module "bullmq" {
+  export interface Job<T = unknown> {
+    data: T;
+  }
+  export class Queue<T = unknown> {
+    constructor(name: string, opts?: { connection?: unknown });
+    add(jobName: string, data: T): Promise<unknown>;
+  }
+  export class Worker<T = unknown> {
+    constructor(
+      name: string,
+      processor: (job: Job<T>) => Promise<void>,
+      opts?: { connection?: unknown }
+    );
+  }
+}
+
+declare module "nats" {
+  export interface NatsConnection {
+    publish(subject: string, data: Uint8Array): void;
+    close(): Promise<void>;
+  }
+  export function connect(opts?: { servers?: string | string[] }): Promise<NatsConnection>;
+  export interface Codec<T> {
+    encode(d: T): Uint8Array;
+    decode(a: Uint8Array): T;
+  }
+  export function JSONCodec<T>(): Codec<T>;
+}
+
+declare module "got" {
+  interface ResponsePromise {
+    json<T>(): Promise<T>;
+  }
+  interface Got {
+    get(url: string): ResponsePromise;
+    post(url: string, opts?: { json?: unknown }): ResponsePromise;
+  }
+  const got: Got;
+  export default got;
+}

--- a/tests/fixtures/xrepo-corpus-3/fulfillment-worker/src/worker.ts
+++ b/tests/fixtures/xrepo-corpus-3/fulfillment-worker/src/worker.ts
@@ -1,0 +1,18 @@
+import { Worker } from "bullmq";
+import { DispatchJob } from "./types/fulfillment";
+import { publishStatusChanged } from "./status.publisher";
+
+// BullMQ worker: the queue name is the contract topic.
+export const dispatchWorker = new Worker("shipments.dispatch", async (job) => {
+  const req = job.data as DispatchJob;
+  await dispatchShipment(req);
+  await publishStatusChanged({
+    orderId: req.orderId,
+    status: "dispatched",
+    occurredAt: new Date().toISOString(),
+  });
+});
+
+async function dispatchShipment(req: DispatchJob): Promise<void> {
+  void req;
+}

--- a/tests/fixtures/xrepo-corpus-3/fulfillment-worker/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-3/fulfillment-worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "lib": ["ES2020"]
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-3/inventory-svc/expected.json
+++ b/tests/fixtures/xrepo-corpus-3/inventory-svc/expected.json
@@ -1,0 +1,45 @@
+{
+  "endpoints": [
+    {
+      "method": "GET",
+      "path": "/warehouses/:warehouseId/stock/:sku",
+      "owner": "app",
+      "primary_type_symbol": "StockLevel",
+      "resolved_type": "{ sku: string; warehouseId: string; onHand: number; reserved: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "calls": [],
+  "pubsub_operations": [
+    {
+      "role": "producer",
+      "service": "inventory-svc",
+      "key": "pubsub|inventory.stock.adjust",
+      "topic": "inventory.stock.adjust",
+      "broker": "rabbitmq",
+      "side": "subscriber",
+      "source": "src/mq/stock.subscriber.ts",
+      "primary_type_symbol": "StockAdjustCommand",
+      "resolved_type": "{ sku: string; delta: number; reason: string; orderId: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "producer",
+      "service": "inventory-svc",
+      "key": "pubsub|catalog.price.updated",
+      "topic": "catalog.price.updated",
+      "broker": "nats",
+      "side": "subscriber",
+      "source": "src/mq/price.subscriber.ts",
+      "primary_type_symbol": "PriceUpdatedEvent",
+      "resolved_type": "{ productId: string; price: { amount: number; currency: string; }; effectiveAt: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "_must_not_emit": [
+    { "kind": "call", "method": "GET", "path": "/warehouses/:warehouseId/stock/:sku" }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-3/inventory-svc/package.json
+++ b/tests/fixtures/xrepo-corpus-3/inventory-svc/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "inventory-svc",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "amqplib": "0.10.4",
+    "express": "4.19.2",
+    "nats": "2.28.2",
+    "zod": "3.23.0"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/inventory-svc/src/http/app.ts
+++ b/tests/fixtures/xrepo-corpus-3/inventory-svc/src/http/app.ts
@@ -1,0 +1,18 @@
+import express from "express";
+import { StockLevel } from "../types/stock";
+
+const app = express();
+
+app.get("/warehouses/:warehouseId/stock/:sku", (req, res) => {
+  const level: StockLevel = {
+    sku: req.params.sku,
+    warehouseId: req.params.warehouseId,
+    onHand: 120,
+    reserved: 8,
+  };
+  res.json(level);
+});
+
+app.listen(4002);
+
+export { app };

--- a/tests/fixtures/xrepo-corpus-3/inventory-svc/src/jobs/reindex.ts
+++ b/tests/fixtures/xrepo-corpus-3/inventory-svc/src/jobs/reindex.ts
@@ -1,0 +1,10 @@
+// Nightly cache warm: hits this service's own HTTP surface over localhost.
+// An intra-repo self-call — not a cross-repo consumer, must not be extracted
+// as a data call.
+export async function warmStockCache(warehouseIds: string[], skus: string[]): Promise<void> {
+  for (const wid of warehouseIds) {
+    for (const sku of skus) {
+      await fetch(`http://localhost:4002/warehouses/${wid}/stock/${sku}`);
+    }
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/inventory-svc/src/mq/price.subscriber.ts
+++ b/tests/fixtures/xrepo-corpus-3/inventory-svc/src/mq/price.subscriber.ts
@@ -1,0 +1,20 @@
+import { connect, StringCodec } from "nats";
+import { PriceUpdatedEvent } from "../types/stock";
+
+const sc = StringCodec();
+
+// Fan-out subscriber A (ops-console is B): reprice stock valuation when the
+// catalog announces a price change.
+export async function watchPriceUpdates(): Promise<void> {
+  const nc = await connect({ servers: process.env.NATS_URL });
+  nc.subscribe("catalog.price.updated", {
+    callback: (_err, msg) => {
+      const evt = JSON.parse(sc.decode(msg.data)) as PriceUpdatedEvent;
+      reprice(evt);
+    },
+  });
+}
+
+function reprice(evt: PriceUpdatedEvent): void {
+  void evt;
+}

--- a/tests/fixtures/xrepo-corpus-3/inventory-svc/src/mq/setup.ts
+++ b/tests/fixtures/xrepo-corpus-3/inventory-svc/src/mq/setup.ts
@@ -1,0 +1,10 @@
+import { connect } from "amqplib";
+
+// Queue topology setup — administration, not consumption. Must not be
+// extracted as a pub/sub operation.
+export async function ensureQueues(): Promise<void> {
+  const conn = await connect(process.env.AMQP_URL);
+  const ch = await conn.createChannel();
+  await ch.assertQueue("inventory.stock.adjust");
+  await ch.assertQueue("inventory.dead-letter");
+}

--- a/tests/fixtures/xrepo-corpus-3/inventory-svc/src/mq/stock.subscriber.ts
+++ b/tests/fixtures/xrepo-corpus-3/inventory-svc/src/mq/stock.subscriber.ts
@@ -1,0 +1,18 @@
+import { connect } from "amqplib";
+import { StockAdjustSchema, StockAdjustCommand } from "../types/stock";
+
+// RabbitMQ work queue: orders-api publishes stock reservations here.
+export async function runStockSubscriber(): Promise<void> {
+  const conn = await connect(process.env.AMQP_URL);
+  const ch = await conn.createChannel();
+  await ch.consume("inventory.stock.adjust", (msg) => {
+    if (!msg) return;
+    const cmd: StockAdjustCommand = StockAdjustSchema.parse(JSON.parse(msg.content.toString()));
+    applyAdjustment(cmd);
+    ch.ack(msg);
+  });
+}
+
+function applyAdjustment(cmd: StockAdjustCommand): void {
+  void cmd;
+}

--- a/tests/fixtures/xrepo-corpus-3/inventory-svc/src/types/stock.ts
+++ b/tests/fixtures/xrepo-corpus-3/inventory-svc/src/types/stock.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+// The wire contract for stock adjustments is the zod schema; the type is
+// derived from it.
+export const StockAdjustSchema = z.object({
+  sku: z.string(),
+  delta: z.number(),
+  reason: z.string(),
+  orderId: z.string(),
+});
+export type StockAdjustCommand = z.infer<typeof StockAdjustSchema>;
+
+export interface StockLevel {
+  sku: string;
+  warehouseId: string;
+  onHand: number;
+  reserved: number;
+}
+
+export interface PriceUpdatedEvent {
+  productId: string;
+  price: { amount: number; currency: string };
+  effectiveAt: string;
+}

--- a/tests/fixtures/xrepo-corpus-3/inventory-svc/src/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-3/inventory-svc/src/types/stubs.d.ts
@@ -1,0 +1,75 @@
+// Ambient stubs — keep types resolvable without npm install.
+// Just enough surface for the call sites; the scanner reads AST structure.
+
+declare module "express" {
+  export interface Request {
+    params: Record<string, string>;
+    query: Record<string, string>;
+    body: unknown;
+  }
+  export interface Response {
+    json(body: unknown): void;
+    status(code: number): Response;
+    send(body?: unknown): void;
+  }
+  export interface Application {
+    get(path: string, handler: (req: Request, res: Response) => void | Promise<void>): void;
+    post(path: string, handler: (req: Request, res: Response) => void | Promise<void>): void;
+    listen(port: number): void;
+  }
+  export default function express(): Application;
+}
+
+declare module "amqplib" {
+  export interface ConsumeMessage {
+    content: Buffer;
+  }
+  export interface Channel {
+    assertQueue(queue: string): Promise<unknown>;
+    sendToQueue(queue: string, content: Buffer): boolean;
+    consume(queue: string, onMessage: (msg: ConsumeMessage | null) => void): Promise<unknown>;
+    ack(msg: ConsumeMessage): void;
+  }
+  export interface Connection {
+    createChannel(): Promise<Channel>;
+  }
+  export function connect(url?: string): Promise<Connection>;
+}
+
+declare module "nats" {
+  export interface Msg {
+    subject: string;
+    data: Uint8Array;
+  }
+  export interface Subscription extends AsyncIterable<Msg> {}
+  export interface SubscriptionOptions {
+    callback: (err: unknown, msg: Msg) => void;
+  }
+  export interface NatsConnection {
+    subscribe(subject: string, opts?: SubscriptionOptions): Subscription;
+    close(): Promise<void>;
+  }
+  export function connect(opts?: { servers?: string | string[] }): Promise<NatsConnection>;
+  export interface Codec<T> {
+    encode(d: T): Uint8Array;
+    decode(a: Uint8Array): T;
+  }
+  export function StringCodec(): Codec<string>;
+}
+
+// Ambient zod stub — keeps `z.infer` computable without npm install.
+declare module "zod" {
+  export interface ZodType<Output> {
+    readonly _output: Output;
+    parse(data: unknown): Output;
+  }
+  export namespace z {
+    export type infer<T extends ZodType<any>> = T["_output"];
+    export function object<S extends Record<string, ZodType<any>>>(
+      shape: S
+    ): ZodType<{ [K in keyof S]: S[K]["_output"] }>;
+    export function string(): ZodType<string>;
+    export function number(): ZodType<number>;
+    export function boolean(): ZodType<boolean>;
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/inventory-svc/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-3/inventory-svc/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "lib": ["ES2020", "DOM"]
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-3/ops-console/carrick.json
+++ b/tests/fixtures/xrepo-corpus-3/ops-console/carrick.json
@@ -1,0 +1,3 @@
+{
+  "internalEnvVars": ["ORDERS_API_URL", "CATALOG_URL"]
+}

--- a/tests/fixtures/xrepo-corpus-3/ops-console/expected.json
+++ b/tests/fixtures/xrepo-corpus-3/ops-console/expected.json
@@ -1,0 +1,55 @@
+{
+  "endpoints": [],
+  "calls": [
+    {
+      "method": "GET",
+      "path": "/orders/:param/timeline",
+      "path_contains": "/timeline",
+      "import_source": null,
+      "primary_type_symbol": "TimelineEntry",
+      "resolved_type": "{ at: string; status: string; note?: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/v2/products/:param",
+      "path_contains": "/api/v2/products/",
+      "import_source": null,
+      "primary_type_symbol": "ProductRecord",
+      "resolved_type": "{ id: string; name: string; description: string; price?: { amount: number; currency: string; }; tags: string[]; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "graphql_operations": [
+    {
+      "role": "consumer",
+      "service": "ops-console",
+      "key": "graphql|mutation|escalateTicket",
+      "kind": "mutation",
+      "field": "escalateTicket",
+      "source": "src/gql.ts",
+      "primary_type_symbol": "EscalationReceipt",
+      "resolved_type": "{ ticketId: string; assignee: string; escalatedAt: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "pubsub_operations": [
+    {
+      "role": "producer",
+      "service": "ops-console",
+      "key": "pubsub|catalog.price.updated",
+      "topic": "catalog.price.updated",
+      "broker": "nats",
+      "side": "subscriber",
+      "source": "src/price.watch.ts",
+      "primary_type_symbol": "PriceAlert",
+      "resolved_type": "{ productId: string; price: { amount: number; currency: string; }; effectiveAt?: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "_must_not_emit": []
+}

--- a/tests/fixtures/xrepo-corpus-3/ops-console/package.json
+++ b/tests/fixtures/xrepo-corpus-3/ops-console/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ops-console",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "graphql-request": "6.1.0",
+    "graphql-tag": "2.12.6",
+    "nats": "2.28.2"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/ops-console/src/config.ts
+++ b/tests/fixtures/xrepo-corpus-3/ops-console/src/config.ts
@@ -1,0 +1,5 @@
+// Central config object: env bases are read here, not inline at call sites.
+export const config = {
+  ordersApiUrl: process.env.ORDERS_API_URL ?? "http://localhost:4003",
+  catalogUrl: process.env.CATALOG_URL ?? "http://localhost:4001",
+};

--- a/tests/fixtures/xrepo-corpus-3/ops-console/src/gql.ts
+++ b/tests/fixtures/xrepo-corpus-3/ops-console/src/gql.ts
@@ -1,0 +1,30 @@
+import { gql } from "graphql-tag";
+import { GraphQLClient } from "graphql-request";
+
+const client = new GraphQLClient(process.env.SUPPORT_GQL_URL ?? "http://localhost:4005/graphql");
+
+const ESCALATE_MUTATION = gql`
+  mutation escalateTicket($id: ID!, $reason: String!) {
+    escalateTicket(id: $id, reason: $reason) {
+      ticketId
+      assignee
+      escalatedAt
+    }
+  }
+`;
+
+// Expects an assignee the producer's EscalationResult does not carry —
+// missing-required-field mismatch.
+export interface EscalationReceipt {
+  ticketId: string;
+  assignee: string;
+  escalatedAt: string;
+}
+
+export async function escalateTicket(id: string, reason: string): Promise<EscalationReceipt> {
+  const data = await client.request<{ escalateTicket: EscalationReceipt }>(ESCALATE_MUTATION, {
+    id,
+    reason,
+  });
+  return data.escalateTicket;
+}

--- a/tests/fixtures/xrepo-corpus-3/ops-console/src/lib/apiClient.ts
+++ b/tests/fixtures/xrepo-corpus-3/ops-console/src/lib/apiClient.ts
@@ -1,0 +1,18 @@
+// Hand-rolled HTTP client: the base URL is applied inside the wrapper, so
+// call sites carry only relative paths + a result generic.
+export function makeClient(baseUrl: string) {
+  return {
+    async get<T>(path: string): Promise<T> {
+      const res = await fetch(`${baseUrl}${path}`);
+      return res.json() as Promise<T>;
+    },
+    async patch<T>(path: string, body: unknown): Promise<T> {
+      const res = await fetch(`${baseUrl}${path}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return res.json() as Promise<T>;
+    },
+  };
+}

--- a/tests/fixtures/xrepo-corpus-3/ops-console/src/orders.ts
+++ b/tests/fixtures/xrepo-corpus-3/ops-console/src/orders.ts
@@ -1,0 +1,16 @@
+import { makeClient } from "./lib/apiClient";
+import { config } from "./config";
+
+const ordersClient = makeClient(config.ordersApiUrl);
+
+// The console renders a single "latest event" card — typed as a scalar, but
+// the producer returns TimelineEvent[]. Array-vs-scalar mismatch.
+export interface TimelineEntry {
+  at: string;
+  status: string;
+  note?: string;
+}
+
+export async function loadTimeline(orderId: string): Promise<TimelineEntry> {
+  return ordersClient.get<TimelineEntry>(`/orders/${orderId}/timeline`);
+}

--- a/tests/fixtures/xrepo-corpus-3/ops-console/src/price.watch.ts
+++ b/tests/fixtures/xrepo-corpus-3/ops-console/src/price.watch.ts
@@ -1,0 +1,24 @@
+import { connect, StringCodec } from "nats";
+
+const sc = StringCodec();
+
+// Fan-out subscriber B (inventory-svc is A). effectiveAt is optional here
+// while the publisher always sends it — safe required->optional narrowing,
+// this edge is compatible.
+export interface PriceAlert {
+  productId: string;
+  price: { amount: number; currency: string };
+  effectiveAt?: string;
+}
+
+export async function watchPriceAlerts(): Promise<void> {
+  const nc = await connect({ servers: process.env.NATS_URL });
+  for await (const msg of nc.subscribe("catalog.price.updated")) {
+    const alert = JSON.parse(sc.decode(msg.data)) as PriceAlert;
+    notifyOps(alert);
+  }
+}
+
+function notifyOps(alert: PriceAlert): void {
+  void alert;
+}

--- a/tests/fixtures/xrepo-corpus-3/ops-console/src/products.ts
+++ b/tests/fixtures/xrepo-corpus-3/ops-console/src/products.ts
@@ -1,0 +1,24 @@
+import { makeClient } from "./lib/apiClient";
+import { config } from "./config";
+
+const catalogClient = makeClient(config.catalogUrl);
+
+// price is optional here; the producer models "no price" as `price: null`.
+// null is not undefined — the deliberate mismatch on this edge.
+export interface ProductRecord {
+  id: string;
+  name: string;
+  description: string;
+  price?: { amount: number; currency: string };
+  tags: string[];
+}
+
+export interface ProductPatch {
+  name?: string;
+  description?: string;
+  tags?: string[];
+}
+
+export async function updateProduct(id: string, patch: ProductPatch): Promise<ProductRecord> {
+  return catalogClient.patch<ProductRecord>(`/api/v2/products/${id}`, patch);
+}

--- a/tests/fixtures/xrepo-corpus-3/ops-console/src/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-3/ops-console/src/types/stubs.d.ts
@@ -1,0 +1,32 @@
+// Ambient stubs — keep types resolvable without npm install.
+// Just enough surface for the call sites; the scanner reads AST structure.
+
+declare module "graphql-tag" {
+  export function gql(literals: TemplateStringsArray, ...args: unknown[]): unknown;
+  export default gql;
+}
+
+declare module "graphql-request" {
+  export class GraphQLClient {
+    constructor(url: string);
+    request<T = unknown>(document: unknown, variables?: Record<string, unknown>): Promise<T>;
+  }
+}
+
+declare module "nats" {
+  export interface Msg {
+    subject: string;
+    data: Uint8Array;
+  }
+  export interface Subscription extends AsyncIterable<Msg> {}
+  export interface NatsConnection {
+    subscribe(subject: string): Subscription;
+    close(): Promise<void>;
+  }
+  export function connect(opts?: { servers?: string | string[] }): Promise<NatsConnection>;
+  export interface Codec<T> {
+    encode(d: T): Uint8Array;
+    decode(a: Uint8Array): T;
+  }
+  export function StringCodec(): Codec<string>;
+}

--- a/tests/fixtures/xrepo-corpus-3/ops-console/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-3/ops-console/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "lib": ["ES2020", "DOM"]
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-3/orders-api/expected.json
+++ b/tests/fixtures/xrepo-corpus-3/orders-api/expected.json
@@ -1,0 +1,78 @@
+{
+  "endpoints": [
+    {
+      "method": "POST",
+      "path": "/orders",
+      "owner": "server",
+      "primary_type_symbol": "OrderCreated",
+      "resolved_type": "{ orderId: string; status: \"pending\" | \"confirmed\"; total: { amount: number; currency: string; }; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "GET",
+      "path": "/orders/:orderId/timeline",
+      "owner": "server",
+      "primary_type_symbol": "TimelineEvent",
+      "resolved_type": "{ at: string; status: string; note?: string; }[]",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "calls": [],
+  "pubsub_operations": [
+    {
+      "role": "consumer",
+      "service": "orders-api",
+      "key": "pubsub|inventory.stock.adjust",
+      "topic": "inventory.stock.adjust",
+      "broker": "rabbitmq",
+      "side": "publisher",
+      "source": "src/mq/stock.publisher.ts",
+      "primary_type_symbol": "StockAdjustCommand",
+      "resolved_type": "{ sku: string; delta: number; reason: string; orderId: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "consumer",
+      "service": "orders-api",
+      "key": "pubsub|shipments.dispatch",
+      "topic": "shipments.dispatch",
+      "broker": "bullmq",
+      "side": "publisher",
+      "source": "src/mq/dispatch.publisher.ts",
+      "primary_type_symbol": "DispatchRequest",
+      "resolved_type": "{ orderId: string; warehouseId: string; dispatchAfter: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "producer",
+      "service": "orders-api",
+      "key": "pubsub|orders.status.changed",
+      "topic": "orders.status.changed",
+      "broker": "kafka",
+      "side": "subscriber",
+      "source": "src/mq/status.subscriber.ts",
+      "primary_type_symbol": "OrderStatusChanged",
+      "resolved_type": "{ orderId: string; status: \"picked\" | \"dispatched\" | \"delivered\"; occurredAt: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "consumer",
+      "service": "orders-api",
+      "key": "pubsub|notifications.digest",
+      "topic": "notifications.digest",
+      "broker": "sqs",
+      "side": "publisher",
+      "source": "src/mq/digest.publisher.ts",
+      "primary_type_symbol": "OrderDigest",
+      "resolved_type": "{ date: string; orderCount: number; totalAmount: number; }",
+      "type_state": "Explicit",
+      "tier": "roadmap"
+    }
+  ],
+  "_must_not_emit": []
+}

--- a/tests/fixtures/xrepo-corpus-3/orders-api/package.json
+++ b/tests/fixtures/xrepo-corpus-3/orders-api/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "orders-api",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@aws-sdk/client-sqs": "3.645.0",
+    "amqplib": "0.10.4",
+    "bullmq": "5.12.0",
+    "fastify": "4.28.1",
+    "kafkajs": "2.2.4"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/orders-api/src/http/server.ts
+++ b/tests/fixtures/xrepo-corpus-3/orders-api/src/http/server.ts
@@ -1,0 +1,18 @@
+import fastify from "fastify";
+import { CreateOrder, OrderCreated, TimelineEvent } from "../types/orders";
+import { createOrder, loadTimeline } from "../store";
+
+const app = fastify();
+
+app.post<OrderCreated>("/orders", async (request) => {
+  const order = request.body as CreateOrder;
+  const created: OrderCreated = await createOrder(order);
+  return created;
+});
+
+app.get<TimelineEvent[]>("/orders/:orderId/timeline", async (request) => {
+  const events: TimelineEvent[] = await loadTimeline(request.params.orderId);
+  return events;
+});
+
+app.listen({ port: 4003 });

--- a/tests/fixtures/xrepo-corpus-3/orders-api/src/mq/digest.publisher.ts
+++ b/tests/fixtures/xrepo-corpus-3/orders-api/src/mq/digest.publisher.ts
@@ -1,0 +1,15 @@
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import { OrderDigest } from "../types/orders";
+
+const sqs = new SQSClient({});
+
+// Roadmap case: the queue identity lives in a URL template (env-templated
+// topic). Must not be emitted as an HTTP call either.
+export async function publishDailyDigest(digest: OrderDigest): Promise<void> {
+  await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: `${process.env.SQS_BASE_URL}/notifications.digest`,
+      MessageBody: JSON.stringify(digest),
+    })
+  );
+}

--- a/tests/fixtures/xrepo-corpus-3/orders-api/src/mq/dispatch.publisher.ts
+++ b/tests/fixtures/xrepo-corpus-3/orders-api/src/mq/dispatch.publisher.ts
@@ -1,0 +1,10 @@
+import { Queue } from "bullmq";
+import { DispatchRequest } from "../types/orders";
+
+// BullMQ: the contract topic is the QUEUE name ("shipments.dispatch"); the
+// job name passed to add() is not part of the identity.
+const dispatchQueue = new Queue("shipments.dispatch");
+
+export async function scheduleDispatch(req: DispatchRequest): Promise<void> {
+  await dispatchQueue.add("dispatch", req);
+}

--- a/tests/fixtures/xrepo-corpus-3/orders-api/src/mq/status.subscriber.ts
+++ b/tests/fixtures/xrepo-corpus-3/orders-api/src/mq/status.subscriber.ts
@@ -1,0 +1,24 @@
+import { Kafka } from "kafkajs";
+import { OrderStatusChanged } from "../types/orders";
+
+// Mid-migration bridge: fulfillment publishes this topic on NATS; the mirrored
+// Kafka topic is what this legacy subscriber still reads. Same topic string,
+// different broker — the contract is the topic.
+const kafka = new Kafka({ clientId: "orders-api", brokers: ["kafka:9092"] });
+const consumer = kafka.consumer({ groupId: "orders-status" });
+
+export async function runStatusSubscriber(): Promise<void> {
+  await consumer.connect();
+  await consumer.subscribe({ topic: "orders.status.changed" });
+  await consumer.run({
+    eachMessage: async ({ message }) => {
+      if (!message.value) return;
+      const evt = JSON.parse(message.value.toString("utf8")) as OrderStatusChanged;
+      applyStatus(evt);
+    },
+  });
+}
+
+function applyStatus(evt: OrderStatusChanged): void {
+  void evt;
+}

--- a/tests/fixtures/xrepo-corpus-3/orders-api/src/mq/stock.publisher.ts
+++ b/tests/fixtures/xrepo-corpus-3/orders-api/src/mq/stock.publisher.ts
@@ -1,0 +1,10 @@
+import { connect } from "amqplib";
+import { StockAdjustCommand } from "../types/orders";
+
+// Reserve stock when an order is placed: RabbitMQ work queue consumed by
+// inventory-svc.
+export async function reserveStock(cmd: StockAdjustCommand): Promise<void> {
+  const conn = await connect(process.env.AMQP_URL);
+  const ch = await conn.createChannel();
+  ch.sendToQueue("inventory.stock.adjust", Buffer.from(JSON.stringify(cmd)));
+}

--- a/tests/fixtures/xrepo-corpus-3/orders-api/src/store.ts
+++ b/tests/fixtures/xrepo-corpus-3/orders-api/src/store.ts
@@ -1,0 +1,16 @@
+import { CreateOrder, OrderCreated, TimelineEvent } from "./types/orders";
+
+export async function createOrder(order: CreateOrder): Promise<OrderCreated> {
+  return {
+    orderId: `ord_${order.customerId}`,
+    status: "pending",
+    total: { amount: 0, currency: "EUR" },
+  };
+}
+
+export async function loadTimeline(orderId: string): Promise<TimelineEvent[]> {
+  return [
+    { at: "2026-07-01T09:00:00Z", status: "placed" },
+    { at: "2026-07-01T10:00:00Z", status: "picked", note: `order ${orderId} left the shelf` },
+  ];
+}

--- a/tests/fixtures/xrepo-corpus-3/orders-api/src/types/orders.ts
+++ b/tests/fixtures/xrepo-corpus-3/orders-api/src/types/orders.ts
@@ -1,0 +1,44 @@
+export interface CreateOrder {
+  customerId: string;
+  items: { sku: string; quantity: number }[];
+}
+
+export interface OrderCreated {
+  orderId: string;
+  status: "pending" | "confirmed";
+  total: { amount: number; currency: string };
+}
+
+export interface TimelineEvent {
+  at: string;
+  status: string;
+  note?: string;
+}
+
+// Sent to inventory when an order reserves stock.
+export interface StockAdjustCommand {
+  sku: string;
+  delta: number;
+  reason: string;
+  orderId: string;
+}
+
+// Enqueued for the fulfillment worker. dispatchAfter is an ISO timestamp
+// string on the wire — the worker's expectation of a Date is the bug.
+export interface DispatchRequest {
+  orderId: string;
+  warehouseId: string;
+  dispatchAfter: string;
+}
+
+export interface OrderStatusChanged {
+  orderId: string;
+  status: "picked" | "dispatched" | "delivered";
+  occurredAt: string;
+}
+
+export interface OrderDigest {
+  date: string;
+  orderCount: number;
+  totalAmount: number;
+}

--- a/tests/fixtures/xrepo-corpus-3/orders-api/src/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-3/orders-api/src/types/stubs.d.ts
@@ -1,0 +1,98 @@
+// Ambient stubs — keep types resolvable without npm install.
+// Just enough surface for the call sites; the scanner reads AST structure.
+
+declare module "fastify" {
+  interface FastifyRequest {
+    params: Record<string, string>;
+    query: Record<string, string>;
+    body: unknown;
+  }
+  interface FastifyReply {
+    send(payload?: unknown): FastifyReply;
+    status(code: number): FastifyReply;
+  }
+  type RouteHandler<TReply = unknown> = (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ) => Promise<TReply> | TReply;
+  interface FastifyInstance {
+    get<TReply = unknown>(path: string, handler: RouteHandler<TReply>): this;
+    post<TReply = unknown>(path: string, handler: RouteHandler<TReply>): this;
+    listen(opts: { port: number }): Promise<void>;
+  }
+  function fastify(): FastifyInstance;
+  export = fastify;
+}
+
+declare module "amqplib" {
+  export interface ConsumeMessage {
+    content: Buffer;
+  }
+  export interface Channel {
+    assertQueue(queue: string): Promise<unknown>;
+    sendToQueue(queue: string, content: Buffer): boolean;
+    consume(queue: string, onMessage: (msg: ConsumeMessage | null) => void): Promise<unknown>;
+    ack(msg: ConsumeMessage): void;
+  }
+  export interface Connection {
+    createChannel(): Promise<Channel>;
+  }
+  export function connect(url?: string): Promise<Connection>;
+}
+
+declare module "bullmq" {
+  export interface Job<T = unknown> {
+    data: T;
+  }
+  export class Queue<T = unknown> {
+    constructor(name: string, opts?: { connection?: unknown });
+    add(jobName: string, data: T): Promise<unknown>;
+  }
+  export class Worker<T = unknown> {
+    constructor(
+      name: string,
+      processor: (job: Job<T>) => Promise<void>,
+      opts?: { connection?: unknown }
+    );
+  }
+}
+
+declare module "kafkajs" {
+  export interface KafkaMessage {
+    value: Buffer | null;
+  }
+  export interface EachMessagePayload {
+    topic: string;
+    partition: number;
+    message: KafkaMessage;
+  }
+  export interface ConsumerSubscribeTopic {
+    topic: string;
+    fromBeginning?: boolean;
+  }
+  export interface ConsumerRunConfig {
+    eachMessage: (payload: EachMessagePayload) => Promise<void>;
+  }
+  export interface Consumer {
+    connect(): Promise<void>;
+    subscribe(subscription: ConsumerSubscribeTopic): Promise<void>;
+    run(config: ConsumerRunConfig): Promise<void>;
+  }
+  export interface ConsumerConfig {
+    groupId: string;
+  }
+  export class Kafka {
+    constructor(config: { clientId: string; brokers: string[] });
+    consumer(config: ConsumerConfig): Consumer;
+  }
+}
+
+declare module "@aws-sdk/client-sqs" {
+  export class SQSClient {
+    constructor(config: Record<string, unknown>);
+    send(command: unknown): Promise<unknown>;
+  }
+  export class SendMessageCommand {
+    constructor(input: { QueueUrl: string; MessageBody: string });
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/orders-api/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-3/orders-api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "lib": ["ES2020"]
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/carrick.json
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/carrick.json
@@ -1,0 +1,9 @@
+{
+  "services": [
+    {
+      "name": "catalog-api",
+      "directory": "packages/catalog-api",
+      "tsconfig": "tsconfig.json"
+    }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/expected.json
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/expected.json
@@ -1,0 +1,59 @@
+{
+  "endpoints": [
+    {
+      "method": "GET",
+      "path": "/api/v2/products/:id",
+      "owner": "productsRouter",
+      "primary_type_symbol": "Product",
+      "resolved_type": "{ id: string; name: string; description: string; price: null | { amount: number; currency: string; }; tags: string[]; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "GET",
+      "path": "/api/v2/products/:id/variants/:variantId",
+      "owner": "productsRouter",
+      "primary_type_symbol": "VariantDetail",
+      "resolved_type": "{ id: string; productId: string; sku: string; price: { amount: number; currency: string; }; inStock: boolean; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/v2/products/:id",
+      "owner": "productsRouter",
+      "primary_type_symbol": "Product",
+      "resolved_type": "{ id: string; name: string; description: string; price: null | { amount: number; currency: string; }; tags: string[]; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v2/products/:id",
+      "owner": "productsRouter",
+      "primary_type_symbol": null,
+      "resolved_type": null,
+      "type_state": null,
+      "tier": "capability"
+    }
+  ],
+  "calls": [],
+  "pubsub_operations": [
+    {
+      "role": "consumer",
+      "service": "catalog-api",
+      "key": "pubsub|catalog.price.updated",
+      "topic": "catalog.price.updated",
+      "broker": "nats",
+      "side": "publisher",
+      "source": "packages/catalog-api/src/pricing.publisher.ts",
+      "primary_type_symbol": "PriceUpdated",
+      "resolved_type": "{ productId: string; price: { amount: number; currency: string; }; effectiveAt: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "_must_not_emit": [
+    { "kind": "call", "method": "GET", "path": "/api/v2/health" }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/package.json
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "platform-monorepo",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/contracts",
+    "packages/catalog-api"
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/package.json
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "catalog-api",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@koa/router": "12.0.1",
+    "@meridian/contracts": "0.1.0",
+    "koa": "2.15.3",
+    "nats": "2.28.2",
+    "zod": "3.23.0"
+  },
+  "devDependencies": {
+    "supertest": "7.0.0"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/src/pricing.publisher.ts
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/src/pricing.publisher.ts
@@ -1,0 +1,11 @@
+import { connect, StringCodec } from "nats";
+import { PriceUpdated } from "@meridian/contracts";
+
+const sc = StringCodec();
+
+// Fan-out: inventory-svc and ops-console both subscribe to this subject.
+export async function publishPriceUpdated(evt: PriceUpdated): Promise<void> {
+  const nc = await connect({ servers: process.env.NATS_URL });
+  nc.publish("catalog.price.updated", sc.encode(JSON.stringify(evt)));
+  await nc.close();
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/src/products.routes.ts
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/src/products.routes.ts
@@ -1,0 +1,27 @@
+import Router from "@koa/router";
+import { Product, VariantDetail } from "@meridian/contracts";
+import { loadProduct, loadVariant, applyProductPatch, removeProduct } from "./store";
+
+export const productsRouter = new Router();
+
+// v2 only — the storefront's legacy v1 client was never migrated and must not
+// resolve against these routes.
+productsRouter.get("/api/v2/products/:id", async (ctx) => {
+  const product: Product = await loadProduct(ctx.params.id);
+  ctx.body = product;
+});
+
+productsRouter.get("/api/v2/products/:id/variants/:variantId", async (ctx) => {
+  const variant: VariantDetail = await loadVariant(ctx.params.id, ctx.params.variantId);
+  ctx.body = variant;
+});
+
+productsRouter.patch("/api/v2/products/:id", async (ctx) => {
+  const updated: Product = await applyProductPatch(ctx.params.id, ctx.request.body);
+  ctx.body = updated;
+});
+
+productsRouter.del("/api/v2/products/:id", async (ctx) => {
+  await removeProduct(ctx.params.id);
+  ctx.status = 204;
+});

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/src/server.ts
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/src/server.ts
@@ -1,0 +1,10 @@
+import Koa from "koa";
+import { productsRouter } from "./products.routes";
+
+const app = new Koa();
+app.use(productsRouter.routes());
+app.use(productsRouter.allowedMethods());
+
+app.listen(4001);
+
+export { app };

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/src/store.ts
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/src/store.ts
@@ -1,0 +1,32 @@
+import { Product, VariantDetail } from "@meridian/contracts";
+
+// In-memory stand-ins for the catalog database. Static fixture: bodies are
+// illustrative, the types are the contract.
+export async function loadProduct(id: string): Promise<Product> {
+  return {
+    id,
+    name: "Meridian mug",
+    description: "Stoneware, 350ml",
+    price: { amount: 1450, currency: "EUR" },
+    tags: ["kitchen", "ceramics"],
+  };
+}
+
+export async function loadVariant(productId: string, variantId: string): Promise<VariantDetail> {
+  return {
+    id: variantId,
+    productId,
+    sku: `SKU-${variantId}`,
+    price: { amount: 1450, currency: "EUR" },
+    inStock: true,
+  };
+}
+
+export async function applyProductPatch(id: string, patch: unknown): Promise<Product> {
+  const current = await loadProduct(id);
+  return { ...current, ...(patch as Partial<Product>) };
+}
+
+export async function removeProduct(id: string): Promise<void> {
+  void id;
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/test/products.test.ts
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/test/products.test.ts
@@ -1,0 +1,13 @@
+import request from "supertest";
+import { app } from "../src/server";
+
+// Test-client traffic: exercises routes in-process. This is NOT a runtime
+// consumer and must not be extracted as a data call.
+describe("catalog-api smoke", () => {
+  it("responds on the health probe", async () => {
+    await request(app).get("/api/v2/health").expect(200);
+  });
+});
+
+declare function describe(name: string, fn: () => void): void;
+declare function it(name: string, fn: () => Promise<void>): void;

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "baseUrl": ".",
+    "paths": {
+      "@meridian/contracts": ["../contracts/src/index.ts"]
+    }
+  },
+  "include": ["src", "test", "typings", "../contracts/src"]
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/typings/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/catalog-api/typings/stubs.d.ts
@@ -1,0 +1,53 @@
+// Ambient stubs — keep types resolvable without npm install.
+// Just enough surface for the call sites; the scanner reads AST structure.
+
+declare module "koa" {
+  class Koa {
+    use(mw: unknown): this;
+    listen(port: number): void;
+  }
+  export = Koa;
+}
+
+declare module "@koa/router" {
+  export interface RouterContext {
+    params: Record<string, string>;
+    body: unknown;
+    status: number;
+    request: { body: unknown };
+  }
+  type Middleware = (ctx: RouterContext) => Promise<void> | void;
+  class Router {
+    get(path: string, mw: Middleware): this;
+    patch(path: string, mw: Middleware): this;
+    del(path: string, mw: Middleware): this;
+    routes(): unknown;
+    allowedMethods(): unknown;
+  }
+  export = Router;
+}
+
+declare module "nats" {
+  export interface NatsConnection {
+    publish(subject: string, data: Uint8Array): void;
+    close(): Promise<void>;
+  }
+  export function connect(opts?: { servers?: string | string[] }): Promise<NatsConnection>;
+  export interface Codec<T> {
+    encode(d: T): Uint8Array;
+    decode(a: Uint8Array): T;
+  }
+  export function StringCodec(): Codec<string>;
+}
+
+declare module "supertest" {
+  interface Test {
+    expect(status: number): Promise<unknown>;
+  }
+  interface Agent {
+    get(path: string): Test;
+    post(path: string): Test;
+  }
+  function request(app: unknown): Agent;
+  export = request;
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/contracts/package.json
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/contracts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@meridian/contracts",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "zod": "3.23.0"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/contracts/src/index.ts
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/contracts/src/index.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+// Contract shapes shared across the platform monorepo. The zod schemas are the
+// source of truth; the exported types are derived via z.infer.
+export const PriceSchema = z.object({
+  amount: z.number(),
+  currency: z.string(),
+});
+export type Price = z.infer<typeof PriceSchema>;
+
+export const VariantDetailSchema = z.object({
+  id: z.string(),
+  productId: z.string(),
+  sku: z.string(),
+  price: PriceSchema,
+  inStock: z.boolean(),
+});
+export type VariantDetail = z.infer<typeof VariantDetailSchema>;
+
+export interface Product {
+  id: string;
+  name: string;
+  description: string;
+  price: Price | null;
+  tags: string[];
+}
+
+export interface PriceUpdated {
+  productId: string;
+  price: Price;
+  effectiveAt: string;
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/contracts/src/zod-stub.d.ts
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/contracts/src/zod-stub.d.ts
@@ -1,0 +1,18 @@
+// Ambient zod stub — keeps `z.infer` computable without npm install. The
+// mapped type mirrors real zod's output derivation for the subset used here
+// (required object fields only; optionality lives on plain interfaces).
+declare module "zod" {
+  export interface ZodType<Output> {
+    readonly _output: Output;
+    parse(data: unknown): Output;
+  }
+  export namespace z {
+    export type infer<T extends ZodType<any>> = T["_output"];
+    export function object<S extends Record<string, ZodType<any>>>(
+      shape: S
+    ): ZodType<{ [K in keyof S]: S[K]["_output"] }>;
+    export function string(): ZodType<string>;
+    export function number(): ZodType<number>;
+    export function boolean(): ZodType<boolean>;
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/contracts/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/packages/contracts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tests/fixtures/xrepo-corpus-3/platform-monorepo/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-3/platform-monorepo/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "baseUrl": "."
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-3/storefront-web/carrick.json
+++ b/tests/fixtures/xrepo-corpus-3/storefront-web/carrick.json
@@ -1,0 +1,3 @@
+{
+  "internalEnvVars": ["NEXT_PUBLIC_ORDERS_API_URL", "NEXT_PUBLIC_CATALOG_URL"]
+}

--- a/tests/fixtures/xrepo-corpus-3/storefront-web/expected.json
+++ b/tests/fixtures/xrepo-corpus-3/storefront-web/expected.json
@@ -1,0 +1,57 @@
+{
+  "endpoints": [],
+  "calls": [
+    {
+      "method": "POST",
+      "path": "/orders",
+      "path_contains": "/orders",
+      "import_source": null,
+      "primary_type_symbol": "OrderAck",
+      "resolved_type": "{ orderId: string; status: \"pending\" | \"confirmed\"; total: { amount: number; currency: string; }; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/products/:param",
+      "path_contains": "/api/v1/products/",
+      "import_source": null,
+      "primary_type_symbol": "LegacyProduct",
+      "resolved_type": "{ id: string; name: string; priceCents: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "graphql_operations": [
+    {
+      "role": "consumer",
+      "service": "storefront-web",
+      "key": "graphql|query|ticket",
+      "kind": "query",
+      "field": "ticket",
+      "source": "lib/support.ts",
+      "primary_type_symbol": "TicketView",
+      "resolved_type": "{ id: string; subject: string; status: \"OPEN\" | \"ESCALATED\" | \"CLOSED\"; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "socket_events": [
+    {
+      "role": "consumer",
+      "service": "storefront-web",
+      "key": "socket|CLIENT->SERVER|support:message",
+      "event": "support:message",
+      "direction": "CLIENT->SERVER",
+      "side": "emitter",
+      "source": "lib/supportSocket.ts",
+      "primary_type_symbol": "SupportMessage",
+      "resolved_type": "{ ticketId: string; body: string; sentAt: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "_must_not_emit": [
+    { "kind": "endpoint", "method": "GET", "path": "/api/v2/promotions/:id" }
+  ]
+}

--- a/tests/fixtures/xrepo-corpus-3/storefront-web/lib/checkout.ts
+++ b/tests/fixtures/xrepo-corpus-3/storefront-web/lib/checkout.ts
@@ -1,0 +1,18 @@
+import ky from "ky";
+
+const ORDERS_BASE = process.env.NEXT_PUBLIC_ORDERS_API_URL ?? "http://localhost:4003";
+
+export interface NewOrder {
+  customerId: string;
+  items: { sku: string; quantity: number }[];
+}
+
+export interface OrderAck {
+  orderId: string;
+  status: "pending" | "confirmed";
+  total: { amount: number; currency: string };
+}
+
+export async function placeOrder(order: NewOrder): Promise<OrderAck> {
+  return ky.post(`${ORDERS_BASE}/orders`, { json: order }).json<OrderAck>();
+}

--- a/tests/fixtures/xrepo-corpus-3/storefront-web/lib/forms.ts
+++ b/tests/fixtures/xrepo-corpus-3/storefront-web/lib/forms.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+// Client-side form validation — zod 4 in real use (the dep-conflict vehicle:
+// the monorepo and inventory-svc pin zod 3).
+export const CheckoutFormSchema = z.object({
+  email: z.string(),
+  promoCode: z.string(),
+});
+
+export type CheckoutForm = z.infer<typeof CheckoutFormSchema>;
+
+export function validateCheckoutForm(input: unknown): CheckoutForm {
+  return CheckoutFormSchema.parse(input);
+}

--- a/tests/fixtures/xrepo-corpus-3/storefront-web/lib/legacy.ts
+++ b/tests/fixtures/xrepo-corpus-3/storefront-web/lib/legacy.ts
@@ -1,0 +1,14 @@
+const CATALOG_BASE = process.env.NEXT_PUBLIC_CATALOG_URL ?? "http://localhost:4001";
+
+// Never migrated off the retired v1 API. The catalog serves only /api/v2 —
+// this call has no producer and must not match the v2 routes.
+export interface LegacyProduct {
+  id: string;
+  name: string;
+  priceCents: number;
+}
+
+export async function fetchLegacyProduct(id: string): Promise<LegacyProduct> {
+  const res = await fetch(`${CATALOG_BASE}/api/v1/products/${id}`);
+  return res.json() as Promise<LegacyProduct>;
+}

--- a/tests/fixtures/xrepo-corpus-3/storefront-web/lib/support.ts
+++ b/tests/fixtures/xrepo-corpus-3/storefront-web/lib/support.ts
@@ -1,0 +1,28 @@
+import { gql } from "graphql-tag";
+import { GraphQLClient } from "graphql-request";
+
+// The gql URL is deliberately NOT in carrick.json internalEnvVars: GraphQL
+// matches on operation identity, not the connection URL.
+const client = new GraphQLClient(process.env.NEXT_PUBLIC_SUPPORT_GQL_URL ?? "http://localhost:4005/graphql");
+
+const TICKET_QUERY = gql`
+  query ticket($id: ID!) {
+    ticket(id: $id) {
+      id
+      subject
+      status
+    }
+  }
+`;
+
+// Result shape bound only by co-location — no call-site generic on request().
+export interface TicketView {
+  id: string;
+  subject: string;
+  status: "OPEN" | "ESCALATED" | "CLOSED";
+}
+
+export async function loadTicket(id: string): Promise<TicketView> {
+  const data = await client.request(TICKET_QUERY, { id });
+  return (data as { ticket: TicketView }).ticket;
+}

--- a/tests/fixtures/xrepo-corpus-3/storefront-web/lib/supportSocket.ts
+++ b/tests/fixtures/xrepo-corpus-3/storefront-web/lib/supportSocket.ts
@@ -1,0 +1,15 @@
+import { io } from "socket.io-client";
+
+const socket = io(process.env.NEXT_PUBLIC_SUPPORT_WS_URL ?? "http://localhost:4005");
+
+export interface SupportMessage {
+  ticketId: string;
+  body: string;
+  sentAt: string;
+}
+
+// Client emitter: the CLIENT->SERVER contract consumer; support-desk's server
+// listener is the producer.
+export function sendSupportMessage(msg: SupportMessage): void {
+  socket.emit("support:message", msg);
+}

--- a/tests/fixtures/xrepo-corpus-3/storefront-web/mocks/handlers.ts
+++ b/tests/fixtures/xrepo-corpus-3/storefront-web/mocks/handlers.ts
@@ -1,0 +1,9 @@
+import { http, HttpResponse } from "msw";
+
+// Storybook/test mocks: route *registrations* that exist only in the mock
+// service worker. Not producers — must not be extracted as endpoints.
+export const handlers = [
+  http.get("/api/v2/promotions/:id", () =>
+    HttpResponse.json({ id: "promo-1", percentOff: 10 })
+  ),
+];

--- a/tests/fixtures/xrepo-corpus-3/storefront-web/package.json
+++ b/tests/fixtures/xrepo-corpus-3/storefront-web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "storefront-web",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "graphql-request": "6.1.0",
+    "graphql-tag": "2.12.6",
+    "ky": "1.4.0",
+    "socket.io-client": "4.7.5",
+    "zod": "4.0.0"
+  },
+  "devDependencies": {
+    "msw": "2.3.1"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/storefront-web/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-3/storefront-web/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2020", "DOM"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "exclude": ["node_modules"]
+}

--- a/tests/fixtures/xrepo-corpus-3/storefront-web/types/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-3/storefront-web/types/stubs.d.ts
@@ -1,0 +1,65 @@
+// Ambient stubs — keep types resolvable without npm install.
+// Just enough surface for the call sites; the scanner reads AST structure.
+
+declare module "ky" {
+  interface KyResponse {
+    json<T>(): Promise<T>;
+  }
+  interface Ky {
+    get(url: string): KyResponse;
+    post(url: string, opts?: { json?: unknown }): KyResponse;
+  }
+  const ky: Ky;
+  export default ky;
+}
+
+declare module "graphql-tag" {
+  export function gql(literals: TemplateStringsArray, ...args: unknown[]): unknown;
+  export default gql;
+}
+
+declare module "graphql-request" {
+  export class GraphQLClient {
+    constructor(url: string);
+    request<T = unknown>(document: unknown, variables?: Record<string, unknown>): Promise<T>;
+  }
+}
+
+declare module "socket.io-client" {
+  export interface ClientSocket {
+    emit(event: string, payload: unknown): void;
+    on(event: string, handler: (payload: unknown) => void): void;
+  }
+  export function io(url?: string): ClientSocket;
+}
+
+declare module "msw" {
+  export interface HttpHandler {
+    readonly __mswHandler: true;
+  }
+  type Resolver = () => unknown;
+  export const http: {
+    get(path: string, resolver: Resolver): HttpHandler;
+    post(path: string, resolver: Resolver): HttpHandler;
+  };
+  export const HttpResponse: {
+    json(body: unknown): unknown;
+  };
+}
+
+// Ambient zod stub — keeps `z.infer` computable without npm install.
+declare module "zod" {
+  export interface ZodType<Output> {
+    readonly _output: Output;
+    parse(data: unknown): Output;
+  }
+  export namespace z {
+    export type infer<T extends ZodType<any>> = T["_output"];
+    export function object<S extends Record<string, ZodType<any>>>(
+      shape: S
+    ): ZodType<{ [K in keyof S]: S[K]["_output"] }>;
+    export function string(): ZodType<string>;
+    export function number(): ZodType<number>;
+    export function boolean(): ZodType<boolean>;
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/support-desk/expected.json
+++ b/tests/fixtures/xrepo-corpus-3/support-desk/expected.json
@@ -1,0 +1,68 @@
+{
+  "endpoints": [
+    {
+      "method": "GET",
+      "path": "/tickets/:id",
+      "owner": "findOne",
+      "primary_type_symbol": null,
+      "resolved_type": "{ id: string; subject: string; ageDays: number; }",
+      "type_state": "Implicit",
+      "tier": "capability"
+    }
+  ],
+  "calls": [],
+  "graphql_operations": [
+    {
+      "role": "producer",
+      "service": "support-desk",
+      "key": "graphql|query|ticket",
+      "kind": "query",
+      "field": "ticket",
+      "source": "src/schema.graphql",
+      "primary_type_symbol": "Ticket",
+      "resolved_type": "{ id: string; subject: string; status: \"OPEN\" | \"ESCALATED\" | \"CLOSED\"; priority: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "producer",
+      "service": "support-desk",
+      "key": "graphql|mutation|escalateTicket",
+      "kind": "mutation",
+      "field": "escalateTicket",
+      "source": "src/schema.graphql",
+      "primary_type_symbol": "EscalationResult!",
+      "resolved_type": "{ ticketId: string; escalatedAt: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    },
+    {
+      "role": "producer",
+      "service": "support-desk",
+      "key": "graphql|subscription|ticketUpdated",
+      "kind": "subscription",
+      "field": "ticketUpdated",
+      "source": "src/schema.graphql",
+      "primary_type_symbol": "Ticket!",
+      "resolved_type": "{ id: string; subject: string; status: \"OPEN\" | \"ESCALATED\" | \"CLOSED\"; priority: number; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "socket_events": [
+    {
+      "role": "producer",
+      "service": "support-desk",
+      "key": "socket|CLIENT->SERVER|support:message",
+      "event": "support:message",
+      "direction": "CLIENT->SERVER",
+      "side": "listener",
+      "source": "src/support.gateway.ts",
+      "primary_type_symbol": "SupportMessage",
+      "resolved_type": "{ ticketId: string; body: string; sentAt: string; }",
+      "type_state": "Explicit",
+      "tier": "capability"
+    }
+  ],
+  "_must_not_emit": []
+}

--- a/tests/fixtures/xrepo-corpus-3/support-desk/package.json
+++ b/tests/fixtures/xrepo-corpus-3/support-desk/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "support-desk",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@nestjs/common": "10.3.10",
+    "graphql": "16.9.0",
+    "socket.io": "4.7.5"
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/support-desk/src/schema.graphql
+++ b/tests/fixtures/xrepo-corpus-3/support-desk/src/schema.graphql
@@ -1,0 +1,29 @@
+type Ticket {
+  id: ID!
+  subject: String!
+  status: TicketStatus!
+  priority: Int!
+}
+
+enum TicketStatus {
+  OPEN
+  ESCALATED
+  CLOSED
+}
+
+type EscalationResult {
+  ticketId: ID!
+  escalatedAt: String!
+}
+
+type Query {
+  ticket(id: ID!): Ticket
+}
+
+type Mutation {
+  escalateTicket(id: ID!, reason: String!): EscalationResult!
+}
+
+type Subscription {
+  ticketUpdated(id: ID!): Ticket!
+}

--- a/tests/fixtures/xrepo-corpus-3/support-desk/src/support.gateway.ts
+++ b/tests/fixtures/xrepo-corpus-3/support-desk/src/support.gateway.ts
@@ -1,0 +1,16 @@
+import { Server } from "socket.io";
+import { SupportMessage } from "./types/tickets";
+
+const io = new Server(4005);
+
+// Server listener: the producer of the CLIENT->SERVER contract; the
+// storefront's client emitter is the consumer.
+io.on("connection", (socket) => {
+  socket.on("support:message", (msg: SupportMessage) => {
+    recordMessage(msg);
+  });
+});
+
+function recordMessage(msg: SupportMessage): void {
+  void msg;
+}

--- a/tests/fixtures/xrepo-corpus-3/support-desk/src/tickets.controller.ts
+++ b/tests/fixtures/xrepo-corpus-3/support-desk/src/tickets.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, Param } from "@nestjs/common";
+
+@Controller("tickets")
+export class TicketsController {
+  // No return annotation on purpose: the response shape must be inferred
+  // (the corpus's Implicit type-state case).
+  @Get(":id")
+  async findOne(@Param("id") id: string) {
+    return {
+      id,
+      subject: "Cracked mug on arrival",
+      ageDays: 3,
+    };
+  }
+}

--- a/tests/fixtures/xrepo-corpus-3/support-desk/src/tickets.resolver.ts
+++ b/tests/fixtures/xrepo-corpus-3/support-desk/src/tickets.resolver.ts
@@ -1,0 +1,23 @@
+import { Ticket, EscalationResult } from "./types/tickets";
+
+// Resolvers for src/schema.graphql root fields.
+export async function resolveTicket(id: string): Promise<Ticket> {
+  return {
+    id,
+    subject: "Cracked mug on arrival",
+    status: "OPEN",
+    priority: 2,
+  };
+}
+
+export async function resolveEscalateTicket(id: string, reason: string): Promise<EscalationResult> {
+  void reason;
+  return {
+    ticketId: id,
+    escalatedAt: "2026-07-02T12:00:00Z",
+  };
+}
+
+export async function* resolveTicketUpdated(id: string): AsyncGenerator<Ticket> {
+  yield await resolveTicket(id);
+}

--- a/tests/fixtures/xrepo-corpus-3/support-desk/src/types/tickets.ts
+++ b/tests/fixtures/xrepo-corpus-3/support-desk/src/types/tickets.ts
@@ -1,0 +1,19 @@
+export interface Ticket {
+  id: string;
+  subject: string;
+  status: "OPEN" | "ESCALATED" | "CLOSED";
+  priority: number;
+}
+
+// Note: no assignee — ops-console expects one; that edge is the
+// missing-required-field mismatch.
+export interface EscalationResult {
+  ticketId: string;
+  escalatedAt: string;
+}
+
+export interface SupportMessage {
+  ticketId: string;
+  body: string;
+  sentAt: string;
+}

--- a/tests/fixtures/xrepo-corpus-3/support-desk/tsconfig.json
+++ b/tests/fixtures/xrepo-corpus-3/support-desk/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "lib": ["ES2020"],
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/fixtures/xrepo-corpus-3/support-desk/typings/stubs.d.ts
+++ b/tests/fixtures/xrepo-corpus-3/support-desk/typings/stubs.d.ts
@@ -1,0 +1,19 @@
+// Ambient stubs — keep types resolvable without npm install.
+// Just enough surface for the call sites; the scanner reads AST structure.
+
+declare module "@nestjs/common" {
+  export function Controller(prefix?: string): ClassDecorator;
+  export function Get(path?: string): MethodDecorator;
+  export function Param(name?: string): ParameterDecorator;
+}
+
+declare module "socket.io" {
+  export interface ServerSocket {
+    on(event: string, handler: (payload: any) => void): void;
+    emit(event: string, payload: unknown): void;
+  }
+  export class Server {
+    constructor(port?: number);
+    on(event: "connection", handler: (socket: ServerSocket) => void): void;
+  }
+}


### PR DESCRIPTION
## What

Adds **xrepo-corpus-3**, the third authored cross-repo accuracy corpus: seven statically-analyzable repos exercising the axes corpus-1 (request/response) and corpus-2 (event-driven) leave untested — breadth, indirection, and type depth **within the four shipped protocol families**. No new protocol family (gRPC/tRPC deliberately out of scope). Selected via `CARRICK_EVAL_CORPUS=xrepo-corpus-3`; default corpus unaffected.

### New coverage (gap-driven, from a scanner-surface + corpus audit)

- **Pub/sub**: RabbitMQ (`amqplib`) + BullMQ brokers riding the broker-agnostic `pubsub_operations` schema (zero scanner changes expected); the first **cross-broker edge** (NATS publisher → Kafka subscriber, same topic); the first **fan-out** (two subscriber repos = two producers on one key).
- **Consumer indirection**: hand-rolled `apiClient` fetch-wrapper (relative paths + call-site generics), env bases behind a **config object**, `got` and `ky` clients.
- **Type depth**: `zod` `z.infer` contract types (zod was a phantom dep in c1; here used in code and the dep-conflict vehicle 3.23.0 vs 4.0.0), a shared workspace package (`@meridian/contracts`) imported across monorepo package boundaries, an HTTP array response, DELETE→204 null-anchor, one Implicit inference case.
- **New compat axes**: `Date` vs ISO string, array-vs-scalar, `T | null` vs `?: T`, missing-required-field — plus two subtle *compatible* true negatives.
- **HTTP shapes**: Koa (`@koa/router`, incl. `router.del`), PATCH, nested params, **version-drift negative** (v1 consumer must NOT match v2 producer).
- **GraphQL/socket**: first *matched* mutation edge; `gql`-tag consumer with **no call-site generic** (#298 hint path); first CLIENT->SERVER socket edge.
- **Decoys**: supertest test-client call, msw mock handlers, intra-repo HTTP self-call, `assertQueue` topology setup (non-HTTP, documented-not-scored like corpus-2).

### Harness change (scoped)

`score_decoy_leak` now respects the previously-dead `kind` field (`endpoint`/`call` set partitioning). Required so the self-call decoy — which shares `(method, path)` with the repo's legit endpoint — can be labelled without flagging the endpoint. Existing c1/c2 decoy labels already carry set-correct `kind` values; the pinned unit test is unchanged and green. Adds a `corpus3_has_the_expected_protocol_and_edge_shape` answer-key-drift guard (corpus-gated, no-op elsewhere).

### Ground-truth discipline

Labels are spec-of-record, authored before code. `resolved_type` strings were pinned to the sidecar's canonical `expandTypeStructural` printer form via an offline ts-morph probe over the fixture tsconfigs (deterministic; no scanner output involved). Notable printer facts encoded: `null | { … }` union order, `{ … }[]` array form, `Date` kept by name.

## Validation

- `cargo test --test eval_xrepo` green under corpus-1, -2, -3 (27 tests each).
- Offline mock plumbing smoke over corpus-3: 7 repos scan + join (`xrepo_mock_plumbing_smoke`).
- `npm install` succeeds in all 7 repos (registry versions + workspace linking verified); lockfiles not committed, matching c1/c2.
- Full pre-commit suite green (Rust 486+493, ts_check 85).

## Next

Baseline live eval (`eval-xrepo.yml -f corpus=xrepo-corpus-3 -f runs=3`) off this branch, then the per-edge fix loop toward ~95% capability. Tier flips only when detection lands, never to inflate the score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)