### PR TITLE
feat: persist per-pair ts_check verdicts into CloudRepoData (#351 part 1)

### DIFF
--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -458,6 +458,7 @@ impl CloudStorage for AwsStorage {
                     package_json_hash: None,
                     cache_version: None,
                     type_extraction_status: None,
+                    compat_verdicts: None,
                 };
                 repo_s3_urls.insert(adjacent.repo.clone(), adjacent.s3_url);
                 all_repo_data.push(repo_data);

--- a/src/cloud_storage/mock_storage.rs
+++ b/src/cloud_storage/mock_storage.rs
@@ -112,6 +112,7 @@ impl CloudStorage for MockStorage {
                     package_json_hash: None,
                     cache_version: None,
                     type_extraction_status: None,
+                    compat_verdicts: None,
                 },
                 CloudRepoData {
                     repo_name: "repo-b".to_string(),
@@ -137,6 +138,7 @@ impl CloudStorage for MockStorage {
                     package_json_hash: None,
                     cache_version: None,
                     type_extraction_status: None,
+                    compat_verdicts: None,
                 },
             ];
             result.extend(mock_repos);

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -106,6 +106,44 @@ pub struct TypeManifestEntry {
     pub primary_type_symbol: Option<String>,
 }
 
+/// A persisted per-pair type-compatibility verdict, keyed by CANONICAL pair
+/// identity (never display labels — that is the #324 fail-open trap). Emitted at
+/// scan time from the cross-repo [`crate::analyzer::CrossRepoMatch`] edges this
+/// repo's calls participate in as the consumer, so the cloud MCP
+/// `check_compatibility` tool can surface the REAL ts_check verdict CI already
+/// computes instead of a structural-matching-only answer.
+///
+/// Only edges ts_check actually EVALUATED are persisted (`type_compatible`
+/// `Some(_)`), so `compatible` is never a fabricated `true`: a pair with no
+/// stored verdict is "not compared", never "compatible". The four key fields are
+/// the exact `OperationKey::canonical()` / `service_name ?? repo_name` strings
+/// the cloud reconstructs from the same persisted blob it already reads, so the
+/// join is byte-identical and drift-free.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct CompatVerdict {
+    /// Producer repo id (`service_name ?? repo_name`).
+    pub producer_repo: String,
+    /// Producer endpoint `OperationKey::canonical()` (e.g. `http|GET|/orders/:id`).
+    pub producer_key: String,
+    /// Consumer repo id (`service_name ?? repo_name`).
+    pub consumer_repo: String,
+    /// Consumer call `OperationKey::canonical()` (host-free, URL-normalized;
+    /// equal to the persisted `DataFetchingCall::canonical_path` for every edge
+    /// that yields a match).
+    pub consumer_key: String,
+    /// `true` = ts_check found the request/response types compatible, `false` =
+    /// incompatible. Only evaluated edges reach here, so this is never a
+    /// fabricated `true`.
+    pub compatible: bool,
+    /// Populated iff `!compatible`: the human-readable mismatch reason ts_check
+    /// emitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mismatch_reason: Option<String>,
+    /// Scanner release that produced this verdict (`CARGO_PKG_VERSION`), so a
+    /// reader can see how stale the verdict is relative to the current scanner.
+    pub scanner_version: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CloudRepoData {
     pub repo_name: String,
@@ -156,6 +194,14 @@ pub struct CloudRepoData {
     /// of that being indistinguishable from "endpoints have no types".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub type_extraction_status: Option<String>,
+    /// Per-pair ts_check type-compat verdicts for cross-repo edges where THIS
+    /// repo's calls are the consumer, keyed by canonical pair identity (#351).
+    /// Additive and optional: blobs scanned before this field carry `None`, and
+    /// the MCP `check_compatibility` tool falls back to structural-matching-only
+    /// (fail closed) for any pair without a stored verdict. Populated after
+    /// cross-repo type checking by `attach_compat_verdicts`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compat_verdicts: Option<Vec<CompatVerdict>>,
 }
 
 impl CloudRepoData {
@@ -230,6 +276,7 @@ impl CloudRepoData {
             package_json_hash: None,
             cache_version: None,
             type_extraction_status: None,
+            compat_verdicts: None,
         }
     }
 }
@@ -351,6 +398,82 @@ pub trait CloudStorage {
     ) -> Result<(), StorageError>;
 }
 
