### PR TITLE
fix(comment): polish contract-risk rows: runner paths, stray quote, declared param names

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -295,7 +295,7 @@ fn consumer_identity(location: &str) -> (String, u32) {
     parse_file_location(location)
 }
 
-/// Strip the GitHub Actions checkout prefix (`/home/runner/work/<owner>/<repo>/`)
+/// Strip the GitHub Actions checkout prefix (`/home/runner/work/<repo>/<repo>/`)
 /// from a call-site location so PR-comment risk rows cite `server.ts:66`, not
 /// the runner's absolute workspace path (#337). Anything else (local absolute
 /// paths, already-relative paths) passes through unchanged.

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -295,6 +295,20 @@ fn consumer_identity(location: &str) -> (String, u32) {
     parse_file_location(location)
 }
 
+/// Strip the GitHub Actions checkout prefix (`/home/runner/work/<owner>/<repo>/`)
+/// from a call-site location so PR-comment risk rows cite `server.ts:66`, not
+/// the runner's absolute workspace path (#337). Anything else (local absolute
+/// paths, already-relative paths) passes through unchanged.
+fn strip_ci_workspace_prefix(location: &str) -> &str {
+    location
+        .strip_prefix("/home/runner/work/")
+        .and_then(|rest| rest.split_once('/'))
+        .and_then(|(_, rest)| rest.split_once('/'))
+        .map(|(_, rest)| rest)
+        .filter(|rest| !rest.is_empty())
+        .unwrap_or(location)
+}
+
 /// Collapse any dynamic path segment (`:id`, `{id}`, `[id]`) to `:param` so the
 /// compat verdict join is param-NAME-agnostic. The cross-repo edge's
 /// `producer_key` keeps the source param name (`/orders/:id`), while ts_check's
