### PR TITLE
fix(sidecar): tolerate SWC 1-based spans when binding a call_result locator

### DIFF
--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -2413,12 +2413,24 @@ export class TypeInferrer {
     spanStart: number,
     spanEnd: number
   ): CallExpression | undefined {
+    // Tolerate the SWC span convention (#336): the scanner sends raw SWC
+    // BytePos offsets, which are 1-based (BytePos(1) is the file's first
+    // byte), while ts-morph offsets are 0-based — so an SWC-sourced span
+    // sits one byte past the call on BOTH ends. Under strict containment the
+    // shifted end overshoots the call's own end, the true call is excluded,
+    // and the smallest ENCLOSING call wins: for a data call inside a route
+    // registration that is the whole `router.get("/status", handler)`
+    // expression, anchoring the router type instead of the payload. The
+    // slack admits both conventions; the size-delta pick below still prefers
+    // the call whose extent matches the span, so the exactly-covered inner
+    // call always beats its enclosing registration.
+    const SPAN_SLACK = 2;
     const callExpressions = sourceFile
       .getDescendantsOfKind(SyntaxKind.CallExpression);
     const candidates = callExpressions.filter((expr) => {
       const start = expr.getStart();
       const end = expr.getEnd();
-      return start <= spanStart && spanEnd <= end;
+      return start - SPAN_SLACK <= spanStart && spanEnd <= end + SPAN_SLACK;
     });
 
     if (candidates.length === 0) {

--- a/src/sidecar/test/fixtures/sample-repo/src/wrapper-multiline.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/wrapper-multiline.ts
@@ -29,3 +29,21 @@ export async function getOrderCount(): Promise<number> {
   const orderCount = ordersResponse.data.length;
   return orderCount;
 }
+
+// #336 third path: the live locator is an SWC-shaped SPAN (1-based BytePos,
+// so both ends sit one byte past the ts-morph 0-based offsets). Under strict
+// containment that excludes the real call — the shifted end overshoots the
+// call's end by one byte — and escalates to the smallest ENCLOSING call, the
+// route registration, whose type anchors the router instead of the payload.
+// Mirrors the live `notificationRouter.get("/status", async handler)`.
+interface FakeRouter {
+  get(path: string, handler: () => Promise<void>): FakeRouter;
+}
+declare const fakeRouter: FakeRouter;
+
+fakeRouter.get('/status', async () => {
+  const statusOrders = await apiGetOrders<OrderData[]>(
+    `${ORDER_SERVICE_URL}/api/orders-status`,
+  );
+  console.log(statusOrders.data.length);
+});

--- a/src/sidecar/test/infer-call-result-array-anchor.test.ts
+++ b/src/sidecar/test/infer-call-result-array-anchor.test.ts
@@ -257,7 +257,10 @@ describe('call_result array payloads anchor on the element symbol with array_dep
   ];
 
   it('multi-line call located by the single-line LLM print → anchor OrderData, depth 1 (#336 live shape)', async () => {
-    const callStart = spanOf('apiGetOrders<OrderData[]>(', MULTILINE_FIXTURE);
+    const callStart = spanOf(
+      'apiGetOrders<OrderData[]>(\n    `${ORDER_SERVICE_URL}/api/orders`,',
+      MULTILINE_FIXTURE
+    );
     const response = await client.send<InferResponseShape>({
       action: 'infer',
       request_id: 'call-arr-multiline-text',
@@ -298,9 +301,11 @@ describe('call_result array payloads anchor on the element symbol with array_dep
 
   it('terminal scalar use (`.data.length`) must not erase the call payload anchor (span locator)', async () => {
     const source = fs.readFileSync(MULTILINE_FIXTURE, 'utf-8');
-    const start = source.indexOf('apiGetOrders<OrderData[]>(');
+    const callText =
+      'apiGetOrders<OrderData[]>(\n    `${ORDER_SERVICE_URL}/api/orders`,\n  )';
+    const start = source.indexOf(callText);
     assert.ok(start >= 0, 'fixture must contain the multi-line call');
-    const end = source.indexOf(');', start) + 1;
+    const end = start + callText.length;
     const line = source.slice(0, start).split('\n').length;
 
     const response = await client.send<InferResponseShape>({
@@ -332,5 +337,56 @@ describe('call_result array payloads anchor on the element symbol with array_dep
       `anchor must come from the call's payload, not the terminal use, got ${JSON.stringify(inferred.primary_type_symbol)} (type_string: ${JSON.stringify(inferred.type_string)})`
     );
     assert.strictEqual(inferred.array_depth, 1);
+  });
+
+  it('SWC-shaped span (1-based) inside a route registration binds the payload call, not the registration (#336 third path)', async () => {
+    // The scanner sends raw SWC BytePos spans: 1-based, so both ends sit one
+    // byte past the ts-morph 0-based offsets. Strict containment excluded the
+    // real call (the shifted end overshoots its end by one byte) and bound the
+    // enclosing `fakeRouter.get(...)` registration instead, anchoring the
+    // router type with no depth — so the explicit bundle rendered the bare
+    // element interface and the [] was erased.
+    const source = fs.readFileSync(MULTILINE_FIXTURE, 'utf-8');
+    const callText =
+      'apiGetOrders<OrderData[]>(\n    `${ORDER_SERVICE_URL}/api/orders-status`,\n  )';
+    const start = source.indexOf(callText);
+    assert.ok(start >= 0, 'fixture must contain the registration-wrapped call');
+    const end = start + callText.length;
+    const line = source.slice(0, start).split('\n').length;
+
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'call-arr-swc-span',
+      extraction_config: { rules: MULTILINE_RULES },
+      requests: [
+        {
+          file_path: MULTILINE_FIXTURE,
+          line_number: line,
+          // SWC convention: BytePos(1) is the first byte of the file.
+          span_start: start + 1,
+          span_end: end + 1,
+          infer_kind: 'call_result',
+          alias: 'OrderArraySwcSpanConsumer',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'OrderArraySwcSpanConsumer'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.strictEqual(
+      inferred.primary_type_symbol,
+      'OrderData',
+      `span lookup must bind the payload call, not the enclosing registration, got ${JSON.stringify(inferred.primary_type_symbol)} (type_string: ${JSON.stringify(inferred.type_string)})`
+    );
+    assert.strictEqual(
+      inferred.array_depth,
+      1,
+      'without the depth the explicit bundle renders the bare element and the [] is erased'
+    );
   });
 });

--- a/tests/sidecar_integration_test.rs
+++ b/tests/sidecar_integration_test.rs
@@ -855,6 +855,201 @@ export async function getOrderCount(): Promise<number> {
     );
 }
 
+/// #336 third path: the live rescan on v0.2.4 still dropped the depth because
+/// the extraction supplied an SWC SPAN locator (no expression text). SWC
+/// BytePos is 1-based, so the span sits one byte past the ts-morph 0-based
+/// call on BOTH ends; strict containment excluded the real `axios.get` call
+/// and escalated to the smallest ENCLOSING call — the whole
+/// `notificationRouter.get("/status", handler)` registration — anchoring
+/// `Router` instead of `Order`, so `apply_inferred_array_depth` had nothing to
+/// copy and the bundle rendered the depth-less interface again. Mirrors the
+/// live file_results data_call exactly: span locator, `primary_type_symbol`
+/// "Order", `type_import_source` set, multi-line call inside a route
+/// registration, scalar terminal use.
+#[test]
+fn test_swc_span_call_result_bundles_array_definition() {
+    use carrick::services::type_sidecar::{
+        ExtractionConfig, ExtractionRule, InferKind, InferRequestItem, SymbolRequest, TypeSidecar,
+    };
+    use std::time::Duration;
+
+    if !is_node_available() {
+        eprintln!("Skipping test: Node.js not available");
+        return;
+    }
+    let sidecar_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/sidecar/dist/src/index.js");
+    if !sidecar_path.exists() {
+        eprintln!("Skipping test: Sidecar not built (run: cd src/sidecar && npm run build)");
+        return;
+    }
+
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let repo = temp_dir.path().join("consumer");
+    fs::create_dir_all(repo.join("src")).expect("Failed to create src");
+    fs::create_dir_all(repo.join("node_modules/axios")).expect("Failed to create axios stub dir");
+    fs::write(
+        repo.join("package.json"),
+        r#"{ "name": "consumer-app", "version": "1.0.0", "dependencies": { "axios": "^1.6.0" } }"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("node_modules/axios/package.json"),
+        r#"{ "name": "axios", "version": "1.6.0", "main": "index.js", "types": "index.d.ts" }"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("node_modules/axios/index.d.ts"),
+        r#"export interface AxiosResponse<T = any> {
+  data: T;
+  status: number;
+}
+export interface AxiosInstance {
+  get<T = any>(url: string): Promise<AxiosResponse<T>>;
+}
+declare const axios: AxiosInstance;
+export default axios;
+"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("src/types.ts"),
+        r#"export interface Order {
+  id: number;
+  userId: number;
+  product: string;
+  amount: number;
+}
+"#,
+    )
+    .unwrap();
+    // The registration-wrapped call mirrors the live server.ts shape.
+    let api_source = r#"import axios from 'axios';
+import { Order } from './types';
+
+const ORDER_SERVICE_URL = 'http://localhost:3002';
+
+interface Router {
+  get(path: string, handler: () => Promise<void>): Router;
+}
+declare const notificationRouter: Router;
+
+notificationRouter.get('/status', async () => {
+  const ordersResponse = await axios.get<Order[]>(
+    `${ORDER_SERVICE_URL}/api/orders`,
+  );
+  const orderCount = ordersResponse.data.length;
+  console.log(orderCount);
+});
+"#;
+    fs::write(repo.join("src/api.ts"), api_source).unwrap();
+
+    // SWC-style span of the multi-line call: 1-based BytePos on both ends,
+    // exactly as the scanner's `span_range` (`span.lo.0`, `span.hi.0`) emits.
+    let call_text = "axios.get<Order[]>(\n    `${ORDER_SERVICE_URL}/api/orders`,\n  )";
+    let call_start = api_source
+        .find(call_text)
+        .expect("api.ts must contain the multi-line call");
+    let span_start = (call_start + 1) as u32;
+    let span_end = (call_start + call_text.len() + 1) as u32;
+    let line_number = (api_source[..call_start].matches('\n').count() + 1) as u32;
+
+    let sidecar = TypeSidecar::spawn(&sidecar_path).expect("Failed to spawn sidecar");
+    sidecar.start_init(&repo, None);
+    sidecar
+        .wait_ready(Duration::from_secs(60))
+        .expect("Sidecar failed to initialize");
+
+    let alias = "Endpoint_4022e5b76e4552db_Response_Call8904b52acc58d4d6";
+    let explicit = vec![SymbolRequest {
+        symbol_name: "Order".to_string(),
+        source_file: repo.join("src/types.ts").to_string_lossy().to_string(),
+        alias: Some(alias.to_string()),
+        array_depth: None,
+    }];
+    // Span locator only — the live data_call carried no expression text.
+    let infer = vec![InferRequestItem {
+        file_path: repo.join("src/api.ts").to_string_lossy().to_string(),
+        line_number,
+        span_start: Some(span_start),
+        span_end: Some(span_end),
+        expression_text: None,
+        expression_line: None,
+        infer_kind: InferKind::CallResult,
+        alias: Some(alias.to_string()),
+        param_name: None,
+    }];
+    let config = ExtractionConfig {
+        rules: vec![ExtractionRule {
+            wrapper_symbols: vec!["AxiosResponse".to_string()],
+            origin_module_globs: vec!["axios".to_string(), "axios/*".to_string()],
+            payload_generic_index: Some(0),
+            ..Default::default()
+        }],
+    };
+
+    let result = sidecar
+        .resolve_all_types(&explicit, &infer, Some(&config))
+        .expect("resolve_all_types failed");
+    let dts = result.dts_content.expect("expected bundled dts content");
+
+    assert!(
+        !dts.contains(&format!("export interface {}", alias)),
+        "bundled alias must not render as a depth-less interface:\n{}",
+        dts
+    );
+    let alias_line = dts
+        .lines()
+        .find(|l| l.contains(&format!("export type {} =", alias)))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected an `export type {} = ...` alias in:\n{}",
+                alias, dts
+            )
+        });
+    assert!(
+        alias_line.trim_end().trim_end_matches(';').ends_with("[]"),
+        "bundled alias must keep the use-site array depth, got: {}",
+        alias_line
+    );
+
+    let definitions = sidecar
+        .resolve_definitions(&dts, &[alias.to_string()])
+        .expect("resolve_definitions failed");
+    let def = definitions
+        .iter()
+        .find(|d| d.type_alias == alias)
+        .expect("expected a resolved definition for the consumer alias");
+    assert!(
+        def.definition
+            .trim_end()
+            .trim_end_matches(';')
+            .ends_with("[]"),
+        "resolved_definition dropped the array depth: {}",
+        def.definition
+    );
+    assert!(
+        def.expanded.trim_end().ends_with("[]"),
+        "expanded_definition dropped the array depth: {}",
+        def.expanded
+    );
+}
+
 // ============================================================================
 // Integration with Carrick CLI (when available)
 // ============================================================================


### PR DESCRIPTION
References #336 (third live path, after #344).

## What the live scan actually hit

The v0.2.4 rescan (carrick-demo-notification-service `c30d80d9`) supplied a **span locator with no expression text**: `call_expression_span_start 1282 / span_end 1352`. In `server.ts` those bytes are `"xios.get<Order[]>(...);"` — the real call sits at ts-morph 0-based offsets `[1281, 1351)`. The scanner's `span_range` emits raw SWC BytePos (`span.lo.0` / `span.hi.0`), which is **1-based** (`BytePos(1)` is the file's first byte; the per-file `SourceMap` already makes them file-local), while ts-morph offsets are 0-based. So every SWC-sourced span sits one byte past the call on both ends.

`findCallExpressionAtSpan` required strict containment (`start <= spanStart && spanEnd <= end`). The one-byte overshoot at the end excluded the real `axios.get<Order[]>` call, and the lookup escalated to the smallest **enclosing** CallExpression — the whole `notificationRouter.get("/status", handler)` registration (lines 24–68). Reproducing the exact live inputs against the sidecar:

```
INFERRED: primary_type_symbol "Router", no array_depth, source_location lines 24-68
```

With `Router != Order`, `apply_inferred_array_depth` copied nothing (symbol-agreement guard), and the explicit bundle rendered the depth-less `export interface Endpoint_..._Call... { id: number; ... }` — byte-identical to the stored live artifact.

**Not the hypothesized symbol-render gap:** the bundle renderer has consumed `array_depth` since #248, and #344's anchor fix works — the depth never *arrived* because the span bound the wrong call.

## Fix

`findCallExpressionAtSpan` now admits candidates within a 2-byte slack on each end. The existing size-delta pick still prefers the call whose extent matches the span, so the exactly-covered inner call always beats its enclosing registration, and exact 0-based spans (sidecar tests, tooling) keep binding identically.

With this, the exact live inputs (span 1282–1352, LLM symbol `Order`, `type_import_source "types/order"`) produce end-to-end:

```
export type Endpoint_4022e5b76e4552db_Response_Call8904b52acc58d4d6 = { id: number; userId: number; product: string; amount: number; }[];
```

## Tests (failing-first against the pre-fix sidecar)

- `src/sidecar/test/infer-call-result-array-anchor.test.ts`: "SWC-shaped span (1-based) inside a route registration binds the payload call, not the registration" — pre-fix it anchored `FakeRouter` (the live `Router` escalation); the fixture gains a registration-wrapped multi-line call.
- `tests/sidecar_integration_test.rs::test_swc_span_call_result_bundles_array_definition`: end-artifact test mirroring the live `file_results` data_call exactly (span locator only, `primary_type_symbol` "Order", `type_import_source`, registration-wrapped multi-line call, scalar terminal use) through `resolve_all_types` + `resolve_definitions`. Pre-fix it fails with the exact live `export interface` artifact.

Suites: sidecar 111 pass / 0 fail (1 pre-existing skip), full `cargo test` all 21 binaries green, ts_check 90 pass, clippy clean, pre-commit hook run in full.

Follow-up worth tracking separately: `findNodeAtSpan` and `findContainingFunctionBySpan` use the same strict containment and carry the same systematic one-byte bias for SWC-sourced spans; they currently absorb it by binding enclosing statements. Aligning them (or normalizing the convention at the scanner boundary, which would also change `candidate_id`) is a larger-blast-radius change than this fix needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)