### PR TITLE
fix(engine): exclude workspace-internal packages from the synthetic type-check npm install

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2884,22 +2884,21 @@ fn dts_alias_is_trivially_unknown(content: &str, alias: &str) -> bool {
     }
 }
 
-/// Recreate package.json and tsconfig.json in the output directory
-fn recreate_package_and_tsconfig(
-    output_dir: &std::path::Path,
+/// Dependencies for the synthetic `carrick-type-check` package.json: the
+/// merged repo dependencies with (a) unusable versions dropped (empty, the
+/// literal "undefined", or digit-less — npm turns `typescript@undefined` into
+/// a hard ERESOLVE that aborts the whole cross-repo type pass), and (b)
+/// packages the scanned repos declare THEMSELVES dropped — a workspace-internal
+/// package (a monorepo's `@meridian/contracts`) resolves via the workspace
+/// link, not the registry, so `npm install` 404s and (per the #149 fail-loud)
+/// would abort type checking. Nothing is lost by dropping it: the bundle
+/// carries its shapes structurally inlined.
+fn synthetic_type_check_dependencies(
     packages: &Packages,
-) -> Result<(), Box<dyn std::error::Error>> {
-    // Create package.json
-    let package_json_path = output_dir.join("package.json");
-    let package_dependencies = packages.get_dependencies();
-
-    // Convert PackageInfo objects to simple version strings for npm. Drop
-    // entries whose version is unusable (empty, the literal "undefined", or a
-    // value with no digit) — a merged repo can carry these, and npm turns
-    // `typescript@undefined` into a hard ERESOLVE that aborts the whole
-    // cross-repo type pass.
+) -> std::collections::HashMap<String, String> {
+    let internal = packages.internal_package_names();
     let mut dependencies = std::collections::HashMap::new();
-    for (name, package_info) in package_dependencies {
+    for (name, package_info) in packages.get_dependencies() {
         let version = package_info.version.trim();
         if version.is_empty()
             || version == "undefined"
@@ -2908,8 +2907,26 @@ fn recreate_package_and_tsconfig(
             debug!("Skipping dependency {name} with unusable version {version:?}");
             continue;
         }
+        if internal.contains(name) {
+            debug!(
+                "Skipping workspace-internal dependency {name} (declared by a scanned \
+                 package.json; not registry-resolvable)"
+            );
+            continue;
+        }
         dependencies.insert(name.clone(), version.to_string());
     }
+    dependencies
+}
+
+/// Recreate package.json and tsconfig.json in the output directory
+fn recreate_package_and_tsconfig(
+    output_dir: &std::path::Path,
+    packages: &Packages,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Create package.json
+    let package_json_path = output_dir.join("package.json");
+    let mut dependencies = synthetic_type_check_dependencies(packages);
 
     // Pin the TypeScript toolchain we control for this synthetic type-check
     // package. Overwrite (not insert-if-missing): a merged repo may pin a
@@ -3010,6 +3027,51 @@ mod tests {
     use crate::services::type_sidecar::{InferredType, SourceLocation};
     use crate::visitor::{OwnerType, TypeReference};
     use std::path::PathBuf;
+
+    #[test]
+    fn synthetic_type_check_deps_exclude_workspace_internal_packages() {
+        // catalog-api depends on the workspace package @meridian/contracts.
+        // Installing that from the registry 404s and (fail-loud #149) aborts
+        // the whole type pass — the synthetic package must exclude any name a
+        // scanned package.json declares itself, while keeping real deps from
+        // both sides of the workspace.
+        use crate::packages::{PackageJson, Packages};
+        use std::collections::HashMap;
+
+        let mut packages = Packages::default();
+        packages.package_jsons.push(PackageJson {
+            name: Some("@meridian/contracts".to_string()),
+            version: Some("0.1.0".to_string()),
+            dependencies: HashMap::from([("zod".to_string(), "3.23.0".to_string())]),
+            dev_dependencies: HashMap::new(),
+            peer_dependencies: HashMap::new(),
+        });
+        packages.package_jsons.push(PackageJson {
+            name: Some("catalog-api".to_string()),
+            version: Some("1.0.0".to_string()),
+            dependencies: HashMap::from([
+                ("@meridian/contracts".to_string(), "0.1.0".to_string()),
+                ("koa".to_string(), "2.15.3".to_string()),
+            ]),
+            dev_dependencies: HashMap::new(),
+            peer_dependencies: HashMap::new(),
+        });
+        packages
+            .source_paths
+            .push(PathBuf::from("packages/contracts/package.json"));
+        packages
+            .source_paths
+            .push(PathBuf::from("packages/catalog-api/package.json"));
+        packages.resolve_dependencies();
+
+        let deps = synthetic_type_check_dependencies(&packages);
+        assert!(
+            !deps.contains_key("@meridian/contracts"),
+            "workspace-internal package must not be npm-installed"
+        );
+        assert_eq!(deps.get("koa").map(String::as_str), Some("2.15.3"));
+        assert_eq!(deps.get("zod").map(String::as_str), Some("3.23.0"));
+    }
 
     #[test]
     fn test_ast_stripping_removes_nodes() {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2025,13 +2025,19 @@ fn load_packages_for_service(
 ) -> Result<Packages, Box<dyn std::error::Error>> {
     let ignore_patterns = service_ignore_patterns(service);
     let (_, package_json_path) = find_service_files(repo_path, service, &ignore_patterns);
-    if let Some(package_path) = package_json_path {
+    let mut packages = if let Some(package_path) = package_json_path {
         debug!("Found package.json: {}", package_path.display());
         Packages::new(vec![package_path.clone()])
-            .map_err(|e| format!("Failed to parse {}: {}", package_path.display(), e).into())
+            .map_err(|e| format!("Failed to parse {}: {}", package_path.display(), e))?
     } else {
-        Ok(Packages::default())
-    }
+        Packages::default()
+    };
+    // Names of every package.json in the WHOLE repo tree (not just this
+    // service's): a workspace member like `packages/contracts` is not a
+    // service, but a dependency on it is internal, not a registry package.
+    packages.internal_names =
+        crate::packages::collect_internal_package_names(std::path::Path::new(repo_path));
+    Ok(packages)
 }
 
 /// Resolve per-endpoint type definitions using the sidecar's compiler.
@@ -3071,6 +3077,42 @@ mod tests {
         );
         assert_eq!(deps.get("koa").map(String::as_str), Some("2.15.3"));
         assert_eq!(deps.get("zod").map(String::as_str), Some("3.23.0"));
+    }
+
+    #[test]
+    fn synthetic_type_check_deps_exclude_tree_walked_internal_names() {
+        // Production shape (the corpus-3 baseline failure): only the
+        // SERVICE's package.json is loaded into package_jsons — a workspace
+        // member like packages/contracts never is — so the exclusion must
+        // also honour the tree-walked internal_names set.
+        use crate::packages::{PackageJson, Packages};
+        use std::collections::HashMap;
+
+        let mut packages = Packages::default();
+        packages.package_jsons.push(PackageJson {
+            name: Some("catalog-api".to_string()),
+            version: Some("1.0.0".to_string()),
+            dependencies: HashMap::from([
+                ("@meridian/contracts".to_string(), "0.1.0".to_string()),
+                ("koa".to_string(), "2.15.3".to_string()),
+            ]),
+            dev_dependencies: HashMap::new(),
+            peer_dependencies: HashMap::new(),
+        });
+        packages
+            .source_paths
+            .push(PathBuf::from("packages/catalog-api/package.json"));
+        packages.resolve_dependencies();
+        packages
+            .internal_names
+            .insert("@meridian/contracts".to_string());
+
+        let deps = synthetic_type_check_dependencies(&packages);
+        assert!(
+            !deps.contains_key("@meridian/contracts"),
+            "tree-walked internal name must not be npm-installed"
+        );
+        assert_eq!(deps.get("koa").map(String::as_str), Some("2.15.3"));
     }
 
     #[test]

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -32,6 +32,44 @@ pub struct Packages {
     pub package_jsons: Vec<PackageJson>,
     pub source_paths: Vec<PathBuf>,
     pub merged_dependencies: HashMap<String, PackageInfo>,
+    /// Package names declared by ANY package.json in the scanned repo tree —
+    /// not just the service-scoped ones in `package_jsons`. A monorepo's
+    /// shared workspace package (`@meridian/contracts` under
+    /// `packages/contracts/`) is not a service, so its package.json is never
+    /// loaded into `package_jsons`; this set is how it is still recognized as
+    /// internal (registry-unresolvable). `default` for CloudRepoData
+    /// payloads persisted before the field existed.
+    #[serde(default)]
+    pub internal_names: std::collections::HashSet<String>,
+}
+
+/// Names declared by every package.json under `repo_root` (workspace members
+/// included), skipping dependency/build directories. Used to recognize
+/// workspace-internal packages that must not be treated as registry deps.
+pub fn collect_internal_package_names(
+    repo_root: &std::path::Path,
+) -> std::collections::HashSet<String> {
+    const SKIP_DIRS: [&str; 4] = ["node_modules", "dist", "build", ".next"];
+    let mut names = std::collections::HashSet::new();
+    let walker = walkdir::WalkDir::new(repo_root)
+        .into_iter()
+        .filter_entry(|e| {
+            !(e.file_type().is_dir()
+                && e.file_name()
+                    .to_str()
+                    .is_some_and(|n| SKIP_DIRS.contains(&n)))
+        });
+    for entry in walker.flatten() {
+        if entry.file_type().is_file()
+            && entry.file_name() == "package.json"
+            && let Ok(text) = std::fs::read_to_string(entry.path())
+            && let Ok(json) = serde_json::from_str::<serde_json::Value>(&text)
+            && let Some(name) = json.get("name").and_then(|n| n.as_str())
+        {
+            names.insert(name.to_string());
+        }
+    }
+    names
 }
 
 impl Packages {
@@ -150,14 +188,16 @@ impl Packages {
         &self.merged_dependencies
     }
 
-    /// Names the scanned package.json files declare themselves (workspace
-    /// members / the repo's own packages). A dependency on one of these is an
-    /// internal, registry-unresolvable link (e.g. an npm-workspaces package
-    /// like `@meridian/contracts`), not an installable third-party package.
+    /// Names the scanned repo declares itself (loaded package.json files plus
+    /// the tree-walked `internal_names`, which covers non-service workspace
+    /// members). A dependency on one of these is an internal,
+    /// registry-unresolvable link (e.g. an npm-workspaces package like
+    /// `@meridian/contracts`), not an installable third-party package.
     pub fn internal_package_names(&self) -> std::collections::HashSet<String> {
         self.package_jsons
             .iter()
             .filter_map(|p| p.name.clone())
+            .chain(self.internal_names.iter().cloned())
             .collect()
     }
 
@@ -177,5 +217,52 @@ impl Packages {
         names.sort();
         names.truncate(DEPENDENCY_NAME_CAP);
         names
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_internal_package_names_walks_tree_and_skips_dep_dirs() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(
+            repo.path().join("package.json"),
+            r#"{ "name": "platform-monorepo" }"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(repo.path().join("packages/contracts")).unwrap();
+        std::fs::write(
+            repo.path().join("packages/contracts/package.json"),
+            r#"{ "name": "@meridian/contracts", "version": "0.1.0" }"#,
+        )
+        .unwrap();
+        // Installed dependency — must NOT be treated as internal.
+        std::fs::create_dir_all(repo.path().join("node_modules/koa")).unwrap();
+        std::fs::write(
+            repo.path().join("node_modules/koa/package.json"),
+            r#"{ "name": "koa" }"#,
+        )
+        .unwrap();
+
+        let names = collect_internal_package_names(repo.path());
+        assert!(names.contains("platform-monorepo"));
+        assert!(names.contains("@meridian/contracts"));
+        assert!(
+            !names.contains("koa"),
+            "node_modules packages are not internal"
+        );
+    }
+
+    /// Regression anchor on the real corpus-3 fixture: the workspace member
+    /// that 404'd the type-check npm install must be recognized as internal.
+    #[test]
+    fn collect_internal_package_names_finds_corpus3_contracts_package() {
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/xrepo-corpus-3/platform-monorepo");
+        let names = collect_internal_package_names(&fixture);
+        assert!(names.contains("@meridian/contracts"));
+        assert!(names.contains("catalog-api"));
     }
 }

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -150,6 +150,17 @@ impl Packages {
         &self.merged_dependencies
     }
 
+    /// Names the scanned package.json files declare themselves (workspace
+    /// members / the repo's own packages). A dependency on one of these is an
+    /// internal, registry-unresolvable link (e.g. an npm-workspaces package
+    /// like `@meridian/contracts`), not an installable third-party package.
+    pub fn internal_package_names(&self) -> std::collections::HashSet<String> {
+        self.package_jsons
+            .iter()
+            .filter_map(|p| p.name.clone())
+            .collect()
+    }
+
     /// Merged dependency names cleaned for cloud requests: the cloud drops
     /// entries with whitespace or longer than 256 chars and caps the list at
     /// [`DEPENDENCY_NAME_CAP`], so filter here and send only well-formed


### PR DESCRIPTION
Reopens #304 (auto-closed when its stacked base branch was deleted on the #303 merge; GitHub cannot retarget a closed PR). Same two commits, rebased onto main.

The synthetic `carrick-type-check` package npm-installs the merged repo dependencies; a workspace-internal package (`@meridian/contracts`) is not registry-resolvable → E404 → the #149 fail-loud aborts Phase A (eval run 28608036617). Two layers, both needed:
1. Exclude dependency names declared by any collected package.json (`Packages::internal_package_names`).
2. Tree-walk the whole repo for package.json names into `Packages.internal_names` — only the SERVICE's package.json is ever collected, so a non-service workspace member (`packages/contracts`) is otherwise invisible (this is exactly how the first cut failed live, run 28608868100).

Unit tests for both layers (verified failing pre-fix) + a regression anchor on the real corpus-3 fixture. Eval evidence on the stack: corpus-3 95%, corpus-1 97%, corpus-2 96% (see #303 comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)