### PR TITLE
fix(extraction): normalize spurious .ts on type_import_source deterministically (flake pattern 1)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1578,8 +1578,56 @@ impl FileOrchestrator {
         )
     }
 
+    /// Strip a trailing TypeScript/JavaScript source-file extension from a module
+    /// specifier, returning `Some(stripped)` only when one was present. TS import
+    /// specifiers are written without a source extension, so a specifier that
+    /// carries one (e.g. `../types/events.ts`) is a model artifact.
+    fn strip_source_file_extension(spec: &str) -> Option<&str> {
+        for ext in [
+            ".d.ts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
+        ] {
+            if let Some(stripped) = spec.strip_suffix(ext) {
+                return Some(stripped);
+            }
+        }
+        None
+    }
+
+    /// Normalize a spurious source-file extension the lite model sometimes
+    /// appends to `type_import_source` (e.g. `../types/events.ts`). We rewrite
+    /// ONLY when the extension-less form matches the symbol's import-table entry,
+    /// so a specifier that legitimately lacks an extension — a scoped package
+    /// like `@metamask/network-controller`, a same-file type — is left untouched.
+    /// Deterministic and framework-agnostic: the AST import table is the source
+    /// of truth, never a hard-coded library list.
+    fn normalize_import_extension(
+        primary: &Option<String>,
+        source: &mut Option<String>,
+        symbol_table: &SymbolTable,
+    ) {
+        let (Some(symbol), Some(src)) = (primary.as_deref(), source.as_deref()) else {
+            return;
+        };
+        let Some(stripped) = Self::strip_source_file_extension(src) else {
+            return;
+        };
+        let root = symbol
+            .split_once('.')
+            .map(|(root, _)| root)
+            .unwrap_or(symbol);
+        if let Some(imported) = symbol_table.imported_symbols.get(root)
+            && imported.source.as_str() == stripped
+        {
+            *source = Some(stripped.to_string());
+        }
+    }
+
     fn validate_type_hints(result: &mut FileAnalysisResult, symbol_table: &SymbolTable) {
         let validate = |primary: &mut Option<String>, source: &mut Option<String>| {
+            // Normalize a spurious `.ts`/`.js` suffix first so a hint that only
+            // differs from its import by the extension is kept (not nulled below).
+            Self::normalize_import_extension(primary, source, symbol_table);
+
             let Some(symbol) = primary.as_ref() else {
                 *source = None;
                 return;
@@ -1624,6 +1672,18 @@ impl FileOrchestrator {
             validate(
                 &mut data_call.primary_type_symbol,
                 &mut data_call.type_import_source,
+            );
+        }
+
+        // Pub/sub type hints intentionally skip the reject-on-mismatch `validate`
+        // above (their payload symbols come from many messaging libraries whose
+        // shapes the import-table check is not tuned for), but the spurious
+        // source-file extension is a universal model artifact, so normalize it.
+        for op in &mut result.pubsub_operations {
+            Self::normalize_import_extension(
+                &op.primary_type_symbol,
+                &mut op.type_import_source,
+                symbol_table,
             );
         }
     }
@@ -3942,6 +4002,138 @@ mod tests {
         let data_call = &result.data_calls[0];
         assert_eq!(data_call.primary_type_symbol.as_deref(), Some("LocalType"));
         assert!(data_call.type_import_source.is_none());
+    }
+
+    #[test]
+    fn test_validate_type_hints_strips_spurious_source_extension() {
+        use crate::agents::file_analyzer_agent::PubsubOperation;
+        use crate::operation::PubsubRole;
+
+        let mut result = FileAnalysisResult {
+            graphql_consumer_locates: vec![],
+            mounts: vec![],
+            endpoints: vec![EndpointResult {
+                candidate_id: "span:1-2".to_string(),
+                line_number: 10,
+                owner_node: "app".to_string(),
+                method: "GET".to_string(),
+                path: "/orders".to_string(),
+                handler_name: "handler".to_string(),
+                pattern_matched: "app.get".to_string(),
+                call_expression_span_start: None,
+                call_expression_span_end: None,
+                payload_expression_text: None,
+                payload_expression_line: None,
+                response_expression_text: None,
+                response_expression_line: None,
+                emission_style: None,
+                // `.ts` appended by the model; the extension-less form is imported.
+                primary_type_symbol: Some("OrderPlacedEvent".to_string()),
+                type_import_source: Some("../types/events.ts".to_string()),
+            }],
+            data_calls: vec![DataCallResult {
+                call_kind: None,
+                candidate_id: "span:3-4".to_string(),
+                line_number: 12,
+                target: "/x".to_string(),
+                method: Some("GET".to_string()),
+                pattern_matched: "fetch(".to_string(),
+                call_expression_span_start: None,
+                call_expression_span_end: None,
+                call_expression_text: None,
+                call_expression_line: None,
+                payload_expression_text: None,
+                payload_expression_line: None,
+                primary_type_symbol: Some("OrderPlacedEvent".to_string()),
+                type_import_source: Some("../types/events.tsx".to_string()),
+            }],
+            graphql_operations: vec![],
+            pubsub_operations: vec![
+                // (a) spurious `.ts` that matches the import table -> stripped + kept.
+                PubsubOperation {
+                    topic: "order.placed".to_string(),
+                    role: Some(PubsubRole::Subscriber),
+                    line_number: 20,
+                    primary_type_symbol: Some("OrderPlacedEvent".to_string()),
+                    type_import_source: Some("../types/events.ts".to_string()),
+                    broker: None,
+                },
+                // (b) scoped-package source (no extension) -> untouched (canary safety).
+                PubsubOperation {
+                    topic: "AccountsController:selectedAccountChange".to_string(),
+                    role: Some(PubsubRole::Subscriber),
+                    line_number: 30,
+                    primary_type_symbol: Some("InternalAccount".to_string()),
+                    type_import_source: Some("@metamask/keyring-internal-api".to_string()),
+                    broker: None,
+                },
+                // (c) `.ts` whose stripped form is NOT in the import table -> left as-is
+                //     (we normalize only against evidence, never guess).
+                PubsubOperation {
+                    topic: "other".to_string(),
+                    role: Some(PubsubRole::Publisher),
+                    line_number: 40,
+                    primary_type_symbol: Some("OrderPlacedEvent".to_string()),
+                    type_import_source: Some("../wrong/path.ts".to_string()),
+                    broker: None,
+                },
+            ],
+        };
+
+        let mut imported_symbols = HashMap::new();
+        imported_symbols.insert(
+            "OrderPlacedEvent".to_string(),
+            ImportedSymbol {
+                local_name: "OrderPlacedEvent".to_string(),
+                imported_name: "OrderPlacedEvent".to_string(),
+                source: "../types/events".to_string(),
+                kind: SymbolKind::Named,
+            },
+        );
+        imported_symbols.insert(
+            "InternalAccount".to_string(),
+            ImportedSymbol {
+                local_name: "InternalAccount".to_string(),
+                imported_name: "InternalAccount".to_string(),
+                source: "@metamask/keyring-internal-api".to_string(),
+                kind: SymbolKind::Named,
+            },
+        );
+
+        let symbol_table = SymbolTable {
+            local_types: HashSet::new(),
+            imported_symbols,
+        };
+
+        FileOrchestrator::validate_type_hints(&mut result, &symbol_table);
+
+        // endpoint + data_call: extension stripped, hint kept (not nulled).
+        assert_eq!(
+            result.endpoints[0].primary_type_symbol.as_deref(),
+            Some("OrderPlacedEvent")
+        );
+        assert_eq!(
+            result.endpoints[0].type_import_source.as_deref(),
+            Some("../types/events")
+        );
+        assert_eq!(
+            result.data_calls[0].type_import_source.as_deref(),
+            Some("../types/events")
+        );
+
+        // pubsub (a) stripped; (b) scoped package untouched; (c) no match, unchanged.
+        assert_eq!(
+            result.pubsub_operations[0].type_import_source.as_deref(),
+            Some("../types/events")
+        );
+        assert_eq!(
+            result.pubsub_operations[1].type_import_source.as_deref(),
+            Some("@metamask/keyring-internal-api")
+        );
+        assert_eq!(
+            result.pubsub_operations[2].type_import_source.as_deref(),
+            Some("../wrong/path.ts")
+        );
     }
 
     #[test]

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1579,9 +1579,12 @@ impl FileOrchestrator {
     }
 
     /// Strip a trailing TypeScript/JavaScript source-file extension from a module
-    /// specifier, returning `Some(stripped)` only when one was present. TS import
-    /// specifiers are written without a source extension, so a specifier that
-    /// carries one (e.g. `../types/events.ts`) is a model artifact.
+    /// specifier, returning `Some(stripped)` only when one was present. Import
+    /// specifiers CAN legitimately carry extensions (NodeNext/bundler ESM writes
+    /// `./foo.js`), so this alone never decides anything: the caller rewrites
+    /// only when the extension-less form matches the AST import table, i.e. when
+    /// the source demonstrably imported without the extension and the suffix was
+    /// added by the model.
     fn strip_source_file_extension(spec: &str) -> Option<&str> {
         for ext in [
             ".d.ts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",


### PR DESCRIPTION
## What this is

The measurement-driven fix step for the file-analyzer extraction-flake program. Three confirmed flake patterns were triaged in the `prompt-harness` and reproduced under `pass^20` (gemini-3.1-flash-lite, thinking=low, low concurrency):

| # | pattern | fixture(s) | baseline pass^20 |
|---|---|---|---|
| 1 | `type_import_source` gets a spurious `.ts` suffix | `c2-kafka-consumer-subscribe`, `c2-redis-publisher` | 0%, 20% |
| 2 | `primary_type_symbol` borrows the REQUEST body type when the response is un-typed | `c1-payments-audit-sdk-decoy` | 75% |
| 3 | graphql-over-http `target` = transport URL instead of the operation | `c3-graphql-over-http` | 70% |

## Headline finding: the schema-description lever is not safe on this model

The program's default lever was tightening schema field descriptions (deployless — the scanner posts `file_analysis_schema()` verbatim). Every description edit was measured. **Each one fixed its target flake locally but collaterally collapsed a baseline-stable fixture**, so none passed the "don't drop any fixture below 100%" gate:

| schema state | target fixtures | collateral: `messenger-inprocess-controller` (×3, k=20) |
|---|---|---|
| baseline | — | 100%, 100%, 100% |
| + 4 `type_import_source` "no-extension" edits | kafka/redis → 100% | 0% (also regressed `c2-kafka-billing-producer` 100→60, `messenger-template` 100→35, `c1-express-payments` 100→75) |
| + 2 `data_calls` edits only (target + anti-borrow) | audit + graphql → 100% | 5%, 40%, 30% |
| + `data_calls.target` edit ALONE (single shortest edit) | graphql → 100% | 0%, 0% |

Two mechanisms, both confirmed:
- **Global schema-prompt sensitivity.** Expanding *any* description — even one short field, even in a section the fixture never exercises (`messenger-inprocess-controller` emits only pub/sub ops, yet the `data_calls.target` edit collapsed it) — destabilises the lite model's type extraction on a hard fixture.
- **Negation-priming.** Naming `.ts` in a "never append `.ts`" instruction made the model emit `.ts` *more* often on a sibling fixture (`c2-kafka-billing-producer` regressed 100% → 60%).

Conclusion: no schema-description change ships. Pattern 1 is an **encoding invariant** (a TS import specifier never carries a source extension), so it is fixed deterministically here. Patterns 2 & 3 are left for structural follow-ups (below).

## What this PR ships (Pattern 1, deterministic)

`validate_type_hints` already compared `type_import_source` byte-for-byte against the AST import table and **NULLed the whole type hint on mismatch** — so a `.ts` suffix silently *destroyed* the type on endpoints/data_calls, while pub/sub ops (never validated) passed the `.ts` straight through to the sidecar.

- New `strip_source_file_extension` + `normalize_import_extension`: rewrite the specifier to its extension-less form **only when that form matches the symbol's import-table entry**. A specifier that legitimately lacks an extension (scoped package like `@metamask/network-controller`, same-file type) is untouched; a `.ts` with no matching import is left as-is. We normalise against evidence, never guess — this is why it is canary-safe.
- endpoints/data_calls normalise *before* the existing reject check (recovering a type that was being nulled); pub/sub ops get the same normalisation (they had none).
- Framework-agnostic: the import table is the source of truth, no hard-coded library list.
- Covered by `test_validate_type_hints_strips_spurious_source_extension` (endpoint + data_call + three pub/sub cases: strip-on-match, scoped-package no-op, no-match-left-alone). Full `cargo test` + `ts_check` + clippy green.

Note: the harness scores the raw LLM response and does not run this post-processing, so this fix is validated by the unit test rather than a harness `pass^20` delta.

## Patterns 2 & 3 — measured, not shipped

Both had clean *local* description fixes (audit 75→100, graphql 70→100 under pass^20) but were rejected by the canary collateral above. They need structural/deterministic handling rather than a longer prompt:

- **Pattern 2:** the request type is already carried by `payload_expression_text`; suppress `data_calls.primary_type_symbol` when the emitted symbol resolves (via the AST) to the request-payload expression's type rather than the call result.
- **Pattern 3:** the graphql operation/document name is derivable from the AST (the document passed to the request call); prefer it for the data_call `target` when the call dispatches a named document over a shared-endpoint client.

`c1-payments-audit-sdk-decoy` also surfaced an upstream **recall** flake (the live axios call is dropped ~1/3 runs while the harness never drops a presented candidate) — filed as candidate-generation issue #359.

## Companion changes (carrick-cloud, branch `feat/harness-flake-program`)

- `passk.ts` retries Vertex JSON-truncation noise before counting it as a failure.
- `response_schema.json` kept in sync (no description changes land).
- `fixtures/README.md` results table with every attempt + rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
