### PR TITLE
fix(action): fail loudly on missing id-token, live scan output, MCP endpoint + audit cleanup

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,7 @@
 {
   "mcpServers": {
     "carrick": {
-      "url": "https://api.carrick.tools/mcp",
-      "headers": {
-        "Authorization": "Bearer ${CARRICK_API_KEY}"
-      }
+      "url": "https://api.carrick.tools/mcp"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,12 @@ request/response types.
 ### Connect the agent
 
 ```
-claude mcp add --transport http carrick-carrick-ci https://api.carrick.tools/mcp/p/carrick-ci
+claude mcp add --transport http carrick https://api.carrick.tools/mcp
 ```
+
+One install serves every project in the workspace. On Carrick tool calls
+from this repo, pass `project: "carrick-ci"` (or `repo: "<owner/repo>"`
+from the git remote) so Carrick queries the right system.
 
 ### When to reach for Carrick
 

--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,10 @@ inputs:
 
 outputs:
   success:
-    description: "Analysis completed successfully (also 'true' when the run was skipped, e.g. fork PRs where OIDC is unavailable)"
+    description: "Analysis completed successfully (also 'true' when the run was skipped on a fork PR, where GitHub withholds OIDC credentials)"
     value: ${{ steps.fork-check.outputs.skip == 'true' && 'true' || steps.analysis.outputs.success }}
   issues-found:
-    description: "Number of API issues detected ('0' can also mean the run was skipped, e.g. fork PRs where OIDC is unavailable)"
+    description: "Number of API issues detected ('0' can also mean the run was skipped on a fork PR, where GitHub withholds OIDC credentials)"
     value: ${{ steps.fork-check.outputs.skip == 'true' && '0' || steps.analysis.outputs.issues-found }}
 
 runs:
@@ -35,18 +35,19 @@ runs:
         # from forks, so the scanner cannot authenticate to the Carrick cloud.
         # Skip successfully rather than fail the contributor's PR red — the
         # scan runs when a maintainer pushes the branch to this repository.
+        #
+        # Only genuine forks (head repo differs from base repo) get the green
+        # skip. A same-repo run with the OIDC env vars absent means the
+        # workflow forgot `permissions: id-token: write` — fail loudly with the
+        # fix instead of silently never scanning.
         SKIP=false
-        if [ "$EVENT_NAME" = "pull_request" ]; then
-          if [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" != "$BASE_REPO" ]; then
-            SKIP=true
-          elif [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
-            # Belt-and-braces: OIDC env vars absent on a pull_request run —
-            # same fork situation even if the head-repo comparison missed it.
-            SKIP=true
-          fi
-        fi
-        if [ "$SKIP" = "true" ]; then
+        if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+          SKIP=true
           echo "::notice::Carrick skipped: fork PRs don't receive OIDC credentials, so this run can't authenticate to the Carrick cloud. The check will run when a maintainer pushes the branch to this repository."
+        elif [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+          echo "::error::Carrick can't mint an OIDC token: this run has no ACTIONS_ID_TOKEN_REQUEST_URL / ACTIONS_ID_TOKEN_REQUEST_TOKEN. Add 'permissions: id-token: write' to the workflow (or job) so Carrick can authenticate to the cloud."
+          echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
+          exit 1
         fi
         echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
 
@@ -143,16 +144,21 @@ runs:
         # sends it as X-Carrick-OIDC. No API key required.
         CI: "true"
       run: |
+        # Stream output live (multi-minute scans shouldn't look hung) while
+        # still capturing it for the issue-count grep below. The log lives in
+        # RUNNER_TEMP so it never pollutes the user's workspace.
+        LOG_FILE="$RUNNER_TEMP/carrick-analysis.log"
+
         set +e
-        "${{ steps.download.outputs.dist-dir }}/carrick" "${{ inputs.path }}" > analysis.log 2>&1
-        EXIT_CODE=$?
+        "${{ steps.download.outputs.dist-dir }}/carrick" "${{ inputs.path }}" 2>&1 | tee "$LOG_FILE"
+        EXIT_CODE=${PIPESTATUS[0]}
         set -e
 
         ISSUES=0
-        if grep -q "CARRICK_ISSUE_COUNT:" analysis.log; then
+        if grep -q "CARRICK_ISSUE_COUNT:" "$LOG_FILE"; then
           # -m1: only the first marker counts — log echoes of the output (or a
           # rerun appending to the same log) must not yield a multi-line value.
-          ISSUES=$(grep -m1 "CARRICK_ISSUE_COUNT:" analysis.log | sed 's/.*CARRICK_ISSUE_COUNT:\([0-9]*\).*/\1/')
+          ISSUES=$(grep -m1 "CARRICK_ISSUE_COUNT:" "$LOG_FILE" | sed 's/.*CARRICK_ISSUE_COUNT:\([0-9]*\).*/\1/')
         fi
 
         if [ $EXIT_CODE -eq 0 ]; then
@@ -169,5 +175,4 @@ runs:
         # comment (gated on the project's pr_comments_enabled toggle). No
         # github-script step or pull-requests:write permission is needed here.
 
-        cat analysis.log
         exit $EXIT_CODE

--- a/tests/fixtures/imported-routers/package-lock.json
+++ b/tests/fixtures/imported-routers/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@types/body-parser": {
@@ -143,27 +143,56 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/bytes": {
@@ -316,9 +345,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -343,39 +372,39 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -495,9 +524,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -667,9 +696,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -686,12 +715,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -710,16 +740,45 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -811,14 +870,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -830,13 +889,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
Launch-polish batch for the public repo.

## Changes

- **action.yml — fork-check refinement**: the green skip now applies *only* to genuine fork PRs (head repo differs from base). A same-repo run with the OIDC env vars absent means the workflow forgot `permissions: id-token: write` — that now fails loudly with the exact fix in the error message, instead of silently green-skipping and never scanning. Output descriptions tightened to match.
- **action.yml — live output**: the analysis step streams scanner output via `tee` (exit code preserved through `PIPESTATUS`) instead of buffering everything into a log that's only cat-ed at the end — multi-minute scans no longer look hung. The log moved to `$RUNNER_TEMP` so it never pollutes the user's workspace.
- **AGENTS.md**: replaced the dead per-project MCP URL (`/mcp/p/carrick-ci`, 404s) with the single-endpoint install + per-call `project`/`repo` args.
- **.mcp.json**: removed the hardcoded `Authorization: Bearer ${CARRICK_API_KEY}` header so fresh clones go through MCP OAuth discovery instead of requiring an env var.
- **Dependabot cleanup**: `npm audit fix` in `tests/fixtures/imported-routers` (the only source of the advisories — fixture code that never ships): path-to-regexp, qs, body-parser, express transitive bumps within the declared semver ranges; `npm audit` now reports 0. `package.json` untouched.

## Verification

- `action.yml` + all workflow files parse as valid YAML; step guards from #321 semantics unchanged.
- `cargo test --test integration_test` (exercises the imported-routers fixture): 3 passed, 0 failed.
- No Rust source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyZNbXMA1pgr2L6ixy2sv8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyZNbXMA1pgr2L6ixy2sv8)_