### PR TITLE
feat(intents): CARRICK_SKIP_INTENTS flag skips /generate-intent lambda calls

### DIFF
--- a/.github/workflows/eval-xrepo.yml
+++ b/.github/workflows/eval-xrepo.yml
@@ -88,6 +88,11 @@ jobs:
           CARRICK_EVAL_LIVE: "1"
           CARRICK_EVAL_RUNS: ${{ inputs.runs }}
           CARRICK_EVAL_CORPUS: ${{ inputs.corpus }}
+          # Intents feed only the MCP index — no eval dimension consumes them —
+          # and they are one LLM call per eligible function, the dominant cost
+          # term on large corpora (fresh eval runs never carry a prior scan's
+          # content-hash cache). Skip them in eval scans.
+          CARRICK_SKIP_INTENTS: "1"
         run: |
           cargo test --release --test eval_xrepo -- \
             --ignored xrepo_live_scorer --test-threads=1 --nocapture

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -203,6 +203,12 @@ pub async fn generate_function_intents(
             "CARRICK_SKIP_INTENTS set — skipping intent generation for {} function(s)",
             eligible.len()
         );
+        // Contract under the flag: NO intents at all — clear any pre-seeded
+        // values so a caller can never upload stale ones.
+        for def in function_definitions.values_mut() {
+            def.intent = None;
+            def.intent_input_hash = None;
+        }
         strip_body_source(function_definitions);
         return;
     }
@@ -655,10 +661,12 @@ mod tests {
         );
     }
 
