### PR TITLE
fix(sidecar): recover the consumer array depth for multi-line call sites

### DIFF
--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -617,17 +617,28 @@ export class TypeInferrer {
     typeString = this.unwrapPromise(typeString, returnType);
 
     // #336: consumer analogue of the #306 producer anchor. Anchor on the
-    // actual payload (the rule-extracted Type, else the awaited use-site
+    // CALL's own payload (the rule-extracted Type, else the awaited call
     // type), peeling array levels to the element symbol + depth. Without the
     // depth, `apply_inferred_array_depth` (Rust) has nothing to copy onto the
     // explicit SymbolRequest that pre-claims this alias, and the bundle for
     // `axios.get<Order[]>` renders the bare `Order` interface with the `[]`
-    // gone. A wrapper that unwrapped to no single payload (union join,
-    // verified machinery) carries no payloadType and anchors nothing; the
-    // wrapper's own symbol must never anchor.
-    const anchorSource = unwrapResult.wasUnwrapped
-      ? unwrapResult.payloadType
-      : this.unwrapPromiseType(returnType);
+    // gone. The anchor must come from the call expression, NOT the terminal
+    // node: the def-use walk follows the binding to its last use, and in the
+    // live repro that is `ordersResponse.data.length` — a `number` with no
+    // symbol and no depth — while the response contract the manifest alias
+    // describes is the call's payload (`Order[]`). A wrapper that unwrapped
+    // to no single payload (union join, verified machinery) carries no
+    // payloadType and anchors nothing; the wrapper's own symbol must never
+    // anchor via that path.
+    const callPayloadType = this.unwrapPromiseType(callExpr.getType());
+    const callUnwrap = this.unwrapTypeWithConfig(
+      callPayloadType,
+      callExpr,
+      extractionConfig
+    );
+    const anchorSource = callUnwrap.wasUnwrapped
+      ? callUnwrap.payloadType
+      : callPayloadType;
     const anchor = anchorSource
       ? this.unwrapArrayLevels(this.unwrapPromiseType(anchorSource))
       : undefined;
@@ -2306,11 +2317,19 @@ export class TypeInferrer {
    * and that one comma used to defeat exact AND containment matching for
    * the payload and every enclosing node (#335). Applied symmetrically to
    * node text and target, so both sides compare equal.
+   *
+   * Also strips the space left AFTER `(` `[` `{` by the collapse: a
+   * multi-line call whose arguments start on the next line normalizes to
+   * `f( x)` while the LLM's compact print is `f(x)`, and that one space
+   * defeated exact matching for the call and every enclosing node — the
+   * opening-delimiter mirror of the #335 trailing comma (#336). Symmetric
+   * for the same reason.
    */
   private normalizeWhitespace(text: string): string {
     return text
       .replace(/\s+/g, ' ')
       .replace(/\s*,?\s*([}\)\]])/g, '$1')
+      .replace(/([\(\[{])\s+/g, '$1')
       .trim();
   }
 

--- a/src/sidecar/test/fixtures/sample-repo/src/wrapper-multiline.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/wrapper-multiline.ts
@@ -1,0 +1,31 @@
+import type { ApiResponse } from 'wrapper-lib';
+
+// #336 live shape (carrick-demo-notification-service): the call is MULTI-LINE
+// (argument on its own line, with a trailing comma) and the binding's last use
+// is a scalar projection (`.data.length`), not the payload itself. Two things
+// must survive that shape:
+//  1. the locator must find the call from the LLM's compact single-line print
+//     (the newline after `(` must not defeat exact matching), and
+//  2. the anchor must be derived from the CALL's own payload
+//     (`OrderData[]` → `OrderData` + depth 1), not from the terminal use
+//     (`number`), which carries no symbol and no depth.
+// Lives in its own fixture file — sidecar.test.ts hardcodes byte offsets into
+// wrapper-usage.ts.
+interface OrderData {
+  id: number;
+  userId: number;
+  product: string;
+  amount: number;
+}
+
+declare function apiGetOrders<T>(url: string): Promise<ApiResponse<T>>;
+
+const ORDER_SERVICE_URL = 'http://localhost:3002';
+
+export async function getOrderCount(): Promise<number> {
+  const ordersResponse = await apiGetOrders<OrderData[]>(
+    `${ORDER_SERVICE_URL}/api/orders`,
+  );
+  const orderCount = ordersResponse.data.length;
+  return orderCount;
+}

--- a/src/sidecar/test/infer-call-result-array-anchor.test.ts
+++ b/src/sidecar/test/infer-call-result-array-anchor.test.ts
@@ -17,6 +17,7 @@ import { SidecarClient, FIXTURES_PATH } from './helpers.js';
 
 const FIXTURE = path.join(FIXTURES_PATH, 'src/wrapper-usage.ts');
 const OPAQUE_FIXTURE = path.join(FIXTURES_PATH, 'src/wrapper-opaque.ts');
+const MULTILINE_FIXTURE = path.join(FIXTURES_PATH, 'src/wrapper-multiline.ts');
 
 /** Byte span of `text` in the fixture (ASCII-only file, so byte == char offsets). */
 function spanOf(
@@ -237,5 +238,99 @@ describe('call_result array payloads anchor on the element symbol with array_dep
       undefined,
       `a scalar must not report an array_depth, got ${inferred.array_depth}`
     );
+  });
+
+  // #336 reopened: the live repro is a MULTI-LINE `axios.get<Order[]>(` call
+  // whose binding is last used as a scalar projection (`.data.length`). Both
+  // halves of that shape used to lose the anchor:
+  //  - the LLM's compact single-line locator failed exact matching (the
+  //    normalized node text keeps a space after `(`), so the fallback bound a
+  //    fragment inside the call instead of the call, and
+  //  - even with the call found, the terminal-use walk anchored on `number`
+  //    (no symbol, no depth) instead of the call's own payload.
+  const MULTILINE_RULES = [
+    {
+      wrapperSymbols: ['ApiResponse'],
+      originModuleGlobs: ['wrapper-lib', 'wrapper-lib/*'],
+      payloadGenericIndex: 0,
+    },
+  ];
+
+  it('multi-line call located by the single-line LLM print → anchor OrderData, depth 1 (#336 live shape)', async () => {
+    const callStart = spanOf('apiGetOrders<OrderData[]>(', MULTILINE_FIXTURE);
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'call-arr-multiline-text',
+      extraction_config: { rules: MULTILINE_RULES },
+      requests: [
+        {
+          file_path: MULTILINE_FIXTURE,
+          line_number: callStart.line,
+          infer_kind: 'call_result',
+          // The LLM prints the call compactly on one line; the source spreads
+          // it over three lines with a trailing comma.
+          expression_text:
+            'apiGetOrders<OrderData[]>(`${ORDER_SERVICE_URL}/api/orders`)',
+          expression_line: callStart.line,
+          alias: 'OrderArrayMultilineConsumer',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'OrderArrayMultilineConsumer'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.strictEqual(
+      inferred.primary_type_symbol,
+      'OrderData',
+      `anchor must be the call payload's element symbol, got ${JSON.stringify(inferred.primary_type_symbol)} (type_string: ${JSON.stringify(inferred.type_string)})`
+    );
+    assert.strictEqual(
+      inferred.array_depth,
+      1,
+      'without the depth the explicit bundle renders the bare element and the [] is erased'
+    );
+  });
+
+  it('terminal scalar use (`.data.length`) must not erase the call payload anchor (span locator)', async () => {
+    const source = fs.readFileSync(MULTILINE_FIXTURE, 'utf-8');
+    const start = source.indexOf('apiGetOrders<OrderData[]>(');
+    assert.ok(start >= 0, 'fixture must contain the multi-line call');
+    const end = source.indexOf(');', start) + 1;
+    const line = source.slice(0, start).split('\n').length;
+
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'call-arr-multiline-span',
+      extraction_config: { rules: MULTILINE_RULES },
+      requests: [
+        {
+          file_path: MULTILINE_FIXTURE,
+          line_number: line,
+          span_start: start,
+          span_end: end,
+          infer_kind: 'call_result',
+          alias: 'OrderArraySpanConsumer',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'OrderArraySpanConsumer'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.strictEqual(
+      inferred.primary_type_symbol,
+      'OrderData',
+      `anchor must come from the call's payload, not the terminal use, got ${JSON.stringify(inferred.primary_type_symbol)} (type_string: ${JSON.stringify(inferred.type_string)})`
+    );
+    assert.strictEqual(inferred.array_depth, 1);
   });
 });

--- a/tests/sidecar_integration_test.rs
+++ b/tests/sidecar_integration_test.rs
@@ -655,6 +655,206 @@ fn test_path_normalization() {
     );
 }
 
+/// #336 (reopened): the END ARTIFACT for an `axios.get<Order[]>`-shaped
+/// consumer must carry the array depth. The live repro is a MULTI-LINE call
+/// whose binding is last used as a scalar projection:
+///
+/// ```ts
+/// const ordersResponse = await axios.get<Order[]>(
+///   `${ORDER_SERVICE_URL}/api/orders`,
+/// );
+/// const orderCount = ordersResponse.data.length;
+/// ```
+///
+/// The LLM anchor is the bare element (`Order`), so the explicit bundle
+/// pre-claims the consumer alias; the depth must be recovered by inference and
+/// copied onto the `SymbolRequest` (`apply_inferred_array_depth`). Before the
+/// fix, the single-line locator print missed the multi-line call AND the
+/// terminal-use walk anchored on `number`, so the bundle rendered
+/// `export interface <alias> {...}` with the `[]` gone and every scan reported
+/// a false `{...}[] not assignable` contract risk. This asserts the rendered
+/// definition — the artifact the manifest stores and ts_check compares — not
+/// the intermediate inference.
+#[test]
+fn test_multiline_call_result_bundles_array_definition() {
+    use carrick::services::type_sidecar::{
+        ExtractionConfig, ExtractionRule, InferKind, InferRequestItem, SymbolRequest, TypeSidecar,
+    };
+    use std::time::Duration;
+
+    if !is_node_available() {
+        eprintln!("Skipping test: Node.js not available");
+        return;
+    }
+    let sidecar_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/sidecar/dist/src/index.js");
+    if !sidecar_path.exists() {
+        eprintln!("Skipping test: Sidecar not built (run: cd src/sidecar && npm run build)");
+        return;
+    }
+
+    // Consumer repo mirroring carrick-demo-notification-service, with a stub
+    // axios so no npm install is needed.
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let repo = temp_dir.path().join("consumer");
+    fs::create_dir_all(repo.join("src")).expect("Failed to create src");
+    fs::create_dir_all(repo.join("node_modules/axios")).expect("Failed to create axios stub dir");
+    fs::write(
+        repo.join("package.json"),
+        r#"{ "name": "consumer-app", "version": "1.0.0", "dependencies": { "axios": "^1.6.0" } }"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("node_modules/axios/package.json"),
+        r#"{ "name": "axios", "version": "1.6.0", "main": "index.js", "types": "index.d.ts" }"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("node_modules/axios/index.d.ts"),
+        r#"export interface AxiosResponse<T = any> {
+  data: T;
+  status: number;
+}
+export interface AxiosInstance {
+  get<T = any>(url: string): Promise<AxiosResponse<T>>;
+}
+declare const axios: AxiosInstance;
+export default axios;
+"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("src/types.ts"),
+        r#"export interface Order {
+  id: number;
+  userId: number;
+  product: string;
+  amount: number;
+}
+"#,
+    )
+    .unwrap();
+    // The call spans three lines with a trailing comma (line 7 = call start).
+    fs::write(
+        repo.join("src/api.ts"),
+        r#"import axios from 'axios';
+import { Order } from './types';
+
+const ORDER_SERVICE_URL = 'http://localhost:3002';
+
+export async function getOrderCount(): Promise<number> {
+  const ordersResponse = await axios.get<Order[]>(
+    `${ORDER_SERVICE_URL}/api/orders`,
+  );
+  const orderCount = ordersResponse.data.length;
+  return orderCount;
+}
+"#,
+    )
+    .unwrap();
+
+    let sidecar = TypeSidecar::spawn(&sidecar_path).expect("Failed to spawn sidecar");
+    sidecar.start_init(&repo, None);
+    sidecar
+        .wait_ready(Duration::from_secs(60))
+        .expect("Sidecar failed to initialize");
+
+    let alias = "Endpoint_4022e5b76e4552db_Response_Call8904b52acc58d4d6";
+    // The LLM-extracted anchor: bare element symbol, alias pre-claimed.
+    let explicit = vec![SymbolRequest {
+        symbol_name: "Order".to_string(),
+        source_file: repo.join("src/types.ts").to_string_lossy().to_string(),
+        alias: Some(alias.to_string()),
+        array_depth: None,
+    }];
+    // The LLM's compact single-line locator for the multi-line call.
+    let infer = vec![InferRequestItem {
+        file_path: repo.join("src/api.ts").to_string_lossy().to_string(),
+        line_number: 7,
+        span_start: None,
+        span_end: None,
+        expression_text: Some("axios.get<Order[]>(`${ORDER_SERVICE_URL}/api/orders`)".to_string()),
+        expression_line: Some(7),
+        infer_kind: InferKind::CallResult,
+        alias: Some(alias.to_string()),
+        param_name: None,
+    }];
+    let config = ExtractionConfig {
+        rules: vec![ExtractionRule {
+            wrapper_symbols: vec!["AxiosResponse".to_string()],
+            origin_module_globs: vec!["axios".to_string(), "axios/*".to_string()],
+            payload_generic_index: Some(0),
+            ..Default::default()
+        }],
+    };
+
+    let result = sidecar
+        .resolve_all_types(&explicit, &infer, Some(&config))
+        .expect("resolve_all_types failed");
+    let dts = result.dts_content.expect("expected bundled dts content");
+
+    // The bundled alias must be an array-form type alias. An
+    // `export interface` structurally cannot carry the depth — that is the
+    // exact live artifact this test locks out.
+    assert!(
+        !dts.contains(&format!("export interface {}", alias)),
+        "bundled alias must not render as a depth-less interface:\n{}",
+        dts
+    );
+    let alias_line = dts
+        .lines()
+        .find(|l| l.contains(&format!("export type {} =", alias)))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected an `export type {} = ...` alias in:\n{}",
+                alias, dts
+            )
+        });
+    assert!(
+        alias_line.trim_end().trim_end_matches(';').ends_with("[]"),
+        "bundled alias must keep the use-site array depth, got: {}",
+        alias_line
+    );
+
+    // And the definition the manifest stores (resolved_definition /
+    // expanded_definition) must resolve to the same array form.
+    let definitions = sidecar
+        .resolve_definitions(&dts, &[alias.to_string()])
+        .expect("resolve_definitions failed");
+    let def = definitions
+        .iter()
+        .find(|d| d.type_alias == alias)
+        .expect("expected a resolved definition for the consumer alias");
+    assert!(
+        def.definition
+            .trim_end()
+            .trim_end_matches(';')
+            .ends_with("[]"),
+        "resolved_definition dropped the array depth: {}",
+        def.definition
+    );
+    assert!(
+        def.expanded.trim_end().ends_with("[]"),
+        "expanded_definition dropped the array depth: {}",
+        def.expanded
+    );
+}
+
 // ============================================================================
 // Integration with Carrick CLI (when available)
 // ============================================================================


