### PR TITLE
ci: build carrick-match wasm artifact on release and dispatch pin bump to carrick-cloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,15 @@ jobs:
           git push -f origin v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Builds the carrick-match wasm artifact, attaches it to the release, and
+  # dispatches the pin-bump PR in carrick-cloud (#325). Lives in the same
+  # workflow because release-please creates the release with GITHUB_TOKEN,
+  # which never fires `release:`-triggered workflows.
+  wasm-artifact:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ./.github/workflows/wasm-artifact.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit

--- a/.github/workflows/wasm-artifact.yml
+++ b/.github/workflows/wasm-artifact.yml
@@ -15,6 +15,10 @@ on:
         description: "Release tag to build from and attach assets to"
         required: true
         type: string
+    secrets:
+      CARRICK_CLOUD_DISPATCH_TOKEN:
+        description: "Fine-grained PAT able to fire repository_dispatch on daveymoores/carrick-cloud (contents:write + pull-requests:write there). Optional: without it assets still attach; only the notify step fails."
+        required: false
   workflow_dispatch:
     inputs:
       tag:
@@ -60,6 +64,13 @@ jobs:
 
       - name: Generate Node.js glue
         run: wasm-bindgen --target nodejs --out-dir wasm-artifact target/wasm32-unknown-unknown/release/carrick_match.wasm
+
+      # The artifact runs on carrick-cloud's Node 22 Lambda runtime — smoke
+      # it under the same major, not whatever the runner's default is.
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
 
       # Same assertions as ci.yml's wasm-match smoke, but against the exact
       # bytes being attached to the release.

