### PR TITLE
fix(matching): a param segment never matches an empty or whitespace segment

### DIFF
--- a/crates/carrick-match/src/lib.rs
+++ b/crates/carrick-match/src/lib.rs
@@ -85,6 +85,13 @@ fn path_matches_with_params(endpoint_path: &str, call_path: &str) -> bool {
         // syntaxes (`{id}`, `<id>`, `[id]`) so that routes captured verbatim from
         // frameworks that don't use Express-style colons still match cross-repo.
         if is_param_segment(seg) || is_param_segment(call_seg) {
+            // A param stands in for a real path value; an empty or
+            // whitespace-only segment on the other side is not one. Without
+            // this guard a route indexed with a stray blank segment (#332,
+            // "/api/users/ ") reads as satisfying "/api/users/:userId".
+            if seg.trim().is_empty() || call_seg.trim().is_empty() {
+                return false;
+            }
             continue;
         }
 
@@ -223,6 +230,30 @@ mod tests {
         assert!(path_matches_with_wildcards("/files/**", "/files/foo"));
         assert!(path_matches_with_wildcards("/files/**", "/files/foo/bar"));
         assert!(!path_matches_with_wildcards("/files/*slug", "/files/foo"));
+    }
+
+    #[test]
+    fn test_param_never_matches_empty_or_whitespace_segment() {
+        // Regression (#333): an endpoint whose full_path carried a trailing
+        // whitespace segment ("/api/users/ ", see #332) matched the consumer
+        // call "/api/users/:userId" because a param on either side skipped the
+        // comparison entirely. A param stands in for a real path value, and an
+        // empty or whitespace segment is not one.
+        assert!(!path_matches_with_params(
+            "/api/users/ ",
+            "/api/users/:userId"
+        ));
+        assert!(!path_matches_with_params(
+            "/api/users/:userId",
+            "/api/users/ "
+        ));
+        assert!(!path_matches_with_params(
+            "/api/users/",
+            "/api/users/:userId"
+        ));
+        assert!(!paths_match("/api/users/ ", "/api/users/:userId"));
+        // Real values still match a param on the other side.
+        assert!(path_matches_with_params("/api/users/:id", "/api/users/123"));
     }
 
     #[test]


### PR DESCRIPTION
## Bug

`path_matches_with_params` in `crates/carrick-match/src/lib.rs` treats a param segment on either side as matching whatever sits opposite it. That includes an empty or whitespace-only segment: with the endpoint `full_path` `"/api/users/ "` in the index (trailing space, #332), the consumer call `/api/users/:userId` matched it because segment 4 is `" "` vs `:userId` and `is_param_segment(call_seg)` short-circuits the comparison.

Live evidence: the carrick-demo-order-service PR 1 comment listed `GET /api/users/` and `GET /api/orders/` as Verified with no real matching consumer; both matches were `:param`-vs-whitespace.

## Fix

Inside the param branch, a segment that is empty or whitespace-only after `trim()` fails the match. A param stands in for a real path value, and a blank segment is not one. Param segments themselves are never blank (`is_param_segment` requires a leading marker character), so real param-vs-value and param-vs-param matching is unchanged.

Regression test covers the live case in both argument orders, the empty-segment variant (`"/api/users/"`), the `paths_match` entry point, and confirms `/api/users/:id` vs `/api/users/123` still matches.

The crate stays dependency-free and pure, so the wasm build is unaffected (`cargo check -p carrick-match --features wasm` passes).

Fixes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)