### PR DESCRIPTION
Fixes #336 (reopened).

## The remaining gap was upstream of the renderer, not in it

The reopened evidence pointed at the definition renderer, but the bundle path has consumed `array_depth` since #248 and `apply_inferred_array_depth` (#306) correctly copies an inference-reported depth onto the explicit `SymbolRequest`. Reproducing the exact live shape against the sidecar showed the depth never *reached* that machinery: for the real call in carrick-demo-notification-service (commit eec5baf)

```ts
const ordersResponse = await axios.get<Order[]>(
  `${ORDER_SERVICE_URL}/api/orders`,
);
const orderCount = ordersResponse.data.length;
```

the `call_result` inference reported `type_string: "any"` (text locator) or `"number"` (call found), with no `primary_type_symbol` and no `array_depth`. With nothing to copy, the explicit bundle rendered the bare element as `export interface Alias {...}` and the `[]` was gone by construction. #341's fix was correct but only reachable when the call is single-line and the binding's last use is the payload itself.

## Two independent drops

**1. Locator: one space after `(` defeated exact matching.** `normalizeWhitespace` collapses the multi-line call to `axios.get<Order[]>( \`...\`)` while the LLM's compact print has no space after the paren. Exact match failed, the CallExpression lookup missed, and the substring fallback bound the template-literal fragment *inside* the call. This is the opening-delimiter mirror of the #335/#339 trailing-comma fix; the normalizer now strips whitespace after `(` `[` `{` symmetrically.