+/// Attach per-pair ts_check verdicts to each service payload, for the cross-repo
+/// edges where that service is the CONSUMER. Reads the verdicts off the
+/// `CrossRepoMatch` edges `get_results` produced (compat already overlaid), and
+/// keys each by the canonical pair identity the cloud reconstructs (#351/#324).
+///
+/// Fail-closed by construction: only edges ts_check actually evaluated
+/// (`type_compatible.is_some()`) become a `CompatVerdict`; an unevaluated or
+/// unmatched pair simply has no stored verdict, which the cloud reads as "not
+/// compared", never "compatible". Multiple call sites collapsing onto one
+/// producer/consumer canonical pair are deduped with incompatible-wins, so a
+/// real mismatch is never masked by a sibling call site that happened to agree.
+pub fn attach_compat_verdicts(
+    payloads: &mut [CloudRepoData],
+    matches: &[crate::analyzer::CrossRepoMatch],
+) {
+    let scanner_version = env!("CARGO_PKG_VERSION");
+    for payload in payloads.iter_mut() {
+        let service_id = payload
+            .service_name
+            .clone()
+            .unwrap_or_else(|| payload.repo_name.clone());
+
+        // Dedup by canonical pair key; incompatible wins if call sites disagree.
+        let mut by_pair: std::collections::BTreeMap<
+            (String, String, String, String),
+            CompatVerdict,
+        > = std::collections::BTreeMap::new();
+
+        for m in matches {
+            if m.consumer_repo != service_id {
+                continue;
+            }
+            let Some(compatible) = m.type_compatible else {
+                // ts_check did not evaluate this edge — persist nothing so the
+                // cloud falls back to structural-matching-only (fail closed).
+                continue;
+            };
+            let pair = (
+                m.producer_repo.clone(),
+                m.producer_key.clone(),
+                m.consumer_repo.clone(),
+                m.consumer_key.clone(),
+            );
+            let verdict = CompatVerdict {
+                producer_repo: m.producer_repo.clone(),
+                producer_key: m.producer_key.clone(),
+                consumer_repo: m.consumer_repo.clone(),
+                consumer_key: m.consumer_key.clone(),
+                compatible,
+                mismatch_reason: if compatible {
+                    None
+                } else {
+                    m.mismatch_reason.clone()
+                },
+                scanner_version: scanner_version.to_string(),
+            };
+            by_pair
+                .entry(pair)
+                .and_modify(|existing| {
+                    // Incompatible-wins: a mismatch on any call site to this pair
+                    // is the verdict worth surfacing.
+                    if existing.compatible && !verdict.compatible {
+                        *existing = verdict.clone();
+                    }
+                })
+                .or_insert(verdict);
+        }
+
+        payload.compat_verdicts = if by_pair.is_empty() {
+            None
+        } else {
+            Some(by_pair.into_values().collect())
+        };
+    }
+}
+
 pub fn get_current_commit_hash(repo_path: &str) -> String {
     std::process::Command::new("git")
         .args(["rev-parse", "HEAD"])
@@ -408,5 +531,205 @@ mod tests {
 
         let back: TypeManifestEntry = serde_json::from_value(json).unwrap();
         assert_eq!(back.key, key);
+    }
+
+    use crate::analyzer::CrossRepoMatch;
+
+    fn empty_repo(repo_name: &str, service_name: Option<&str>) -> CloudRepoData {
+        CloudRepoData {
+            repo_name: repo_name.to_string(),
+            service_name: service_name.map(String::from),
+            endpoints: vec![],
+            calls: vec![],
+            mounts: vec![],
+            apps: HashMap::new(),
+            imported_handlers: vec![],
+            function_definitions: HashMap::new(),
+            config_json: None,
+            package_json: None,
+            packages: None,
+            last_updated: Utc::now(),
+            commit_hash: "deadbeef".to_string(),
+            mount_graph: None,
+            bundled_types: None,
+            type_manifest: None,
+            file_results: None,
+            cached_detection: None,
+            cached_guidance: None,
+            cached_extraction_config: None,
+            package_json_hash: None,
+            cache_version: None,
+            type_extraction_status: None,
+            compat_verdicts: None,
+        }
+    }
+
+    fn edge(
+        producer_repo: &str,
+        producer_key: &str,
+        consumer_repo: &str,
+        consumer_key: &str,
+        type_compatible: Option<bool>,
+        mismatch_reason: Option<&str>,
+    ) -> CrossRepoMatch {
+        CrossRepoMatch {
+            producer_repo: producer_repo.to_string(),
+            producer_key: producer_key.to_string(),
+            consumer_repo: consumer_repo.to_string(),
+            consumer_key: consumer_key.to_string(),
+            consumer_location: Some("src/client.ts".to_string()),
+            match_score: 1.0,
+            type_compatible,
+            mismatch_reason: mismatch_reason.map(String::from),
+        }
+    }
+
+    /// An old blob that predates `compat_verdicts` deserializes with the field
+    /// defaulted to `None` — additive and backwards compatible.
+    #[test]
+    fn cloud_repo_data_without_compat_verdicts_deserializes_to_none() {
+        let json = r#"{
+            "repo_name": "org/api",
+            "endpoints": [],
+            "calls": [],
+            "mounts": [],
+            "apps": {},
+            "imported_handlers": [],
+            "function_definitions": {},
+            "config_json": null,
+            "package_json": null,
+            "packages": null,
+            "last_updated": "2026-01-01T00:00:00Z",
+            "commit_hash": "abc123"
+        }"#;
+        let data: CloudRepoData = serde_json::from_str(json).unwrap();
+        assert!(data.compat_verdicts.is_none());
+    }
+
+    /// A verdict round-trips through JSON keyed by canonical pair identity, and a
+    /// `None` (unevaluated) edge is omitted, not serialized as compatible.
+    #[test]
+    fn compat_verdicts_round_trip_keyed_canonically() {
+        let mut payloads = vec![empty_repo(
+            "org/notification-service",
+            Some("notification-service"),
+        )];
+        let matches = vec![
+            // Evaluated + incompatible → persisted with reason.
+            edge(
+                "order-service",
+                "http|GET|/orders/:id",
+                "notification-service",
+                "http|GET|/orders/:id",
+                Some(false),
+                Some("Order[] vs Order"),
+            ),
+            // Evaluated + compatible → persisted, no reason.
+            edge(
+                "order-service",
+                "http|GET|/health",
+                "notification-service",
+                "http|GET|/health",
+                Some(true),
+                None,
+            ),
+            // Not evaluated → NOT persisted (fail closed).
+            edge(
+                "order-service",
+                "http|POST|/orders",
+                "notification-service",
+                "http|POST|/orders",
+                None,
+                None,
+            ),
+        ];
+
+        attach_compat_verdicts(&mut payloads, &matches);
+        let verdicts = payloads[0]
+            .compat_verdicts
+            .clone()
+            .expect("verdicts present");
+        assert_eq!(verdicts.len(), 2, "only evaluated edges are persisted");
+
+        // Round-trips through the wire.
+        let json = serde_json::to_string(&payloads[0]).unwrap();
+        let back: CloudRepoData = serde_json::from_str(&json).unwrap();
+        let back_verdicts = back.compat_verdicts.unwrap();
+        let incompat = back_verdicts
+            .iter()
+            .find(|v| v.producer_key == "http|GET|/orders/:id")
+            .unwrap();
+        assert!(!incompat.compatible);
+        assert_eq!(
+            incompat.mismatch_reason.as_deref(),
+            Some("Order[] vs Order")
+        );
+        assert_eq!(incompat.consumer_repo, "notification-service");
+        assert_eq!(incompat.scanner_version, env!("CARGO_PKG_VERSION"));
+
+        let compat = back_verdicts
+            .iter()
+            .find(|v| v.producer_key == "http|GET|/health")
+            .unwrap();
+        assert!(compat.compatible);
+        assert!(compat.mismatch_reason.is_none());
+
+        // The unevaluated POST /orders pair is absent — the cloud reads its
+        // absence as "not compared", never "compatible".
+        assert!(
+            !back_verdicts
+                .iter()
+                .any(|v| v.producer_key == "http|POST|/orders"),
+            "unevaluated edge must not be persisted"
+        );
+    }
+
+    /// Verdicts are attributed CONSUMER-side: an edge whose consumer is a
+    /// different repo is not stored on this payload.
+    #[test]
+    fn attach_compat_verdicts_only_stores_consumer_side_edges() {
+        let mut payloads = vec![empty_repo("org/order-service", Some("order-service"))];
+        // order-service is the PRODUCER here, notification-service the consumer:
+        // this verdict belongs on notification-service's blob, not order-service's.
+        let matches = vec![edge(
+            "order-service",
+            "http|GET|/orders/:id",
+            "notification-service",
+            "http|GET|/orders/:id",
+            Some(false),
+            Some("Order[] vs Order"),
+        )];
+        attach_compat_verdicts(&mut payloads, &matches);
+        assert!(payloads[0].compat_verdicts.is_none());
+    }
+
+    /// When two call sites hit the same producer/consumer canonical pair and
+    /// disagree, the incompatible verdict wins (a real risk is never masked).
+    #[test]
+    fn attach_compat_verdicts_dedup_incompatible_wins() {
+        let mut payloads = vec![empty_repo("org/consumer", Some("consumer"))];
+        let matches = vec![
+            edge(
+                "producer",
+                "http|GET|/x",
+                "consumer",
+                "http|GET|/x",
+                Some(true),
+                None,
+            ),
+            edge(
+                "producer",
+                "http|GET|/x",
+                "consumer",
+                "http|GET|/x",
+                Some(false),
+                Some("mismatch"),
+            ),
+        ];
+        attach_compat_verdicts(&mut payloads, &matches);
+        let verdicts = payloads[0].compat_verdicts.clone().unwrap();
+        assert_eq!(verdicts.len(), 1);
+        assert!(!verdicts[0].compatible);
+        assert_eq!(verdicts[0].mismatch_reason.as_deref(), Some("mismatch"));
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -269,12 +269,18 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         );
     }
 
