### PR TITLE
fix(extraction): suppress non-matchable call noise (templated wrapper paths + graphql transport POSTs)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -2513,10 +2513,23 @@ impl FileOrchestrator {
                     );
                     continue;
                 }
+                // Drop calls whose canonical path has no literal segment left
+                // to match on (`${baseUrl}${path}`, a bare `${GQL_URL}`): they
+                // can never join a producer key, so they are pure index noise
+                // (#307) — typically a wrapper's internal fetch, whose resolved
+                // call-site emissions are extracted separately and do match.
+                let canonical_path = normalizer.consumer_call_path(&data_call.target);
+                if !UrlNormalizer::canonical_path_has_literal_segment(&canonical_path) {
+                    debug!(
+                        "Skipping data call with no literal path segment: {} ({})",
+                        data_call.target, file_path
+                    );
+                    continue;
+                }
                 graph.data_calls.push(DataFetchingCall {
                     method,
                     target_url: data_call.target.clone(),
-                    canonical_path: normalizer.consumer_call_path(&data_call.target),
+                    canonical_path,
                     client: data_call.pattern_matched.clone(),
                     file_location: format!("{}:{}", file_path, data_call.line_number),
                     call_kind: data_call.call_kind,
@@ -3139,6 +3152,63 @@ mod tests {
             "https://api.example.com/data"
         );
         assert_eq!(graph.data_calls[0].method, "POST");
+    }
+
+    /// #307 (class 1): a wrapper-internal call whose canonical path is nothing
+    /// but template interpolations (`${baseUrl}${path}`, a bare `${GQL_URL}`)
+    /// can never match a producer key and must not enter the graph; a call
+    /// with any literal segment stays.
+    #[test]
+    fn test_build_mount_graph_drops_calls_with_no_literal_path_segment() {
+        let agent_service = AgentService::new();
+        let orchestrator = FileOrchestrator::new(agent_service);
+
+        let mk_call = |id: &str, target: &str, method: &str| DataCallResult {
+            call_kind: None,
+            candidate_id: id.to_string(),
+            line_number: 6,
+            target: target.to_string(),
+            method: Some(method.to_string()),
+            pattern_matched: "fetch(".to_string(),
+            call_expression_span_start: None,
+            call_expression_span_end: None,
+            call_expression_text: None,
+            call_expression_line: None,
+            payload_expression_text: None,
+            payload_expression_line: None,
+            primary_type_symbol: None,
+            type_import_source: None,
+        };
+        let mut file_results = HashMap::new();
+        file_results.insert(
+            "src/lib/apiClient.ts".to_string(),
+            FileAnalysisResult {
+                graphql_consumer_locates: vec![],
+                mounts: vec![],
+                endpoints: vec![],
+                data_calls: vec![
+                    mk_call("c1", "${baseUrl}${path}", "GET"),
+                    mk_call("c2", "${NEXT_PUBLIC_GATEWAY_GQL_URL}", "POST"),
+                    mk_call("c3", "/orders/${orderId}/timeline", "GET"),
+                ],
+                graphql_operations: vec![],
+                pubsub_operations: vec![],
+            },
+        );
+
+        let graph =
+            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+
+        let targets: Vec<&str> = graph
+            .data_calls
+            .iter()
+            .map(|c| c.target_url.as_str())
+            .collect();
+        assert_eq!(
+            targets,
+            vec!["/orders/${orderId}/timeline"],
+            "fully-templated targets must be dropped, literal-segment targets kept"
+        );
     }
 
     #[test]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1215,9 +1215,13 @@ fn scan_protocol_extractions(
 /// the document ops are the real modeled contract, so the transport call is
 /// folded into them. Only env-templated / absolute-URL targets are folded: a
 /// plain relative literal path in the same file is a distinct same-origin REST
-/// call and is kept. Known limitation (logged): a REST call built on a
-/// DIFFERENT env-var base inside a gql-consumer file is folded too — accepted
-/// over leaking a phantom HTTP contract for every GraphQL client file.
+/// call and is kept. The shape test reads the RAW `target_url`, not
+/// `canonical_path` — `consumer_call_path` strips a declared-internal env-var
+/// base (`${GQL_URL}/graphql` → `/graphql`), which would otherwise let the
+/// transport leak for exactly the users who configured `internalEnvVars`.
+/// Known limitation (logged): a REST call built on a DIFFERENT env-var base
+/// inside a gql-consumer file is folded too — accepted over leaking a phantom
+/// HTTP contract for every GraphQL client file.
 fn fold_graphql_transport_calls(
     mount_graph: &mut crate::mount_graph::MountGraph,
     graphql: &crate::graphql::GraphqlExtraction,
@@ -1239,9 +1243,11 @@ fn fold_graphql_transport_calls(
         .map(|op| normalize_file(&op.file_path))
         .collect();
     mount_graph.data_calls.retain(|call| {
-        let is_transport_shape = call.canonical_path.contains("${")
-            || call.canonical_path.starts_with("http://")
-            || call.canonical_path.starts_with("https://");
+        let raw = call.target_url.trim_matches(['`', '"', '\'']);
+        let is_transport_shape = raw.contains("${")
+            || raw.contains("process.env.")
+            || raw.starts_with("http://")
+            || raw.starts_with("https://");
         if !is_transport_shape {
             return true;
         }
@@ -4598,6 +4604,40 @@ mod tests {
             .map(|c| c.target_url.as_str())
             .collect();
         assert_eq!(targets, vec!["/api/tickets", "${ORDERS_API}/orders"]);
+    }
+
+    /// A declared-internal env-var base strips to a bare path in
+    /// `canonical_path` (`${GQL_URL}/graphql` → `/graphql`), so the transport
+    /// shape must be read off the RAW target or the fold would leak for
+    /// exactly the users who configured `internalEnvVars` (Copilot review).
+    #[test]
+    fn fold_reads_raw_target_not_stripped_canonical() {
+        let mut mount_graph = MountGraph::new();
+        mount_graph.data_calls = vec![crate::mount_graph::DataFetchingCall {
+            method: "POST".to_string(),
+            target_url: "`${SUPPORT_GQL_URL}/graphql`".to_string(),
+            canonical_path: "/graphql".to_string(),
+            client: "fetch(".to_string(),
+            file_location: "src/gql.ts:25".to_string(),
+            call_kind: None,
+            repo_name: None,
+        }];
+        let graphql = crate::graphql::GraphqlExtraction {
+            producers: vec![],
+            consumers: vec![graphql_consumer_op_at(
+                crate::operation::GraphqlOperationKind::Mutation,
+                "escalateTicket",
+                "src/gql.ts",
+                None,
+            )],
+        };
+
+        fold_graphql_transport_calls(&mut mount_graph, &graphql);
+
+        assert!(
+            mount_graph.data_calls.is_empty(),
+            "internal-stripped canonical must still fold via the raw target"
+        );
     }
 
     /// The file join must normalize path components: the graphql walk can

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -959,7 +959,16 @@ async fn analyze_current_repo_incremental(
 
             // Rebuild mount graph from full merged results
             let graph_orchestrator = FileOrchestrator::new(agent_service.clone());
-            let mount_graph = graph_orchestrator.build_mount_graph(&merged_results, &normalizer);
+            let mut mount_graph =
+                graph_orchestrator.build_mount_graph(&merged_results, &normalizer);
+
+            // Deterministic protocol scans run BEFORE the graph is projected:
+            // the GraphQL consumer file set folds transport data calls out of
+            // the graph (#307) so every downstream surface (cloud projection,
+            // type manifest, type requests) sees the same call set.
+            let protocol_extractions =
+                scan_protocol_extractions(repo_path, service, &files, &merged_results);
+            fold_graphql_transport_calls(&mut mount_graph, &protocol_extractions.graphql);
 
             // Generate function intents (also strips body_source before upload).
             // Run on the same path as the full analysis so incremental scans
@@ -1000,11 +1009,9 @@ async fn analyze_current_repo_incremental(
                 packages,
                 function_definitions,
             );
-            let protocol_extractions = append_deterministic_protocol_operations(
+            append_deterministic_protocol_operations(
                 &mut cloud_data,
-                repo_path,
-                service,
-                &files,
+                &protocol_extractions,
                 &merged_results,
             );
 
@@ -1181,13 +1188,84 @@ fn service_graphql_roots(repo_path: &str, service: &Config) -> Vec<PathBuf> {
     roots
 }
 
-fn append_deterministic_protocol_operations(
-    cloud_data: &mut CloudRepoData,
+/// Run the deterministic protocol scans (GraphQL SDL/documents, Socket.IO)
+/// and join in the file-analyzer's located types. Split from
+/// `append_deterministic_protocol_operations` so the extractions exist BEFORE
+/// the mount graph is projected into cloud data — the GraphQL consumer file
+/// set drives `fold_graphql_transport_calls` on the graph first (#307).
+fn scan_protocol_extractions(
     repo_path: &str,
     service: &Config,
     files: &[PathBuf],
     file_results: &HashMap<String, crate::agents::file_analyzer_agent::FileAnalysisResult>,
 ) -> ProtocolExtractions {
+    let scan_roots = service_graphql_roots(repo_path, service);
+    let mut graphql = crate::graphql::scan_repo(&scan_roots, files);
+    merge_graphql_resolver_locations(&mut graphql, file_results);
+    merge_graphql_consumer_locations(&mut graphql, file_results);
+    let sockets = crate::socket_io::scan_files(files);
+    ProtocolExtractions { graphql, sockets }
+}
+
+/// #307 (class 2): drop LLM HTTP data calls that are the TRANSPORT of
+/// deterministically-extracted GraphQL consumer operations — one contract must
+/// not be indexed twice. A file whose `gql` documents produced consumer ops
+/// executes them over a POST to the client's endpoint URL, which the
+/// file-analyzer also reports as an HTTP data call (`POST ${GQL_URL}/graphql`);
+/// the document ops are the real modeled contract, so the transport call is
+/// folded into them. Only env-templated / absolute-URL targets are folded: a
+/// plain relative literal path in the same file is a distinct same-origin REST
+/// call and is kept. Known limitation (logged): a REST call built on a
+/// DIFFERENT env-var base inside a gql-consumer file is folded too — accepted
+/// over leaking a phantom HTTP contract for every GraphQL client file.
+fn fold_graphql_transport_calls(
+    mount_graph: &mut crate::mount_graph::MountGraph,
+    graphql: &crate::graphql::GraphqlExtraction,
+) {
+    if graphql.consumers.is_empty() {
+        return;
+    }
+    // Normalize both sides component-wise so a `./`-prefixed walk path and a
+    // bare file key still join (`components()` keeps a LEADING CurDir, so it
+    // is skipped explicitly).
+    let normalize_file = |p: &Path| -> PathBuf {
+        p.components()
+            .skip_while(|c| matches!(c, std::path::Component::CurDir))
+            .collect()
+    };
+    let consumer_files: HashSet<PathBuf> = graphql
+        .consumers
+        .iter()
+        .map(|op| normalize_file(&op.file_path))
+        .collect();
+    mount_graph.data_calls.retain(|call| {
+        let is_transport_shape = call.canonical_path.contains("${")
+            || call.canonical_path.starts_with("http://")
+            || call.canonical_path.starts_with("https://");
+        if !is_transport_shape {
+            return true;
+        }
+        let Some((file, _line)) = call.file_location.rsplit_once(':') else {
+            return true;
+        };
+        let file_norm = normalize_file(Path::new(file));
+        if consumer_files.contains(&file_norm) {
+            debug!(
+                "Folding GraphQL transport call {} {} ({}) into its document operations",
+                call.method, call.canonical_path, file
+            );
+            false
+        } else {
+            true
+        }
+    });
+}
+
+fn append_deterministic_protocol_operations(
+    cloud_data: &mut CloudRepoData,
+    extractions: &ProtocolExtractions,
+    file_results: &HashMap<String, crate::agents::file_analyzer_agent::FileAnalysisResult>,
+) {
     // Same "{file}:{line}" convention the mount-graph conversions use
     let to_details = |key: OperationKey, file_path: &Path, line: u32| ApiEndpointDetails {
         owner: None,
@@ -1203,10 +1281,7 @@ fn append_deterministic_protocol_operations(
         service_name: None,
     };
 
-    let scan_roots = service_graphql_roots(repo_path, service);
-    let mut graphql = crate::graphql::scan_repo(&scan_roots, files);
-    merge_graphql_resolver_locations(&mut graphql, file_results);
-    merge_graphql_consumer_locations(&mut graphql, file_results);
+    let graphql = &extractions.graphql;
     if !graphql.is_empty() {
         debug!(
             producers = graphql.producers.len(),
@@ -1227,7 +1302,7 @@ fn append_deterministic_protocol_operations(
         );
     }
 
-    let sockets = crate::socket_io::scan_files(files);
+    let sockets = &extractions.sockets;
     if !sockets.is_empty() {
         debug!(
             listeners = sockets.listeners.len(),
@@ -1249,8 +1324,6 @@ fn append_deterministic_protocol_operations(
     }
 
     append_pubsub_operations(cloud_data, file_results, &to_details);
-
-    ProtocolExtractions { graphql, sockets }
 }
 
 /// Fold the file-analyzer's `pubsub_operations` into `cloud_data` so they reach
@@ -2496,6 +2569,19 @@ async fn analyze_current_repo(
     // 4c. Compose function signatures, inferring unannotated slots via sidecar.
     populate_function_signatures(sidecar, &mut function_definitions, repo_path);
 
+    // 4d. Deterministic protocol scans run BEFORE the graph is projected: the
+    // GraphQL consumer file set folds transport data calls out of the mount
+    // graph (#307) so every downstream surface (cloud projection, type
+    // manifest, type requests) sees the same call set.
+    let protocol_extractions =
+        scan_protocol_extractions(repo_path, service, &files, &analysis_result.file_results);
+    let mut analysis_result = analysis_result;
+    fold_graphql_transport_calls(
+        &mut analysis_result.mount_graph,
+        &protocol_extractions.graphql,
+    );
+    let analysis_result = analysis_result;
+
     // 5. Build CloudRepoData directly from multi-agent results (bypassing Analyzer adapter layer)
     let mut cloud_data = CloudRepoData::from_multi_agent_results(
         repo_name.clone(),
@@ -2506,11 +2592,9 @@ async fn analyze_current_repo(
         Some(packages.clone()),
         function_definitions.clone(),
     );
-    let protocol_extractions = append_deterministic_protocol_operations(
+    append_deterministic_protocol_operations(
         &mut cloud_data,
-        repo_path,
-        service,
-        &files,
+        &protocol_extractions,
         &analysis_result.file_results,
     );
 
@@ -4469,6 +4553,98 @@ mod tests {
             consumer_located_type_symbol: None,
             consumer_located_type_source: None,
         }
+    }
+
+    /// #307 (class 2) helper: an LLM HTTP data call at a given file/target.
+    fn transport_call(target: &str, file_location: &str) -> crate::mount_graph::DataFetchingCall {
+        crate::mount_graph::DataFetchingCall {
+            method: "POST".to_string(),
+            target_url: target.to_string(),
+            canonical_path: target.to_string(),
+            client: "fetch(".to_string(),
+            file_location: file_location.to_string(),
+            call_kind: None,
+            repo_name: None,
+        }
+    }
+
+    /// #307 (class 2): an env-templated HTTP call in a file whose gql documents
+    /// produced consumer ops is that file's transport — folded. A relative
+    /// literal call in the same file (same-origin REST) and an env-templated
+    /// call in an unrelated file both stay.
+    #[test]
+    fn fold_drops_graphql_transport_calls_only() {
+        let mut mount_graph = MountGraph::new();
+        mount_graph.data_calls = vec![
+            transport_call("${SUPPORT_GQL_URL}/graphql", "src/gql.ts:25"),
+            transport_call("/api/tickets", "src/gql.ts:30"),
+            transport_call("${ORDERS_API}/orders", "src/orders.ts:12"),
+        ];
+        let graphql = crate::graphql::GraphqlExtraction {
+            producers: vec![],
+            consumers: vec![graphql_consumer_op_at(
+                crate::operation::GraphqlOperationKind::Mutation,
+                "escalateTicket",
+                "src/gql.ts",
+                None,
+            )],
+        };
+
+        fold_graphql_transport_calls(&mut mount_graph, &graphql);
+
+        let targets: Vec<&str> = mount_graph
+            .data_calls
+            .iter()
+            .map(|c| c.target_url.as_str())
+            .collect();
+        assert_eq!(targets, vec!["/api/tickets", "${ORDERS_API}/orders"]);
+    }
+
+    /// The file join must normalize path components: the graphql walk can
+    /// yield a `./`-prefixed path while the data call's file key is bare.
+    #[test]
+    fn fold_joins_dot_prefixed_walk_paths() {
+        let mut mount_graph = MountGraph::new();
+        mount_graph.data_calls = vec![transport_call(
+            "https://support.example.com/graphql",
+            "src/gql.ts:25",
+        )];
+        let graphql = crate::graphql::GraphqlExtraction {
+            producers: vec![],
+            consumers: vec![graphql_consumer_op_at(
+                crate::operation::GraphqlOperationKind::Query,
+                "ticket",
+                "./src/gql.ts",
+                None,
+            )],
+        };
+
+        fold_graphql_transport_calls(&mut mount_graph, &graphql);
+
+        assert!(
+            mount_graph.data_calls.is_empty(),
+            "absolute-URL transport in a ./-walked gql-consumer file must fold"
+        );
+    }
+
+    /// Producer-only extractions (an SDL service with no documents) must not
+    /// fold anything — the transport fold is a CONSUMER-side dedup.
+    #[test]
+    fn fold_ignores_producer_only_extractions() {
+        let mut mount_graph = MountGraph::new();
+        mount_graph.data_calls = vec![transport_call("${SOME_API}/things", "src/schema.ts:5")];
+        let graphql = crate::graphql::GraphqlExtraction {
+            producers: vec![graphql_op(
+                crate::operation::GraphqlOperationKind::Query,
+                "order",
+                Some("Order"),
+            )],
+            consumers: vec![],
+        };
+
+        fold_graphql_transport_calls(&mut mount_graph, &graphql);
+
+        assert_eq!(mount_graph.data_calls.len(), 1);
     }
 
     /// Variant of `graphql_consumer_op` with a caller-chosen `kind` and

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -348,7 +348,9 @@ impl MountGraph {
     /// Returns true if a single path segment is a route parameter placeholder in any
     /// of the common syntaxes: `:id` (Express/path-to-regexp), `{id}` (OpenAPI/Fastify),
     /// `<id>` (Flask-style), or `[id]`/`[...id]` (Next.js dynamic segments).
-    fn is_param_segment(seg: &str) -> bool {
+    /// Also the param definition `canonical_path_has_literal_segment` (#307)
+    /// reuses, so the noise gate and the matcher agree on what a placeholder is.
+    pub(crate) fn is_param_segment(seg: &str) -> bool {
         seg.starts_with(':')
             || (seg.starts_with('{') && seg.ends_with('}'))
             || (seg.starts_with('<') && seg.ends_with('>'))

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -523,7 +523,13 @@ impl UrlNormalizer {
             return true;
         }
         path.split('/').any(|segment| {
-            if segment.is_empty() || segment == "*" || segment.starts_with(':') {
+            // Placeholder styles are the MATCHER's definition
+            // (`MountGraph::is_param_segment`: `:id`, `{id}`, `<id>`, `[id]`),
+            // so the gate and the matcher agree on what can never be literal.
+            if segment.is_empty()
+                || segment == "*"
+                || crate::mount_graph::MountGraph::is_param_segment(segment)
+            {
                 return false;
             }
             // Strip leading `${...}` interpolations; any residue is literal
@@ -900,6 +906,13 @@ mod tests {
         assert!(!has("/${slug}"));
         assert!(!has("/:param"));
         assert!(!has("/"));
+
+        // Non-colon placeholder styles are params by the MATCHER's own
+        // definition (`MountGraph::is_param_segment`), never literals.
+        assert!(!has("/{id}"));
+        assert!(!has("/<id>"));
+        assert!(!has("/[...slug]"));
+        assert!(has("/users/{id}"));
 
         // Any literal segment keeps the call, wherever the template sits.
         assert!(has("${SUPPORT_GQL_URL}/graphql"));

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -508,6 +508,37 @@ impl UrlNormalizer {
         }
     }
 
+    /// Whether a canonical consumer path carries at least one LITERAL segment —
+    /// text that could ever equal a producer path segment. A call whose
+    /// canonical path is nothing but template interpolations and params
+    /// (`${baseUrl}${path}`, `${GATEWAY_GQL_URL}`, `/:id`) can never match any
+    /// producer key, so it is pure index noise (#307): typically a wrapper's
+    /// internal fetch, whose RESOLVED call-site emissions are extracted
+    /// separately and do match. Full http(s) URLs count as literal — an
+    /// external call kept verbatim is a real reportable operation, host and
+    /// all.
+    pub fn canonical_path_has_literal_segment(path: &str) -> bool {
+        let path = path.split(['?', '#']).next().unwrap_or(path);
+        if path.starts_with("http://") || path.starts_with("https://") {
+            return true;
+        }
+        path.split('/').any(|segment| {
+            if segment.is_empty() || segment == "*" || segment.starts_with(':') {
+                return false;
+            }
+            // Strip leading `${...}` interpolations; any residue is literal
+            // text (`v${n}` counts as literal, `${a}${b}` does not).
+            let mut rest = segment;
+            while let Some(after) = rest.strip_prefix("${") {
+                match after.find('}') {
+                    Some(end) => rest = &after[end + 1..],
+                    None => return true, // unterminated template: treat as literal
+                }
+            }
+            !rest.is_empty()
+        })
+    }
+
     /// Heuristic check for URL-like inputs to avoid matching variable names as paths.
     pub fn is_probable_url(&self, url: &str) -> bool {
         let trimmed = url.trim();
@@ -854,6 +885,34 @@ mod tests {
         let path = normalizer.extract_path("https://example.com/api/users?page=1");
 
         assert_eq!(path, "/api/users");
+    }
+
+    /// #307 (class 1): the noise gate — a canonical path with nothing but
+    /// template/param segments can never match a producer key.
+    #[test]
+    fn canonical_path_literal_segment_detection() {
+        let has = UrlNormalizer::canonical_path_has_literal_segment;
+
+        // Pure noise: wrapper-internal templates and bare env-var bases.
+        assert!(!has("${baseUrl}${path}"));
+        assert!(!has("${NEXT_PUBLIC_GATEWAY_GQL_URL}"));
+        assert!(!has("${GATEWAY_GQL_WS_URL}"));
+        assert!(!has("/${slug}"));
+        assert!(!has("/:param"));
+        assert!(!has("/"));
+
+        // Any literal segment keeps the call, wherever the template sits.
+        assert!(has("${SUPPORT_GQL_URL}/graphql"));
+        assert!(has("/orders/:orderId/timeline"));
+        assert!(has("/orders/${orderId}/timeline"));
+        assert!(has("/track"));
+        assert!(has("/v${apiVersion}")); // mixed segment counts as literal
+
+        // Full URLs are substantive as-is (external calls stay reportable),
+        // and a query interpolation never counts against the path.
+        assert!(has("https://api.stripe.com/v1/charges"));
+        assert!(has("https://orders.internal/api/orders?user=${userId}"));
+        assert!(!has("/${a}?page=${n}"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #307. Stacked on #309 (merge that first, then retarget or use `--delete-branch=false`).

## Problem

Call-set precision on corpus-3 (raw ~0.72, F1 0.83) is dragged by two extra-call classes; the c1/c2 baselines carry the same classes (`POST ${NEXT_PUBLIC_GATEWAY_GQL_URL}`, `POST ${GATEWAY_GQL_WS_URL}`):

1. Wrapper-internal fully-templated calls: `GET ${baseUrl}${path}` / `PATCH ${baseUrl}${path}` emitted from inside `apiClient.ts`. Zero literal path segments, so the canonical key can never match any producer. The resolved call-site emissions already exist and matched.
2. GraphQL client transport leaking as HTTP: `POST ${SUPPORT_GQL_URL}/graphql` emitted alongside the extracted `graphql|mutation|escalateTicket` consumer op from the same file, double-counting one contract.

## Fix

Class 1: `UrlNormalizer::canonical_path_has_literal_segment` gates mount-graph insertion next to the existing `is_valid_route_shape` filter. A canonical path made of nothing but template interpolations and params is dropped; any literal segment (including mixed segments like `v${n}`) keeps the call, and full http(s) URLs always count as literal so external calls stay reportable. Filtering at graph insertion keeps every downstream surface consistent (cloud projection, type manifest, type requests).

Class 2: the deterministic protocol scan is split out of `append_deterministic_protocol_operations` (`scan_protocol_extractions`) so it runs before the mount graph is projected, and `fold_graphql_transport_calls` drops env-templated / absolute-URL data calls in files whose gql documents produced consumer ops. Relative literal paths in the same file are kept (same-origin REST next to gql documents). The file join is component-normalized so a `./`-prefixed walk path still matches.

Known limitation, documented in the fold's doc-comment: a REST call built on a different env-var base inside a gql-consumer file folds too. Accepted over leaking a phantom HTTP contract for every GraphQL client file; the fold logs each drop at debug.

The LLM's line attribution for the transport call is not stable run-to-run, so the fold deliberately joins at file granularity rather than file+line.

## Verification

- New unit tests: predicate cases (all observed noise keys from the three corpora's diags), mount-graph drop (proven to fail with the gate inverted), fold semantics (fold/keep/producer-only/`./`-join).
- Full suite + cassette hard gate green (the frozen fixture's call has literal segments, so the golden is untouched).
- Live eval (runs=3 per corpus) on this stack: results posted in a comment once the batch completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)