### PR TITLE
fix: canonicalize literal-origin consumer call keys + suppress self-calls

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -2622,6 +2622,42 @@ impl FileOrchestrator {
         // Sixth pass: resolve full paths for endpoints
         self.resolve_endpoint_paths(&mut graph);
 
+        // Seventh pass: suppress self-calls. A data call whose (method, canonical
+        // path) matches one of THIS service's own resolved endpoints is the
+        // service hitting its own HTTP surface (e.g. a cron/reindex job fetching
+        // `http://localhost:PORT/warehouses/:id/stock/:sku`), not a cross-repo
+        // dependency. Emitting it would (a) inject a spurious self producer↔
+        // consumer edge and (b) leak an operation the service already exposes as
+        // a producer. The mount graph is built per service, so a call matching an
+        // endpoint in the SAME graph is necessarily intra-service; a genuine
+        // cross-service-same-repo call lives in a different service's graph and is
+        // untouched. Runs after path resolution so the endpoint `full_path`s are
+        // final, and matches param-aware (`find_matching_endpoints`) so a
+        // canonicalized `/warehouses/:wid/...` still matches a declared
+        // `/warehouses/:warehouseId/...`. This is only reachable once the literal
+        // origin is stripped from the call key (see `consumer_call_path`); a raw
+        // `http://host:port/...` key matches no endpoint and would evade it.
+        let keep_call: Vec<bool> = graph
+            .data_calls
+            .iter()
+            .map(|call| {
+                let is_self_call = !graph
+                    .find_matching_endpoints(&call.canonical_path, &call.method)
+                    .is_empty();
+                if is_self_call {
+                    debug!(
+                        "Suppressing self-call to own endpoint: {} {} ({})",
+                        call.method, call.canonical_path, call.file_location
+                    );
+                }
+                !is_self_call
+            })
+            .collect();
+        let mut keep_iter = keep_call.into_iter();
+        graph
+            .data_calls
+            .retain(|_| keep_iter.next().unwrap_or(true));
+
         graph
     }
 
@@ -3233,6 +3269,91 @@ mod tests {
             "https://api.example.com/data"
         );
         assert_eq!(graph.data_calls[0].method, "POST");
+    }
+
+    /// A data call to the service's OWN endpoint (same mount graph) is a
+    /// self-call — the service hitting its own HTTP surface — and must be
+    /// dropped so it neither leaks as an indexed consumer op nor forms a
+    /// spurious self producer↔consumer edge. The literal `http://localhost:PORT`
+    /// origin is stripped to a bare param path (`consumer_call_path`), which then
+    /// matches the declared endpoint param-aware (`:wid` ≡ `:warehouseId`). A
+    /// call to a DIFFERENT path survives. Fails before the origin-strip +
+    /// suppression pass: both calls' keys keep the raw `http://host:port/...`
+    /// origin, so nothing matches the endpoint and both survive (len == 2).
+    #[test]
+    fn test_build_mount_graph_suppresses_self_calls() {
+        let agent_service = AgentService::new();
+        let orchestrator = FileOrchestrator::new(agent_service);
+
+        let mk_call = |id: &str, target: &str| DataCallResult {
+            call_kind: None,
+            candidate_id: id.to_string(),
+            line_number: 7,
+            target: target.to_string(),
+            method: Some("GET".to_string()),
+            pattern_matched: "fetch(".to_string(),
+            call_expression_span_start: None,
+            call_expression_span_end: None,
+            call_expression_text: None,
+            call_expression_line: None,
+            payload_expression_text: None,
+            payload_expression_line: None,
+            primary_type_symbol: None,
+            type_import_source: None,
+        };
+
+        let mut file_results = HashMap::new();
+        file_results.insert(
+            "src/app.ts".to_string(),
+            FileAnalysisResult {
+                graphql_consumer_locates: vec![],
+                mounts: vec![],
+                endpoints: vec![EndpointResult {
+                    candidate_id: "span:1-40".to_string(),
+                    line_number: 5,
+                    owner_node: "app".to_string(),
+                    method: "GET".to_string(),
+                    path: "/warehouses/:warehouseId/stock/:sku".to_string(),
+                    handler_name: "getStock".to_string(),
+                    pattern_matched: ".get(".to_string(),
+                    call_expression_span_start: None,
+                    call_expression_span_end: None,
+                    payload_expression_text: None,
+                    payload_expression_line: None,
+                    response_expression_text: None,
+                    response_expression_line: None,
+                    emission_style: None,
+                    primary_type_symbol: None,
+                    type_import_source: None,
+                }],
+                data_calls: vec![
+                    // Self-call to the service's own endpoint over localhost.
+                    mk_call(
+                        "span:100-160",
+                        "http://localhost:4002/warehouses/${wid}/stock/${sku}",
+                    ),
+                    // Genuine outbound call to a different path — survives.
+                    mk_call("span:200-260", "http://localhost:9000/catalog/${id}"),
+                ],
+                graphql_operations: vec![],
+                pubsub_operations: vec![],
+            },
+        );
+
+        let graph =
+            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+
+        let call_paths: Vec<&str> = graph
+            .data_calls
+            .iter()
+            .map(|c| c.canonical_path.as_str())
+            .collect();
+        assert_eq!(
+            graph.data_calls.len(),
+            1,
+            "self-call must be suppressed, surviving calls: {call_paths:?}"
+        );
+        assert_eq!(graph.data_calls[0].canonical_path, "/catalog/:id");
     }
 
     /// #307 (class 1): a wrapper-internal call whose canonical path is nothing

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -2653,10 +2653,15 @@ impl FileOrchestrator {
                 !is_self_call
             })
             .collect();