-    // 5. Conditionally upload each service's data to cloud storage.
+    // 5. Prepare each service's upload payload, but DEFER the actual upload
+    //    until after cross-repo analysis (step 6) so every payload can carry the
+    //    per-pair ts_check compat verdicts that analysis computes (#351). Every
+    //    payload is materialised now (cheap clones), so a serialization problem
+    //    can't surface halfway through a multi-service upload.
+    //
     //    The production index keys on (workspace, project, repo) only, so it
-    //    cannot yet hold more than one service per repo — a multi-service
-    //    upload would clobber. Gate it on the backend advertising support;
-    //    cross-repo analysis below still runs locally regardless.
-    if should_upload {
+    //    cannot yet hold more than one service per repo — a multi-service upload
+    //    would clobber. Gate it on the backend advertising support; cross-repo
+    //    analysis below still runs locally regardless. `None` = do not upload
+    //    (PR/branch mode, or an unsupported multi-service repo).
+    let upload_payloads: Option<Vec<CloudRepoData>> = if should_upload {
         if multi_service && !storage.supports_multi_service() {
             warn!(
                 "Skipping index upload: {} services declared but the cloud key has no \
@@ -282,43 +288,19 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
                  Cross-repo analysis still runs locally.",
                 services.len()
             );
+            None
         } else {
-            let sp = logging::spinner("Uploading results...");
-            // Prepare every payload before uploading any, so a serialization
-            // problem can't surface halfway through a multi-service upload.
-            let payloads: Vec<CloudRepoData> = current_services_data
-                .iter()
-                .map(|data| strip_ast_nodes(data.clone()))
-                .collect();
-            for (i, payload) in payloads.iter().enumerate() {
-                if let Err(e) = storage.upload_repo_data(payload).await {
-                    // Uploads are keyed per (repo, service) and idempotent, so
-                    // a re-run restores consistency — but until then the index
-                    // holds this run's data for some services and the previous
-                    // run's for the rest. Make that state explicit.
-                    let uploaded: Vec<&str> = payloads[..i]
-                        .iter()
-                        .map(|d| d.service_name.as_deref().unwrap_or(&d.repo_name))
-                        .collect();
-                    let not_uploaded: Vec<&str> = payloads[i..]
-                        .iter()
-                        .map(|d| d.service_name.as_deref().unwrap_or(&d.repo_name))
-                        .collect();
-                    return Err(format!(
-                        "Failed to upload repo data: {}. Uploaded: [{}]; not uploaded: [{}]. \
-                         The index is mixed-generation for this repo until a successful re-run.",
-                        e,
-                        uploaded.join(", "),
-                        not_uploaded.join(", ")
-                    )
-                    .into());
-                }
-            }
-            logging::finish_spinner(&sp, "Uploaded results to Carrick Cloud");
+            Some(
+                current_services_data
+                    .iter()
+                    .map(|data| strip_ast_nodes(data.clone()))
+                    .collect(),
+            )
         }
     } else {
         debug!("Skipping upload (PR/branch mode)");
-    }
+        None
+    };
 
     // On a PR run, capture this repo's previously-indexed endpoints (its last
     // uploaded state, i.e. main) before they're removed below, so the diff can
