### PR TITLE
refactor(matching): extract carrick-match crate (paths_match + is_param_segment) with wasm feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,62 @@ jobs:
       - name: Run library tests
         run: cargo test --lib --verbose
 
+      # Workspace members are NOT covered by the steps above: this is a
+      # non-virtual workspace, so plain `cargo test` invocations only run the
+      # root package. Every member crate needs its own explicit step.
+      - name: Run carrick-match tests
+        run: cargo test -p carrick-match --verbose
+
+  wasm-match:
+    name: carrick-match wasm smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-wasm-
+
+      - name: Build carrick-match for wasm32
+        run: cargo build --target wasm32-unknown-unknown -p carrick-match --features wasm --release
+
+      # Version must match the exact wasm-bindgen pin in
+      # crates/carrick-match/Cargo.toml; bump both in lockstep.
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --version 0.2.126 --locked
+
+      - name: Generate Node.js glue
+        run: wasm-bindgen --target nodejs --out-dir target/wasm-smoke target/wasm32-unknown-unknown/release/carrick_match.wasm
+
+      # Smoke only: proves the glue loads and the exports answer correctly
+      # under Node. The artifact is not uploaded; the committed copy consumed
+      # by carrick-cloud is produced and pinned separately.
+      - name: Load glue in Node and assert matching
+        run: |
+          node -e "
+            const assert = require('assert');
+            const m = require('./target/wasm-smoke/carrick_match.js');
+            assert.strictEqual(m.paths_match('/users/:id', '/users/123'), true);
+            assert.strictEqual(m.paths_match('/users/123', '/users/:id'), true);
+            assert.strictEqual(m.paths_match('/api/**', '/api/users/123/orders'), true);
+            assert.strictEqual(m.paths_match('/users', '/orders'), false);
+            assert.strictEqual(m.is_param_segment(':id'), true);
+            assert.strictEqual(m.is_param_segment('users'), false);
+            console.log('wasm smoke ok');
+          "
+
   lint:
     name: Linting
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,7 @@ name = "carrick"
 version = "0.2.1"
 dependencies = [
  "async-trait",
+ "carrick-match",
  "chrono",
  "dirs",
  "futures",
@@ -235,6 +236,13 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "walkdir",
+]
+
+[[package]]
+name = "carrick-match"
+version = "0.0.1"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -994,11 +1002,12 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2627,48 +2636,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2676,31 +2669,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,15 @@ name = "carrick"
 version = "0.2.1"
 edition = "2024"
 
+# Non-virtual workspace on purpose: release-please's rust strategy edits this
+# root [package] version, so the root package must stay intact. Members are
+# versioned independently, outside release-please.
+[workspace]
+members = ["crates/carrick-match"]
+
 [dependencies]
 async-trait = "0.1"
+carrick-match = { path = "crates/carrick-match" }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5.0"
 futures = "0.3.32"

--- a/crates/carrick-match/Cargo.toml
+++ b/crates/carrick-match/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "carrick-match"
+# Deliberately versioned outside release-please: the root `carrick` package is
+# the only release-please target. Bump manually if the crate is ever published.
+version = "0.0.1"
+edition = "2024"
+
+[lib]
+# `cdylib` is required for the wasm32 build; `rlib` keeps the crate usable as a
+# normal dependency of the scanner.
+crate-type = ["rlib", "cdylib"]
+
+[features]
+# Adds wasm-bindgen exports for Node.js consumers. Default off so the native
+# scanner build pulls in zero new external dependencies.
+wasm = ["dep:wasm-bindgen"]
+
+[dependencies]
+# Pinned exactly: wasm-bindgen requires the CLI that generates the JS glue to
+# match this version. Bump the `cargo install wasm-bindgen-cli --version` pin
+# in .github/workflows/ci.yml in lockstep.
+wasm-bindgen = { version = "=0.2.126", optional = true }