+        // `keep_call` was derived element-for-element from `graph.data_calls`
+        // just above, so the iterator running dry mid-retain can only mean that
+        // invariant was broken — fail loudly rather than silently keeping calls.
         let mut keep_iter = keep_call.into_iter();
-        graph
-            .data_calls
-            .retain(|_| keep_iter.next().unwrap_or(true));
+        graph.data_calls.retain(|_| {
+            keep_iter
+                .next()
+                .expect("keep_call must be exactly as long as graph.data_calls")
+        });
 
         graph
     }

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -227,7 +227,6 @@ impl MountGraph {
     ///
     /// This is the basic matching method that does not perform URL normalization.
     /// For cross-service matching with full URLs, use `find_matching_endpoints_normalized`.
-    #[allow(dead_code)]
     pub fn find_matching_endpoints(&self, path: &str, method: &str) -> Vec<&ResolvedEndpoint> {
         self.endpoints
             .iter()

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -103,6 +103,23 @@ impl UrlNormalizer {
             return self.normalize_env_var_pattern(url, original);
         }
 
+        // Handle full URLs with a LITERAL absolute origin (`scheme://host[:port]`)
+        // BEFORE the `process.env`/`${` branches. A target like
+        // `http://localhost:4002/warehouses/${wid}/stock/${sku}` contains `${`,
+        // so the interpolation branch would fire first and never strip the
+        // literal origin — the host `localhost:4002` would survive into the key.
+        // Dispatching on the concrete scheme prefix first strips the origin and
+        // then converts any `${...}` PATH interpolations to `:param`, so the key
+        // is a bare comparable path (`/warehouses/:wid/stock/:sku`).
+        if url.starts_with("http://") || url.starts_with("https://") {
+            return self.normalize_full_url(url, original);
+        }
+
+        // Handle protocol-relative URLs (//domain.com/path)
+        if url.starts_with("//") {
+            return self.normalize_protocol_relative_url(url, original);
+        }
+
         // Handle process.env patterns (e.g., process.env.API_URL + "/users")
         if url.contains("process.env.") {
             return self.normalize_process_env_pattern(url, original);
@@ -111,16 +128,6 @@ impl UrlNormalizer {
         // Handle template literal interpolations (e.g., ${API_URL}/users/${id})
         if url.contains("${") {
             return self.normalize_template_literal(url, original);
-        }
-
-        // Handle full URLs with protocol
-        if url.starts_with("http://") || url.starts_with("https://") {
-            return self.normalize_full_url(url, original);
-        }
-
-        // Handle protocol-relative URLs (//domain.com/path)
-        if url.starts_with("//") {
-            return self.normalize_protocol_relative_url(url, original);
         }
 
         // Already a path - just clean it up
@@ -380,6 +387,14 @@ impl UrlNormalizer {
         let is_internal = self.is_internal_host(&host);
         let is_external = self.is_external_host(&host);
 
+        // Convert any `${...}` PATH interpolations to `:param` so a literal
+        // absolute URL with template path segments
+        // (`http://host:port/warehouses/${wid}/stock/${sku}`) yields a bare
+        // comparable path (`/warehouses/:wid/stock/:sku`), not a key that still
+        // carries the raw interpolation. `clean_path` drops the query string
+        // first, so a query-only interpolation never reaches this.
+        let path = self.convert_interpolations_to_params(&path);
+
         NormalizedUrl {
             path: self.clean_path(&path),
             is_internal,
@@ -490,18 +505,32 @@ impl UrlNormalizer {
         self.normalize(url).path
     }
 
-    /// Canonical path to key a CONSUMER data call on. Strips the host ONLY for a
-    /// declared-internal env-var base (carrick.json `internalEnvVars`) or a plain
-    /// relative path (no host). External/unknown-base and full-URL targets are
-    /// returned VERBATIM, so (a) a third-party call can't collide with an internal
-    /// producer's path, (b) the "unclassified env var" config-suggestion still sees
-    /// the raw var, and (c) a full URL with a query interpolation
-    /// (`https://h/p?u=${id}`) is not mangled into `/https:/h/p`.
+    /// Canonical path to key a CONSUMER data call on. Strips the origin for:
+    /// a declared-internal env-var base (carrick.json `internalEnvVars`), a plain
+    /// relative path (no host), or a LITERAL absolute URL
+    /// (`scheme://host[:port]/path`, incl. protocol-relative `//host/path`) — the
+    /// origin of a concrete URL is a structural prefix, so stripping it never
+    /// depends on a hostname allowlist. This is what lets a service's self-call
+    /// over its own `http://localhost:PORT/...` surface canonicalize to the bare
+    /// path and match its own endpoint (a literal origin that survived into the
+    /// key could match nothing and evaded the self-call / decoy checks).
+    ///
+    /// An UNKNOWN/undeclared env-var BASE (`${SOME_URL}/charges`, not in
+    /// `internalEnvVars`) is still returned VERBATIM: there is no concrete origin
+    /// to strip, so keeping the raw `${VAR}` (a) prevents a third-party call from
+    /// colliding with an internal producer's path and (b) lets the "unclassified
+    /// env var" config-suggestion still see the raw var.
+    ///
+    /// The raw target is always retained separately on the call (`target_url`)
+    /// for per-call classification/display; only the MATCH key is canonicalized.
     pub fn consumer_call_path(&self, url: &str) -> String {
         let trimmed = url.trim_matches(|c| c == '`' || c == '"' || c == '\'');
         let is_relative_path = trimmed.starts_with('/') && !trimmed.starts_with("//");
+        let is_absolute_url = trimmed.starts_with("http://")
+            || trimmed.starts_with("https://")
+            || trimmed.starts_with("//");
         let normalized = self.normalize(url);
-        if normalized.is_internal || is_relative_path {
+        if normalized.is_internal || is_relative_path || is_absolute_url {
             normalized.path
         } else {
             url.to_string()
@@ -943,18 +972,30 @@ mod tests {
         // Plain relative path: kept as its clean path.
         assert_eq!(normalizer.consumer_call_path("/track"), "/track");
 
-        // Unknown/external base (STRIPE_URL is not in internalEnvVars): VERBATIM,
-        // so a third-party call can't collide with an internal producer's path
-        // and the "unclassified env var" config-suggestion still sees the raw var.
+        // Unknown/external env-var base (STRIPE_URL is not in internalEnvVars):
+        // VERBATIM, so a third-party call can't collide with an internal
+        // producer's path and the "unclassified env var" config-suggestion still
+        // sees the raw var. There is no concrete origin to strip here.
         assert_eq!(
             normalizer.consumer_call_path("${process.env.STRIPE_URL}/charges"),
             "${process.env.STRIPE_URL}/charges"
         );
 
-        // A full URL with a query interpolation is kept verbatim, not mangled.
+        // A LITERAL absolute URL has its origin (`scheme://host[:port]`) stripped
+        // for the key even with a query interpolation — the origin of a concrete
+        // URL is a structural prefix, so this needs no hostname allowlist. The raw
+        // target is retained separately on the call (`target_url`) for
+        // classification; only the match key is canonicalized. This is what lets a
+        // self-call over the service's own `http://localhost:PORT/...` surface
+        // canonicalize to its bare path and match its own endpoint.
         assert_eq!(
             normalizer.consumer_call_path("https://orders.internal/api/orders?user=${userId}"),
-            "https://orders.internal/api/orders?user=${userId}"
+            "/api/orders"
+        );
+        // A literal origin with `${...}` PATH segments → bare param path.
+        assert_eq!(
+            normalizer.consumer_call_path("http://localhost:4002/warehouses/${wid}/stock/${sku}"),
+            "/warehouses/:wid/stock/:sku"
         );
 
         // A declared-internal base with a param interpolation collapses to a clean

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -391,8 +391,10 @@ impl UrlNormalizer {
         // absolute URL with template path segments
         // (`http://host:port/warehouses/${wid}/stock/${sku}`) yields a bare
         // comparable path (`/warehouses/:wid/stock/:sku`), not a key that still
-        // carries the raw interpolation. `clean_path` drops the query string
-        // first, so a query-only interpolation never reaches this.
+        // carries the raw interpolation. Interpolations are converted first —
+        // including any inside a query string — and `clean_path` below then cuts
+        // at the first `?`/`#`, so a query-only interpolation
+        // (`/orders?user=${id}`) never survives into the final path.
         let path = self.convert_interpolations_to_params(&path);
 
         NormalizedUrl {

--- a/tests/fixtures/llm-mocked-api/__golden__.json
+++ b/tests/fixtures/llm-mocked-api/__golden__.json
@@ -83,15 +83,21 @@
   ],
   "calls": [
     {
-      "key": "http|GET|https://orders.internal/api/orders?user=${userId}",
+      "key": "http|GET|/api/orders",
       "protocol": "http",
       "method": "GET",
-      "path": "https://orders.internal/api/orders?user=${userId}",
+      "path": "/api/orders",
       "handler": "fetch(",
       "request_type": null,
       "response_type": null,
       "file": "tests/fixtures/llm-mocked-api/src/client.ts",
-      "line": 4
+      "line": 4,
+      "type_alias": "Endpoint_4022e5b76e4552db_Response_Callf3eb15148afd184a",
+      "type_state": "Explicit",
+      "resolved_definition": "export interface Endpoint_4022e5b76e4552db_Response_Callf3eb15148afd184a { id: number; userId: number; total: number; }",
+      "expanded_definition": "{ id: number; userId: number; total: number; }",
+      "is_explicit": true,
+      "primary_type_symbol": "Order"
     }
   ],
   "cross_repo_matches": [],

--- a/tests/fixtures/llm-mocked-api/__golden__.json
+++ b/tests/fixtures/llm-mocked-api/__golden__.json
@@ -92,9 +92,9 @@
       "response_type": null,
       "file": "tests/fixtures/llm-mocked-api/src/client.ts",
       "line": 4,
-      "type_alias": "Endpoint_4022e5b76e4552db_Response_Callf3eb15148afd184a",
+      "type_alias": "Endpoint_4022e5b76e4552db_Response_Call0000000000000000",
       "type_state": "Explicit",
-      "resolved_definition": "export interface Endpoint_4022e5b76e4552db_Response_Callf3eb15148afd184a { id: number; userId: number; total: number; }",
+      "resolved_definition": "export interface Endpoint_4022e5b76e4552db_Response_Call0000000000000000 { id: number; userId: number; total: number; }",
       "expanded_definition": "{ id: number; userId: number; total: number; }",
       "is_explicit": true,
       "primary_type_symbol": "Order"

--- a/tests/llm_cassette_hard_gate_test.rs
+++ b/tests/llm_cassette_hard_gate_test.rs
@@ -18,10 +18,40 @@
 //! CARRICK_MOCK_ALL=1 CARRICK_OUTPUT_JSON=1 \
 //!   CARRICK_MOCK_FIXTURE_DIR=tests/fixtures/llm-mocked-api/__llm__/ \
 //!   cargo run -- tests/fixtures/llm-mocked-api \
-//!   | sed "s#$(pwd)/##" > tests/fixtures/llm-mocked-api/__golden__.json
+//!   | sed "s#$(pwd)/##" \
+//!   | sed -E 's/_Call[0-9a-f]{16}/_Call0000000000000000/g' \
+//!   > tests/fixtures/llm-mocked-api/__golden__.json
 //! ```
+//!
+//! The second sed masks consumer call-site ids: `build_call_site_id` hashes the
+//! ABSOLUTE call-site file path (its uniqueness contract is per-run, so that is
+//! fine at runtime), which makes any `Endpoint_<hash>_<Kind>_Call<id>` alias
+//! machine-specific. The test applies the same mask to both sides, so the
+//! comparison is invariant to where the golden was recorded while still gating
+//! on everything semantic (keys, paths, resolved definitions, type states).
 
 use std::process::Command;
+
+/// Mask the 16-hex call-site id in `_Call<id>` alias suffixes (see module doc).
+fn mask_call_site_ids(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    const TAG: &str = "_Call";
+    while let Some(idx) = rest.find(TAG) {
+        let after = &rest[idx + TAG.len()..];
+        let is_id = after.len() >= 16 && after.as_bytes()[..16].iter().all(u8::is_ascii_hexdigit);
+        if is_id {
+            out.push_str(&rest[..idx + TAG.len()]);
+            out.push_str("0000000000000000");
+            rest = &after[16..];
+        } else {
+            out.push_str(&rest[..idx + TAG.len()]);
+            rest = after;
+        }
+    }
+    out.push_str(rest);
+    out
+}
 
 #[test]
 fn cassette_hard_gate_llm_mocked_api() {
@@ -47,13 +77,17 @@ fn cassette_hard_gate_llm_mocked_api() {
     // Relativise the absolute repo root so the golden is portable across
     // machines / CI runners. The scanner is invoked with `{repo}/...`, so file
     // paths in the projection are anchored at the same prefix.
-    let normalized = stdout.replace(&format!("{repo}/"), "");
+    // Mask machine-specific call-site ids on BOTH sides (see module doc): the
+    // id hashes the absolute file path, so it can never byte-match across
+    // machines/CI runners no matter where the golden was recorded.
+    let normalized = mask_call_site_ids(&stdout.replace(&format!("{repo}/"), ""));
 
     let actual: serde_json::Value =
         serde_json::from_str(&normalized).expect("scanner output was not valid JSON");
-    let golden: serde_json::Value =
-        serde_json::from_str(include_str!("fixtures/llm-mocked-api/__golden__.json"))
-            .expect("golden fixture was not valid JSON");
+    let golden: serde_json::Value = serde_json::from_str(&mask_call_site_ids(include_str!(
+        "fixtures/llm-mocked-api/__golden__.json"
+    )))
+    .expect("golden fixture was not valid JSON");
 
     assert_eq!(
         actual, golden,


### PR DESCRIPTION
## Symptom (issue #292 class)

An HTTP consumer call whose target has a **literal absolute origin AND `${...}` template segments** survived un-canonicalized into the cross-repo eval projection. Live instance (xrepo-corpus-3 `inventory-svc/src/jobs/reindex.ts`, a self-call to its own endpoint):

```
fetch(`http://localhost:4002/warehouses/${wid}/stock/${sku}`)
→ projection key: http|GET|http://localhost:4002/warehouses/${wid}/stock/${sku}
```

Because the key stayed raw it (a) matched nothing → extra-call precision hit, and (b) **evaded** both self-call handling and the `decoy_leak` counter — `expected.json` lists this under `_must_not_emit` as `GET /warehouses/:warehouseId/stock/:sku`, but the raw string never equals the param form, so `decoy_leak` read 0.

## Root cause

The leak was in `UrlNormalizer`. `normalize()` dispatched on `${` **before** the `http(s)://` scheme check, so a URL with both routed to `normalize_template_literal`, which only strips a leading `${VAR}` base and never a literal `scheme://host:port` origin. `consumer_call_path` then returned the raw target verbatim for any non-internal, non-relative URL, and that mangled origin reached the projection key (`cloud_storage::mount_graph_to_api_details` keys the call on `canonical_path`).

There was **no existing self-call suppression** (the issue's assumed "existing suppression" does not exist); canonicalizing alone would have turned a hidden extra into a *visible* decoy leak + a spurious self edge, so suppression is built here too.

## Mechanism

- **Origin strip (structural, no hostname allowlist):** dispatch `http(s)://` / `//` before the `process.env`/`${` branches, and convert `${...}` PATH interpolations inside `normalize_full_url`. A literal absolute URL now yields a bare param path (`/warehouses/:wid/stock/:sku`). `consumer_call_path` returns that stripped path; the raw target is still retained on `target_url` for classification/display (#294 model). Undeclared env-var bases (`${AUDIT_WEBHOOK_URL}/...`) stay verbatim — no concrete origin to strip, and keeping the raw var avoids colliding with an internal producer path.
- **Self-call suppression:** `build_mount_graph` drops (per service, param-aware via `find_matching_endpoints`) any data call whose canonical `(method, path)` matches one of the same service's own resolved endpoints. A service hitting its own HTTP surface is an internal detail, not a cross-repo dependency. Only reachable once the origin is stripped.

## Outcome

- **corpus-3 warehouses self-call:** canonicalizes to `/warehouses/:wid/stock/:sku`, matches inventory-svc's own endpoint, and is **suppressed** — gone from projection `calls`, no self edge, `decoy_leak` stays 0 (verified via mock projection). ✅
- **corpus-1 audit call** (`${AUDIT_WEBHOOK_URL}/audit/events`, undeclared env base): **unchanged** by this PR — it is not a literal absolute origin, so it stays verbatim. See label question below.

## Label question (reported, not actioned)

The corpus-1 `POST ${AUDIT_WEBHOOK_URL}/audit/events` call (real axios call in `payments-svc/lib/audit.ts`) is a genuine external webhook on an **undeclared** env var. It is neither in `payments-svc` expected calls nor in `_must_not_emit`, so it counts as an extra in the capability call set. The scorer (`tests/eval_xrepo.rs`) has **no external-exemption** — it counts every HTTP `proj.calls` op. Canonicalizing it to `/audit/events` provides no scoring benefit (still an extra, no matching producer) and adds internal-collision risk, so the scanner is left as-is. Resolving its "extra" status is a **ground-truth / scorer-semantics decision** (list it as an expected external call, add it to `_must_not_emit`, or exempt undeclared-external calls in the scorer) — not made here.

## Tests

- New `test_build_mount_graph_suppresses_self_calls` and updated `consumer_call_path_strips_internal_base_keeps_external_raw` — both **fail before** the fix (raw key survives / call not suppressed) and pass after.
- `llm-mocked-api` cassette golden re-recorded: its `https://orders.internal/...?user=${userId}` call now canonicalizes to `/api/orders`. As an **intended consequence**, the call now joins the type manifest and carries resolved type metadata (`type_state: Explicit`, resolved/expanded definitions, `primary_type_symbol: Order`) — verified to reproduce identically on CI. The joined alias embeds `build_call_site_id`, a hash of the **absolute** call-site file path, which is machine-specific by design (per-run uniqueness contract); the gate now masks the `_Call<16hex>` suffix on both sides before comparing (and the golden is recorded through the same mask), so the golden is portable while still gating on keys, paths, definitions, and type states. The CI run's actual output, masked, equals the committed golden byte-for-byte.
- Full `cargo test` + `cargo fmt --check` + `cargo clippy -D warnings` + ts_check suite green (pre-commit hook).

## Cross-corpus risk

Low. The only bare literal absolute URL in any corpus source is the corpus-3 self-call; every other `http://localhost` literal is a `process.env.X ?? "..."` default the LLM extracts as an env-base form (unaffected). Origin-strip could in theory let a genuine third-party literal URL with a path collide with an internal producer path, but no such call exists across corpora 1–3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