@@ -438,7 +420,19 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
 
     let sp = logging::spinner("Running cross-repo analysis...");
     let analyzer =
-        build_cross_repo_analyzer(all_repo_data, current_services_data, ts_check_dir).await?;
+        match build_cross_repo_analyzer(all_repo_data, current_services_data, ts_check_dir).await {
+            Ok(analyzer) => analyzer,
+            Err(e) => {
+                // Cross-repo analysis (which is what runs ts_check) failed. Preserve
+                // the prior behavior where the per-repo index upload happened BEFORE
+                // cross-repo analysis: still upload this run's data — verdict-less —
+                // so the index stays fresh, then propagate the failure.
+                if let Some(payloads) = &upload_payloads {
+                    upload_service_payloads(storage, payloads).await?;
+                }
+                return Err(e);
+            }
+        };
     logging::finish_spinner(&sp, "Cross-repo analysis complete");
 
     let results = analyzer.get_results();
@@ -446,12 +440,24 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     // Eval harness output mode: emit a machine-readable projection of the
     // results and skip the human Markdown report + PR-comment relay. Consumed
     // by the offline scorer (Slice 1 of the evals plan). Deliberately terminal —
-    // an eval run wants only the JSON, no upload or comment side effects.
+    // an eval run wants only the JSON, no upload or comment side effects. (Eval
+    // mode never uploads, so `upload_payloads` is always `None` here.)
     if std::env::var("CARRICK_OUTPUT_JSON").is_ok() {
         let projection =
             crate::eval_output::EvalProjection::from_results(&results, &eval_type_manifest);
         println!("{}", serde_json::to_string_pretty(&projection)?);
         return Ok(());
+    }
+
+    // 6b. Upload each service's data, now carrying the per-pair ts_check compat
+    //     verdicts cross-repo analysis just computed for the edges this repo's
+    //     calls consume (#351). Keyed by canonical pair identity so the cloud
+    //     MCP `check_compatibility` tool can surface the real verdict instead of
+    //     structural-matching-only. Absent for edges ts_check didn't evaluate,
+    //     which the cloud reads as "not compared" (fail closed, #324).
+    if let Some(mut payloads) = upload_payloads {
+        crate::cloud_storage::attach_compat_verdicts(&mut payloads, &results.cross_repo_matches);
+        upload_service_payloads(storage, &payloads).await?;
     }
 
     let topology = crate::findings::Topology {
@@ -620,6 +626,39 @@ where
         }
     }
     Ok(T::default())
