### PR TITLE
feat(extraction): pub/sub candidates are an exhaustive checklist for the analyzer

### DIFF
--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -907,6 +907,7 @@ For each pubsub_operation, include: topic, role, line_number, primary_type_symbo
   - primary_type_symbol: the DECODED application payload type (unwrap envelope/transport wrappers and wire types down to the inner named type); null if untyped
   - type_import_source: import path where primary_type_symbol is defined (from the import table), or null if local; null whenever primary_type_symbol is null
   - broker: the messaging library/transport if evident (e.g. "kafka"), else null
+  - COMPLETENESS: the pub/sub candidates in CANDIDATE TARGETS are an exhaustive checklist. For EVERY candidate whose pattern is a publish/subscribe call, either emit a pubsub_operations entry (resolving same-file consts and `${{name}}:event` template topics to their literal string) or skip it ONLY because it is a request/response action invocation (e.g. .call / registerActionHandler / registerMethodActionHandlers) or its topic cannot be resolved to a literal. Never omit one because the file is long or the call site is late in the file.
 
 Return ONLY the JSON object, no explanations."#,
             // Section order is load-bearing for Vertex implicit prompt caching.


### PR DESCRIPTION
## What

Adds one rule to the analyzer's pubsub instruction block (scanner-side user-message template — the pubsub rules live here, not in the cloud system prompt, so this is **not deploy-gated**): publish/subscribe CANDIDATE TARGETS form an exhaustive checklist — each must yield a `pubsub_operations` entry unless it is an action invocation (`.call`/`registerActionHandler`) or its topic cannot be resolved to a literal.

Stacked on #319 (the shape gate) — retarget to main after it merges.

## Why

The live external-OSS eval showed an omission class on large files: a 4,409-line real controller with 22 publish sites emitted most but deterministically dropped a late-file site (and the live run dropped 3 of that file's 9 labeled topics). Reproduced offline in the prompt harness at temp 0.

## Evidence (prompt harness, temp 0, 2 runs each)

- Big-file fixture (`messenger-bigfile-omission`): labeled topics 8/9 → **9/9** with the rule; the recovered site is the deterministic drop (`postTransactionBalanceUpdated`, line 3722).
- Action-decoy fixture (`messenger-inprocess-controller`): still exactly its 3 real ops — all 8 `.call()` action decoys rejected, so "exhaustive" does not cause action leakage.
- Kafka envelope fixture: unchanged, 3/3.

Template tail sits after the per-file content, outside the cacheable front block — prompt-cache section order untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)