### PR TITLE
fix(corpus-1): label audit-webhook call + add resolveOrders resolver

### DIFF
--- a/tests/eval_xrepo.rs
+++ b/tests/eval_xrepo.rs
@@ -2835,6 +2835,58 @@ mod scoring_tests {
         assert_eq!(dc.severity, "critical");
     }
 
+    /// PROOF (owner ruling 2026-07-12): the undeclared-env-var audit-webhook call
+    /// joins the LIVE projected key. payments-svc/lib/audit.ts posts to
+    /// `${process.env.AUDIT_WEBHOOK_URL ?? ...}/audit/events`, and because
+    /// AUDIT_WEBHOOK_URL is deliberately NOT declared in payments-svc/carrick.json,
+    /// the live projection keys the call with the raw env-var base intact:
+    /// `http|POST|${AUDIT_WEBHOOK_URL}/audit/events` (post-#294/#354). The offline
+    /// mock can't synthesize this LLM-extracted call, so this test loads the
+    /// COMMITTED label and asserts it fuzzy-joins that exact op — i.e. the call
+    /// scores as an expected consumer, never as an extra.
+    #[test]
+    fn audit_webhook_label_joins_live_projected_key() {
+        if corpus_name() != "xrepo-corpus-1" {
+            return;
+        }
+        let corpus = corpus_dir();
+        let repos = discover_repos(&corpus);
+        let repo_expected = load_repo_expected(&repos);
+        let (_r, payments) = repo_expected
+            .iter()
+            .find(|(r, _)| r == "payments-svc")
+            .expect("payments-svc repo present");
+        let audit = payments
+            .calls
+            .iter()
+            .find(|c| c.path_contains.as_deref() == Some("/audit/events"))
+            .expect("committed audit-webhook call label present");
+
+        // The op EXACTLY as the live projection emits it: `http_ep` yields
+        // key `http|POST|${AUDIT_WEBHOOK_URL}/audit/events` and the same path,
+        // the raw-env-var-base form that survives for the undeclared var.
+        let live = http_ep("POST", "${AUDIT_WEBHOOK_URL}/audit/events");
+        assert_eq!(live.key, "http|POST|${AUDIT_WEBHOOK_URL}/audit/events");
+        assert!(
+            fuzzy_call_match(audit, &live),
+            "committed audit label must join the live env-var-base key"
+        );
+
+        // Negative control: same method, different path must NOT join, so the
+        // `path_contains` constraint is load-bearing (not match-anything).
+        let other = http_ep("POST", "${AUDIT_WEBHOOK_URL}/other/path");
+        assert!(
+            !fuzzy_call_match(audit, &other),
+            "the label's path_contains constraint is load-bearing"
+        );
+        // Method discrimination: a GET to the same path must NOT join.
+        let wrong_method = http_ep("GET", "${AUDIT_WEBHOOK_URL}/audit/events");
+        assert!(
+            !fuzzy_call_match(audit, &wrong_method),
+            "method must match for the fuzzy call join"
+        );
+    }
+
     #[test]
     fn decoy_leak_respects_projection_set_kind() {
         // Corpus-3's intra-repo self-call decoy shares (method, path) with the

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/expected.json
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/expected.json
@@ -68,7 +68,7 @@
       "field": "orders",
       "source": "packages/gateway/src/schema.graphql",
       "primary_type_symbol": "[Order!]!",
-      "resolved_type": "{ id: string; total: { amountCents: number; currency: string; }; status: { kind: \"placed\"; placedAt: string; } | { kind: \"refunded\"; refundedAt: string; reason?: string; }; note?: string; }[]",
+      "resolved_type": "{ data: { id: string; total: { amountCents: number; currency: string; }; status: { kind: \"placed\"; placedAt: string; } | { kind: \"refunded\"; refundedAt: string; reason?: string; }; note?: string; }[]; errors: string[]; }",
       "type_state": "Explicit",
       "tier": "capability"
     },

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/index.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/index.ts
@@ -3,6 +3,7 @@ export { healthCheckHandler, routeRegistry } from './health.handler';
 export { server as mcpServer } from './mcp-tools';
 export {
   resolveOrder,
+  resolveOrders,
   resolveRefundOrder,
   resolveOrderUpdated,
 } from './orders.resolver';

--- a/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/orders.resolver.ts
+++ b/tests/fixtures/xrepo-corpus-1/orders-monorepo/packages/gateway/src/orders.resolver.ts
@@ -47,6 +47,33 @@ export async function resolveOrder(id: string): Promise<ApiResponse<Order>> {
   };
 }
 
