### PR TITLE
fix(sidecar): trailing comma no longer defeats matchByText, reverse match needs 50% coverage

### DIFF
--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -2200,12 +2200,21 @@ export class TypeInferrer {
 
     // Fall back to substring match
     // For the reverse direction (target contains node text), require a minimum node text
-    // length to avoid matching tiny identifiers like "res" or "body" too broadly
+    // length to avoid matching tiny identifiers like "res" or "body" too broadly.
+    // Also require the node to cover at least half of the target: the reverse
+    // branch exists for a locator with minor syntactic drift around the true
+    // node, not for binding to a fragment. Without the floor, a 100+ char
+    // locator whose exact match failed would bind to the smallest embedded
+    // sub-expression (pickBestMatch prefers small nodes), e.g. the 8-char
+    // literal "active" inside a res.json object payload (#335).
     const MIN_REVERSE_MATCH_LEN = 8;
+    const MIN_REVERSE_MATCH_COVERAGE = 0.5;
     const substringMatches = candidates.filter(
       (c) =>
         c.text.includes(normalizedTarget) ||
-        (c.text.length >= MIN_REVERSE_MATCH_LEN && normalizedTarget.includes(c.text))
+        (c.text.length >= MIN_REVERSE_MATCH_LEN &&
+          c.text.length >= normalizedTarget.length * MIN_REVERSE_MATCH_COVERAGE &&
+          normalizedTarget.includes(c.text))
     );
 
     if (substringMatches.length > 0) {
@@ -2252,9 +2261,18 @@ export class TypeInferrer {
   /**
    * Normalize whitespace for text comparison:
    * collapse runs of whitespace into single spaces, trim.
+   *
+   * Also strips trailing commas before `}` `)` `]`: multi-line source
+   * literals carry them but the LLM's single-line locator print does not,
+   * and that one comma used to defeat exact AND containment matching for
+   * the payload and every enclosing node (#335). Applied symmetrically to
+   * node text and target, so both sides compare equal.
    */
   private normalizeWhitespace(text: string): string {
-    return text.replace(/\s+/g, ' ').trim();
+    return text
+      .replace(/\s+/g, ' ')
+      .replace(/\s*,?\s*([}\)\]])/g, '$1')
+      .trim();
   }
 
   /**

--- a/src/sidecar/test/fixtures/sample-repo/src/trailing-comma-locator.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/trailing-comma-locator.ts
@@ -1,0 +1,24 @@
+// #335: multi-line object literal with trailing commas, matched by an LLM
+// text locator that prints the same expression single-line WITHOUT the
+// trailing comma. `normalizeWhitespace` only collapsed whitespace, so the
+// comma defeated exact AND containment matching and the reverse-substring
+// fallback bound the locator to the smallest embedded fragment ("active").
+interface StatusPayload {
+  service: string;
+  status: string;
+  timestamp: string;
+  userCount: number;
+}
+
+interface StatusResLike {
+  json: (data: StatusPayload) => void;
+}
+
+export function sendStatus(res: StatusResLike, userCount: number) {
+  res.json({
+    service: "notification-service",
+    status: "active",
+    timestamp: new Date().toISOString(),
+    userCount: userCount,
+  });
+}

--- a/src/sidecar/test/infer-trailing-comma-locator.test.ts
+++ b/src/sidecar/test/infer-trailing-comma-locator.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression for #335: a trailing comma defeats matchByText and the producer
+ * response type is captured as the string literal "active".
+ *
+ * The source `res.json({...})` payload is a multi-line object literal with a
+ * trailing comma (`userCount: userCount,`). The LLM's `response_expression_text`
+ * is the same expression printed single-line WITHOUT the trailing comma.
+ * `normalizeWhitespace` only collapsed whitespace, so:
+ *
+ *  1. Exact match failed on the comma, for the object literal and for every
+ *     enclosing node (`res.json(...)`, the statement, ...).
+ *  2. Forward containment (node text includes target) failed the same way.
+ *  3. The reverse-substring branch (target includes node text, min length 8)
+ *     matched many tiny sub-expressions: `"active"` (8 chars), `userCount`,
+ *     `status: "active"`, `new Date().toISOString()`, ...
+ *  4. `pickBestMatch` prefers the smallest node, so `"active"` won,
+ *     deterministically, and every consumer of the endpoint got a permanent
+ *     CAUTION contract risk (`producer "active" vs consumer ...`).
+ *
+ * The fix strips trailing commas before `}` `)` `]` in the normalization step
+ * (applied symmetrically to node text and target, so the exact match succeeds)
+ * and requires a reverse-substring match to cover at least half of the target,
+ * so a 100+ char locator can never bind to an 8-char fragment.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const FIXTURE = path.join(FIXTURES_PATH, 'src/trailing-comma-locator.ts');
+const FIXTURE_SOURCE = fs.readFileSync(FIXTURE, 'utf-8');
+
+/**
+ * The locator exactly as the LLM reports it: the multi-line source expression
+ * printed on a single line, without the trailing comma before `}`.
+ */
+const LLM_LOCATOR_TEXT =
+  'res.json({ service: "notification-service", status: "active", timestamp: new Date().toISOString(), userCount: userCount })';
+
+/** 1-based line number of the (unique) line containing `anchorText`. */
+function lineOf(anchorText: string): number {
+  const idx = FIXTURE_SOURCE.indexOf(anchorText);
+  assert.ok(idx >= 0, `fixture must contain: ${anchorText}`);
+  assert.strictEqual(
+    FIXTURE_SOURCE.indexOf(anchorText, idx + 1),
+    -1,
+    `fixture must contain exactly one occurrence of: ${anchorText}`
+  );
+  return FIXTURE_SOURCE.slice(0, idx).split('\n').length;
+}
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    infer_kind: string;
+    is_explicit: boolean;
+  }>;
+  errors?: string[];
+}
+
+describe('response_body text locator vs trailing comma (#335)', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'trailing-comma-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('resolves the object literal payload, not the embedded "active" literal', async () => {
+    const line = lineOf('res.json({');
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'trailing-comma-producer',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: line,
+          expression_text: LLM_LOCATOR_TEXT,
+          expression_line: line,
+          infer_kind: 'response_body',
+          alias: 'StatusProducer',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'StatusProducer'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+
+    // The bug: the smallest-node fallback bound the locator to `"active"`.
+    assert.notStrictEqual(
+      inferred.type_string,
+      '"active"',
+      'locator must not bind to the embedded string literal "active"'
+    );
+
+    // The fix: the payload resolves to the full object shape.
+    assert.strictEqual(
+      inferred.type_string,
+      '{ service: string; status: string; timestamp: string; userCount: number; }',
+      `expected the payload object shape, got ${inferred.type_string}`
+    );
+  });
+});