+}
+
+/// Upload each already-prepared service payload to the cloud index, in order.
+/// On a mid-sequence failure, reports which services made it and which didn't:
+/// uploads are keyed per (repo, service) and idempotent, so a re-run restores
+/// consistency, but until then the index is mixed-generation for this repo.
+async fn upload_service_payloads<T: CloudStorage>(
+    storage: &T,
+    payloads: &[CloudRepoData],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sp = logging::spinner("Uploading results...");
+    for (i, payload) in payloads.iter().enumerate() {
+        if let Err(e) = storage.upload_repo_data(payload).await {
+            let uploaded: Vec<&str> = payloads[..i]
+                .iter()
+                .map(|d| d.service_name.as_deref().unwrap_or(&d.repo_name))
+                .collect();
+            let not_uploaded: Vec<&str> = payloads[i..]
+                .iter()
+                .map(|d| d.service_name.as_deref().unwrap_or(&d.repo_name))
+                .collect();
+            return Err(format!(
+                "Failed to upload repo data: {}. Uploaded: [{}]; not uploaded: [{}]. \
+                 The index is mixed-generation for this repo until a successful re-run.",
+                e,
+                uploaded.join(", "),
+                not_uploaded.join(", ")
+            )
+            .into());
+        }
+    }
+    logging::finish_spinner(&sp, "Uploaded results to Carrick Cloud");
+    Ok(())
 }
 
 /// Remove AST nodes from CloudRepoData for serialization.
@@ -2005,6 +2044,7 @@ fn build_cloud_data_from_mount_graph(
         package_json_hash: None,
         cache_version: None,
         type_extraction_status: None,
+        compat_verdicts: None,
     }
 }
 
@@ -3778,6 +3818,7 @@ mod tests {
             package_json_hash: None,
             cache_version: None,
             type_extraction_status: None,
+            compat_verdicts: None,
         };
 
         // Verify strip_ast_nodes removes AST nodes
@@ -3818,6 +3859,7 @@ mod tests {
             package_json_hash: None,
             cache_version: None,
             type_extraction_status: None,
+            compat_verdicts: None,
         }];
 
         // Test Config merging
@@ -3894,6 +3936,7 @@ mod tests {
             package_json_hash: None,
             cache_version: None,
             type_extraction_status: None,
+            compat_verdicts: None,
         }];
 
         // Test that cross-repo builder doesn't fail with SourceMap issues
@@ -4434,6 +4477,7 @@ mod tests {
             package_json_hash: None,
             cache_version: Some(CACHE_VERSION),
             type_extraction_status: None,
+            compat_verdicts: None,
         };
 
         let stripped = strip_ast_nodes(data);
@@ -4477,6 +4521,7 @@ mod tests {
             package_json_hash: None,
             cache_version: Some(CACHE_VERSION),
             type_extraction_status: None,
+            compat_verdicts: None,
         };
 
         let stripped = strip_ast_nodes(data);
@@ -4612,6 +4657,7 @@ mod tests {
             package_json_hash: Some("abc123hash".to_string()),
             cache_version: Some(CACHE_VERSION),
             type_extraction_status: None,
+            compat_verdicts: None,
         };
 
         let json = serde_json::to_string(&data).expect("should serialize");