@@ -2263,11 +2277,13 @@ impl Analyzer {
                 let (method, path) = parse_compat_endpoint(endpoint)
                     .unwrap_or_else(|| ("UNKNOWN".to_string(), endpoint.to_string()));
                 // The consumer call site is the actionable location — it's
-                // where the broken read/write happens.
+                // where the broken read/write happens. In CI the manifest
+                // carries the runner's absolute checkout path; strip it so
+                // the risk row cites the repo-relative file.
                 let call_sites = mismatch
                     .get("consumerLocation")
                     .and_then(|c| c.as_str())
-                    .map(|loc| vec![loc.to_string()])
+                    .map(|loc| vec![strip_ci_workspace_prefix(loc).to_string()])
                     .unwrap_or_default();
                 Some(Finding::type_mismatch(
                     method,
@@ -2324,6 +2340,13 @@ impl Analyzer {
             .replace("': ", ": ")
             .replace("' is not assignable to type '", " not assignable to ")
             .replace("'.", "");
+
+        // ts_check's own errorDetails wrapper has no trailing period
+        // ("... type 'Y'"), so the "'." replacement above never fires on the
+        // closing quote; drop the unbalanced closer here.
+        if let Some(stripped) = cleaned.strip_suffix('\'') {
+            cleaned = stripped.to_string();
+        }
 
         // Replace hash-based type aliases in error messages
         for (alias, display) in display_names {
@@ -3429,6 +3452,56 @@ mod tests {
             "a producer absent from the mismatch list is compatible (verdict reached)"
         );
         assert!(matches[1].mismatch_reason.is_none());
+    }
+
+    /// PR-comment polish (#337): the risk row's call site must not leak the CI
+    /// runner workspace prefix, and the assignability detail must not end with
+    /// an unbalanced quote. ts_check builds its own errorDetails as
+    /// `Type 'X' is not assignable to type 'Y'` with no trailing period, so
+    /// `clean_error_message`'s `"'."` replacement never fires on the closer.
+    #[test]
+    fn type_mismatch_finding_strips_runner_prefix_and_trailing_quote() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let results = r#"{
+            "mismatches": [
+                { "endpoint": "GET /api/notifications/status (response)",
+                  "producerType": "NotificationStatus",
+                  "consumerType": "StatusView",
+                  "consumerLocation": "/home/runner/work/user-service/user-service/server.ts:66",
+                  "error": "Type 'NotificationStatus' is not assignable to type 'StatusView'" }
+            ]
+        }"#;
+        let analyzer = analyzer_with_results(dir.path(), Some(results));
+
+        let findings = analyzer.get_type_mismatch_findings();
+        assert_eq!(findings.len(), 1);
+        let Finding::TypeMismatch {
+            call_sites, detail, ..
+        } = &findings[0]
+        else {
+            panic!("expected a TypeMismatch finding, got {:?}", findings[0]);
+        };
+        assert_eq!(call_sites, &vec!["server.ts:66".to_string()]);
+        assert_eq!(detail, "NotificationStatus not assignable to StatusView");
+    }
+
+    /// A consumer location outside the GitHub Actions workspace passes through
+    /// untouched; the prefix strip must not eat local or repo-relative paths.
+    #[test]
+    fn strip_ci_workspace_prefix_leaves_non_runner_paths_alone() {
+        assert_eq!(
+            strip_ci_workspace_prefix("payments-svc/src/client.ts:12"),
+            "payments-svc/src/client.ts:12"
+        );
+        assert_eq!(
+            strip_ci_workspace_prefix("/home/runner/work/repo/repo/src/api.ts:7"),
+            "src/api.ts:7"
+        );
+        // Degenerate: nothing after the checkout dir → keep the original.
+        assert_eq!(
+            strip_ci_workspace_prefix("/home/runner/work/repo/repo"),
+            "/home/runner/work/repo/repo"
+        );
     }
 
     /// No results file → `check_type_compatibility` errs → every edge keeps

--- a/ts_check/lib/type-checker.test.ts
+++ b/ts_check/lib/type-checker.test.ts
@@ -1114,6 +1114,55 @@ describe('TypeCompatibilityChecker', () => {
       );
     });
 
+    it('labels an HTTP mismatch with the producer declared path, not the normalized :param form (#337)', async () => {
+      // The matcher keys HTTP matches on the normalized consumer path, which
+      // collapses every param name to `:param`. The mismatch label built from
+      // that key rendered `GET /api/orders/:param` in the PR-comment risk row
+      // while the Verified table showed the declared `GET /api/orders/:id`.
+      // The label must carry the producer's declared route; the Rust
+      // verdict-join is param-name-agnostic (normalize_compat_path collapses
+      // both sides back to `:param`), so the declared name is join-safe.
+      const typesProject = new Project({
+        compilerOptions: { strict: true, skipLibCheck: true },
+      });
+      typesProject.createSourceFile(
+        'types.d.ts',
+        `
+        export type OrderResponse = { id: number };
+        export type OrderView = { id: string };
+        `,
+        { overwrite: true }
+      );
+
+      const producers: TypeManifest = {
+        repo_name: 'orders-svc',
+        commit_hash: 'abc',
+        entries: [
+          createManifestEntry('GET', '/api/orders/:id', 'OrderResponse', 'producer', 'routes.ts', 10),
+        ],
+      };
+      const consumers: TypeManifest = {
+        repo_name: 'web-frontend',
+        commit_hash: 'def',
+        entries: [
+          createManifestEntry('GET', '/api/orders/:orderId', 'OrderView', 'consumer', 'api.ts', 5),
+        ],
+      };
+
+      const result = await typeChecker.checkCompatibility(
+        producers,
+        consumers,
+        typesProject
+      );
+
+      assert.strictEqual(result.mismatches.length, 1);
+      assert.strictEqual(
+        result.mismatches[0].endpoint,
+        'GET /api/orders/:id (response)',
+        `the mismatch label must carry the declared param name, got: ${result.mismatches[0].endpoint}`
+      );
+    });
+
     it('reads a dangling consumer name as unverifiable but its structural shape as incompatible (#257)', async () => {
       // The #257 inference bug: a consumer like `res.json() as Promise<OrderView>`
       // wrote the bare NAME `= OrderView` into the cross-repo bundle. The bundle

--- a/ts_check/lib/type-checker.ts
+++ b/ts_check/lib/type-checker.ts
@@ -188,7 +188,7 @@ export class TypeCompatibilityChecker {
       // (normalize_compat_path collapses both sides back to `:param`).
       // Non-HTTP matches keep the key (`DIRECTION|event`, `kind|field`, topic).
       const displayPath =
-        match.producer.protocol === 'http' && match.producer.path
+        match.producer.protocol === "http" && match.producer.path
           ? match.producer.path
           : match.path;
       const endpoint = `${match.method} ${displayPath} (${match.type_kind})`;

--- a/ts_check/lib/type-checker.ts
+++ b/ts_check/lib/type-checker.ts
@@ -181,7 +181,17 @@ export class TypeCompatibilityChecker {
 
     // For each match, compare the types
     for (const match of matches) {
-      const endpoint = `${match.method} ${match.path} (${match.type_kind})`;
+      // HTTP matches are keyed on the normalized consumer path, which
+      // collapses every param name to `:param`. Label the pair with the
+      // producer's declared route (`/orders/:id`) so the PR comment agrees
+      // with the Verified table; the Rust verdict-join is param-name-agnostic
+      // (normalize_compat_path collapses both sides back to `:param`).
+      // Non-HTTP matches keep the key (`DIRECTION|event`, `kind|field`, topic).
+      const displayPath =
+        match.producer.protocol === 'http' && match.producer.path
+          ? match.producer.path
+          : match.path;
+      const endpoint = `${match.method} ${displayPath} (${match.type_kind})`;
       const producerUnknown =
         match.producer.type_state === "unknown" ||
         match.producer.evidence?.type_state === "unknown";


### PR DESCRIPTION
Fixes #337

Three rendering defects visible on the carrick-demo verification PRs, all originating scanner-side.

## Runner path leak

Risk rows cited the CI checkout path (`/home/runner/work/<owner>/<repo>/server.ts:66`). The path comes from ts_check's `consumerLocation`, which carries the manifest's absolute `file_path` verbatim; the cloud renderer displays `call_sites[0]` as-is. `get_type_mismatch_findings` now strips the GitHub Actions workspace prefix when building `call_sites`, so the row cites `server.ts:66`. Local and already-relative paths pass through unchanged.

## Stray trailing quote

ts_check builds its own `errorDetails` as `Type 'X' is not assignable to type 'Y'` with no trailing period, unlike raw tsc diagnostics. `clean_error_message` removed the openers via `.replace("Type '", ...)` and `.replace("' is not assignable to type '", ...)` but only removed a closer spelled `'.`, so every message ended with an unbalanced quote. The cleaner now drops a trailing lone quote.

## :param vs :id label

The matcher keys HTTP matches on the normalized consumer path, which collapses every param name to `:param`; the mismatch label was built from that key, so the risk row showed `GET /api/orders/:param` while the Verified table showed the declared `GET /api/orders/:id`. The label now carries the producer's declared route. This is join-safe: the Rust verdict-join (`apply_compat_verdicts`) runs `normalize_compat_path` on both sides, so param names never participate in the join.

## Tests

- `type_mismatch_finding_strips_runner_prefix_and_trailing_quote` and `strip_ci_workspace_prefix_leaves_non_runner_paths_alone` (analyzer unit tests): written first, failed pre-fix with the exact live symptoms.
- `labels an HTTP mismatch with the producer declared path, not the normalized :param form (#337)` (ts_check): failed pre-fix with `GET /api/orders/:param (response)`.
- Full `cargo test` (526 lib + integration, incl. the cassette hard gate) and `ts_check` suite (90) pass.

## Descoped

The missing "In this PR" strip for call-only PRs is not a small delta tweak: `PrDelta` (computed in `src/engine/mod.rs`) only diffs endpoint keys against the prior index, and surfacing call/producer-type changes needs a wire-schema extension plus carrick-cloud renderer support. Left to a follow-up on #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)