### PR TITLE
fix: suppress intra-repo pub/sub self-loops in cross-repo projection

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1719,6 +1719,17 @@ impl Analyzer {
                     (producer_repos_by_key.get(&canonical), consumer_repo)
                 {
                     for producer_repo in producer_repos {
+                        // Same-repo publisher↔subscriber (or listener↔emitter) is
+                        // an intra-repo self-loop, not a cross-repo contract edge.
+                        // Drop it structurally on repo identity alone (never on
+                        // topic-name or library patterns) so a dead-letter retry
+                        // loop or any in-process fan-out doesn't surface as a
+                        // self-match. A key that OTHER repos also participate on
+                        // still emits its genuine cross-repo edges — only the
+                        // producer==consumer pair is skipped.
+                        if *producer_repo == consumer_repo {
+                            continue;
+                        }
                         cross_repo_matches.push(CrossRepoMatch {
                             producer_repo: producer_repo.clone(),
                             producer_key: canonical.clone(),
@@ -3012,6 +3023,69 @@ mod tests {
         // Compat is filled in later by overlay_compat_verdicts, not here; pub/sub
         // compat machinery is deferred, so it stays None.
         assert_eq!(e.type_compatible, None);
+    }
+
+    #[test]
+    fn pubsub_intra_repo_self_loop_emits_no_edge() {
+        // Corpus-2 `_must_not_emit`: orders-engine BOTH subscribes (producer /
+        // endpoint) and publishes (consumer / call) the internal `__dlq.retry`
+        // dead-letter topic. Same repo on both sides with no other participant is
+        // an intra-repo self-loop, not a cross-repo contract — no edge.
+        let cm = Lrc::new(SourceMap::default());
+        let mut analyzer = Analyzer::new(Config::default(), cm);
+
+        analyzer.endpoints.push(op_details_in_repo(
+            OperationKey::pubsub("__dlq.retry"),
+            "orders-engine/src/kafka/dlq.ts:26",
+            "orders-engine",
+        ));
+        analyzer.calls.push(op_details_in_repo(
+            OperationKey::pubsub("__dlq.retry"),
+            "orders-engine/src/kafka/dlq.ts:19",
+            "orders-engine",
+        ));
+
+        let (_, _, edges) = analyzer.analyze_exact_key_matches(crate::operation::Protocol::Pubsub);
+        assert!(
+            edges.is_empty(),
+            "intra-repo self-loop must not emit a cross-repo edge, got {edges:?}"
+        );
+    }
+
+    #[test]
+    fn pubsub_self_edge_dropped_but_cross_edges_survive() {
+        // Fan-in must not regress: two repos subscribe `order.placed`
+        // (producers), and orders-engine ALSO publishes it (consumer). Only the
+        // orders-engine→orders-engine self-edge is dropped; the genuine
+        // orders-engine(publisher) → notifications-svc(subscriber) cross edge
+        // survives.
+        let cm = Lrc::new(SourceMap::default());
+        let mut analyzer = Analyzer::new(Config::default(), cm);
+
+        analyzer.endpoints.push(op_details_in_repo(
+            OperationKey::pubsub("order.placed"),
+            "notifications-svc/src/consume.ts:4",
+            "notifications-svc",
+        ));
+        analyzer.endpoints.push(op_details_in_repo(
+            OperationKey::pubsub("order.placed"),
+            "orders-engine/src/consume.ts:4",
+            "orders-engine",
+        ));
+        analyzer.calls.push(op_details_in_repo(
+            OperationKey::pubsub("order.placed"),
+            "orders-engine/src/producer.ts:7",
+            "orders-engine",
+        ));
+
+        let (_, _, edges) = analyzer.analyze_exact_key_matches(crate::operation::Protocol::Pubsub);
+        assert_eq!(
+            edges.len(),
+            1,
+            "self-edge dropped, cross edge kept; got {edges:?}"
+        );
+        assert_eq!(edges[0].producer_repo, "notifications-svc");
+        assert_eq!(edges[0].consumer_repo, "orders-engine");
     }
 
     #[test]

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -147,7 +147,16 @@ impl EvalProjection {
         // behaves identically for Kafka/Redis/NATS/RabbitMQ and socket events. A
         // key that any OTHER repo also touches (fan-in/fan-out), or that a single
         // repo only produces OR only consumes (an orphan), is left untouched.
-        let self_loop_keys = Self::intra_repo_self_loop_keys(result);
+        let self_loops = Self::intra_repo_self_loops(result);
+        // Drop an op only when its OWN repo attribution matches the self-loop
+        // repo for its key. An op with no attribution is undecidable (it might
+        // belong to a different, untagged repo) and is kept — mirroring the
+        // skip in `intra_repo_self_loops`.
+        let is_self_loop_op = |d: &&ApiEndpointDetails| {
+            self_loops.get(&d.key.canonical()).is_some_and(|loop_repo| {
+                d.service_name.as_deref().or(d.repo_name.as_deref()) == Some(loop_repo)
+            })
+        };
         Self {
             // `endpoints` are producers and `calls` are consumers; the role
             // selects which manifest slot each op joins to. A shared canonical
@@ -159,13 +168,13 @@ impl EvalProjection {
             endpoints: result
                 .endpoints
                 .iter()
-                .filter(|d| !self_loop_keys.contains(&d.key.canonical()))
+                .filter(|d| !is_self_loop_op(d))
                 .map(|d| EvalOp::from_details(d, &manifest_index, ManifestRole::Producer))
                 .collect(),
             calls: result
                 .calls
                 .iter()
-                .filter(|d| !self_loop_keys.contains(&d.key.canonical()))
+                .filter(|d| !is_self_loop_op(d))
                 .map(|d| EvalOp::from_details(d, &manifest_index, ManifestRole::Consumer))
                 .collect(),
             cross_repo_matches,
@@ -173,15 +182,17 @@ impl EvalProjection {
         }
     }
 
-    /// Canonical keys of exact-key (non-HTTP) operations that are pure intra-repo
-    /// self-loops: produced AND consumed within a single repo, with no other repo
-    /// on the key. Those ops are filtered out of the cross-repo projection.
+    /// Pure intra-repo self-loops among exact-key (non-HTTP) operations:
+    /// canonical key → the single repo that both produces AND consumes it, with
+    /// no other repo on the key. The projection filters out the ops of that repo
+    /// on that key.
     ///
     /// HTTP ops are excluded — they get repo provenance from the mount graph, not
     /// from `repo_name`, and localhost self-calls are already dropped at
     /// extraction. A non-HTTP op with no repo attribution is skipped (self-loop is
-    /// undecidable without both repo ids).
-    fn intra_repo_self_loop_keys(result: &ApiAnalysisResult) -> std::collections::HashSet<String> {
+    /// undecidable without both repo ids), on both sides: it neither votes here
+    /// nor gets dropped by the filter.
+    fn intra_repo_self_loops(result: &ApiAnalysisResult) -> HashMap<String, String> {
         use std::collections::HashSet;
         let mut producer_repos: HashMap<String, HashSet<&str>> = HashMap::new();
         let mut consumer_repos: HashMap<String, HashSet<&str>> = HashMap::new();
@@ -198,17 +209,18 @@ impl EvalProjection {
                 }
             }
         }
-        let mut drop_keys = HashSet::new();
+        let mut self_loops = HashMap::new();
         for (key, producers) in &producer_repos {
             let Some(consumers) = consumer_repos.get(key) else {
                 continue; // orphan producer — surfaces as an endpoint, not a self-loop
             };
-            let repos: HashSet<&&str> = producers.iter().chain(consumers.iter()).collect();
+            let repos: HashSet<&str> = producers.iter().chain(consumers.iter()).copied().collect();
             if repos.len() == 1 {
-                drop_keys.insert(key.clone());
+                let repo = repos.iter().next().expect("len checked above");
+                self_loops.insert(key.clone(), repo.to_string());
             }
         }
-        drop_keys
+        self_loops
     }
 }
 
@@ -672,6 +684,60 @@ mod tests {
         assert!(call_keys.contains(&"pubsub|order.placed"));
         // Orphan producer (no consumer) survives.
         assert!(endpoint_keys.contains(&"pubsub|user.registered"));
+    }
+
+    /// An op WITHOUT repo attribution on a self-loop key must survive: with no
+    /// repo id it is undecidable whether it belongs to the self-looping repo or
+    /// to another (untagged) participant, so only the attributed self-loop ops
+    /// are dropped.
+    #[test]
+    fn unattributed_op_on_self_loop_key_survives() {
+        let result = ApiAnalysisResult {
+            endpoints: vec![
+                // attributed self-loop producer: dropped
+                pubsub_op(
+                    "__dlq.retry",
+                    "orders-engine/src/kafka/dlq.ts:26",
+                    "orders-engine",
+                ),
+                // UNATTRIBUTED producer on the same key: kept (undecidable)
+                ApiEndpointDetails {
+                    repo_name: None,
+                    ..pubsub_op("__dlq.retry", "unknown/src/consume.ts:3", "ignored")
+                },
+            ],
+            calls: vec![
+                // attributed self-loop consumer: dropped
+                pubsub_op(
+                    "__dlq.retry",
+                    "orders-engine/src/kafka/dlq.ts:19",
+                    "orders-engine",
+                ),
+            ],
+            findings: vec![],
+            dependency_conflicts: vec![],
+            verified_endpoints: vec![],
+            detected_graphql_libraries: vec![],
+            graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
+        };
+
+        let projection = EvalProjection::from_results(&result, &[]);
+        let surviving: Vec<(&str, &str)> = projection
+            .endpoints
+            .iter()
+            .map(|o| (o.key.as_str(), o.file.as_str()))
+            .collect();
+        assert_eq!(
+            surviving,
+            vec![("pubsub|__dlq.retry", "unknown/src/consume.ts")],
+            "only the unattributed op survives; attributed self-loop ops are dropped"
+        );
+        assert!(
+            projection.calls.is_empty(),
+            "attributed self-loop call must be dropped, got {:?}",
+            projection.calls.iter().map(|o| &o.key).collect::<Vec<_>>()
+        );
     }
 
     /// Build a projection with a cross-repo match, manifest-joined op fields,

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -137,6 +137,17 @@ impl EvalProjection {
             .map(EvalDependencyConflict::from_conflict)
             .collect();
         dependency_conflicts.sort_by(|a, b| a.package.cmp(&b.package));
+        // Intra-repo pub/sub (and any exact-key) self-loops must not surface in
+        // the cross-repo projection. A topic that ONE repo both produces and
+        // consumes, with no other repo on the key, is a self-edge — not a
+        // contract edge (the matcher already drops the self-EDGE; this keeps the
+        // producer/consumer OPS out of the endpoint/call sets too, so e.g. a
+        // dead-letter retry loop can't inflate them). Keyed on repo identity +
+        // canonical key alone — never on topic-name or library patterns — so it
+        // behaves identically for Kafka/Redis/NATS/RabbitMQ and socket events. A
+        // key that any OTHER repo also touches (fan-in/fan-out), or that a single
+        // repo only produces OR only consumes (an orphan), is left untouched.
+        let self_loop_keys = Self::intra_repo_self_loop_keys(result);
         Self {
             // `endpoints` are producers and `calls` are consumers; the role
             // selects which manifest slot each op joins to. A shared canonical
@@ -148,16 +159,56 @@ impl EvalProjection {
             endpoints: result
                 .endpoints
                 .iter()
+                .filter(|d| !self_loop_keys.contains(&d.key.canonical()))
                 .map(|d| EvalOp::from_details(d, &manifest_index, ManifestRole::Producer))
                 .collect(),
             calls: result
                 .calls
                 .iter()
+                .filter(|d| !self_loop_keys.contains(&d.key.canonical()))
                 .map(|d| EvalOp::from_details(d, &manifest_index, ManifestRole::Consumer))
                 .collect(),
             cross_repo_matches,
             dependency_conflicts,
         }
+    }
+
+    /// Canonical keys of exact-key (non-HTTP) operations that are pure intra-repo
+    /// self-loops: produced AND consumed within a single repo, with no other repo
+    /// on the key. Those ops are filtered out of the cross-repo projection.
+    ///
+    /// HTTP ops are excluded — they get repo provenance from the mount graph, not
+    /// from `repo_name`, and localhost self-calls are already dropped at
+    /// extraction. A non-HTTP op with no repo attribution is skipped (self-loop is
+    /// undecidable without both repo ids).
+    fn intra_repo_self_loop_keys(result: &ApiAnalysisResult) -> std::collections::HashSet<String> {
+        use std::collections::HashSet;
+        let mut producer_repos: HashMap<String, HashSet<&str>> = HashMap::new();
+        let mut consumer_repos: HashMap<String, HashSet<&str>> = HashMap::new();
+        for (ops, repos) in [
+            (&result.endpoints, &mut producer_repos),
+            (&result.calls, &mut consumer_repos),
+        ] {
+            for d in ops {
+                if matches!(d.key.protocol(), crate::operation::Protocol::Http) {
+                    continue;
+                }
+                if let Some(repo) = d.service_name.as_deref().or(d.repo_name.as_deref()) {
+                    repos.entry(d.key.canonical()).or_default().insert(repo);
+                }
+            }
+        }
+        let mut drop_keys = HashSet::new();
+        for (key, producers) in &producer_repos {
+            let Some(consumers) = consumer_repos.get(key) else {
+                continue; // orphan producer — surfaces as an endpoint, not a self-loop
+            };
+            let repos: HashSet<&&str> = producers.iter().chain(consumers.iter()).collect();
+            if repos.len() == 1 {
+                drop_keys.insert(key.clone());
+            }
+        }
+        drop_keys
     }
 }
 
@@ -531,6 +582,96 @@ mod tests {
             repo_name: None,
             service_name: None,
         }
+    }
+
+    fn pubsub_op(topic: &str, file_line: &str, repo: &str) -> ApiEndpointDetails {
+        ApiEndpointDetails {
+            owner: None,
+            key: OperationKey::pubsub(topic),
+            params: vec![],
+            request_body: None,
+            response_body: None,
+            handler_name: None,
+            request_type: None,
+            response_type: None,
+            file_path: PathBuf::from(file_line),
+            repo_name: Some(repo.to_string()),
+            service_name: None,
+        }
+    }
+
+    /// Intra-repo pub/sub self-loop (corpus-2 `_must_not_emit`): a topic one repo
+    /// both publishes and subscribes, with no other repo on it, must NOT surface
+    /// as an endpoint or a call in the projection. A fan-in topic (distinct
+    /// producer/consumer repos) and an orphan producer (no consumer) must survive.
+    #[test]
+    fn intra_repo_pubsub_self_loop_dropped_from_projection() {
+        let result = ApiAnalysisResult {
+            // subscribers are producers (endpoints); publishers are consumers (calls)
+            endpoints: vec![
+                // self-loop: orders-engine subscribes __dlq.retry
+                pubsub_op(
+                    "__dlq.retry",
+                    "orders-engine/src/kafka/dlq.ts:26",
+                    "orders-engine",
+                ),
+                // fan-in: billing-svc subscribes order.placed
+                pubsub_op(
+                    "order.placed",
+                    "billing-svc/src/consume.ts:4",
+                    "billing-svc",
+                ),
+                // orphan producer: nobody publishes user.registered
+                pubsub_op(
+                    "user.registered",
+                    "orders-engine/src/consume.ts:9",
+                    "orders-engine",
+                ),
+            ],
+            calls: vec![
+                // self-loop: orders-engine publishes __dlq.retry
+                pubsub_op(
+                    "__dlq.retry",
+                    "orders-engine/src/kafka/dlq.ts:19",
+                    "orders-engine",
+                ),
+                // fan-in: orders-engine publishes order.placed (other repo consumes)
+                pubsub_op(
+                    "order.placed",
+                    "orders-engine/src/producer.ts:7",
+                    "orders-engine",
+                ),
+            ],
+            findings: vec![],
+            dependency_conflicts: vec![],
+            verified_endpoints: vec![],
+            detected_graphql_libraries: vec![],
+            graphql_operations_indexed: false,
+            cross_repo_matches: vec![],
+        };
+
+        let projection = EvalProjection::from_results(&result, &[]);
+        let endpoint_keys: Vec<&str> = projection
+            .endpoints
+            .iter()
+            .map(|o| o.key.as_str())
+            .collect();
+        let call_keys: Vec<&str> = projection.calls.iter().map(|o| o.key.as_str()).collect();
+
+        // Self-loop dropped from BOTH sets.
+        assert!(
+            !endpoint_keys.contains(&"pubsub|__dlq.retry"),
+            "self-loop endpoint must be dropped, got {endpoint_keys:?}"
+        );
+        assert!(
+            !call_keys.contains(&"pubsub|__dlq.retry"),
+            "self-loop call must be dropped, got {call_keys:?}"
+        );
+        // Fan-in (distinct repos) survives.
+        assert!(endpoint_keys.contains(&"pubsub|order.placed"));
+        assert!(call_keys.contains(&"pubsub|order.placed"));
+        // Orphan producer (no consumer) survives.
+        assert!(endpoint_keys.contains(&"pubsub|user.registered"));
     }
 
     /// Build a projection with a cross-repo match, manifest-joined op fields,


### PR DESCRIPTION
## Symptom

xrepo-corpus-2's `orders-engine` both publishes and subscribes the internal `__dlq.retry` Kafka topic — an intra-repo dead-letter retry loop, labelled under `_must_not_emit` in `orders-engine/expected.json`. The scan leaked three false rows into the eval projection, each costing a precision dimension:

- an XTRA pubsub endpoint `pubsub|__dlq.retry`
- an XTRA pubsub call `pubsub|__dlq.retry`
- a self-match edge `orders-engine|pubsub|__dlq.retry -> orders-engine|pubsub|__dlq.retry`

## Root cause

The exact-key matcher (`analyze_exact_key_matches`) emits an edge for every producer/consumer pair sharing a topic key, including the same-repo pair. Separately, the projection surfaces every extracted op regardless of whether any other repo participates on its topic. A same-repo publisher/subscriber pair is a self-edge, not a cross-repo contract.

## Mechanism

Framework-agnostic and structural — keyed on repo identity + topic only, never on topic-name (`__dlq`, "dead letter") or library (Kafka/Redis/NATS/RabbitMQ) patterns:

- **`analyze_exact_key_matches`** (`src/analyzer/mod.rs`): skip the edge when `producer_repo == consumer_repo`. Applies to all exact-key protocols (pubsub/socket/graphql). A topic that *other* repos also touch keeps its genuine cross edges — only the same-repo pair is dropped, so fan-in/fan-out is untouched.
- **`EvalProjection::from_results`** (`src/eval_output.rs`): drop the endpoint/call ops of any non-HTTP key that a single repo both produces AND consumes with no other repo on it. Orphan producers (no consumer) and multi-repo keys are left untouched. HTTP is excluded (localhost self-calls are already dropped at extraction, and HTTP gets repo provenance from the mount graph).

Verified against all three corpora: no expected non-HTTP op is a same-repo self-loop, so the suppression can only ever drop `_must_not_emit`-labelled ops.

## Test

Three unit tests, each confirmed to FAIL pre-fix by reverting the corresponding hunk:

- `analyzer::tests::pubsub_intra_repo_self_loop_emits_no_edge`
- `analyzer::tests::pubsub_self_edge_dropped_but_cross_edges_survive` (proves fan-in survives)
- `eval_output::tests::intra_repo_pubsub_self_loop_dropped_from_projection` (proves self-loop dropped, fan-in + orphan producer kept)

Full pre-commit suite green (Rust + doctests + ts_check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)