@@ -4683,6 +4729,7 @@ mod tests {
             package_json_hash: None,
             cache_version: Some(CACHE_VERSION),
             type_extraction_status: None,
+            compat_verdicts: None,
         };
 
         let json = serde_json::to_string(&data).expect("should serialize");
@@ -6561,6 +6608,7 @@ mod tests {
             package_json_hash: None,
             cache_version: None,
             type_extraction_status: None,
+            compat_verdicts: None,
         };
 
         // Local mirror of TypeManifestFile for reading back the written JSON
@@ -6727,6 +6775,7 @@ mod tests {
             package_json_hash: None,
             cache_version: None,
             type_extraction_status: None,
+            compat_verdicts: None,
         };
 
         #[derive(serde::Deserialize)]
@@ -6806,6 +6855,7 @@ mod tests {
             package_json_hash: None,
             cache_version: None,
             type_extraction_status: None,
+            compat_verdicts: None,
         }
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -423,10 +423,14 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         match build_cross_repo_analyzer(all_repo_data, current_services_data, ts_check_dir).await {
             Ok(analyzer) => analyzer,
             Err(e) => {
-                // Cross-repo analysis (which is what runs ts_check) failed. Preserve
-                // the prior behavior where the per-repo index upload happened BEFORE
-                // cross-repo analysis: still upload this run's data — verdict-less —
-                // so the index stays fresh, then propagate the failure.
+                // Cross-repo analysis (which is what runs ts_check) failed. Close
+                // the spinner with a warning first so the upload's own spinner
+                // and log lines don't interleave with an unfinished one in
+                // non-TTY CI logs, then preserve the prior behavior where the
+                // per-repo index upload happened BEFORE cross-repo analysis:
+                // still upload this run's data — verdict-less — so the index
+                // stays fresh, then propagate the failure.
+                logging::finish_spinner_warn(&sp, "Cross-repo analysis failed");
                 if let Some(payloads) = &upload_payloads {
                     upload_service_payloads(storage, payloads).await?;
                 }
@@ -457,6 +461,13 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     //     which the cloud reads as "not compared" (fail closed, #324).
     if let Some(mut payloads) = upload_payloads {
         crate::cloud_storage::attach_compat_verdicts(&mut payloads, &results.cross_repo_matches);
+        // The size guard already ran once inside strip_ast_nodes, but the
+        // verdicts were appended after it — re-apply so a payload that was
+        // near the cap can't be re-inflated past it and 413 the upload
+        // (verdicts are tiny; the caches are what gets dropped).
+        for payload in &mut payloads {
+            enforce_payload_size_limit(payload);
+        }
         upload_service_payloads(storage, &payloads).await?;
     }
 
@@ -672,8 +683,24 @@ fn strip_ast_nodes(mut data: CloudRepoData) -> CloudRepoData {
     data.endpoints.iter_mut().for_each(strip_endpoint_ast);
     data.calls.iter_mut().for_each(strip_endpoint_ast);
 
-    // Payload size guard: Lambda function URLs have a 6MB request payload limit.
-    // If serialized data exceeds ~5MB, drop file_results to stay under the limit.
+    enforce_payload_size_limit(&mut data);
+
+    data
+}
+
+/// Payload size guard: Lambda function URLs have a 6MB request payload limit.
+/// If serialized data exceeds ~5MB, drop the incremental caches (file_results
+/// being the bulk) to stay under the limit; warn loudly if it is still over
+/// Lambda's hard limit afterwards.
+///
+/// Called twice per upload payload: inside [`strip_ast_nodes`] when the payload
+/// is prepared, and again after [`crate::cloud_storage::attach_compat_verdicts`]
+/// adds the per-pair type verdicts (#351) — anything appended after the first
+/// pass could otherwise re-inflate the JSON past the cap and 413 the upload.
+/// Degradation order is deliberate: verdicts are tiny (a handful of short
+/// strings per cross-repo edge) while `file_results` is the multi-MB bulk, so
+/// the caches are always what gets dropped; verdicts are kept.
+fn enforce_payload_size_limit(data: &mut CloudRepoData) {
     const MAX_PAYLOAD_BYTES: usize = 5 * 1024 * 1024; // 5MB safety margin
     const LAMBDA_HARD_LIMIT_BYTES: usize = 6 * 1024 * 1024;
     if let Ok(serialized) = serde_json::to_string(&data)
@@ -704,8 +731,6 @@ fn strip_ast_nodes(mut data: CloudRepoData) -> CloudRepoData {
             );
         }
     }
-
-    data
 }
 
 /// Get files changed between a base commit and HEAD.
