### PR TITLE
fix(sidecar): anchor call_result from the explicit call generic when the client type is untyped

### DIFF
--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -639,9 +639,42 @@ export class TypeInferrer {
     const anchorSource = callUnwrap.wasUnwrapped
       ? callUnwrap.payloadType
       : callPayloadType;
-    const anchor = anchorSource
+    let anchor = anchorSource
       ? this.unwrapArrayLevels(this.unwrapPromiseType(anchorSource))
       : undefined;
+
+    // #336 CI shape: the scanned checkout often has NO node_modules (the
+    // GitHub Action scans a bare checkout), so the client library resolves to
+    // `any`, the call's semantic type carries no symbol, and the anchor above
+    // is empty — erasing the depth even though the caller wrote it out. The
+    // payload claim is still in the AST: a SINGLE explicit call generic
+    // (`axios.get<Order[]>`), whose type resolves against the repo's own
+    // sources regardless of the untyped client. This is the same generic the
+    // LLM's `primary_type_symbol` schema contract extracts, and the Rust
+    // depth-copy's symbol-agreement guard makes a mismatched fallback inert.
+    // Multi-generic calls are ambiguous and anchor nothing here.
+    if (!anchor || !this.primaryTypeSymbol(anchor.element)) {
+      const typeArgs = callExpr.getTypeArguments();
+      if (typeArgs.length === 1) {
+        const argType = this.unwrapPromiseType(typeArgs[0].getType());
+        const argUnwrap = this.unwrapTypeWithConfig(
+          argType,
+          typeArgs[0],
+          extractionConfig
+        );
+        const argSource = argUnwrap.wasUnwrapped
+          ? argUnwrap.payloadType
+          : argType;
+        if (argSource) {
+          const argAnchor = this.unwrapArrayLevels(
+            this.unwrapPromiseType(argSource)
+          );
+          if (this.primaryTypeSymbol(argAnchor.element)) {
+            anchor = argAnchor;
+          }
+        }
+      }
+    }
 
     return this.createInferredType(
       request,

--- a/src/sidecar/test/fixtures/sample-repo/src/wrapper-multiline.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/wrapper-multiline.ts
@@ -47,3 +47,19 @@ fakeRouter.get('/status', async () => {
   );
   console.log(statusOrders.data.length);
 });
+
+// #336 fourth path (the CI shape): the scanned checkout has NO node_modules —
+// the demo workflow is checkout + carrick with no npm install — so the client
+// library resolves to `any` and the call's SEMANTIC type carries nothing to
+// anchor on. The caller's payload claim is still in the AST: the single
+// explicit call generic (`axios.get<Order[]>`), whose type resolves against
+// the repo's OWN sources regardless of the untyped client. `untypedAxios: any`
+// mirrors what `import axios from 'axios'` resolves to without node_modules.
+declare const untypedAxios: any;
+
+fakeRouter.get('/orders-untyped', async () => {
+  const ordersResponse = await untypedAxios.get<OrderData[]>(
+    `${ORDER_SERVICE_URL}/api/orders-untyped`,
+  );
+  console.log(ordersResponse.data.length);
+});

--- a/src/sidecar/test/infer-call-result-array-anchor.test.ts
+++ b/src/sidecar/test/infer-call-result-array-anchor.test.ts
@@ -389,4 +389,56 @@ describe('call_result array payloads anchor on the element symbol with array_dep
       'without the depth the explicit bundle renders the bare element and the [] is erased'
     );
   });
+
+  it('untyped client (`any`, no node_modules in CI) still anchors from the explicit call generic (#336 CI shape)', async () => {
+    // The live CI scan runs against a checkout with NO node_modules, so
+    // `axios` is `any`, the call's semantic type is `any`, and the semantic
+    // anchor path finds no symbol — the depth was erased even with the span
+    // and unwrap fixes in place. The single explicit generic on the call is
+    // the caller's payload claim and must anchor instead.
+    const source = fs.readFileSync(MULTILINE_FIXTURE, 'utf-8');
+    const callText =
+      'untypedAxios.get<OrderData[]>(\n    `${ORDER_SERVICE_URL}/api/orders-untyped`,\n  )';
+    const start = source.indexOf(callText);
+    assert.ok(start >= 0, 'fixture must contain the untyped-client call');
+    const end = start + callText.length;
+    const line = source.slice(0, start).split('\n').length;
+
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'call-arr-untyped-client',
+      // Rules are present (the cloud generates them either way) but inert:
+      // they cannot match a wrapper on an `any` call type, exactly as in CI.
+      extraction_config: { rules: MULTILINE_RULES },
+      requests: [
+        {
+          file_path: MULTILINE_FIXTURE,
+          line_number: line,
+          // SWC convention, as the scanner sends it.
+          span_start: start + 1,
+          span_end: end + 1,
+          infer_kind: 'call_result',
+          alias: 'OrderArrayUntypedClientConsumer',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'OrderArrayUntypedClientConsumer'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    assert.strictEqual(
+      inferred.primary_type_symbol,
+      'OrderData',
+      `an untyped client must anchor from the explicit call generic, got ${JSON.stringify(inferred.primary_type_symbol)} (type_string: ${JSON.stringify(inferred.type_string)})`
+    );
+    assert.strictEqual(
+      inferred.array_depth,
+      1,
+      'without the depth the explicit bundle renders the bare element and the [] is erased'
+    );
+  });
 });