-    /// Env vars are process-global and tests run in parallel: any test that
-    /// sets a CARRICK_* flag — or calls generate_function_intents while
-    /// another test could have one set — serializes on this lock. Tokio's
-    /// mutex, so the guard may be held across await points.
+    /// Env vars are process-global and tests run in parallel: every test in
+    /// THIS module that sets a CARRICK_* flag — or calls
+    /// generate_function_intents while another of them could have one set —
+    /// serializes on this lock (it is module-private, not a crate-wide
+    /// guarantee). Tokio's mutex, so the guard may be held across await
+    /// points.
     static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
     fn def_with_body(name: &str, body: &str) -> FunctionDefinition {
@@ -791,7 +799,13 @@ mod tests {
         };
         let agent = AgentService::new();
 
-        // SAFETY: tests in this binary share env; no other test reads these
+        // Snapshot pre-existing values so a developer/CI environment that
+        // already sets these flags is restored, not clobbered.
+        let prev_mock = std::env::var("CARRICK_MOCK_ALL").ok();
+        let prev_skip = std::env::var("CARRICK_SKIP_INTENTS").ok();
+
+        // SAFETY: env vars are process-global; ENV_LOCK serializes this
+        // module's env-touching tests, and no test outside it reads these
         // vars mid-flight (the network-averse tests above assert cache/skip
         // behavior that MOCK_ALL does not alter).
         unsafe {
@@ -829,8 +843,17 @@ mod tests {
             &HashMap::new(),
         )
         .await;
+
+        // Restore whatever the environment had before the test.
         unsafe {
-            std::env::remove_var("CARRICK_MOCK_ALL");
+            match prev_mock {
+                Some(v) => std::env::set_var("CARRICK_MOCK_ALL", v),
+                None => std::env::remove_var("CARRICK_MOCK_ALL"),
+            }
+            match prev_skip {
+                Some(v) => std::env::set_var("CARRICK_SKIP_INTENTS", v),
+                None => std::env::remove_var("CARRICK_SKIP_INTENTS"),
+            }
         }
         assert_eq!(
             defs["helper"].intent.as_deref(),

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -192,6 +192,21 @@ pub async fn generate_function_intents(
         }
     }
 
+    // CARRICK_SKIP_INTENTS: stop before any /generate-intent lambda call.
+    // Intents are one LLM call per eligible function — the dominant cost of
+    // scanning a large repo — and feed only the MCP index; no cross-repo
+    // analysis or eval dimension consumes them. Everything deterministic has
+    // already happened above (`calls` is populated), and body_source is still
+    // stripped (source stays in GitHub, not AWS).
+    if std::env::var("CARRICK_SKIP_INTENTS").is_ok() {
+        debug!(
+            "CARRICK_SKIP_INTENTS set — skipping intent generation for {} function(s)",
+            eligible.len()
+        );
+        strip_body_source(function_definitions);
+        return;
+    }
+
     // Topological sort into levels: functions at the same level can run in parallel
     let levels = topological_levels(&eligible, &deps);
 
@@ -640,6 +655,12 @@ mod tests {
         );
     }
 
+    /// Env vars are process-global and tests run in parallel: any test that
+    /// sets a CARRICK_* flag — or calls generate_function_intents while
+    /// another test could have one set — serializes on this lock. Tokio's
+    /// mutex, so the guard may be held across await points.
+    static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
     fn def_with_body(name: &str, body: &str) -> FunctionDefinition {
         FunctionDefinition {
             name: name.to_string(),
@@ -665,6 +686,7 @@ mod tests {
     /// they clear the trivial-body gate.
     #[tokio::test]
     async fn full_cache_hit_makes_no_lambda_calls() {
+        let _env = ENV_LOCK.lock().await;
         // `main` calls `helper`; helper is the leaf (level 0).
         let helper_body = "const rate = table[region];\nreturn base * rate;";
         let main_body = "const base = order.subtotal;\nreturn helper(base);";
@@ -732,6 +754,7 @@ mod tests {
     /// were), no intent is recorded, and body_source is still stripped.
     #[tokio::test]
     async fn trivial_functions_are_skipped_without_lambda_calls() {
+        let _env = ENV_LOCK.lock().await;
         let mut defs = HashMap::new();
         defs.insert("getId".to_string(), def_with_body("getId", "return x.id;"));
 
@@ -747,5 +770,72 @@ mod tests {
         assert!(defs["getId"].intent.is_none());
         assert!(defs["getId"].intent_input_hash.is_none());
         assert!(defs["getId"].body_source.is_none());
+    }
+
+    /// CARRICK_SKIP_INTENTS stops intent generation before any lambda call
+    /// while keeping the deterministic parts: `calls` is populated and
+    /// body_source is stripped. Both cases run inside one test (sequentially)
+    /// because env vars are process-global. Under CARRICK_MOCK_ALL the lambda
+    /// path returns a mock intent, so pre-fix the skip case would record
+    /// `Some("Mock intent: …")` and fail the `None` assertions.
+    #[tokio::test]
+    async fn skip_intents_flag_skips_lambda_calls_but_strips_bodies() {
+        let _env = ENV_LOCK.lock().await;
+        let helper_body = "const rate = table[region];\nreturn base * rate;";
+        let main_body = "const base = order.subtotal;\nreturn helper(base);";
+        let make_defs = || {
+            let mut defs = HashMap::new();
+            defs.insert("helper".to_string(), def_with_body("helper", helper_body));
+            defs.insert("main".to_string(), def_with_body("main", main_body));
+            defs
+        };
+        let agent = AgentService::new();
+
+        // SAFETY: tests in this binary share env; no other test reads these
+        // vars mid-flight (the network-averse tests above assert cache/skip
+        // behavior that MOCK_ALL does not alter).
+        unsafe {
+            std::env::set_var("CARRICK_MOCK_ALL", "1");
+            std::env::set_var("CARRICK_SKIP_INTENTS", "1");
+        }
+        let mut defs = make_defs();
+        generate_function_intents(
+            &agent,
+            &mut defs,
+            &HashMap::<String, ImportedSymbol>::new(),
+            &HashMap::new(),
+        )
+        .await;
+        unsafe {
+            std::env::remove_var("CARRICK_SKIP_INTENTS");
+        }
+
+        // No intents, no hashes — the lambda path never ran.
+        assert!(defs["helper"].intent.is_none());
+        assert!(defs["main"].intent.is_none());
+        assert!(defs["helper"].intent_input_hash.is_none());
+        // Deterministic outputs are intact: caller→callee edge + stripping.
+        assert_eq!(defs["main"].calls.len(), 1);
+        assert_eq!(defs["main"].calls[0].name, "helper");
+        assert!(defs["helper"].body_source.is_none());
+        assert!(defs["main"].body_source.is_none());
+
+        // Control: with the flag unset (MOCK_ALL still on), intents flow.
+        let mut defs = make_defs();
+        generate_function_intents(
+            &agent,
+            &mut defs,
+            &HashMap::<String, ImportedSymbol>::new(),
+            &HashMap::new(),
+        )
+        .await;
+        unsafe {
+            std::env::remove_var("CARRICK_MOCK_ALL");
+        }
+        assert_eq!(
+            defs["helper"].intent.as_deref(),
+            Some("Mock intent: function does something.")
+        );
+        assert!(defs["main"].intent_input_hash.is_some());
     }
 }


### PR DESCRIPTION
## What

Adds a presence-based `CARRICK_SKIP_INTENTS` env flag that stops intent generation immediately before the `/generate-intent` lambda stage, and sets it in `eval-xrepo.yml`.

## Why

Intent generation runs unconditionally on both scan paths, one LLM call per eligible function. Eval runs start from a fresh temp cache, so every run pays full regeneration for data no eval dimension consumes (intents feed only the MCP index). On the authored corpora this is a few dollars of overhead; on a large OSS repo (the external anti-overfit program: MetaMask core is ~25-45k functions) it is the dominant cost term — ~$15-28/scan vs ~$1-3 for extraction itself.

## Behavior under the flag

- No `/generate-intent` calls; `intent`/`intent_input_hash` stay `None`.
- Deterministic outputs are unchanged: `calls` (local call graph) is still populated.
- `body_source` is still stripped before upload — source stays in GitHub, not AWS.

## Verification

- New test `skip_intents_flag_skips_lambda_calls_but_strips_bodies` (both cases, hermetic via `CARRICK_MOCK_ALL`). Proven pre-fix-failing: with the gate disabled the skip case records mock intents and the `None` assertions fail.
- Env-var races with the module's other `generate_function_intents` tests are serialized on a shared tokio `ENV_LOCK` (a std `MutexGuard` across await tripped clippy).
- Full pre-commit suite green (fmt, clippy, 1000+ tests, ts_check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)