### PR TITLE
fix(sidecar): report element anchor + array_depth on call_result inference

### DIFF
--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -1348,15 +1348,18 @@ export class TypeInferrer {
   ): UnwrapResult | null {
     // The outer extraction already succeeded on the paths below; a recursive
     // inner pass that finds nothing more must not demote the result back to
-    // "not unwrapped" (which would discard the recovered payload). The inner
-    // pass's payload wins when it peeled further; otherwise this level's
-    // payload IS the recovered type.
+    // "not unwrapped" (which would discard the recovered payload). Only when
+    // the inner pass unwrapped NOTHING is this level's payload the recovered
+    // type; an inner pass that did unwrap already decided its own payloadType,
+    // and its absence is deliberate — a union join has no single payload, and
+    // a verified-machinery collapse to `unknown` recovered none, so this
+    // level's (wrapper-shaped) payload must not resurface as an anchor.
     const recurse = (payload: Type): UnwrapResult => {
       const inner = this.unwrapType(payload, node, config, depth + 1);
       return {
         ...inner,
         wasUnwrapped: true,
-        payloadType: inner.payloadType ?? payload,
+        payloadType: inner.wasUnwrapped ? inner.payloadType : payload,
       };
     };
 

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -142,6 +142,15 @@ interface UnwrapResult {
   isExplicit: boolean;
   /** Whether unwrapping was actually performed */
   wasUnwrapped: boolean;
+  /**
+   * The single recovered payload `Type`, when a rule extracted one (#336).
+   * The anchor symbol + array depth must be derived from the PAYLOAD, not the
+   * wrapper: `axios.get<Order[]>` resolves to `AxiosResponse<Order[]>`, whose
+   * own symbol is the wrapper and whose array-ness lives one level down.
+   * Absent when nothing was unwrapped, when a union joined several payloads,
+   * or when verified machinery collapsed to `unknown`.
+   */
+  payloadType?: Type;
 }
 
 /**
@@ -607,12 +616,30 @@ export class TypeInferrer {
 
     typeString = this.unwrapPromise(typeString, returnType);
 
+    // #336: consumer analogue of the #306 producer anchor. Anchor on the
+    // actual payload (the rule-extracted Type, else the awaited use-site
+    // type), peeling array levels to the element symbol + depth. Without the
+    // depth, `apply_inferred_array_depth` (Rust) has nothing to copy onto the
+    // explicit SymbolRequest that pre-claims this alias, and the bundle for
+    // `axios.get<Order[]>` renders the bare `Order` interface with the `[]`
+    // gone. A wrapper that unwrapped to no single payload (union join,
+    // verified machinery) carries no payloadType and anchors nothing; the
+    // wrapper's own symbol must never anchor.
+    const anchorSource = unwrapResult.wasUnwrapped
+      ? unwrapResult.payloadType
+      : this.unwrapPromiseType(returnType);
+    const anchor = anchorSource
+      ? this.unwrapArrayLevels(this.unwrapPromiseType(anchorSource))
+      : undefined;
+
     return this.createInferredType(
       request,
       typeString,
       isExplicit,
       this.getNodeLocation(terminalNode),
-      unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined
+      unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined,
+      anchor ? this.primaryTypeSymbol(anchor.element) : undefined,
+      anchor?.depth
     );
   }
 
@@ -1321,11 +1348,17 @@ export class TypeInferrer {
   ): UnwrapResult | null {
     // The outer extraction already succeeded on the paths below; a recursive
     // inner pass that finds nothing more must not demote the result back to
-    // "not unwrapped" (which would discard the recovered payload).
-    const recurse = (payload: Type): UnwrapResult => ({
-      ...this.unwrapType(payload, node, config, depth + 1),
-      wasUnwrapped: true,
-    });
+    // "not unwrapped" (which would discard the recovered payload). The inner
+    // pass's payload wins when it peeled further; otherwise this level's
+    // payload IS the recovered type.
+    const recurse = (payload: Type): UnwrapResult => {
+      const inner = this.unwrapType(payload, node, config, depth + 1);
+      return {
+        ...inner,
+        wasUnwrapped: true,
+        payloadType: inner.payloadType ?? payload,
+      };
+    };
 
     // 1. Try generic type argument at payloadGenericIndex
     const genericIndex = rule.payloadGenericIndex ?? 0;
@@ -1345,6 +1378,7 @@ export class TypeInferrer {
           typeString: argText,
           isExplicit: true,
           wasUnwrapped: true,
+          payloadType: payloadArg,
         };
       }
 
@@ -1360,6 +1394,7 @@ export class TypeInferrer {
             typeString: text,
             isExplicit: true,
             wasUnwrapped: true,
+            payloadType: argType,
           };
         }
       }
@@ -1388,6 +1423,7 @@ export class TypeInferrer {
             typeString: propText,
             isExplicit: false,
             wasUnwrapped: true,
+            payloadType: currentType,
           };
         }
       }

--- a/src/sidecar/test/fixtures/sample-repo/node_modules/wrapper-lib/index.d.ts
+++ b/src/sidecar/test/fixtures/sample-repo/node_modules/wrapper-lib/index.d.ts
@@ -1,3 +1,12 @@
 export interface ApiResponse<T> {
   data: T;
 }
+
+/**
+ * Non-generic machinery with no recoverable payload: a rule can verify its
+ * identity (wrapperSymbols + originModuleGlobs) but extract nothing, so an
+ * unwrap of this type collapses to `unknown`.
+ */
+export interface OpaqueHandle {
+  readonly token: string;
+}

--- a/src/sidecar/test/fixtures/sample-repo/src/wrapper-opaque.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/wrapper-opaque.ts
@@ -1,0 +1,12 @@
+import type { ApiResponse, OpaqueHandle } from 'wrapper-lib';
+
+// Recursive unwrap whose extracted payload is ITSELF verified machinery with
+// no recoverable payload: the inner pass collapses to `unknown`, and no
+// wrapper symbol may leak into the anchor. Lives in its own fixture file —
+// sidecar.test.ts hardcodes byte offsets into wrapper-usage.ts.
+declare function apiGetOpaque(url: string): Promise<ApiResponse<OpaqueHandle>>;
+
+export async function loadOpaqueHandle() {
+  const handle = await apiGetOpaque('/api/opaque');
+  return handle;
+}

--- a/src/sidecar/test/fixtures/sample-repo/src/wrapper-usage.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/wrapper-usage.ts
@@ -20,3 +20,22 @@ export async function loadWrappedRaw() {
   const resp = await client.fetchUser();
   return resp;
 }
+
+// #336 shape: the payload type comes from an explicit generic on the CALL
+// (`axios.get<Order[]>` in the live repro), so the wrapper-extracted payload
+// is an ARRAY and the anchor must be its element symbol plus a depth.
+declare function apiGet<T>(url: string): Promise<ApiResponse<T>>;
+
+export async function loadWrappedUserArray() {
+  const usersResponse = await apiGet<UserData[]>('/api/users');
+  return usersResponse;
+}
+
+// Same array payload without a wrapper: the no-unwrap branch must anchor on
+// the awaited return type's element.
+declare function fetchUsersDirect(): Promise<UserData[]>;
+
+export async function loadUserArrayDirect() {
+  const users = await fetchUsersDirect();
+  return users;
+}

--- a/src/sidecar/test/infer-call-result-array-anchor.test.ts
+++ b/src/sidecar/test/infer-call-result-array-anchor.test.ts
@@ -16,18 +16,22 @@ import * as fs from 'node:fs';
 import { SidecarClient, FIXTURES_PATH } from './helpers.js';
 
 const FIXTURE = path.join(FIXTURES_PATH, 'src/wrapper-usage.ts');
-const FIXTURE_SOURCE = fs.readFileSync(FIXTURE, 'utf-8');
+const OPAQUE_FIXTURE = path.join(FIXTURES_PATH, 'src/wrapper-opaque.ts');
 
 /** Byte span of `text` in the fixture (ASCII-only file, so byte == char offsets). */
-function spanOf(text: string): { start: number; end: number; line: number } {
-  const start = FIXTURE_SOURCE.indexOf(text);
+function spanOf(
+  text: string,
+  fixturePath: string = FIXTURE
+): { start: number; end: number; line: number } {
+  const source = fs.readFileSync(fixturePath, 'utf-8');
+  const start = source.indexOf(text);
   assert.ok(start >= 0, `fixture must contain: ${text}`);
   assert.strictEqual(
-    FIXTURE_SOURCE.indexOf(text, start + 1),
+    source.indexOf(text, start + 1),
     -1,
     `fixture must contain exactly one occurrence of: ${text}`
   );
-  const line = FIXTURE_SOURCE.slice(0, start).split('\n').length;
+  const line = source.slice(0, start).split('\n').length;
   return { start, end: start + text.length, line };
 }
 
@@ -134,6 +138,64 @@ describe('call_result array payloads anchor on the element symbol with array_dep
     );
     assert.strictEqual(inferred.primary_type_symbol, 'UserData');
     assert.strictEqual(inferred.array_depth, 1);
+  });
+
+  it('recursive unwrap that collapses to `unknown` must not anchor on a wrapper symbol', async () => {
+    const call = spanOf("apiGetOpaque('/api/opaque')", OPAQUE_FIXTURE);
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'call-arr-opaque',
+      extraction_config: {
+        rules: [
+          {
+            wrapperSymbols: ['ApiResponse'],
+            originModuleGlobs: ['wrapper-lib', 'wrapper-lib/*'],
+            payloadGenericIndex: 0,
+            unwrapRecursively: true,
+          },
+          {
+            // Verifies OpaqueHandle's identity but can extract nothing (no
+            // generics, no payloadPropertyPath), so the recursive inner pass
+            // collapses to the unresolved `unknown` sentinel.
+            wrapperSymbols: ['OpaqueHandle'],
+            originModuleGlobs: ['wrapper-lib', 'wrapper-lib/*'],
+          },
+        ],
+      },
+      requests: [
+        {
+          file_path: OPAQUE_FIXTURE,
+          line_number: call.line,
+          span_start: call.start,
+          span_end: call.end,
+          infer_kind: 'call_result',
+          alias: 'OpaqueConsumer',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'OpaqueConsumer'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.strictEqual(
+      inferred.type_string,
+      'unknown',
+      'verified machinery with no recoverable payload collapses to unknown'
+    );
+    assert.strictEqual(
+      inferred.primary_type_symbol,
+      undefined,
+      `an unresolved unwrap must not anchor on the collapsed wrapper, got ${JSON.stringify(inferred.primary_type_symbol)}`
+    );
+    assert.strictEqual(
+      inferred.array_depth,
+      undefined,
+      `an unresolved unwrap must not report an array_depth, got ${inferred.array_depth}`
+    );
   });
 
   it('scalar wrapper payload keeps its anchor and reports NO array_depth', async () => {

--- a/src/sidecar/test/infer-call-result-array-anchor.test.ts
+++ b/src/sidecar/test/infer-call-result-array-anchor.test.ts
@@ -1,0 +1,179 @@
+/**
+ * #336: a `call_result` inference that resolves to an array type must anchor
+ * on the ELEMENT symbol and report the peeled depth, exactly as the producer
+ * paths do since #306. The live repro is `axios.get<Order[]>(...)`: the LLM
+ * anchor is the bare element (`Order`), so the explicit bundle pre-claims the
+ * consumer alias, and without a depth reported here `apply_inferred_array_depth`
+ * (Rust) has nothing to copy onto the `SymbolRequest` and the bundler renders
+ * `export interface <alias> {...}` with the `[]` gone. The producer keeps
+ * `Order[]`, so every scan reports a false array-vs-scalar contract risk.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const FIXTURE = path.join(FIXTURES_PATH, 'src/wrapper-usage.ts');
+const FIXTURE_SOURCE = fs.readFileSync(FIXTURE, 'utf-8');
+
+/** Byte span of `text` in the fixture (ASCII-only file, so byte == char offsets). */
+function spanOf(text: string): { start: number; end: number; line: number } {
+  const start = FIXTURE_SOURCE.indexOf(text);
+  assert.ok(start >= 0, `fixture must contain: ${text}`);
+  assert.strictEqual(
+    FIXTURE_SOURCE.indexOf(text, start + 1),
+    -1,
+    `fixture must contain exactly one occurrence of: ${text}`
+  );
+  const line = FIXTURE_SOURCE.slice(0, start).split('\n').length;
+  return { start, end: start + text.length, line };
+}
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    infer_kind: string;
+    is_explicit: boolean;
+    primary_type_symbol?: string;
+    array_depth?: number;
+  }>;
+  errors?: string[];
+}
+
+describe('call_result array payloads anchor on the element symbol with array_depth (#336)', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'call-arr-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('explicit generic `apiGet<UserData[]>` unwrapped by a rule → anchor UserData, depth 1', async () => {
+    const call = spanOf("apiGet<UserData[]>('/api/users')");
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'call-arr-wrapped',
+      extraction_config: {
+        rules: [
+          {
+            wrapperSymbols: ['ApiResponse'],
+            originModuleGlobs: ['wrapper-lib', 'wrapper-lib/*'],
+            payloadGenericIndex: 0,
+          },
+        ],
+      },
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: call.line,
+          span_start: call.start,
+          span_end: call.end,
+          infer_kind: 'call_result',
+          alias: 'UserArrayConsumer',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'UserArrayConsumer'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.strictEqual(
+      inferred.primary_type_symbol,
+      'UserData',
+      `anchor must be the element symbol, got ${JSON.stringify(inferred.primary_type_symbol)}`
+    );
+    assert.strictEqual(
+      inferred.array_depth,
+      1,
+      'without the depth the explicit bundle for the same alias erases the []'
+    );
+  });
+
+  it('unwrapped `Promise<UserData[]>` call → anchor UserData, depth 1', async () => {
+    const call = spanOf('await fetchUsersDirect()');
+    const callStart = call.start + 'await '.length;
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'call-arr-direct',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: call.line,
+          span_start: callStart,
+          span_end: call.end,
+          infer_kind: 'call_result',
+          alias: 'UserArrayDirectConsumer',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'UserArrayDirectConsumer'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.strictEqual(inferred.primary_type_symbol, 'UserData');
+    assert.strictEqual(inferred.array_depth, 1);
+  });
+
+  it('scalar wrapper payload keeps its anchor and reports NO array_depth', async () => {
+    const call = spanOf('client.fetchUser();\n  return resp.data');
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'call-arr-scalar',
+      extraction_config: {
+        rules: [
+          {
+            wrapperSymbols: ['ApiResponse'],
+            originModuleGlobs: ['wrapper-lib', 'wrapper-lib/*'],
+            payloadGenericIndex: 0,
+          },
+        ],
+      },
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: call.line,
+          span_start: call.start,
+          span_end: call.start + 'client.fetchUser()'.length,
+          infer_kind: 'call_result',
+          alias: 'UserScalarConsumer',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'UserScalarConsumer'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.strictEqual(inferred.primary_type_symbol, 'UserData');
+    assert.strictEqual(
+      inferred.array_depth,
+      undefined,
+      `a scalar must not report an array_depth, got ${inferred.array_depth}`
+    );
+  });
+});


