### PR TITLE
fix(engine): drop duplicate same-key producer manifest entries and dedup identical findings rows

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -449,8 +449,10 @@ fn sort_dedup_cross_repo_matches(matches: &mut Vec<CrossRepoMatch>) {
 /// entry (same-key alias collision, #334) made ts_check emit the same mismatch
 /// once per duplicate, which rendered as identical rows in the PR comment.
 /// Full-struct equality only: findings differing in any field (call site,
-/// detail, types) are legitimately distinct and kept. Linear scan is fine at
-/// findings scale (tens of rows).
+/// detail, types) are legitimately distinct and kept. The `kept.contains`
+/// check inside the loop makes this O(n^2), which is fine at findings scale
+/// (tens of rows); `Finding` is not `Hash`, so a set-based pass isn't worth
+/// the ceremony here.
 fn dedup_findings(findings: &mut Vec<Finding>) {
     let mut kept: Vec<Finding> = Vec::with_capacity(findings.len());
     for finding in findings.drain(..) {

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -443,6 +443,24 @@ fn sort_dedup_cross_repo_matches(matches: &mut Vec<CrossRepoMatch>) {
     });
 }
 
+/// Order-preserving dedup of byte-identical findings rows, run once at the
+/// `get_results` aggregation point so every renderer (PR comment, terminal
+/// report, eval projection) sees each row once. A duplicated producer manifest
+/// entry (same-key alias collision, #334) made ts_check emit the same mismatch
+/// once per duplicate, which rendered as identical rows in the PR comment.
+/// Full-struct equality only: findings differing in any field (call site,
+/// detail, types) are legitimately distinct and kept. Linear scan is fine at
+/// findings scale (tens of rows).
+fn dedup_findings(findings: &mut Vec<Finding>) {
+    let mut kept: Vec<Finding> = Vec::with_capacity(findings.len());
+    for finding in findings.drain(..) {
+        if !kept.contains(&finding) {
+            kept.push(finding);
+        }
+    }
+    *findings = kept;
+}
+
 /// Accept only values whose *shape* is an extractable outgoing-call route, as
 /// produced by the file-analyzer LLM's `target` field (see that lambda's
 /// system prompt): an absolute path (`/users`), a full URL (`http(s)://…`), or
@@ -1980,6 +1998,10 @@ impl Analyzer {
         let mut dependency_conflicts = self.analyze_dependencies();
         dependency_conflicts.sort_by(|a, b| a.package_name.cmp(&b.package_name));
         findings.extend(dependency_conflicts.iter().map(dependency_conflict_finding));
+        // Collapse byte-identical rows (#334) after every source has appended;
+        // order-preserving, so the risks-then-gaps-then-advisories report
+        // ordering above survives.
+        dedup_findings(&mut findings);
 
         // Overlay the per-pair type-compat verdict onto the captured edges. The
         // verdict is keyed by the producer's (METHOD, full_path) AND the consumer's
@@ -2356,6 +2378,37 @@ impl Analyzer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression for #334: a duplicated producer manifest entry made ts_check
+    /// emit the same mismatch once per duplicate, which reached the PR comment
+    /// as byte-identical rows. Identical rows collapse at the aggregation
+    /// point; findings differing in any field (call site, detail, types) are
+    /// legitimately distinct and must survive.
+    #[test]
+    fn dedup_findings_collapses_identical_rows_only() {
+        let mismatch = || {
+            Finding::type_mismatch(
+                "GET",
+                "/api/orders/:id",
+                None,
+                vec!["src/user-routes.ts:12".to_string()],
+                "Order[]",
+                "OrderWithUser",
+                "Property 'user' is missing",
+            )
+        };
+        let other = Finding::missing_endpoint(
+            "GET",
+            "/api/orders/:id",
+            None,
+            vec!["src/user-routes.ts:30".to_string()],
+        );
+        let mut findings = vec![mismatch(), other.clone(), mismatch()];
+
+        dedup_findings(&mut findings);
+
+        assert_eq!(findings, vec![mismatch(), other]);
+    }
 
     /// Cross-service dependency conflicts are reported only when semver-
     /// INCOMPATIBLE (a major-version spread). `zod` 3.22.0 vs 4.0.0 is a real

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2280,6 +2280,15 @@ fn build_type_manifest_entries(
     let normalizer = UrlNormalizer::new(config);
     let mut entries = Vec::new();
 
+    // Producers carry the plain key-only alias (no `_Call<id>` suffix — that
+    // disambiguator exists for consumer fan-in, and the SymbolRequest side
+    // computes the same key-only alias for producers). So two endpoints
+    // colliding on (method, path) — a mis-extracted duplicate route (#332) or a
+    // genuinely twice-declared one — would share one alias and one resolved
+    // definition would silently clobber the other in the bundle (#334). Keep
+    // the first declaration, drop the rest with a warning.
+    let mut seen_producer_keys: HashSet<OperationKey> = HashSet::new();
+
     for endpoint in mount_graph.get_resolved_endpoints() {
         let method = normalize_manifest_method(&endpoint.method);
         if !is_http_method(&method) {
@@ -2291,9 +2300,20 @@ fn build_type_manifest_entries(
         }
         let (file_path, line_number) = parse_file_location(&endpoint.file_location);
 
+        let key = OperationKey::http(&method, path);
+        if !seen_producer_keys.insert(key.clone()) {
+            warn!(
+                "Duplicate producer endpoint {} at {} shares a manifest alias with an \
+                 earlier declaration; dropping this entry to avoid clobbering its \
+                 resolved type definition",
+                key, endpoint.file_location
+            );
+            continue;
+        }
+
         add_manifest_pair(
             &mut entries,
-            OperationKey::http(&method, path),
+            key,
             ManifestRole::Producer,
             &file_path,
             line_number,
@@ -3927,6 +3947,56 @@ mod tests {
             "expected normalized notification path, got {:?}",
             consumer_paths
         );
+    }
+
+    /// Regression for #334: two producer endpoints colliding on (method, path)
+    /// share the plain key-only alias (producers carry no `_Call<id>` suffix),
+    /// so both manifest entries got the same `type_alias` and one resolved
+    /// definition silently clobbered the other in the bundle. Live trigger:
+    /// the file-analyzer emitted a root route as "/:id", duplicating the real
+    /// `GET /api/orders/:id` (#332). The first declaration wins; the duplicate
+    /// is dropped with a warning.
+    #[test]
+    fn test_duplicate_producer_keys_yield_one_manifest_entry() {
+        let config = Config::default();
+        let mk_endpoint = |file: &str| crate::mount_graph::ResolvedEndpoint {
+            method: "GET".to_string(),
+            path: "/api/orders/:id".to_string(),
+            full_path: "/api/orders/:id".to_string(),
+            handler: None,
+            owner: "app".to_string(),
+            file_location: file.to_string(),
+            middleware_chain: vec![],
+            repo_name: None,
+            service_name: None,
+        };
+        let mut mount_graph = MountGraph::new();
+        mount_graph.endpoints = vec![
+            mk_endpoint("src/routes/orders.ts:11"),
+            mk_endpoint("src/routes/orders.ts:42"),
+        ];
+
+        let entries = build_type_manifest_entries(&mount_graph, &config);
+
+        let producer_aliases: Vec<&str> = entries
+            .iter()
+            .filter(|e| e.role == ManifestRole::Producer)
+            .map(|e| e.type_alias.as_str())
+            .collect();
+        let unique: std::collections::HashSet<&&str> = producer_aliases.iter().collect();
+        assert_eq!(
+            producer_aliases.len(),
+            unique.len(),
+            "same-key producers must not share a manifest alias: {:?}",
+            producer_aliases
+        );
+        // The surviving entry is the first declaration.
+        let survivor = entries
+            .iter()
+            .find(|e| e.role == ManifestRole::Producer)
+            .expect("one producer entry expected");
+        assert_eq!(survivor.file_path, "src/routes/orders.ts");
+        assert_eq!(survivor.line_number, 11);
     }
 
     #[test]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -3990,6 +3990,14 @@ mod tests {
             "same-key producers must not share a manifest alias: {:?}",
             producer_aliases
         );
+        // Lock in the drop-with-warning behavior: the duplicate is dropped,
+        // not disambiguated, so exactly one producer entry survives.
+        assert_eq!(
+            producer_aliases.len(),
+            1,
+            "duplicate same-key producer must be dropped, leaving one entry: {:?}",
+            producer_aliases
+        );
         // The surviving entry is the first declaration.
         let survivor = entries
             .iter()


### PR DESCRIPTION
## Bug

Producers carry the plain key-only manifest alias (consumers get a `_Call<id>` suffix; producers deliberately do not, and the SymbolRequest side computes the same key-only alias). When two producer endpoints collide on `(method, path)`, both `type_manifest` entries get the same hash alias, and one resolved type definition silently clobbers the other in the bundle.

Observed live on carrick-demo-order-service (blob commit 1fadc1f): the file-analyzer emitted a root route as `"/:id"`, duplicating the real `GET /api/orders/:id` (#332). Both producer response entries (`primary_type_symbol` "Order" and "OrderWithUser") ended up carrying the list endpoint's `Order[]` definition, and the resulting false contract risk rendered twice as byte-identical rows in the user-service PR comment. Any repo that genuinely declares the same route twice (env-split apps, versioned mounts) reproduces this without LLM involvement.

## Fix

Two layers, per the issue:

1. **Manifest build** (`build_type_manifest_entries`, src/engine/mod.rs): track seen producer keys; the first declaration wins and later same-key endpoints are dropped with a logged warning instead of silently sharing an alias.
2. **Findings aggregation** (`get_results`, src/analyzer/mod.rs): collapse byte-identical findings rows once, at the single aggregation point, so every renderer (PR comment, terminal report, eval projection) sees each row once. Full-struct equality only, order-preserving, so legitimately distinct findings and the risks/gaps/advisories ordering both survive.

## Tests

- `test_duplicate_producer_keys_yield_one_manifest_entry` reproduces the exact live collision (two `GET /api/orders/:id` producers both hashing to `Endpoint_9b4c2a118f951e09_Response`) and asserts the first declaration survives alone. Written first; failed with the duplicated alias before the fix.
- `dedup_findings_collapses_identical_rows_only` asserts identical rows collapse while distinct findings survive in order. Written first; failed before the fix.
- Full `cargo test` (including the cassette hard gate with the sidecar built) passes.

Fixes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)