### PR TITLE
fix(types): keep use-site array-ness on explicit anchor bundles

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4219,6 +4219,7 @@ mod tests {
             },
             infer_kind: InferKind::CallResult,
             primary_type_symbol: None,
+            array_depth: None,
         });
 
         enrich_manifest_with_type_resolution(&mut manifest, &resolution, None);
@@ -4246,6 +4247,7 @@ mod tests {
             },
             infer_kind: InferKind::CallResult,
             primary_type_symbol: None,
+            array_depth: None,
         });
 
         enrich_manifest_with_type_resolution(&mut manifest, &resolution, None);
@@ -4273,6 +4275,7 @@ mod tests {
             },
             infer_kind: InferKind::ResponseBody,
             primary_type_symbol: Some(symbol.to_string()),
+            array_depth: None,
         }
     }
 

--- a/src/services/type_sidecar.rs
+++ b/src/services/type_sidecar.rs
@@ -13,7 +13,7 @@
 //! - **JSON message protocol**: All communication is via stdin/stdout JSON messages
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
@@ -250,8 +250,17 @@ pub struct InferredType {
     /// sidecar's `getSymbol() || getAliasSymbol()` name with TS/lib globals
     /// filtered out. Fills the manifest anchor (`primary_type_symbol`) when the
     /// LLM emitted none, removing the anchor's sole dependency on the model.
+    /// For an array type this is the ELEMENT's symbol (`TimelineEvent` for
+    /// `TimelineEvent[]`), with the peeled levels reported in `array_depth`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub primary_type_symbol: Option<String>,
+    /// Array levels the resolved type wraps around `primary_type_symbol`
+    /// (#306): `TimelineEvent[]` reports symbol `TimelineEvent` + depth 1.
+    /// `resolve_all_types` copies this onto an explicit `SymbolRequest` for the
+    /// same alias/symbol so the bundle keeps the use-site's array-ness instead
+    /// of the bare element. Absent when 0 or when there is no anchor symbol.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub array_depth: Option<u32>,
 }
 
 /// Information about a symbol that failed to resolve
@@ -678,9 +687,29 @@ impl TypeSidecar {
             errors: vec![],
         };
 