### PR DESCRIPTION
Fixes #336

## Bug

Live repro on carrick-demo-notification-service (scanner v0.2.2):

```ts
const ordersResponse = await axios.get<Order[]>(`${ORDER_SERVICE_URL}/api/orders`);
```

was captured as `export interface Endpoint_..._Response_Call... { id: number; ... }` with the `[]` dropped, while the producer correctly emits `Order[]`. Every scan then reported a false `{...}[] not assignable to {...}` contract risk.

## Mechanism

The LLM-extracted anchor is a bare identifier by schema contract (`Order[]` -> `Order`), and the explicit bundle built from it pre-claims the consumer's manifest alias. #309 fixed exactly this for the producer paths (`function_return`, `response_body`): the same-alias inference peels array levels off the resolved use-site type, anchors on the ELEMENT symbol, and reports the depth as `array_depth`; `apply_inferred_array_depth` (Rust) copies that depth onto the matching explicit `SymbolRequest`, and the bundler's `array_depth` wrap (#248) emits `export type <alias> = {...}[]` instead of an interface.

The consumer path, `call_result` inference, never reported `primary_type_symbol` or `array_depth` at all. So there was nothing to copy, the `SymbolRequest` stayed depth-less, and the bundler rendered `export interface <alias> {...}`, which cannot carry array depth by construction.

## Fix

Mirror the #309 anchor on `call_result`, reusing the existing `unwrapArrayLevels` + `primaryTypeSymbol` helpers and the existing Rust join and bundler wrap (no duplication of #309's logic):

- `UnwrapResult` now carries the single recovered payload `Type` when a wrapper rule extracts one (generic arg or property path). The anchor must derive from the PAYLOAD, not the wrapper: `axios.get<Order[]>` resolves to `AxiosResponse<Order[]>`, whose own symbol is the wrapper and whose array-ness lives one level down. A union join or verified-machinery collapse carries no payload type, so a wrapper symbol can never anchor.
- `inferCallResult` peels the payload (or, on the no-unwrap branch, the awaited use-site type) to its element symbol + depth and reports both on the `InferredType`.

The unchanged chain then does the rest: `apply_inferred_array_depth` copies the depth onto the same-alias same-symbol explicit request, and the bundler emits `export type <alias> = { id: number; ... }[]`.

## Tests

New `src/sidecar/test/infer-call-result-array-anchor.test.ts` (written first, failed on the old code with `primary_type_symbol` undefined):

- explicit generic `apiGet<UserData[]>` unwrapped by an extraction rule -> anchor `UserData`, depth 1
- plain `Promise<UserData[]>` call -> anchor `UserData`, depth 1
- scalar wrapper payload -> anchor kept, NO `array_depth`

Full sidecar suite (107 tests), all CI Rust suites (including the cassette hard gate, golden unchanged), and ts_check tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)