### PR TITLE
Intent pipeline: repo-relative cloud paths, full-scan intent reuse, trivial-body gate

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2635,6 +2635,12 @@ async fn analyze_current_repo(
     );
     let analysis_result = analysis_result;
 
+    // Cloud-bound paths must be repo-relative. The incremental path gets
+    // this from build_cloud_data_from_mount_graph; this full path constructs
+    // CloudRepoData directly, so relativize here (after signatures are
+    // composed — they embed the same absolute prefix).
+    relativize_function_definition_paths(&mut function_definitions, repo_path);
+
     // 5. Build CloudRepoData directly from multi-agent results (bypassing Analyzer adapter layer)
     let mut cloud_data = CloudRepoData::from_multi_agent_results(
         repo_name.clone(),
@@ -2643,7 +2649,7 @@ async fn analyze_current_repo(
         serde_json::to_string(config).ok(),
         serde_json::to_string(packages).ok(),
         Some(packages.clone()),
-        function_definitions.clone(),
+        function_definitions,
     );
     append_deterministic_protocol_operations(
         &mut cloud_data,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1088,7 +1088,17 @@ async fn analyze_current_repo_incremental(
 
     // Fallback: full analysis (analyze_current_repo now populates cache fields)
     debug!("Running full analysis...");
-    let cloud_data = analyze_current_repo(repo_path, config, packages, sidecar).await?;
+    // The intent content-hash cache is keyed purely on content
+    // (INTENT_CACHE_VERSION + body + callee intents), so it stays valid even
+    // when the ANALYSIS cache is unusable (cache_version bump, missing
+    // file_results, shallow clone). Seed the full scan with the previous
+    // scan's intents so a full re-analysis re-pays /generate-intent only for
+    // functions whose content actually changed.
+    let prev_intents = previous_data
+        .map(|prev| intents_by_hash(&prev.function_definitions))
+        .unwrap_or_default();
+    let cloud_data =
+        analyze_current_repo(repo_path, config, packages, sidecar, &prev_intents).await?;
 
     let elapsed = start.elapsed();
     debug!("Full analysis complete in {:.1}s", elapsed.as_secs_f64());
@@ -1749,6 +1759,39 @@ fn add_protocol_manifest_entry(
 }
 
 /// Build CloudRepoData from a mount graph (used by incremental path).
+/// Repo-relative paths for cloud-bound function definitions. The scan runs
+/// against a canonicalized absolute repo root (in CI the runner checkout,
+/// e.g. `/home/runner/work/<dir>/<repo>`), and the extractor stamps that
+/// absolute path onto every definition — plus the compiler leaks it into
+/// signatures via `import("/abs/path/x")` type references. Uploading those
+/// verbatim breaks every consumer that joins the path back to the repo
+/// (GitHub deep links, MCP tools telling agents to fetch
+/// `repos/{owner}/{repo}/contents/{file_path}`). Strip the root at the
+/// cloud-projection boundary only — internal passes (sidecar type
+/// resolution, git-diff comparisons) still operate on absolute paths.
+fn relativize_function_definition_paths(
+    function_definitions: &mut HashMap<String, FunctionDefinition>,
+    repo_path: &str,
+) {
+    let root = std::path::Path::new(repo_path);
+    let prefix = format!("{}/", repo_path.trim_end_matches('/'));
+    for def in function_definitions.values_mut() {
+        if let Ok(stripped) = def.file_path.strip_prefix(root) {
+            def.file_path = stripped.to_path_buf();
+        }
+        for call in &mut def.calls {
+            if let Some(stripped) = call.file_path.strip_prefix(&prefix) {
+                call.file_path = stripped.to_string();
+            }
+        }
+        if let Some(sig) = &mut def.signature
+            && sig.contains(&prefix)
+        {
+            *sig = sig.replace(&prefix, "");
+        }
+    }
+}
+
 fn build_cloud_data_from_mount_graph(
     repo_name: &str,
     repo_path: &str,
@@ -1757,6 +1800,8 @@ fn build_cloud_data_from_mount_graph(
     packages: &Packages,
     function_definitions: HashMap<String, FunctionDefinition>,
 ) -> CloudRepoData {
+    let mut function_definitions = function_definitions;
+    relativize_function_definition_paths(&mut function_definitions, repo_path);
     let config_json = serde_json::to_string(config).ok();
     let service_name = config_json.as_ref().and_then(|json| {
         serde_json::from_str::<serde_json::Value>(json)
@@ -2501,6 +2546,7 @@ async fn analyze_current_repo(
     service: &Config,
     packages: &Packages,
     sidecar: Option<&TypeSidecar>,
+    prev_intents_by_hash: &HashMap<String, String>,
 ) -> Result<CloudRepoData, Box<dyn std::error::Error>> {
     // Canonicalize repo_path for consistent path normalization between runs
     let canonical = std::fs::canonicalize(repo_path)
@@ -2561,13 +2607,14 @@ async fn analyze_current_repo(
     let mut function_definitions = function_definitions;
     {
         let intent_agent = AgentService::new();
-        // Full scan: no previous data, so nothing to reuse — every intent is
-        // generated fresh and its content hash recorded for the next scan.
+        // Even on a full scan, intents whose content hash matches the
+        // previous scan are reused — the intent cache is content-addressed
+        // and independent of the analysis cache's validity (see the caller).
         generate_function_intents(
             &intent_agent,
             &mut function_definitions,
             &all_imported_symbols,
-            &HashMap::new(),
+            prev_intents_by_hash,
         )
         .await;
     }
@@ -3123,6 +3170,77 @@ mod tests {
     use crate::services::type_sidecar::{InferredType, SourceLocation};
     use crate::visitor::{OwnerType, TypeReference};
     use std::path::PathBuf;
+
+    /// Cloud-bound function definitions must carry repo-relative paths: the
+    /// extractor stamps the absolute CI checkout path (and the compiler leaks
+    /// it into signatures via `import("...")`), which breaks GitHub deep
+    /// links and the MCP tools' `gh api .../contents/{file_path}` hint.
+    #[test]
+    fn cloud_projection_relativizes_function_paths() {
+        use crate::visitor::{FunctionCallRef, FunctionDefinition};
+
+        let repo_path = "/home/runner/work/acme/acme";
+        let mut defs = HashMap::new();
+        defs.insert(
+            "handler".to_string(),
+            FunctionDefinition {
+                name: "handler".to_string(),
+                file_path: PathBuf::from("/home/runner/work/acme/acme/src/api/handler.ts"),
+                node_type: Default::default(),
+                arguments: vec![],
+                body_source: None,
+                is_exported: true,
+                line_number: 3,
+                intent: Some("handles the thing".to_string()),
+                calls: vec![FunctionCallRef {
+                    name: "helper".to_string(),
+                    file_path: "/home/runner/work/acme/acme/src/lib/helper.ts".to_string(),
+                    line_number: 9,
+                }],
+                return_type: None,
+                return_is_explicit: false,
+                signature: Some(
+                    "(req: import(\"/home/runner/work/acme/acme/src/types\").Req) => void"
+                        .to_string(),
+                ),
+                intent_input_hash: None,
+            },
+        );
+        // A path outside the repo root is left as-is (matches the dashboard's
+        // read-side posture: never mangle what we can't confidently strip).
+        defs.insert(
+            "external".to_string(),
+            FunctionDefinition {
+                name: "external".to_string(),
+                file_path: PathBuf::from("/opt/other/place.ts"),
+                node_type: Default::default(),
+                arguments: vec![],
+                body_source: None,
+                is_exported: true,
+                line_number: 1,
+                intent: None,
+                calls: vec![],
+                return_type: None,
+                return_is_explicit: false,
+                signature: None,
+                intent_input_hash: None,
+            },
+        );
+
+        relativize_function_definition_paths(&mut defs, repo_path);
+
+        let handler = &defs["handler"];
+        assert_eq!(handler.file_path, PathBuf::from("src/api/handler.ts"));
+        assert_eq!(handler.calls[0].file_path, "src/lib/helper.ts");
+        assert_eq!(
+            handler.signature.as_deref(),
+            Some("(req: import(\"src/types\").Req) => void"),
+        );
+        assert_eq!(
+            defs["external"].file_path,
+            PathBuf::from("/opt/other/place.ts")
+        );
+    }
 
     #[test]
     fn synthetic_type_check_deps_exclude_workspace_internal_packages() {

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -77,9 +77,11 @@ const TRIVIAL_BODY_MAX_CHARS: usize = 80;
 
 /// A body too small to carry business logic worth an LLM description:
 /// single-line and at most [`TRIVIAL_BODY_MAX_CHARS`] chars after trim.
+/// Counted in chars, not bytes, so non-ASCII identifiers/strings don't
+/// shrink the effective threshold.
 fn is_trivial_body(body: &str) -> bool {
     let trimmed = body.trim();
-    trimmed.len() <= TRIVIAL_BODY_MAX_CHARS && !trimmed.contains('\n')
+    !trimmed.contains('\n') && trimmed.chars().count() <= TRIVIAL_BODY_MAX_CHARS
 }
 
 /// True when `body` references `name` as a standalone JS identifier.
@@ -712,6 +714,10 @@ mod tests {
         assert!(is_trivial_body("(x) => x.id"));
         assert!(is_trivial_body("{ return user.email; }"));
         assert!(is_trivial_body("  return config.baseUrl;  "));
+        // Threshold counts chars, not bytes: a one-liner of 80 multi-byte
+        // chars (240 bytes here) is still trivial.
+        assert!(is_trivial_body(&"é".repeat(80)));
+        assert!(!is_trivial_body(&"é".repeat(81)));
 
         // Multi-line bodies always get an intent, however short.
         assert!(!is_trivial_body("const a = 1;\nreturn a;"));

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -65,6 +65,23 @@ pub fn intents_by_hash(
         .collect()
 }
 
+/// Bodies at or under this size, on a single line, are trivial
+/// single-expression helpers (getters, re-exports, `(x) => x.id`-style
+/// lambdas). The function's name and signature — already in the index —
+/// say everything an LLM sentence would add, so skipping the
+/// `/generate-intent` call loses nothing while removing a large share of
+/// call volume on real repos. Trivial functions keep `intent = None`;
+/// callers simply get no context line for them (their bodies are equally
+/// readable inline).
+const TRIVIAL_BODY_MAX_CHARS: usize = 80;
+
+/// A body too small to carry business logic worth an LLM description:
+/// single-line and at most [`TRIVIAL_BODY_MAX_CHARS`] chars after trim.
+fn is_trivial_body(body: &str) -> bool {
+    let trimmed = body.trim();
+    trimmed.len() <= TRIVIAL_BODY_MAX_CHARS && !trimmed.contains('\n')
+}
+
 /// True when `body` references `name` as a standalone JS identifier.
 ///
 /// A plain `contains` over-matches short names — `id` inside `userId`, `get`
@@ -93,7 +110,9 @@ fn body_references_identifier(body: &str, name: &str) -> bool {
     false
 }
 
-/// Generate intents for all exported functions that have body source.
+/// Generate intents for all exported functions that have body source,
+/// except trivial single-expression bodies (see [`TRIVIAL_BODY_MAX_CHARS`]),
+/// which keep `intent = None` and never cost a lambda call.
 ///
 /// After generation:
 /// - Each function's `intent` is populated with a 1-2 sentence description
@@ -111,10 +130,16 @@ pub async fn generate_function_intents(
     _imported_symbols: &HashMap<String, ImportedSymbol>,
     prev_intents_by_hash: &HashMap<String, String>,
 ) {
-    // Process all named functions with body source
+    // Process all named functions with body source, skipping trivial
+    // single-expression bodies (see TRIVIAL_BODY_MAX_CHARS) — no lambda
+    // call, no intent, permanently cheap.
     let eligible: Vec<String> = function_definitions
         .iter()
-        .filter(|(_, def)| def.body_source.is_some())
+        .filter(|(_, def)| {
+            def.body_source
+                .as_ref()
+                .is_some_and(|body| !is_trivial_body(body))
+        })
         .map(|(name, _)| name.clone())
         .collect();
 
@@ -634,22 +659,22 @@ mod tests {
     /// When every function's content hash is present in the previous-scan map,
     /// all intents are reused and NO `/generate-intent` call is made (the test
     /// would otherwise hit the network and fail). Also exercises the caller's
-    /// hash composing its callee's resolved intent.
+    /// hash composing its callee's resolved intent. Bodies are multi-line so
+    /// they clear the trivial-body gate.
     #[tokio::test]
     async fn full_cache_hit_makes_no_lambda_calls() {
         // `main` calls `helper`; helper is the leaf (level 0).
+        let helper_body = "const rate = table[region];\nreturn base * rate;";
+        let main_body = "const base = order.subtotal;\nreturn helper(base);";
         let mut defs = HashMap::new();
-        defs.insert("helper".to_string(), def_with_body("helper", "return 1;"));
-        defs.insert(
-            "main".to_string(),
-            def_with_body("main", "return helper();"),
-        );
+        defs.insert("helper".to_string(), def_with_body("helper", helper_body));
+        defs.insert("main".to_string(), def_with_body("main", main_body));
 
         // Reconstruct the exact hashes the generator will compute.
-        let helper_intent = "returns the number one";
-        let helper_hash = compute_intent_hash("return 1;", &[]);
+        let helper_intent = "applies the regional rate to a base amount";
+        let helper_hash = compute_intent_hash(helper_body, &[]);
         let caller_context = vec![format!("- helper: {}", helper_intent)];
-        let main_hash = compute_intent_hash("return helper();", &caller_context);
+        let main_hash = compute_intent_hash(main_body, &caller_context);
 
         let mut prev = HashMap::new();
         prev.insert(helper_hash.clone(), helper_intent.to_string());
@@ -678,5 +703,43 @@ mod tests {
         // body_source is stripped before upload.
         assert!(defs["helper"].body_source.is_none());
         assert!(defs["main"].body_source.is_none());
+    }
+
+    #[test]
+    fn trivial_body_gate() {
+        // Single-expression one-liners: skipped.
+        assert!(is_trivial_body("return 1;"));
+        assert!(is_trivial_body("(x) => x.id"));
+        assert!(is_trivial_body("{ return user.email; }"));
+        assert!(is_trivial_body("  return config.baseUrl;  "));
+
+        // Multi-line bodies always get an intent, however short.
+        assert!(!is_trivial_body("const a = 1;\nreturn a;"));
+        // Long one-liners can still carry real logic.
+        assert!(!is_trivial_body(
+            "return users.filter((u) => u.active && !u.deleted && u.verifiedAt != null).map((u) => u.email);"
+        ));
+    }
+
+    /// Trivial functions are excluded from generation entirely: no lambda
+    /// call is attempted (the test would hit the network and fail if one
+    /// were), no intent is recorded, and body_source is still stripped.
+    #[tokio::test]
+    async fn trivial_functions_are_skipped_without_lambda_calls() {
+        let mut defs = HashMap::new();
+        defs.insert("getId".to_string(), def_with_body("getId", "return x.id;"));
+
+        let agent = AgentService::new();
+        generate_function_intents(
+            &agent,
+            &mut defs,
+            &HashMap::<String, ImportedSymbol>::new(),
+            &HashMap::new(),
+        )
+        .await;
+
+        assert!(defs["getId"].intent.is_none());
+        assert!(defs["getId"].intent_input_hash.is_none());
+        assert!(defs["getId"].body_source.is_none());
     }
 }


### PR DESCRIPTION
Scanner half of the intent-pipeline improvements (cloud half: daveymoores/carrick-cloud#171 — the two are independent; neither blocks the other).

## Repo-relative paths in cloud-bound function definitions

The extractor stamps the canonicalized absolute CI checkout path (`/home/runner/work/<dir>/<repo>/...`) onto every `FunctionDefinition`, and the compiler leaks the same prefix into signatures via `import("...")` type references. Uploading those verbatim breaks GitHub deep links and the MCP tools' hint to fetch `repos/{owner}/{repo}/contents/{file_path}` (the dashboard has been stripping them defensively at read time). `build_cloud_data_from_mount_graph` — the single cloud-projection point for both the incremental and full paths — now relativizes `file_path`, `calls[].file_path`, and embedded signature paths against the repo root. Internal passes (sidecar type resolution, git-diff comparison) still see absolute paths; paths outside the repo root are left untouched.

## Full scans reuse the previous scan's intents

The intent content-hash cache (`INTENT_CACHE_VERSION` + body + sorted callee intents) is valid independently of the *analysis* cache — but the full-analysis fallback passed an empty map, so any full scan (cache_version bump, missing `file_results`, shallow clone) re-paid `/generate-intent` for every function in the repo. `analyze_current_repo` now takes the previous scan's `intents_by_hash` map, making full-scan intent cost O(changed functions).

## Trivial-body gate

Single-line bodies ≤ 80 chars after trim (`return x.id;`, `(x) => x.id`, re-exports) skip intent generation entirely: no lambda call, `intent = None`. Their name + signature — already in the index — carry everything an LLM sentence would add, and they're a meaningful share of call volume on real repos. Callers of a trivial helper simply get no context line for it; their content hash changes once and self-heals.

## Not done (intentionally)

- Body truncation: `extract_source` already caps `body_source` at 2000 chars, so oversized prompts cannot occur.
- No `INTENT_CACHE_VERSION` bump: neither change alters the hash inputs; callers of newly-trivial helpers regenerate once via the normal callee-intent cascade.

## Tests

- 506 lib tests pass (new: `trivial_body_gate`, `trivial_functions_are_skipped_without_lambda_calls`, `cloud_projection_relativizes_function_paths`; `full_cache_hit_makes_no_lambda_calls` updated to non-trivial bodies).
- `intent_incremental_test` integration tests pass; clippy clean, fmt clean.
- The `llm_cassette_hard_gate_test` golden is untouched: its projection contains only endpoints/calls/matches/conflicts (no function definitions), and endpoint paths were already relativized by the test itself. It fails in my container on clean `main` too (missing sidecar Node setup) — expecting it green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bmkvxoihKUeoiqoEG5Ass

---
_Generated by [Claude Code](https://claude.ai/code/session_012bmkvxoihKUeoiqoEG5Ass)_