--- a/tests/sidecar_integration_test.rs
+++ b/tests/sidecar_integration_test.rs
@@ -1050,6 +1050,181 @@ notificationRouter.get('/status', async () => {
     );
 }
 
+/// #336 fourth path — the CI condition proven against the SHIPPED v0.2.5 dist:
+/// the GitHub Action scans a bare checkout (the demo workflow is
+/// `actions/checkout` + `daveymoores/carrick` with no `npm install`), so
+/// `import axios from 'axios'` resolves to `any`, the call's SEMANTIC type
+/// carries no symbol, and the anchor path found nothing — the depth was erased
+/// even with the span-slack (#346) and call-payload-anchor (#344) fixes in
+/// place, because those recover the depth from the resolved type, which no
+/// longer exists. The caller's payload claim is still in the AST: the single
+/// explicit call generic `<Order[]>`, whose type resolves against the repo's
+/// OWN sources. Unlike the sibling tests above, this repo has NO axios stub in
+/// node_modules — exactly like CI.
+#[test]
+fn test_untyped_client_call_result_bundles_array_definition() {
+    use carrick::services::type_sidecar::{
+        ExtractionConfig, ExtractionRule, InferKind, InferRequestItem, SymbolRequest, TypeSidecar,
+    };
+    use std::time::Duration;
+
+    if !is_node_available() {
+        eprintln!("Skipping test: Node.js not available");
+        return;
+    }
+    let sidecar_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/sidecar/dist/src/index.js");
+    if !sidecar_path.exists() {
+        eprintln!("Skipping test: Sidecar not built (run: cd src/sidecar && npm run build)");
+        return;
+    }
+
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let repo = temp_dir.path().join("consumer");
+    fs::create_dir_all(repo.join("src")).expect("Failed to create src");
+    // Deliberately NO node_modules: mirror the Action's bare checkout.
+    fs::write(
+        repo.join("package.json"),
+        r#"{ "name": "consumer-app", "version": "1.0.0", "dependencies": { "axios": "^1.6.0" } }"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("src/types.ts"),
+        r#"export interface Order {
+  id: number;
+  userId: number;
+  product: string;
+  amount: number;
+}
+"#,
+    )
+    .unwrap();
+    let api_source = r#"import axios from 'axios';
+import { Order } from './types';
+
+const ORDER_SERVICE_URL = 'http://localhost:3002';
+
+interface Router {
+  get(path: string, handler: () => Promise<void>): Router;
+}
+declare const notificationRouter: Router;
+
+notificationRouter.get('/status', async () => {
+  const ordersResponse = await axios.get<Order[]>(
+    `${ORDER_SERVICE_URL}/api/orders`,
+  );
+  const orderCount = ordersResponse.data.length;
+  console.log(orderCount);
+});
+"#;
+    fs::write(repo.join("src/api.ts"), api_source).unwrap();
+
+    // SWC-style span (1-based on both ends), as the scanner's span_range emits.
+    let call_text = "axios.get<Order[]>(\n    `${ORDER_SERVICE_URL}/api/orders`,\n  )";
+    let call_start = api_source
+        .find(call_text)
+        .expect("api.ts must contain the multi-line call");
+    let span_start = (call_start + 1) as u32;
+    let span_end = (call_start + call_text.len() + 1) as u32;
+    let line_number = (api_source[..call_start].matches('\n').count() + 1) as u32;
+
+    let sidecar = TypeSidecar::spawn(&sidecar_path).expect("Failed to spawn sidecar");
+    sidecar.start_init(&repo, None);
+    sidecar
+        .wait_ready(Duration::from_secs(60))
+        .expect("Sidecar failed to initialize");
+
+    let alias = "Endpoint_4022e5b76e4552db_Response_Call8904b52acc58d4d6";
+    let explicit = vec![SymbolRequest {
+        symbol_name: "Order".to_string(),
+        source_file: repo.join("src/types.ts").to_string_lossy().to_string(),
+        alias: Some(alias.to_string()),
+        array_depth: None,
+    }];
+    let infer = vec![InferRequestItem {
+        file_path: repo.join("src/api.ts").to_string_lossy().to_string(),
+        line_number,
+        span_start: Some(span_start),
+        span_end: Some(span_end),
+        expression_text: None,
+        expression_line: None,
+        infer_kind: InferKind::CallResult,
+        alias: Some(alias.to_string()),
+        param_name: None,
+    }];
+    // Rules are present (the cloud generates them either way) but inert: they
+    // cannot match a wrapper on an `any` call type, exactly as in CI.
+    let config = ExtractionConfig {
+        rules: vec![ExtractionRule {
+            wrapper_symbols: vec!["AxiosResponse".to_string()],
+            origin_module_globs: vec!["axios".to_string(), "axios/*".to_string()],
+            payload_generic_index: Some(0),
+            ..Default::default()
+        }],
+    };
+
+    let result = sidecar
+        .resolve_all_types(&explicit, &infer, Some(&config))
+        .expect("resolve_all_types failed");
+    let dts = result.dts_content.expect("expected bundled dts content");
+
+    assert!(
+        !dts.contains(&format!("export interface {}", alias)),
+        "bundled alias must not render as a depth-less interface:\n{}",
+        dts
+    );
+    let alias_line = dts
+        .lines()
+        .find(|l| l.contains(&format!("export type {} =", alias)))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected an `export type {} = ...` alias in:\n{}",
+                alias, dts
+            )
+        });
+    assert!(
+        alias_line.trim_end().trim_end_matches(';').ends_with("[]"),
+        "bundled alias must keep the use-site array depth, got: {}",
+        alias_line
+    );
+
+    let definitions = sidecar
+        .resolve_definitions(&dts, &[alias.to_string()])
+        .expect("resolve_definitions failed");
+    let def = definitions
+        .iter()
+        .find(|d| d.type_alias == alias)
+        .expect("expected a resolved definition for the consumer alias");
+    assert!(
+        def.definition
+            .trim_end()
+            .trim_end_matches(';')
+            .ends_with("[]"),
+        "resolved_definition dropped the array depth: {}",
+        def.definition
+    );
+    assert!(
+        def.expanded.trim_end().ends_with("[]"),
+        "expanded_definition dropped the array depth: {}",
+        def.expanded
+    );
+}
+
 // ============================================================================
 // Integration with Carrick CLI (when available)
 // ============================================================================