**2. Anchor source: the terminal-use walk erased the payload.** Even with the call found, `inferCallResult` derived the #341 anchor from the terminal node, and the def-use walk follows the binding to its last use — here `.data.length`, a bare `number` with no symbol and no depth. The manifest alias describes the call's response contract, so the anchor is now derived from the call expression's own payload type (Promise-unwrapped, rule-unwrapped), yielding `(Order, depth 1)` regardless of how the binding is later consumed. All four #341 anchor tests (wrapped array, direct array, opaque collapse, scalar) pass unchanged.

## End-to-end verification

Against the actual demo repo at the failing commit, the pipeline now produces exactly the artifact the issue demands:

```
export type Endpoint_4022e5b76e4552db_Response_Call8904b52acc58d4d6 = { id: number; userId: number; product: string; amount: number; }[];
```

## Tests (all failing-first against the pre-fix sidecar)

- `src/sidecar/test/infer-call-result-array-anchor.test.ts`: multi-line call located by the single-line LLM print anchors `OrderData` + depth 1 (exercises both fixes); span-located variant isolates the terminal-use bug (`.data.length` must not erase the anchor). New fixture `wrapper-multiline.ts` mirrors the live shape.
- `tests/sidecar_integration_test.rs::test_multiline_call_result_bundles_array_definition`: end-artifact test through `resolve_all_types` + `resolve_definitions` asserting the bundled alias is `export type ... = {...}[]` (not an `export interface`) and that `resolved_definition`/`expanded_definition` keep the array form.

Suites: sidecar 110 pass / 0 fail (1 pre-existing skip), `cargo test` all 21 binaries green, ts_check 90 pass, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)