--- a/.github/workflows/wasm-artifact.yml
+++ b/.github/workflows/wasm-artifact.yml
@@ -1,0 +1,121 @@
+name: Wasm Artifact
+
+# Builds the carrick-match wasm artifact (the query-time matcher that
+# carrick-cloud's mcp-server runs — see crates/carrick-match), attaches it to
+# a GitHub release, and dispatches the pin-bump PR in carrick-cloud (#325).
+#
+# Two entry points:
+#   - workflow_call from release.yml, on every release-please release
+#   - workflow_dispatch against an existing tag, to backfill or re-notify
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to build from and attach assets to"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to build from and attach assets to (e.g. carrick-v0.2.2)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  wasm-artifact:
+    name: Build, attach, dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-wasm-
+
+      - name: Build carrick-match for wasm32
+        run: cargo build --target wasm32-unknown-unknown -p carrick-match --features wasm --release
+
+      # Version must match the exact wasm-bindgen pin in
+      # crates/carrick-match/Cargo.toml; bump both in lockstep.
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --version 0.2.126 --locked
+
+      - name: Generate Node.js glue
+        run: wasm-bindgen --target nodejs --out-dir wasm-artifact target/wasm32-unknown-unknown/release/carrick_match.wasm
+
+      # Same assertions as ci.yml's wasm-match smoke, but against the exact
+      # bytes being attached to the release.
+      - name: Load glue in Node and assert matching
+        run: |
+          node -e "
+            const assert = require('assert');
+            const m = require('./wasm-artifact/carrick_match.js');
+            assert.strictEqual(m.paths_match('/users/:id', '/users/123'), true);
+            assert.strictEqual(m.paths_match('/users/123', '/users/:id'), true);
+            assert.strictEqual(m.paths_match('/api/**', '/api/users/123/orders'), true);
+            assert.strictEqual(m.paths_match('/users', '/orders'), false);
+            assert.strictEqual(m.is_param_segment(':id'), true);
+            assert.strictEqual(m.is_param_segment('users'), false);
+            console.log('wasm artifact smoke ok');
+          "
+
+      - name: Write checksums
+        working-directory: wasm-artifact
+        run: sha256sum carrick_match.js carrick_match.d.ts carrick_match_bg.wasm > carrick_match.sha256
+
+      - name: Attach assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ inputs.tag }}" \
+            wasm-artifact/carrick_match.js \
+            wasm-artifact/carrick_match.d.ts \
+            wasm-artifact/carrick_match_bg.wasm \
+            wasm-artifact/carrick_match.sha256 \
+            --clobber --repo "${{ github.repository }}"
+
+      # Fires .github/workflows/wasm-pin-bump.yml in carrick-cloud, which
+      # opens the pin-bump PR against the freshly attached assets. The default
+      # GITHUB_TOKEN cannot dispatch cross-repo: CARRICK_CLOUD_DISPATCH_TOKEN
+      # is a fine-grained PAT with contents:write + pull-requests:write on
+      # daveymoores/carrick-cloud. Assets are already attached by this point,
+      # so a failure here means notify-only is what's missing — re-run via
+      # workflow_dispatch with the same tag once the secret exists.
+      - name: Dispatch pin bump to carrick-cloud
+        env:
+          GH_TOKEN: ${{ secrets.CARRICK_CLOUD_DISPATCH_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "CARRICK_CLOUD_DISPATCH_TOKEN is not set; assets are attached but carrick-cloud was not notified." >&2
+            exit 1
+          fi
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          JS_SHA="$(awk '$2 == "carrick_match.js" {print $1}' wasm-artifact/carrick_match.sha256)"
+          DTS_SHA="$(awk '$2 == "carrick_match.d.ts" {print $1}' wasm-artifact/carrick_match.sha256)"
+          WASM_SHA="$(awk '$2 == "carrick_match_bg.wasm" {print $1}' wasm-artifact/carrick_match.sha256)"
+          gh api "repos/daveymoores/carrick-cloud/dispatches" \
+            -f event_type=carrick-match-release \
+            -f "client_payload[tag]=$TAG" \
+            -f "client_payload[source_sha]=$SOURCE_SHA" \
+            -f "client_payload[js_sha256]=$JS_SHA" \
+            -f "client_payload[dts_sha256]=$DTS_SHA" \
+            -f "client_payload[wasm_sha256]=$WASM_SHA"


### PR DESCRIPTION
## Summary

Adds a reusable `wasm-artifact` workflow that builds `crates/carrick-match` for wasm32, generates the Node.js glue with the pinned `wasm-bindgen-cli 0.2.126`, smoke-asserts the exact bytes, attaches `carrick_match.js` / `carrick_match.d.ts` / `carrick_match_bg.wasm` / `carrick_match.sha256` to the GitHub release, and fires a `repository_dispatch` (`carrick-match-release`) at carrick-cloud so it opens the WASM_PIN bump PR.

Wired into `release.yml` as a job gated on `release_created` (release-please creates releases with `GITHUB_TOKEN`, which never fires `release:`-triggered workflows, so it must live in the same workflow). Also exposed via `workflow_dispatch` with a `tag` input so an existing release (e.g. `carrick-v0.2.2`) can be backfilled for the first cutover.

## Rationale

Today carrick-cloud runs the matcher from a hand-built wasm binary committed to its repo; the WASM_PIN file itself calls that a bootstrap recipe, not a pipeline. This is the scanner half of carrick#325: every release now ships the matcher artifact, and the cloud is notified to bump its pin.

## Setup required before the dispatch step works

`CARRICK_CLOUD_DISPATCH_TOKEN` repo secret: a fine-grained PAT with contents:write + pull-requests:write on daveymoores/carrick-cloud. Until it exists the dispatch step fails loudly after assets are already attached; re-run via `workflow_dispatch` with the same tag to re-notify.

## Tests

- `ruby -ryaml` parse check on both workflows
- Node smoke assertions run in-workflow against the release bytes (same cases as ci.yml's `wasm-match` job)
- Full dry run (release, dispatch, pin-bump PR, deploy) happens after merge via `workflow_dispatch` on `carrick-v0.2.2`, tracked in #325

Part of #325. Companion carrick-cloud PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)