### PR DESCRIPTION
References #336 (fourth live path, after #344 and #346).

## Proven against the shipped artifact

The v0.2.5 release dist verifiably contains #344 + #346 (byte-identical to a repo build of `origin/main`). Driving that **shipped dist** against the exact live checkout (carrick-demo-notification-service `1b1f62b0`) with the exact live request (`span_start 1292 / span_end 1362`, `call_result`, span-only locator) isolated the divergence deterministically:

| scanned checkout | inference | end artifact |
|---|---|---|
| **no `node_modules`** (the CI condition) | `type_string: "any"`, no anchor, no depth | `export interface Endpoint_..._Call... { id: ... }` — the live artifact |
| with `node_modules` | `Order` + depth 1 | `export type ... = {...}[];` — correct |

The demo workflow is `actions/checkout@v4` + `daveymoores/carrick@v1` — **no `npm install`**. My earlier round-3 verification ran against a checkout with `node_modules` installed; that was the harness/CI divergence.

## Mechanism

With a bare checkout, `import axios from 'axios'` resolves to `any`, so the call's *semantic* type carries no symbol. #344/#346 recover the depth from the resolved call type — which no longer exists. The anchor comes back empty, `apply_inferred_array_depth` has nothing to copy (its symbol-agreement guard needs `Order`), and the explicit bundle — `Order` itself resolves fine, `types/order.ts` is in the repo — renders the depth-less interface.

## Fix

In `inferCallResult`, when the semantic anchor path yields no symbol, derive the anchor from the call's **single explicit type-argument node** (`axios.get<Order[]>` → element `Order`, depth 1). The generic's type resolves against the repo's own sources regardless of the untyped client, and it is the same generic the LLM's `primary_type_symbol` schema contract extracts — so the Rust depth-copy's symbol-agreement guard makes a mismatched fallback inert. Multi-generic calls are ambiguous and anchor nothing (current behavior preserved). All prior #341/#344/#346 anchor tests pass unchanged.

Re-running the exact live inputs (shipped-shape request, bare checkout) with the fixed sidecar now yields `primary_type_symbol "Order", array_depth 1` and the end artifact
`export type Endpoint_4022e5b76e4552db_Response_Call8904b52acc58d4d6 = { id: number; userId: number; product: string; amount: number; }[];`

## Tests (failing-first against the pre-fix sidecar)

- `src/sidecar/test/infer-call-result-array-anchor.test.ts`: "untyped client (`any`, no node_modules in CI) still anchors from the explicit call generic" — pre-fix collapsed to `"any"` with no anchor; the fixture gains an untyped-client (`declare const untypedAxios: any`) registration-wrapped multi-line call.
- `tests/sidecar_integration_test.rs::test_untyped_client_call_result_bundles_array_definition`: mirrors the CI execution path — consumer repo with **no node_modules**, unresolved axios import, SWC-style span-only locator, extraction rules present but inert (they cannot match a wrapper on `any`, exactly as in CI) — through `resolve_all_types` + `resolve_definitions`, asserting the array-form end artifact. Pre-fix it fails with the exact live `export interface`.

Suites: sidecar 112 pass / 0 fail (1 pre-existing skip), full `cargo test` all 21 binaries green, ts_check 90 pass, clippy clean, pre-commit hook run in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)