### PR TITLE
docs(readme) + feat(action): launch truthfulness, fork-PR graceful skip, org-move prep

### DIFF
--- a/.github/workflows/carrick.yml
+++ b/.github/workflows/carrick.yml
@@ -13,7 +13,6 @@ on:
 permissions:
   id-token: write
   contents: read
-  pull-requests: write
 
 jobs:
   carrick:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Carrick is a live, type-aware, intent-aware cross-repo index of every TypeScript
 
 > Carrick is TypeScript only. Cross-repo features need at least two services indexed in the same GitHub org. A single-service install still gets same-repo validation.
 
+**Get started:** sign up at [app.carrick.tools](https://app.carrick.tools) · full documentation at [docs.carrick.tools](https://docs.carrick.tools)
+
 ## What an agent can ask
 
 Connect Claude Code, Cursor, Windsurf, or Codex to the Carrick MCP endpoint. Carrick answers semantic questions about your org that an agent normally has to grep across repos to answer, badly:
@@ -33,7 +35,7 @@ The MCP endpoint lives at `https://api.carrick.tools/mcp`.
 claude mcp add --transport http carrick https://api.carrick.tools/mcp
 ```
 
-The recommended authentication is sign-in-with-Carrick: your agent opens a browser, you click Approve once, and no API key changes hands. A manual key paste is available as a fallback. Carrick is currently invite-only. Once your org is provisioned, both paths work.
+The recommended authentication is sign-in-with-Carrick: your agent opens a browser, you click Approve once, and no API key changes hands. A manual key paste is available as a fallback. To get started, sign up at [app.carrick.tools](https://app.carrick.tools) — the full setup guide lives at [docs.carrick.tools](https://docs.carrick.tools).
 
 ## Populate the index
 
@@ -66,7 +68,9 @@ jobs:
       - uses: daveymoores/carrick@v1
 ```
 
-No secrets required. The `id-token: write` permission lets the action mint a short-lived GitHub Actions OIDC token, which Carrick uses to verify the repo's identity and authorize the upload. On pull requests the Carrick App posts the drift comment itself, so the workflow needs no `pull-requests: write` permission and no comment-posting step. Just make sure the Carrick GitHub App is installed on the org and the repo is connected to a project in the dashboard.
+No secrets required. The `id-token: write` permission lets the action mint a short-lived GitHub Actions OIDC token, which Carrick uses to verify the repo's identity and authorize the upload. On pull requests the Carrick App posts the drift comment itself, so the workflow needs no extra permissions and no comment-posting step. Just make sure the Carrick GitHub App is installed on the org and the repo is connected to a project in the dashboard.
+
+Pull requests opened from forks are skipped gracefully: GitHub withholds OIDC credentials from fork runs, so the action prints a notice and exits successfully instead of failing the check. The scan runs when a maintainer pushes the branch to the repository itself.
 
 ## MCP tools
 
@@ -74,6 +78,8 @@ The MCP endpoint exposes the index as structured tools your agent can call direc
 
 | Tool | Purpose |
 | :--- | :--- |
+| `search_by_intent` | Find functions by what they do — a plain-English query matched against the intent descriptions |
+| `list_projects` | The Carrick projects in your workspace and each project's connected repos |
 | `list_services` | Every service Carrick has indexed in your org |
 | `list_function_intents` | One or two sentence descriptions of exported functions, searchable by service |
 | `get_api_endpoints` | Endpoints declared by a given service |
@@ -81,10 +87,11 @@ The MCP endpoint exposes the index as structured tools your agent can call direc
 | `get_type_definition` | Fully resolved TypeScript type by name, across the org |
 | `get_service_dependencies` | Services that call a given producer |
 | `check_compatibility` | Whether service A's call to service B matches the producer's contract |
+| `scaffold` | Generates the files to onboard a repo: the GitHub Actions workflow, an agent guide, and a `carrick.json` skeleton |
 
 ## On pull requests
 
-On pull requests the Carrick App posts a comment summarising drift detected against the indexed services: type mismatches between producers and consumers, mismatched HTTP verbs, missing or orphaned routes, and npm-dependency-version conflicts. It updates the same comment in place on each push to the PR. Enable it per project with the PR comments toggle in the dashboard; PR runs never alter the index.
+On pull requests the Carrick App posts a comment summarising drift detected against the indexed services: type mismatches between producers and consumers, mismatched HTTP verbs, missing or orphaned routes, and npm-dependency-version conflicts. It updates the same comment in place on each push to the PR. PR comments are on by default for new projects and can be toggled per project in the dashboard; PR runs never alter the index.
 
 ## Configuration
 
@@ -144,7 +151,7 @@ Each service also accepts the call-classification fields (`internalEnvVars`, `ex
 ## How it works
 
 1. SWC parses each TypeScript file into an AST.
-2. A static-analysis pass extracts function exports, mounted routers, and pattern-matched HTTP calls.
+2. A static-analysis pass extracts function exports, mounted routers, pattern-matched HTTP calls, GraphQL schemas and operations, and Socket.IO event contracts.
 3. An LLM agent handles the cases pattern matching can't reach: dynamic URLs, factory functions, framework-specific routing.
 4. A TypeScript sidecar resolves request and response types against the actual TypeScript compiler.
 5. A second LLM pass writes the per-function intent description.

--- a/action.yml
+++ b/action.yml
@@ -14,25 +14,61 @@ inputs:
 outputs:
   success:
     description: "Analysis completed successfully"
-    value: ${{ steps.analysis.outputs.success }}
+    value: ${{ steps.fork-check.outputs.skip == 'true' && 'true' || steps.analysis.outputs.success }}
   issues-found:
     description: "Number of API issues detected"
-    value: ${{ steps.analysis.outputs.issues-found }}
+    value: ${{ steps.fork-check.outputs.skip == 'true' && '0' || steps.analysis.outputs.issues-found }}
 
 runs:
   using: "composite"
   steps:
+    - name: Check fork PR (OIDC unavailable)
+      id: fork-check
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        BASE_REPO: ${{ github.repository }}
+      run: |
+        # GitHub withholds OIDC credentials (ACTIONS_ID_TOKEN_REQUEST_URL /
+        # ACTIONS_ID_TOKEN_REQUEST_TOKEN) from pull_request runs that originate
+        # from forks, so the scanner cannot authenticate to the Carrick cloud.
+        # Skip successfully rather than fail the contributor's PR red — the
+        # scan runs when a maintainer pushes the branch to this repository.
+        SKIP=false
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          if [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            SKIP=true
+          elif [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+            # Belt-and-braces: OIDC env vars absent on a pull_request run —
+            # same fork situation even if the head-repo comparison missed it.
+            SKIP=true
+          fi
+        fi
+        if [ "$SKIP" = "true" ]; then
+          echo "::notice::Carrick skipped: fork PRs don't receive OIDC credentials, so this run can't authenticate to the Carrick cloud. The check will run when a maintainer pushes the branch to this repository."
+        fi
+        echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
+
     - name: Set up Node.js
+      if: steps.fork-check.outputs.skip != 'true'
       uses: actions/setup-node@v4
       with:
         node-version: "24"
 
     - name: Download Carrick
+      if: steps.fork-check.outputs.skip != 'true'
       id: download
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        # The repo that hosts this action's releases. GITHUB_ACTION_REPOSITORY
+        # is set by the runner for action steps, so release downloads follow
+        # the action if the repo moves orgs; the literal is a fallback for
+        # runners that don't set it.
+        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-daveymoores/carrick}"
+
         ASSET="carrick-action-linux.tar.gz"
         JQ_ASSET_URL=".assets[] | select(.name==\"$ASSET\") | .browser_download_url"
 
@@ -51,14 +87,14 @@ runs:
         echo "Resolving Carrick release for version $VERSION"
 
         # release-please tags releases as carrick-v<version>.
-        DOWNLOAD_URL=$(gh api "repos/daveymoores/carrick/releases/tags/carrick-v$VERSION" \
+        DOWNLOAD_URL=$(gh api "repos/$ACTION_REPO/releases/tags/carrick-v$VERSION" \
           --jq "$JQ_ASSET_URL" 2>/dev/null || true)
         valid_url "$DOWNLOAD_URL" || DOWNLOAD_URL=""
 
         if [ -z "$DOWNLOAD_URL" ]; then
           # Fallback for any other tag scheme: match a release whose tag ends
           # with this version.
-          DOWNLOAD_URL=$(gh api repos/daveymoores/carrick/releases --paginate \
+          DOWNLOAD_URL=$(gh api "repos/$ACTION_REPO/releases" --paginate \
             --jq ".[] | select(.tag_name | endswith(\"$VERSION\")) | $JQ_ASSET_URL" \
             2>/dev/null | head -n 1 || true)
           valid_url "$DOWNLOAD_URL" || DOWNLOAD_URL=""
@@ -66,12 +102,12 @@ runs:
 
         if [ -z "$DOWNLOAD_URL" ]; then
           echo "::warning::No release found matching version $VERSION (expected when running from an untagged ref); falling back to the latest release"
-          DOWNLOAD_URL=$(gh api repos/daveymoores/carrick/releases/latest --jq "$JQ_ASSET_URL" 2>/dev/null || true)
+          DOWNLOAD_URL=$(gh api "repos/$ACTION_REPO/releases/latest" --jq "$JQ_ASSET_URL" 2>/dev/null || true)
           valid_url "$DOWNLOAD_URL" || DOWNLOAD_URL=""
         fi
 
         if [ -z "$DOWNLOAD_URL" ]; then
-          echo "::error::Could not resolve a download URL for $ASSET from any release of daveymoores/carrick"
+          echo "::error::Could not resolve a download URL for $ASSET from any release of $ACTION_REPO"
           exit 1
         fi
 
@@ -87,14 +123,17 @@ runs:
         echo "dist-dir=$DIST_DIR" >> "$GITHUB_OUTPUT"
 
     - name: Install ts_check dependencies
+      if: steps.fork-check.outputs.skip != 'true'
       shell: bash
       run: cd "${{ steps.download.outputs.dist-dir }}/ts_check" && npm ci
 
     - name: Install sidecar dependencies
+      if: steps.fork-check.outputs.skip != 'true'
       shell: bash
       run: cd "${{ steps.download.outputs.dist-dir }}/sidecar" && npm ci
 
     - name: Run analysis
+      if: steps.fork-check.outputs.skip != 'true'
       id: analysis
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,10 @@ inputs:
 
 outputs:
   success:
-    description: "Analysis completed successfully"
+    description: "Analysis completed successfully (also 'true' when the run was skipped, e.g. fork PRs where OIDC is unavailable)"
     value: ${{ steps.fork-check.outputs.skip == 'true' && 'true' || steps.analysis.outputs.success }}
   issues-found:
-    description: "Number of API issues detected"
+    description: "Number of API issues detected ('0' can also mean the run was skipped, e.g. fork PRs where OIDC is unavailable)"
     value: ${{ steps.fork-check.outputs.skip == 'true' && '0' || steps.analysis.outputs.issues-found }}
 
 runs:

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -47,9 +47,9 @@ impl std::fmt::Display for OidcError {
                 "GitHub Actions OIDC is not available: ACTIONS_ID_TOKEN_REQUEST_URL / \
                  ACTIONS_ID_TOKEN_REQUEST_TOKEN are not set. Add `permissions: id-token: write` \
                  to the workflow job so Carrick can authenticate to the cloud without an API key. \
-                 Note: GitHub never grants OIDC credentials to pull_request runs from forks — \
-                 fork PRs cannot authenticate, and the Carrick Action skips them instead of \
-                 failing."
+                 Note: GitHub never grants OIDC credentials to pull_request runs from forks, \
+                 so fork PRs cannot authenticate (when run via the Carrick GitHub Action, \
+                 fork PRs are skipped instead of failing)."
             ),
             OidcError::Request(e) => write!(f, "OIDC token request failed: {}", e),
             OidcError::BadResponse(e) => write!(f, "OIDC token endpoint error: {}", e),

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -46,7 +46,10 @@ impl std::fmt::Display for OidcError {
                 f,
                 "GitHub Actions OIDC is not available: ACTIONS_ID_TOKEN_REQUEST_URL / \
                  ACTIONS_ID_TOKEN_REQUEST_TOKEN are not set. Add `permissions: id-token: write` \
-                 to the workflow job so Carrick can authenticate to the cloud without an API key."
+                 to the workflow job so Carrick can authenticate to the cloud without an API key. \
+                 Note: GitHub never grants OIDC credentials to pull_request runs from forks — \
+                 fork PRs cannot authenticate, and the Carrick Action skips them instead of \
+                 failing."
             ),
             OidcError::Request(e) => write!(f, "OIDC token request failed: {}", e),
             OidcError::BadResponse(e) => write!(f, "OIDC token endpoint error: {}", e),


### PR DESCRIPTION
Launch-readiness fixes for the public repo, in two commits.

## README truthfulness

- Removes the false "Carrick is currently invite-only" claim (signup is fully self-serve) and adds the missing product URLs: sign up at https://app.carrick.tools, docs at https://docs.carrick.tools — previously the README's only product URL was the MCP endpoint.
- Completes the MCP tools table from 7 to all 10 tools: adds `search_by_intent` (listed first — it answers the README's own headline example), `list_projects`, and `scaffold`.
- "How it works" now reflects multi-protocol extraction (HTTP calls, GraphQL schemas/operations, Socket.IO event contracts — all verified in `src/`).
- PR comments documented as App-posted and on by default; drops the stale `pull-requests: write` from the repo's own dogfood workflow.

## Fork-PR graceful skip (action.yml)

GitHub withholds OIDC credentials from `pull_request` runs originating from forks, so today every external contributor's PR to a Carrick-using repo goes red after minutes of setup, with an error suggesting a fix (`id-token: write`) that's already present and can't help.

- New early `fork-check` step: on a `pull_request` event where the head repo differs from `github.repository` (or OIDC env vars are absent), prints a `::notice` explaining the skip and all remaining steps are if-guarded off. The run exits green; action outputs fall back to `success=true` / `issues-found=0`.
- The scanner's `OidcError::Unavailable` message now explains the fork case instead of only the dead-end `id-token: write` advice.

## Org-move prep

Release-asset downloads now resolve against `$GITHUB_ACTION_REPOSITORY` (with the current literal as fallback), so the coming org transfer won't depend on GitHub rename redirects. After the transfer, a single find/replace of `daveymoores/carrick` fixes the remaining `uses:` examples.

## Verification

- `cargo check` passes; `cargo test --lib oidc` 3/3; `cargo fmt --check` clean.
- action.yml + dogfood workflow parse as valid YAML; every post-check step verified gated on `steps.fork-check.outputs.skip != 'true'`.
- Grep of README for invite-only / `pull-requests: write` / `CARRICK_API_KEY` / HTTP-only — zero matches.

## Trade-off to be aware of

Per the "never red on forks" rule, absent OIDC env vars on a `pull_request` event also trigger the skip — so a same-repo PR whose workflow lacks `id-token: write` silently skips rather than erroring. Push runs still fail loudly with the improved message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyZNbXMA1pgr2L6ixy2sv8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyZNbXMA1pgr2L6ixy2sv8)_