@@ -4530,6 +4555,114 @@ mod tests {
         assert!(
             stripped.file_results.is_some(),
             "file_results should be preserved when payload is small"
+        );
+    }
+
+    /// #351 regression: `attach_compat_verdicts` runs AFTER the strip_ast_nodes
+    /// size-guard pass, so verdicts appended to a payload that squeaked under
+    /// the 5MB cap could re-inflate it past the Lambda limit and 413 the
+    /// upload. The engine re-applies `enforce_payload_size_limit` after
+    /// attachment; this pins that a near-limit payload with verdicts attached
+    /// still respects the cap, with the SAME degradation order as the first
+    /// pass — the bulky caches are dropped, the tiny verdicts are kept.
+    #[test]
+    fn test_payload_size_guard_reapplied_after_verdict_attachment() {
+        const MAX_PAYLOAD_BYTES: usize = 5 * 1024 * 1024; // mirrors the guard
+
+        let base = CloudRepoData {
+            repo_name: "consumer-svc".to_string(),
+            service_name: None,
+            endpoints: vec![],
+            calls: vec![],
+            mounts: vec![],
+            apps: HashMap::new(),
+            imported_handlers: vec![],
+            function_definitions: HashMap::new(),
+            config_json: None,
+            package_json: None,
+            packages: None,
+            last_updated: chrono::Utc::now(),
+            commit_hash: "test-hash".to_string(),
+            mount_graph: None,
+            bundled_types: None,
+            type_manifest: None,
+            file_results: None,
+            cached_detection: None,
+            cached_guidance: None,
+            cached_extraction_config: None,
+            package_json_hash: None,
+            cache_version: Some(CACHE_VERSION),
+            type_extraction_status: None,
+            compat_verdicts: None,
+        };
+
+        // Size the file_results filler so the payload lands just UNDER the 5MB
+        // cap: the strip_ast_nodes guard pass keeps everything, and only the
+        // verdicts appended afterwards push it over.
+        let base_len = serde_json::to_string(&base).unwrap().len();
+        let mut result = make_file_result(vec!["/api/orders"], vec![]);
+        result.endpoints[0].payload_expression_text = Some(String::new());
+        let mut probe = HashMap::new();
+        probe.insert("src/big.ts".to_string(), result.clone());
+        let mut with_empty = base.clone();
+        with_empty.file_results = Some(probe);
+        let overhead = serde_json::to_string(&with_empty).unwrap().len() - base_len;
+        // 200 bytes of headroom below the cap — less than the verdicts add.
+        let filler_len = MAX_PAYLOAD_BYTES - base_len - overhead - 200;
+        result.endpoints[0].payload_expression_text = Some("x".repeat(filler_len));
+        let mut file_results = HashMap::new();
+        file_results.insert("src/big.ts".to_string(), result);
+        let mut data = base;
+        data.file_results = Some(file_results);
+
+        // First guard pass (as strip_ast_nodes runs it): under the cap, so the
+        // caches survive.
+        let mut payloads = vec![strip_ast_nodes(data)];
+        assert!(
+            payloads[0].file_results.is_some(),
+            "test setup: payload must start under the cap with caches intact"
+        );
+        let before = serde_json::to_string(&payloads[0]).unwrap().len();
+        assert!(before <= MAX_PAYLOAD_BYTES);
+
+        // Verdict attachment re-inflates past the cap (mismatch reason > the
+        // 200-byte headroom).
+        let matches = vec![crate::analyzer::CrossRepoMatch {
+            producer_repo: "producer-svc".to_string(),
+            producer_key: "http|GET|/api/orders/:id".to_string(),
+            consumer_repo: "consumer-svc".to_string(),
+            consumer_key: "http|GET|/api/orders/:id".to_string(),
+            consumer_location: Some("src/client.ts".to_string()),
+            match_score: 1.0,
+            type_compatible: Some(false),
+            mismatch_reason: Some("y".repeat(400)),
+        }];
+        crate::cloud_storage::attach_compat_verdicts(&mut payloads, &matches);
+        assert!(
+            serde_json::to_string(&payloads[0]).unwrap().len() > MAX_PAYLOAD_BYTES,
+            "test setup: verdicts must push the payload over the cap"
+        );
+
+        // The engine's post-attachment pass: back under the cap, caches
+        // dropped, verdicts kept.
+        enforce_payload_size_limit(&mut payloads[0]);
+        let after = serde_json::to_string(&payloads[0]).unwrap().len();
+        assert!(
+            after <= MAX_PAYLOAD_BYTES,
+            "payload must respect the cap after verdict attachment ({}KB > {}KB)",
+            after / 1024,
+            MAX_PAYLOAD_BYTES / 1024
+        );
+        assert!(
+            payloads[0].file_results.is_none(),
+            "the bulky caches are what gets dropped"
+        );
+        assert!(
+            payloads[0]
+                .compat_verdicts
+                .as_ref()
+                .is_some_and(|v| v.len() == 1),
+            "the tiny verdicts are kept"
         );
     }
 

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -835,6 +835,7 @@ mod tests {
             package_json_hash: None,
             cache_version: None,
             type_extraction_status: None,
+            compat_verdicts: None,
         }
     }
 