-        // Bundle explicit types
+        // Infer implicit types FIRST: a successful inference is the compiler's
+        // view of the actual use site, and it carries the resolved array depth
+        // relative to its anchor symbol. The explicit bundle below needs that
+        // depth before it runs (#306).
+        if !infer.is_empty() {
+            let infer_response = self.infer_types(infer, extraction_config)?;
+            if let Some(inferred) = infer_response.inferred_types {
+                result.inferred_types = inferred;
+            }
+            if let Some(errors) = infer_response.errors {
+                result.errors.extend(errors);
+            }
+        }
+
+        // Bundle explicit types. An LLM-extracted anchor is a bare identifier
+        // by schema contract (`User[]` → `User`), so bundling it as-is erases
+        // the use-site's array-ness and an array-vs-scalar mismatch scores
+        // compatible (#306). Copy the inference-resolved depth onto each
+        // matching request so the bundler's array_depth wrap (#248) restores
+        // the `[]` levels.
+        let explicit = apply_inferred_array_depth(explicit, &result.inferred_types);
         if !explicit.is_empty() {
-            let bundle_response = self.resolve_types(explicit)?;
+            let bundle_response = self.resolve_types(&explicit)?;
             result.dts_content = bundle_response.dts_content;
             if let Some(manifest) = bundle_response.manifest {
                 result.explicit_manifest = manifest;
@@ -693,17 +722,6 @@ impl TypeSidecar {
             }
         }
 
-        // Infer implicit types
-        if !infer.is_empty() {
-            let infer_response = self.infer_types(infer, extraction_config)?;
-            if let Some(inferred) = infer_response.inferred_types {
-                result.inferred_types = inferred;
-            }
-            if let Some(errors) = infer_response.errors {
-                result.errors.extend(errors);
-            }
-        }
-
         let had_explicit_dts = result.dts_content.is_some();
         let mut combined_dts = result.dts_content.take().unwrap_or_default();
         let mut appended_aliases: HashSet<String> = HashSet::new();
@@ -711,7 +729,7 @@ impl TypeSidecar {
         // Pre-populate with aliases already defined by the bundler so the
         // infer / failure-fallback loops below never shadow them with `= unknown`.
         if had_explicit_dts {
-            for req in explicit {
+            for req in &explicit {
                 if let Some(alias) = &req.alias
                     && Self::dts_defines_alias(&combined_dts, alias)
                 {
@@ -927,6 +945,52 @@ impl TypeSidecar {
     }
 }
 
+/// Copy inference-resolved array depths onto explicit symbol requests (#306).
+///
+/// An LLM-extracted anchor is a bare identifier by schema contract (`User[]` →
+/// `User`), so an explicit bundle built from it erases the use-site's
+/// array-ness: the producer comparand for a handler returning
+/// `TimelineEvent[]` becomes the bare element and an array-vs-scalar mismatch
+/// passes assignability. The inference that runs for the SAME alias resolves
+/// the actual use site through ts-morph and reports the element symbol plus
+/// the peeled depth, so when alias and symbol agree the depth is deterministic
+/// ground truth for the request. Depths already set by the caller (the GraphQL
+/// SDL list marker, #248) are never overwritten; a symbol disagreement means
+/// the anchor doesn't describe the inferred type, so the request is left
+/// untouched.
+fn apply_inferred_array_depth(
+    explicit: &[SymbolRequest],
+    inferred: &[InferredType],
+) -> Vec<SymbolRequest> {
+    // First anchor-carrying inference per alias wins, mirroring the
+    // `or_insert` join `enrich_manifest_with_type_resolution` uses.
+    let mut depth_by_alias: HashMap<&str, (&str, u32)> = HashMap::new();
+    for inf in inferred {
+        if let (Some(symbol), Some(depth)) = (inf.primary_type_symbol.as_deref(), inf.array_depth)
+            && depth > 0
+        {
+            depth_by_alias
+                .entry(inf.alias.as_str())
+                .or_insert((symbol, depth));
+        }
+    }
+
+    explicit
+        .iter()
+        .cloned()
+        .map(|mut req| {
+            if req.array_depth.is_none()
+                && let Some(alias) = req.alias.as_deref()
+                && let Some((symbol, depth)) = depth_by_alias.get(alias)
+                && *symbol == req.symbol_name
+            {
+                req.array_depth = Some(*depth);
+            }
+            req
+        })
+        .collect()
+}
+
 impl Drop for TypeSidecar {
     fn drop(&mut self) {
         debug!("[type_sidecar] Shutting down sidecar");
@@ -1097,6 +1161,90 @@ mod tests {
             SidecarState::Failed("error".to_string()),
             SidecarState::Failed("error".to_string())
         );
+    }
+
+    fn symbol_request(symbol: &str, alias: &str, array_depth: Option<u32>) -> SymbolRequest {
+        SymbolRequest {
+            symbol_name: symbol.to_string(),
+            source_file: "src/types.ts".to_string(),
+            alias: Some(alias.to_string()),
+            array_depth,
+        }
+    }
+
+    fn inferred(alias: &str, symbol: Option<&str>, array_depth: Option<u32>) -> InferredType {
+        InferredType {
+            alias: alias.to_string(),
+            type_string: "{ at: string; }[]".to_string(),
+            is_explicit: false,
+            source_location: SourceLocation {
+                file_path: "src/server.ts".to_string(),
+                start_line: 13,
+                end_line: 16,
+                start_column: None,
+                end_column: None,
+            },
+            infer_kind: InferKind::FunctionReturn,
+            primary_type_symbol: symbol.map(str::to_string),
+            array_depth,
+        }
+    }
+
+    /// #306: the timeline shape. The LLM anchor is the bare element
+    /// (`TimelineEvent` from `TimelineEvent[]`), so the explicit bundle would
+    /// erase the array; the same-alias inference resolved the use site to the
+    /// element symbol at depth 1, which must be copied onto the request.
+    #[test]
+    fn inferred_array_depth_wraps_matching_explicit_request() {
+        let explicit = vec![symbol_request("TimelineEvent", "Alias_Response", None)];
+        let inferred = vec![inferred("Alias_Response", Some("TimelineEvent"), Some(1))];
+
+        let adjusted = apply_inferred_array_depth(&explicit, &inferred);
+
+        assert_eq!(adjusted[0].array_depth, Some(1));
+    }
+
+    /// A depth the caller already set (the GraphQL SDL list marker, #248) is
+    /// authoritative — the inference join must never overwrite it.
+    #[test]
+    fn inferred_array_depth_never_overwrites_caller_depth() {
+        let explicit = vec![symbol_request("Order", "Alias_Response", Some(2))];
+        let inferred = vec![inferred("Alias_Response", Some("Order"), Some(1))];
+
+        let adjusted = apply_inferred_array_depth(&explicit, &inferred);
+
+        assert_eq!(adjusted[0].array_depth, Some(2));
+    }
+
+    /// A symbol disagreement means the inferred type is not "an array of the
+    /// requested anchor", so the request must stay untouched.
+    #[test]
+    fn inferred_array_depth_requires_symbol_agreement() {
+        let explicit = vec![symbol_request("TimelineEvent", "Alias_Response", None)];
+        let inferred = vec![inferred("Alias_Response", Some("SomethingElse"), Some(1))];
+
+        let adjusted = apply_inferred_array_depth(&explicit, &inferred);
+
+        assert_eq!(adjusted[0].array_depth, None);
+    }
+
+    /// A scalar inference (no array_depth on the wire) and a different-alias
+    /// inference both leave the request as-is.
+    #[test]
+    fn inferred_array_depth_ignores_scalars_and_other_aliases() {
+        let explicit = vec![
+            symbol_request("TimelineEntry", "Scalar_Response", None),
+            symbol_request("TimelineEvent", "Unrelated_Response", None),
+        ];
+        let inferred = vec![
+            inferred("Scalar_Response", Some("TimelineEntry"), None),
+            inferred("Other_Response", Some("TimelineEvent"), Some(1)),
+        ];
+
+        let adjusted = apply_inferred_array_depth(&explicit, &inferred);
+
+        assert_eq!(adjusted[0].array_depth, None);
+        assert_eq!(adjusted[1].array_depth, None);
     }
 
     #[test]

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -359,13 +359,15 @@ export class TypeInferrer {
       return null;
     }
 
+    const anchor = this.unwrapArrayLevels(awaitedType);
     return this.createInferredType(
       request,
       typeString,
       isExplicit,
       this.getNodeLocation(func),
       unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined,
-      this.primaryTypeSymbol(awaitedType)
+      this.primaryTypeSymbol(anchor.element),
+      anchor.depth
     );
   }
 
@@ -556,13 +558,15 @@ export class TypeInferrer {
       typeString = this.expandResolvedTypeStructural(resolved, typeString);
     }
 
+    const anchor = this.unwrapArrayLevels(this.unwrapPromiseType(payloadType));
     return this.createInferredType(
       request,
       typeString,
       false,
       this.getNodeLocation(payloadNode),
       unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined,
-      this.primaryTypeSymbol(this.unwrapPromiseType(payloadType))
+      this.primaryTypeSymbol(anchor.element),
+      anchor.depth
     );
   }
 
@@ -1674,6 +1678,32 @@ export class TypeInferrer {
     return name;
   }
 
+  /**
+   * Peel array levels off a resolved type: `TimelineEvent[]` → element
+   * `TimelineEvent`, depth 1. An array type's own symbol is `Array` (builtin,
+   * filtered), so without this a `T[]` payload has NO anchor and — worse — an
+   * explicit anchor bundled for the same alias silently drops the array-ness
+   * (#306: array-vs-scalar scored compatible). The element drives the anchor
+   * symbol; the depth is reported on the `InferredType` so the bundler's
+   * existing `array_depth` wrap (#248) can restore the `[]` levels on the
+   * explicit bundle. Depth is capped at the bundler's sane ceiling; a deeper
+   * type is treated as depth 0 rather than a runaway loop.
+   */
+  private unwrapArrayLevels(type: Type): { element: Type; depth: number } {
+    const MAX_ANCHOR_ARRAY_DEPTH = 10;
+    let element = type;
+    let depth = 0;
+    while (depth < MAX_ANCHOR_ARRAY_DEPTH) {
+      const el = element.getArrayElementType();
+      if (!el) {
+        return { element, depth };
+      }
+      element = el;
+      depth++;
+    }
+    return { element: type, depth: 0 };
+  }
+
   // ===========================================================================
   // Node Finding
   // ===========================================================================
@@ -2431,7 +2461,8 @@ export class TypeInferrer {
     isExplicit: boolean,
     sourceLocation: SourceLocation,
     payloadTypeString?: string,
-    primaryTypeSymbol?: string
+    primaryTypeSymbol?: string,
+    arrayDepth?: number
   ): InferredType {
     const alias =
       request.alias ||
@@ -2445,6 +2476,12 @@ export class TypeInferrer {
       infer_kind: request.infer_kind,
       payload_type_string: payloadTypeString,
       primary_type_symbol: primaryTypeSymbol,
+      // Only meaningful relative to the anchor symbol: without an element
+      // symbol there is nothing for the explicit-bundle correction to match.
+      array_depth:
+        primaryTypeSymbol !== undefined && arrayDepth !== undefined && arrayDepth > 0
+          ? arrayDepth
+          : undefined,
     };
   }
 

--- a/src/sidecar/src/types.ts
+++ b/src/sidecar/src/types.ts
@@ -556,9 +556,20 @@ export interface InferredType {
    * from the ts-morph `Type`'s `getSymbol() || getAliasSymbol()` name with
    * TS/lib globals filtered out. Lets the manifest anchor (`primary_type_symbol`)
    * be filled without depending on the LLM. `undefined` when the resolved type
-   * has no single user-defined symbol to anchor on.
+   * has no single user-defined symbol to anchor on. For array types the anchor
+   * is the ELEMENT's symbol (`TimelineEvent` for `TimelineEvent[]`) — the array
+   * type's own symbol is the builtin `Array`, never an anchor.
    */
   primary_type_symbol?: string;
+  /**
+   * Array levels the resolved type wraps around the anchor symbol (#306):
+   * `TimelineEvent[]` reports `primary_type_symbol: 'TimelineEvent'` +
+   * `array_depth: 1`. Lets `resolve_all_types` copy the use-site's array-ness
+   * onto an explicit `SymbolRequest` for the same alias, which would otherwise
+   * bundle the bare element and erase the array (array-vs-scalar scored
+   * compatible, #306). Omitted when 0 or when there is no anchor symbol.
+   */
+  array_depth?: number;
 }
 
 /**

--- a/src/sidecar/test/fixtures/sample-repo/src/framework-handlers.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/framework-handlers.ts
@@ -40,3 +40,11 @@ export async function bareReturnHandler(): Promise<User> {
   const user: User = { id: 2, name: 'Bob' };
   return user;
 }
+
+// 5. Bare return of an ARRAY (#306): the deterministic anchor must be the
+// ELEMENT symbol (`User`, array_depth 1) — an array type's own symbol is the
+// builtin `Array`, which can never anchor.
+export async function arrayReturnHandler(): Promise<User[]> {
+  const latest: User[] = [{ id: 3, name: 'Cara' }];
+  return latest;
+}

--- a/src/sidecar/test/infer-array-anchor.test.ts
+++ b/src/sidecar/test/infer-array-anchor.test.ts
@@ -1,0 +1,134 @@
+/**
+ * #306: an inference that resolves to an array type must anchor on the ELEMENT
+ * symbol and report the peeled depth. An array type's own symbol is the builtin
+ * `Array` (filtered), so before this the anchor was silently dropped — and,
+ * worse, an explicit anchor bundled for the same alias erased the use-site's
+ * array-ness, scoring an array-vs-scalar mismatch as compatible.
+ *
+ * `array_depth` is what `resolve_all_types` (Rust) copies onto the matching
+ * explicit `SymbolRequest`, so the bundler's existing array wrap (#248)
+ * restores the `[]` levels on the producer comparand.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const HANDLERS_FIXTURE = path.join(FIXTURES_PATH, 'src/framework-handlers.ts');
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    infer_kind: string;
+    primary_type_symbol?: string;
+    array_depth?: number;
+  }>;
+  errors?: string[];
+}
+
+describe('array-typed inference anchors on the element symbol with array_depth (#306)', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({ action: 'init', request_id: 'arr-anchor-init', repo_root: FIXTURES_PATH });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('function_return of `User[]` → element anchor `User`, array_depth 1', async () => {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'arr-anchor-fn-return',
+      requests: [
+        {
+          file_path: HANDLERS_FIXTURE,
+          line_number: 50,
+          expression_text: 'latest',
+          expression_line: 52,
+          infer_kind: 'function_return',
+        },
+      ],
+    });
+
+    assert.ok(
+      response.inferred_types && response.inferred_types.length > 0,
+      `expected inferred_types, got ${JSON.stringify(response)}`
+    );
+    const inferred = response.inferred_types[0];
+    assert.strictEqual(
+      inferred.type_string,
+      '{ id: number; name: string; }[]',
+      `expected structural User[], got ${inferred.type_string}`
+    );
+    assert.strictEqual(
+      inferred.primary_type_symbol,
+      'User',
+      `anchor must be the element symbol, got ${JSON.stringify(inferred.primary_type_symbol)}`
+    );
+    assert.strictEqual(inferred.array_depth, 1);
+  });
+
+  it('response_body payload `users: User[]` → element anchor `User`, array_depth 1', async () => {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'arr-anchor-response-body',
+      requests: [
+        {
+          file_path: HANDLERS_FIXTURE,
+          line_number: 23,
+          expression_text: 'users',
+          expression_line: 23,
+          infer_kind: 'response_body',
+        },
+      ],
+    });
+
+    assert.ok(
+      response.inferred_types && response.inferred_types.length > 0,
+      `expected inferred_types, got ${JSON.stringify(response)}`
+    );
+    const inferred = response.inferred_types[0];
+    assert.strictEqual(
+      inferred.primary_type_symbol,
+      'User',
+      `anchor must be the element symbol, got ${JSON.stringify(inferred.primary_type_symbol)}`
+    );
+    assert.strictEqual(inferred.array_depth, 1);
+  });
+
+  it('scalar return keeps its anchor and reports NO array_depth', async () => {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'arr-anchor-scalar',
+      requests: [
+        {
+          file_path: HANDLERS_FIXTURE,
+          line_number: 40,
+          expression_text: 'user',
+          expression_line: 42,
+          infer_kind: 'function_return',
+        },
+      ],
+    });
+
+    assert.ok(
+      response.inferred_types && response.inferred_types.length > 0,
+      `expected inferred_types, got ${JSON.stringify(response)}`
+    );
+    const inferred = response.inferred_types[0];
+    assert.strictEqual(inferred.primary_type_symbol, 'User');
+    assert.strictEqual(
+      inferred.array_depth,
+      undefined,
+      `a scalar must not report an array_depth, got ${inferred.array_depth}`
+    );
+  });
+});

--- a/src/sidecar/test/infer-array-anchor.test.ts
+++ b/src/sidecar/test/infer-array-anchor.test.ts
@@ -50,9 +50,9 @@ describe('array-typed inference anchors on the element symbol with array_depth (
       requests: [
         {
           file_path: HANDLERS_FIXTURE,
-          line_number: 50,
+          line_number: 47,
           expression_text: 'latest',
-          expression_line: 52,
+          expression_line: 48,
           infer_kind: 'function_return',
         },
       ],
@@ -111,9 +111,9 @@ describe('array-typed inference anchors on the element symbol with array_depth (
       requests: [
         {
           file_path: HANDLERS_FIXTURE,
-          line_number: 40,
+          line_number: 39,
           expression_text: 'user',
-          expression_line: 42,
+          expression_line: 40,
           infer_kind: 'function_return',
         },
       ],

--- a/tests/fixtures/llm-mocked-api/__golden__.json
+++ b/tests/fixtures/llm-mocked-api/__golden__.json
@@ -12,8 +12,8 @@
       "line": 6,
       "type_alias": "Endpoint_a9cce7d0d8d0d9e6_Response",
       "type_state": "Explicit",
-      "resolved_definition": "export interface Endpoint_a9cce7d0d8d0d9e6_Response { id: number; name: string; email: string; }",
-      "expanded_definition": "{ id: number; name: string; email: string; }",
+      "resolved_definition": "export type Endpoint_a9cce7d0d8d0d9e6_Response = { id: number; name: string; email: string; }[];",
+      "expanded_definition": "{ id: number; name: string; email: string; }[]",
       "is_explicit": true,
       "primary_type_symbol": "User"
     },


### PR DESCRIPTION
Closes #306.

## Problem

The corpus-3 edge `orders-api GET /orders/:orderId/timeline -> ops-console` is labelled incompatible (producer returns `TimelineEvent[]`, consumer types a single `TimelineEntry`), but ts_check reported `compat=Some(true)` in all three baseline runs. The producer comparand carried the bare element shape `{ at; status; note? }` instead of the array, so array-vs-scalar passed assignability trivially. The same loss showed up in the resolution dimension: the expected resolved form ends in `[]`.

Root cause: the LLM anchor is a bare identifier by schema contract (`TimelineEvent[]` unwraps to `TimelineEvent`), and the explicit bundle built from that anchor pre-claims the manifest alias in `resolve_all_types`, shadowing the function-return inference that had already resolved the correct `{ ... }[]` form.

## Fix

The inference that already runs for the same alias is the compiler's view of the actual use site, so it now reports the array facts and `resolve_all_types` feeds them back into the bundle:

- `primaryTypeSymbol` (sidecar) peels array levels and anchors on the ELEMENT symbol. An array type's own symbol is the builtin `Array`, which was filtered, so array-typed payloads previously had no deterministic anchor at all.
- `InferredType` carries the peeled depth as `array_depth`.
- `resolve_all_types` runs inference before bundling and copies the depth onto a same-alias, same-symbol explicit `SymbolRequest`. The bundler's existing `array_depth` wrap (#248) restores the `[]` levels. Caller-set depths (the GraphQL SDL list marker) are never overwritten; a symbol disagreement leaves the request untouched.

## Verification

- Offline sidecar probe on the corpus edge itself: the producer comparand now resolves to `{ at: string; status: string; note?: string; }[]`, byte-identical to the ground-truth resolved form.
- New sidecar tests (`infer-array-anchor.test.ts`): fail 2/3 without the inferrer change, pass with it.
- New Rust unit tests for the depth-application join (wrap, no-overwrite, symbol-agreement, scalar/other-alias no-ops).
- The cassette hard-gate golden change is this exact fix surfacing in the frozen fixture: `GET /api/users` sends `users: User[]` and its comparand now reads `{...}[]` where the golden had frozen the scalar form.
- Live eval (runs=3 per corpus) on the #306+#307 stack: results posted in a comment once the batch completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)