--- a/crates/carrick-match/src/lib.rs
+++ b/crates/carrick-match/src/lib.rs
@@ -20,9 +20,10 @@
 /// `endpoint_path` is the declared route on the producer side (it may carry
 /// `:param`/`{param}`/`<param>`/`[param]` placeholders, trailing `?` optional
 /// markers, and `*`/`**`/`(.*)` wildcards). `call_path` is the canonical
-/// consumer call path. Matches on exact equality, parameter segments
-/// (symmetric, see [`path_matches_with_params`]), or wildcards (see
-/// [`path_matches_with_wildcards`]).
+/// consumer call path. Matches on exact equality, on parameter segments
+/// (symmetric: a placeholder on either side matches the other side), or on
+/// wildcard patterns (trailing wildcards are prefix matches; a mid-path `*`
+/// matches exactly one segment).
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 pub fn paths_match(endpoint_path: &str, call_path: &str) -> bool {
     // Exact match
@@ -45,7 +46,7 @@ pub fn paths_match(endpoint_path: &str, call_path: &str) -> bool {
 
 /// Segment-by-segment matching with route parameters (on either side) and
 /// trailing `?` optional segments on the endpoint side.
-pub fn path_matches_with_params(endpoint_path: &str, call_path: &str) -> bool {
+fn path_matches_with_params(endpoint_path: &str, call_path: &str) -> bool {
     let endpoint_segments: Vec<&str> = endpoint_path.split('/').collect();
     let call_segments: Vec<&str> = call_path.split('/').collect();
 
@@ -109,12 +110,17 @@ pub fn is_param_segment(seg: &str) -> bool {
         || (seg.starts_with('[') && seg.ends_with(']'))
 }
 
-/// Match paths with wildcard patterns
+/// Match paths with wildcard patterns.
 ///
-/// Supports:
-/// - `*` matches a single path segment
-/// - `**` or `(.*)` matches zero or more path segments
-pub fn path_matches_with_wildcards(endpoint_path: &str, call_path: &str) -> bool {
+/// Semantics as implemented (kept byte-identical to the scanner's original
+/// matcher):
+/// - An endpoint ending in `/*`, `/**`, or `/(.*)` is a prefix match: the
+///   call path only has to start with the part before the wildcard. A
+///   trailing `/*` therefore matches any number of segments, exactly like
+///   `/**`, not just one.
+/// - Anywhere else, a `*` segment matches exactly one call segment, and both
+///   paths must have the same number of segments.
+fn path_matches_with_wildcards(endpoint_path: &str, call_path: &str) -> bool {
     // Check for catch-all patterns
     if endpoint_path.ends_with("/*") || endpoint_path.ends_with("/**") {
         let prefix = endpoint_path.trim_end_matches("/**").trim_end_matches("/*");

--- a/crates/carrick-match/src/lib.rs
+++ b/crates/carrick-match/src/lib.rs
@@ -1,0 +1,233 @@
+//! Path-matching primitives shared by every Carrick surface that compares
+//! HTTP route paths.
+//!
+//! Extracted verbatim from the scanner's `MountGraph` (whose methods now
+//! delegate here) so the scanner and, via the optional `wasm` feature,
+//! Node.js consumers run the exact same matching semantics. Everything is a
+//! pure function over `&str`; the native build has zero dependencies.
+//!
+//! The `wasm` feature (default off) adds wasm-bindgen exports for
+//! [`paths_match`] and [`is_param_segment`]:
+//!
+//! ```text
+//! cargo build --target wasm32-unknown-unknown -p carrick-match --features wasm
+//! wasm-bindgen --target nodejs --out-dir <dir> \
+//!     target/wasm32-unknown-unknown/<profile>/carrick_match.wasm
+//! ```
+
+/// Whether a producer route path matches a consumer call path.
+///
+/// `endpoint_path` is the declared route on the producer side (it may carry
+/// `:param`/`{param}`/`<param>`/`[param]` placeholders, trailing `?` optional
+/// markers, and `*`/`**`/`(.*)` wildcards). `call_path` is the canonical
+/// consumer call path. Matches on exact equality, parameter segments
+/// (symmetric, see [`path_matches_with_params`]), or wildcards (see
+/// [`path_matches_with_wildcards`]).
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+pub fn paths_match(endpoint_path: &str, call_path: &str) -> bool {
+    // Exact match
+    if endpoint_path == call_path {
+        return true;
+    }
+
+    // Parameter matching (e.g., /users/:id matches /users/123)
+    if path_matches_with_params(endpoint_path, call_path) {
+        return true;
+    }
+
+    // Try matching with wildcards
+    if path_matches_with_wildcards(endpoint_path, call_path) {
+        return true;
+    }
+
+    false
+}
+
+/// Segment-by-segment matching with route parameters (on either side) and
+/// trailing `?` optional segments on the endpoint side.
+pub fn path_matches_with_params(endpoint_path: &str, call_path: &str) -> bool {
+    let endpoint_segments: Vec<&str> = endpoint_path.split('/').collect();
+    let call_segments: Vec<&str> = call_path.split('/').collect();
+
+    // Handle optional segments (e.g., /users/:id?)
+    let endpoint_required_count = endpoint_segments
+        .iter()
+        .filter(|s| !s.ends_with('?'))
+        .count();
+
+    // Call must have at least required segments and at most all segments
+    if call_segments.len() < endpoint_required_count
+        || call_segments.len() > endpoint_segments.len()
+    {
+        return false;
+    }
+
+    for (i, endpoint_seg) in endpoint_segments.iter().enumerate() {
+        // Check if this is an optional segment
+        let is_optional = endpoint_seg.ends_with('?');
+        let seg = endpoint_seg.trim_end_matches('?');
+
+        // If we're past the call segments, remaining endpoint segments must be optional
+        if i >= call_segments.len() {
+            if !is_optional {
+                return false;
+            }
+            continue;
+        }
+
+        let call_seg = call_segments[i];
+
+        // A path parameter on EITHER side matches the other side. This must be
+        // symmetric: a caller URL with a variable normalizes to a `:param` segment
+        // and must match a concrete provider segment, just as a caller's concrete
+        // value must match a provider's `:param`. We also accept the other param
+        // syntaxes (`{id}`, `<id>`, `[id]`) so that routes captured verbatim from
+        // frameworks that don't use Express-style colons still match cross-repo.
+        if is_param_segment(seg) || is_param_segment(call_seg) {
+            continue;
+        }
+
+        // Exact match required for non-parameter segments
+        if seg != call_seg {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Returns true if a single path segment is a route parameter placeholder in any
+/// of the common syntaxes: `:id` (Express/path-to-regexp), `{id}` (OpenAPI/Fastify),
+/// `<id>` (Flask-style), or `[id]`/`[...id]` (Next.js dynamic segments).
+/// Also the param definition `canonical_path_has_literal_segment` (#307)
+/// reuses, so the noise gate and the matcher agree on what a placeholder is.
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+pub fn is_param_segment(seg: &str) -> bool {
+    seg.starts_with(':')
+        || (seg.starts_with('{') && seg.ends_with('}'))
+        || (seg.starts_with('<') && seg.ends_with('>'))
+        || (seg.starts_with('[') && seg.ends_with(']'))
+}
+
+/// Match paths with wildcard patterns
+///
+/// Supports:
+/// - `*` matches a single path segment
+/// - `**` or `(.*)` matches zero or more path segments
+pub fn path_matches_with_wildcards(endpoint_path: &str, call_path: &str) -> bool {
+    // Check for catch-all patterns
+    if endpoint_path.ends_with("/*") || endpoint_path.ends_with("/**") {
+        let prefix = endpoint_path.trim_end_matches("/**").trim_end_matches("/*");
+        return call_path.starts_with(prefix);
+    }
+
+    // Check for regex-style catch-all
+    if endpoint_path.ends_with("/(.*)") {
+        let prefix = endpoint_path.trim_end_matches("/(.*)");
+        return call_path.starts_with(prefix);
+    }
+
+    // Check for single-segment wildcards in the middle
+    let endpoint_segments: Vec<&str> = endpoint_path.split('/').collect();
+    let call_segments: Vec<&str> = call_path.split('/').collect();
+
+    if endpoint_segments.len() != call_segments.len() {
+        return false;
+    }
+
+    for (endpoint_seg, call_seg) in endpoint_segments.iter().zip(call_segments.iter()) {
+        if *endpoint_seg == "*" {
+            continue; // Single-segment wildcard matches anything
+        }
+        if endpoint_seg != call_seg {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_paths_match_dispatch() {
+        // Exact match
+        assert!(paths_match("/users", "/users"));
+        // Parameter matching (e.g., /users/:id matches /users/123)
+        assert!(paths_match("/users/:id", "/users/123"));
+        // Wildcard matching
+        assert!(paths_match("/api/**", "/api/users/123/orders"));
+        // No match
+        assert!(!paths_match("/users", "/orders"));
+        assert!(!paths_match("/users/:id", "/users/123/orders"));
+    }
+
+    #[test]
+    fn test_path_matches_with_optional_segments() {
+        // Test optional segment matching
+        assert!(path_matches_with_params("/users/:id?", "/users"));
+        assert!(path_matches_with_params("/users/:id?", "/users/123"));
+        assert!(!path_matches_with_params("/users/:id", "/users")); // Not optional
+    }
+
+    #[test]
+    fn test_path_matches_with_params_is_symmetric() {
+        // A param on the endpoint side matches a concrete caller segment.
+        assert!(path_matches_with_params("/users/:id", "/users/123"));
+        // ...and a param on the caller side (a normalized `${id}` interpolation) matches
+        // a concrete provider segment. This direction previously failed.
+        assert!(path_matches_with_params("/users/123", "/users/:id"));
+        // Params on both sides match.
+        assert!(path_matches_with_params("/users/:id", "/users/:userId"));
+    }
+
+    #[test]
+    fn test_path_matches_with_params_across_syntaxes() {
+        // A caller normalized to `:id` must match a provider route captured verbatim in
+        // OpenAPI/Fastify (`{id}`), Flask (`<id>`), or Next.js (`[id]`) syntax.
+        assert!(path_matches_with_params("/users/{id}", "/users/:id"));
+        assert!(path_matches_with_params("/users/<id>", "/users/:id"));
+        assert!(path_matches_with_params("/users/[id]", "/users/:id"));
+        // ...and against a concrete value.
+        assert!(path_matches_with_params("/users/{id}", "/users/123"));
+        // Non-param segments must still match exactly.
+        assert!(!path_matches_with_params("/users/{id}", "/orders/123"));
+    }
+
+    #[test]
+    fn test_path_matches_with_wildcards() {
+        // Test wildcard matching
+        assert!(path_matches_with_wildcards("/api/*", "/api/users"));
+        assert!(path_matches_with_wildcards(
+            "/api/**",
+            "/api/users/123/orders"
+        ));
+        assert!(path_matches_with_wildcards(
+            "/files/(.*)",
+            "/files/path/to/file.txt"
+        ));
+
+        // Regression: file-based routing synthesizes Next.js catch-all routes
+        // (`app/files/[...slug]/route.ts`) as `/files/**`, which must match
+        // single- and multi-segment caller URLs. A named catch-all (the old
+        // `*slug` emission) would be treated as a literal and NOT match —
+        // guards against regressing the router.
+        assert!(path_matches_with_wildcards("/files/**", "/files/foo"));
+        assert!(path_matches_with_wildcards("/files/**", "/files/foo/bar"));
+        assert!(!path_matches_with_wildcards("/files/*slug", "/files/foo"));
+    }
+
+    #[test]
+    fn test_is_param_segment_syntaxes() {
+        assert!(is_param_segment(":id"));
+        assert!(is_param_segment("{id}"));
+        assert!(is_param_segment("<id>"));
+        assert!(is_param_segment("[id]"));
+        assert!(is_param_segment("[...slug]"));
+        assert!(!is_param_segment("users"));
+        assert!(!is_param_segment("*"));
+        assert!(!is_param_segment("v${n}"));
+    }
+}

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -318,124 +318,20 @@ impl MountGraph {
             })
     }
 
+    // Path-matching semantics live in the `carrick-match` crate (the single
+    // source of truth, also compiled to wasm for Node.js consumers). The
+    // methods below are thin delegates kept for call-site ergonomics.
+
     fn paths_match(&self, endpoint_path: &str, call_path: &str) -> bool {
-        // Exact match
-        if endpoint_path == call_path {
-            return true;
-        }
-
-        // Parameter matching (e.g., /users/:id matches /users/123)
-        if self.path_matches_with_params(endpoint_path, call_path) {
-            return true;
-        }
-
-        // Try matching with wildcards
-        if self.path_matches_with_wildcards(endpoint_path, call_path) {
-            return true;
-        }
-
-        false
+        carrick_match::paths_match(endpoint_path, call_path)
     }
 
-    fn path_matches_with_params(&self, endpoint_path: &str, call_path: &str) -> bool {
-        let endpoint_segments: Vec<&str> = endpoint_path.split('/').collect();
-        let call_segments: Vec<&str> = call_path.split('/').collect();
-
-        // Handle optional segments (e.g., /users/:id?)
-        let endpoint_required_count = endpoint_segments
-            .iter()
-            .filter(|s| !s.ends_with('?'))
-            .count();
-
-        // Call must have at least required segments and at most all segments
-        if call_segments.len() < endpoint_required_count
-            || call_segments.len() > endpoint_segments.len()
-        {
-            return false;
-        }
-
-        for (i, endpoint_seg) in endpoint_segments.iter().enumerate() {
-            // Check if this is an optional segment
-            let is_optional = endpoint_seg.ends_with('?');
-            let seg = endpoint_seg.trim_end_matches('?');
-
-            // If we're past the call segments, remaining endpoint segments must be optional
-            if i >= call_segments.len() {
-                if !is_optional {
-                    return false;
-                }
-                continue;
-            }
-
-            let call_seg = call_segments[i];
-
-            // A path parameter on EITHER side matches the other side. This must be
-            // symmetric: a caller URL with a variable normalizes to a `:param` segment
-            // and must match a concrete provider segment, just as a caller's concrete
-            // value must match a provider's `:param`. We also accept the other param
-            // syntaxes (`{id}`, `<id>`, `[id]`) so that routes captured verbatim from
-            // frameworks that don't use Express-style colons still match cross-repo.
-            if Self::is_param_segment(seg) || Self::is_param_segment(call_seg) {
-                continue;
-            }
-
-            // Exact match required for non-parameter segments
-            if seg != call_seg {
-                return false;
-            }
-        }
-
-        true
-    }
-
-    /// Returns true if a single path segment is a route parameter placeholder in any
-    /// of the common syntaxes: `:id` (Express/path-to-regexp), `{id}` (OpenAPI/Fastify),
-    /// `<id>` (Flask-style), or `[id]`/`[...id]` (Next.js dynamic segments).
-    /// Also the param definition `canonical_path_has_literal_segment` (#307)
-    /// reuses, so the noise gate and the matcher agree on what a placeholder is.
+    /// Route parameter placeholder check. See [`carrick_match::is_param_segment`];
+    /// it is also the param definition `canonical_path_has_literal_segment`
+    /// (#307) reuses, so the noise gate and the matcher agree on what a
+    /// placeholder is.
     pub(crate) fn is_param_segment(seg: &str) -> bool {
-        seg.starts_with(':')
-            || (seg.starts_with('{') && seg.ends_with('}'))
-            || (seg.starts_with('<') && seg.ends_with('>'))
-            || (seg.starts_with('[') && seg.ends_with(']'))
-    }
-
-    /// Match paths with wildcard patterns
-    ///
-    /// Supports:
-    /// - `*` matches a single path segment
-    /// - `**` or `(.*)` matches zero or more path segments
-    fn path_matches_with_wildcards(&self, endpoint_path: &str, call_path: &str) -> bool {
-        // Check for catch-all patterns
-        if endpoint_path.ends_with("/*") || endpoint_path.ends_with("/**") {
-            let prefix = endpoint_path.trim_end_matches("/**").trim_end_matches("/*");
-            return call_path.starts_with(prefix);
-        }
-
-        // Check for regex-style catch-all
-        if endpoint_path.ends_with("/(.*)") {
-            let prefix = endpoint_path.trim_end_matches("/(.*)");
-            return call_path.starts_with(prefix);
-        }
-
-        // Check for single-segment wildcards in the middle
-        let endpoint_segments: Vec<&str> = endpoint_path.split('/').collect();
-        let call_segments: Vec<&str> = call_path.split('/').collect();
-
-        if endpoint_segments.len() != call_segments.len() {
-            return false;
-        }
-
-        for (endpoint_seg, call_seg) in endpoint_segments.iter().zip(call_segments.iter()) {
-            if *endpoint_seg == "*" {
-                continue; // Single-segment wildcard matches anything
-            }
-            if endpoint_seg != call_seg {
-                return false;
-            }
-        }
-
-        true
+        carrick_match::is_param_segment(seg)
     }
 
     /// Merge mount graphs from multiple repos for cross-repo analysis
@@ -896,62 +792,9 @@ mod tests {
         assert_eq!(result.unwrap().len(), 1);
     }
 
-    #[test]
-    fn test_path_matches_with_optional_segments() {
-        let graph = MountGraph::new();
-
-        // Test optional segment matching
-        assert!(graph.path_matches_with_params("/users/:id?", "/users"));
-        assert!(graph.path_matches_with_params("/users/:id?", "/users/123"));
-        assert!(!graph.path_matches_with_params("/users/:id", "/users")); // Not optional
-    }
-
-    #[test]
-    fn test_path_matches_with_params_is_symmetric() {
-        let graph = MountGraph::new();
-
-        // A param on the endpoint side matches a concrete caller segment.
-        assert!(graph.path_matches_with_params("/users/:id", "/users/123"));
-        // ...and a param on the caller side (a normalized `${id}` interpolation) matches
-        // a concrete provider segment. This direction previously failed.
-        assert!(graph.path_matches_with_params("/users/123", "/users/:id"));
-        // Params on both sides match.
-        assert!(graph.path_matches_with_params("/users/:id", "/users/:userId"));
-    }
-
-    #[test]
-    fn test_path_matches_with_params_across_syntaxes() {
-        let graph = MountGraph::new();
-
-        // A caller normalized to `:id` must match a provider route captured verbatim in
-        // OpenAPI/Fastify (`{id}`), Flask (`<id>`), or Next.js (`[id]`) syntax.
-        assert!(graph.path_matches_with_params("/users/{id}", "/users/:id"));
-        assert!(graph.path_matches_with_params("/users/<id>", "/users/:id"));
-        assert!(graph.path_matches_with_params("/users/[id]", "/users/:id"));
-        // ...and against a concrete value.
-        assert!(graph.path_matches_with_params("/users/{id}", "/users/123"));
-        // Non-param segments must still match exactly.
-        assert!(!graph.path_matches_with_params("/users/{id}", "/orders/123"));
-    }
-
-    #[test]
-    fn test_path_matches_with_wildcards() {
-        let graph = MountGraph::new();
-
-        // Test wildcard matching
-        assert!(graph.path_matches_with_wildcards("/api/*", "/api/users"));
-        assert!(graph.path_matches_with_wildcards("/api/**", "/api/users/123/orders"));
-        assert!(graph.path_matches_with_wildcards("/files/(.*)", "/files/path/to/file.txt"));
-
-        // Regression: file-based routing synthesizes Next.js catch-all routes
-        // (`app/files/[...slug]/route.ts`) as `/files/**`, which must match
-        // single- and multi-segment caller URLs. A named catch-all (the old
-        // `*slug` emission) would be treated as a literal and NOT match —
-        // guards against regressing the router.
-        assert!(graph.path_matches_with_wildcards("/files/**", "/files/foo"));
-        assert!(graph.path_matches_with_wildcards("/files/**", "/files/foo/bar"));
-        assert!(!graph.path_matches_with_wildcards("/files/*slug", "/files/foo"));
-    }
+    // The path-matching unit tests (optional segments, symmetric params, param
+    // syntaxes, wildcards) moved to crates/carrick-match with the functions
+    // they exercise. CI runs them via `cargo test -p carrick-match`.
 
     fn cloud_repo_with_health(
         repo: &str,


### PR DESCRIPTION
## What

Layer 3 (pure code motion) of the overnight matching plan: the scanner's path-matching semantics move into a new workspace member, `crates/carrick-match`, so one implementation can serve both the native scanner and, compiled to wasm, the Node.js side (Layer 4, separate PR in carrick-cloud). Zero behavior change.

## Functions moved (verbatim) into `crates/carrick-match`

- `paths_match(endpoint_path, call_path)` (wasm-exported)
- `path_matches_with_params(endpoint_path, call_path)`
- `path_matches_with_wildcards(endpoint_path, call_path)`
- `is_param_segment(seg)` (wasm-exported; still the single param definition that the #307 noise gate `canonical_path_has_literal_segment` reuses, now via the `MountGraph` delegate)

`MountGraph::paths_match` and `MountGraph::is_param_segment` remain as thin delegates because they have production call sites. The two private helpers had no callers left outside their own unit tests, so per this repo's no-parallel-paths rule the dead delegates were dropped and their unit tests moved (not duplicated) into the crate, where CI now runs them.

## Deliberately NOT moved

- `operation.rs`, `url_normalizer.rs` (including `canonical_path_has_literal_segment` itself), `merge_from_repos`, and all analyzer orchestration: the known multi-day trap, deferred to the `resolve_call` follow-up issue.
- `paths_equal_modulo_param_names`: wrong-verb machinery, same deferred issue.

## Workspace and wasm

- Non-virtual workspace on purpose: the root `[package]` stays intact so release-please's rust strategy keeps editing the root version. `carrick-match` is 0.0.1, outside release-please.
- `wasm` cargo feature (default off) adds wasm-bindgen exports; the native build gains zero new external dependencies.
- wasm-bindgen pinned exactly at 0.2.126 (crate dep `=0.2.126`, CI CLI `--version 0.2.126 --locked`); the two pins must move in lockstep.

## CI

- Test job gains an explicit `cargo test -p carrick-match` step (non-virtual workspace: member tests never run from the root-package invocations).
- New `wasm-match` job: wasm32 build with the `wasm` feature, wasm-bindgen nodejs glue generation, and a Node load-and-assert smoke. No artifact uploaded.

## Gates

- Full `cargo test`: 1141 passed, 0 failed across 21 test targets, including the cassette hard gate, untouched and green.
- `cargo test -p carrick-match`: 6 passed.
- Local wasm proof: `carrick_match_bg.wasm` 35,799 bytes + `carrick_match.js` glue 4,272 bytes; Node smoke asserts `paths_match` in both param directions, wildcards, and a negative.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)