### PR DESCRIPTION
Fixes #335

## Bug mechanism

The `GET /api/notifications/status` producer response type was captured as the string literal `"active"` on two independent production scans, despite a correct LLM locator and an explicit `Response<{...}>` annotation. In `matchByText` (src/sidecar/src/type-inferrer.ts):

1. The source payload is a multi-line object literal with a trailing comma (`userCount: userCount,`); the LLM's `response_expression_text` is the same expression printed single-line without it.
2. `normalizeWhitespace` only collapsed whitespace, so that one comma defeated the exact match for the object literal, `res.json(...)`, and every enclosing node, and defeated the forward containment check (`node text includes target`) the same way.
3. The reverse-substring branch (`target includes node text`, min length 8) then matched many tiny sub-expressions: `"active"` (8 chars), `userCount`, `status: "active"`, `new Date().toISOString()`, ...
4. `pickBestMatch` prefers the smallest node, so `"active"` won, deterministically, and every consumer of the endpoint got a permanent CAUTION contract risk.

## Fix

Two changes in `matchByText`/`normalizeWhitespace`:

- `normalizeWhitespace` now strips trailing commas before `}` `)` `]`. Applied symmetrically to node text and target, so the exact match succeeds for the trailing-comma case and the locator binds the real payload node.
- The reverse-substring branch now requires the node text to cover at least half of the target (`MIN_REVERSE_MATCH_COVERAGE = 0.5`). The reverse branch exists for a locator with minor syntactic drift around the true node, not for binding fragments; a 100+ char locator can no longer bind to an 8-char literal even when exact matching fails for some other, future reason.

## Test

New regression test `src/sidecar/test/infer-trailing-comma-locator.test.ts` with fixture `trailing-comma-locator.ts`: a multi-line `res.json({...})` object literal with trailing commas and the single-line locator without them. Before the fix it resolved a tiny fragment (the 8-char `res.json` property access, same failure class as production's `"active"`); after the fix it resolves the object literal and infers `{ service: string; status: string; timestamp: string; userCount: number; }`.

Verified locally: sidecar suite (105 pass, 0 fail), `cargo test --test sidecar_integration_test` (7 pass), full pre-commit hook (fmt, clippy, full Rust suite, ts_check suite) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)