+// query orders: [Order!]! — producer for `query orders` (orphan producer; no
+// cross-repo consumer). Returns the full order list wrapped in the ApiResponse
+// envelope, so the sidecar resolves ApiResponse<Order[]> for the type-enrichment
+// work (#222 generics-over-array case).
+export async function resolveOrders(): Promise<ApiResponse<Order[]>> {
+  return {
+    data: [
+      {
+        id: "ord_1",
+        total: { amountCents: 4999, currency: "EUR" },
+        status: { kind: "placed", placedAt: new Date().toISOString() },
+        note: "gift wrap",
+      },
+      {
+        id: "ord_2",
+        total: { amountCents: 1200, currency: "EUR" },
+        status: {
+          kind: "refunded",
+          refundedAt: new Date().toISOString(),
+          reason: "damaged in transit",
+        },
+      },
+    ],
+    errors: [],
+  };
+}
+
 // mutation refundOrder(id, reason): Order!
 export async function resolveRefundOrder(
   id: string,

--- a/tests/fixtures/xrepo-corpus-1/payments-svc/expected.json
+++ b/tests/fixtures/xrepo-corpus-1/payments-svc/expected.json
@@ -68,6 +68,18 @@
       "resolved_type": null,
       "type_state": "Unknown",
       "tier": "capability"
+    },
+    {
+      "method": "POST",
+      "path": "/audit/events",
+      "host_contains": null,
+      "path_contains": "/audit/events",
+      "import_source": "axios",
+      "primary_type_symbol": null,
+      "resolved_type": null,
+      "type_state": "Unknown",
+      "tier": "capability",
+      "evidence": "lib/audit.ts: axios.post to `${process.env.AUDIT_WEBHOOK_URL ?? \"http://localhost:3099\"}/audit/events` — an external webhook on the UNDECLARED env var AUDIT_WEBHOOK_URL (deliberately absent from carrick.json internalEnvVars, which lists only ORDERS_SERVICE_URL/BILLING_URL). The live projection keys this call http|POST|${AUDIT_WEBHOOK_URL}/audit/events (raw env-var base survives for undeclared vars, per #294/#354). host_contains is null (no stable host) and path_contains \"/audit/events\" is a substring of the projected path, so fuzzy_call_match joins it. Labelled as an expected call to complete ground truth per owner ruling 2026-07-12."
     }
   ],
   "socket_events": [


### PR DESCRIPTION
Two owner-approved corpus-1 ground-truth rulings (2026-07-12).

## 1. audit-webhook becomes an expected call
`payments-svc/lib/audit.ts` posts to `${process.env.AUDIT_WEBHOOK_URL ?? "http://localhost:3099"}/audit/events` via axios. `AUDIT_WEBHOOK_URL` is deliberately left **undeclared** in `payments-svc/carrick.json` to exercise the config-suggestion flow. Owner ruling: the call must be found and counted as an expected consumer call, not an extra.

- Added to `payments-svc/expected.json` `calls` (capability tier) with `host_contains: null` + `path_contains: "/audit/events"`.
- The live projection keys this call `http|POST|${AUDIT_WEBHOOK_URL}/audit/events` — the raw env-var base survives for undeclared vars (post-#294/#354). The join runs through `fuzzy_call_match` (method eq + `path_contains` substring-of-path; null `host_contains` is vacuous), so the label joins that exact key.
- New unit test `audit_webhook_label_joins_live_projected_key` proves the join against the exact live key (the offline mock can't synthesize the LLM-extracted call), with method/path negative controls.
- Follow-up filed to score the config-suggestion finding itself: #357.

## 2. Add the missing resolveOrders resolver
The gateway SDL declares `orders: [Order!]!` but had no resolver. Owner ruling: real code would have one. Added `resolveOrders(): Promise<ApiResponse<Order[]>>` in `orders.resolver.ts` (ApiResponse wrapper, plausible mock data, sibling doc-comment convention) and wired it in `src/index.ts`.

- The `graphql|query|orders` anchor stays SDL form `[Order!]!` (consistent with resolver-backed `refundOrder`, whose anchor is the SDL `Order!`).
- `resolved_type` changes from the bare SDL array to the envelope-kept resolver return shape `{ data: {...Order...}[]; errors: string[]; }` (mirrors `order`/`refundOrder`, which keep the `ApiResponse` envelope).
- `orders` stays an orphan producer (web-frontend does not consume `query orders`), so `expected-output.json` match labels are unchanged.

## Verification
Full pre-commit suite green: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (incl. the LLM cassette hard gate), and `ts_check` (90 pass). No live eval run (batched by the orchestrator). Changes are corpus-1-fixture-scoped; no other corpus is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)