--- a/tests/mock_storage_test.rs
+++ b/tests/mock_storage_test.rs
@@ -47,6 +47,7 @@ fn create_test_repo_data(repo_name: &str, commit_hash: &str) -> CloudRepoData {
         package_json_hash: None,
         cache_version: None,
         type_extraction_status: None,
+        compat_verdicts: None,
     }
 }
 


### PR DESCRIPTION
**Part 1 of carrick#351.** Scanner side: emit the per-pair type-compat verdicts cross-repo analysis already computes into the uploaded `CloudRepoData` blob, so the cloud MCP `check_compatibility` tool (part 2) can surface the real ts_check verdict instead of a structural-matching-only answer. Refs #324, #207.

## Design

At scan time cross-repo analysis (`get_results` → `overlay_compat_verdicts`) already produces `CrossRepoMatch` edges carrying `type_compatible` + `mismatch_reason`. Those verdicts were computed and then thrown away at upload time. This persists them.

### Blob shape (additive, optional)

New `CloudRepoData.compat_verdicts: Option<Vec<CompatVerdict>>`, `#[serde(default, skip_serializing_if = "Option::is_none")]`. Old blobs (all existing data) deserialize to `None` and keep working; the cloud falls back to today's structural-only answer for any pair without a verdict.

```
CompatVerdict {
    producer_repo: String,   // service_name ?? repo_name
    producer_key:  String,   // OperationKey::canonical()  e.g. "http|GET|/orders/:id"
    consumer_repo: String,   // service_name ?? repo_name
    consumer_key:  String,   // OperationKey::canonical()  host-free, URL-normalized
    compatible:    bool,     // only EVALUATED edges persisted (never a fabricated true)
    mismatch_reason: Option<String>,  // Some iff !compatible
    scanner_version: String, // CARGO_PKG_VERSION — staleness is visible
}
```

### Key derivation (the #324 fix)

The join key is `(producer_repo, producer_key, consumer_repo, consumer_key)` as **literal `canonical()` strings — never display labels** (labels were the #324 fail-open trap). These are the exact strings the cloud reconstructs from the same blob it already reads (`endpoint.full_path`, `call.canonical_path`), so the join is byte-identical. Verified that the scanner's match-time `consumer_key` (`normalize(target).path`) equals the persisted `DataFetchingCall::canonical_path` for exactly the calls that form an edge; unknown-env-var calls never form an edge, so there is no drift class. A param-name mismatch (`/orders/:id` vs `/orders/:userId`) still joins because both sides use identical literals; only a *different* structural pairing misses, and a miss fails **closed** ("not compared"), never open.

### Semantics

- Verdicts are attributed **consumer-side** (edges where this repo's calls consume), matching the MCP read pattern; the cloud merges every repo's `compat_verdicts` into one index.
- Only edges ts_check actually **evaluated** (`type_compatible.is_some()`) are persisted, so a pair with no stored verdict is "not compared", never a fabricated compatible.
- Duplicate call sites collapsing onto one canonical pair dedup **incompatible-wins**, so a real mismatch is never masked.
- `scanner_version` travels with each verdict; no TTL/invalidation invented beyond that.

### Upload ordering

The per-repo upload previously ran *before* cross-repo analysis, so the verdicts didn't exist yet. Upload is now deferred until after analysis and each payload carries its verdicts. The eval-projection path is byte-identical (the cassette golden holds), and if cross-repo analysis fails the run still uploads verdict-less data to keep the index fresh — exactly the pre-change resilience.

## Tests

`src/cloud_storage/mod.rs`:
- `cloud_repo_data_without_compat_verdicts_deserializes_to_none` — old-blob back-compat.
- `compat_verdicts_round_trip_keyed_canonically` — evaluated edges persist keyed canonically + wire round-trip; unevaluated (`None`) edge omitted.
- `attach_compat_verdicts_only_stores_consumer_side_edges` — producer-side edge not stored on this payload.
- `attach_compat_verdicts_dedup_incompatible_wins`.

Full Rust suite (unit + integration + doctests) and the ts_check suite pass via the pre-commit hook; cassette hard-gate golden unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)