### PR TITLE
file-based routing: derive routes relative to the service directory

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -346,7 +346,10 @@ impl FileOrchestrator {
         files: &[PathBuf],
         guidance: &ProtocolGuidance,
         framework_detection: &DetectionResult,
-        repo_root: &Path,
+        // Root for file-based route derivation: the SERVICE directory when
+        // carrick.json declares one, else the repo root. Convention root globs
+        // (`app`, `src/app`, …) are matched against paths relative to THIS.
+        service_root: &Path,
         graphql_producer_hints: &crate::graphql::GraphqlProducerHints,
         graphql_consumer_hints: &crate::graphql::GraphqlConsumerHints,
         normalizer: &UrlNormalizer,
@@ -492,7 +495,7 @@ impl FileOrchestrator {
             let route_endpoints = if conventions.is_empty() {
                 Vec::new()
             } else {
-                let rel_path = file_path.strip_prefix(repo_root).unwrap_or(file_path);
+                let rel_path = file_path.strip_prefix(service_root).unwrap_or(file_path);
                 Self::file_based_endpoints(
                     &self.swc_scanner,
                     rel_path,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1044,13 +1044,14 @@ async fn analyze_current_repo_incremental(
             );
 
             let normalizer = UrlNormalizer::new(config);
+            let service_root = service_scan_root(repo_path, config);
             let new_file_results = if !files_to_analyze.is_empty() {
                 let result = file_orchestrator
                     .analyze_files(
                         &files_to_analyze,
                         &guidance,
                         &detection,
-                        &service_scan_root(repo_path, config),
+                        &service_root,
                         &graphql_producer_hints,
                         &graphql_consumer_hints,
                         &normalizer,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1050,7 +1050,7 @@ async fn analyze_current_repo_incremental(
                         &files_to_analyze,
                         &guidance,
                         &detection,
-                        Path::new(repo_path),
+                        &service_scan_root(repo_path, config),
                         &graphql_producer_hints,
                         &graphql_consumer_hints,
                         &normalizer,
@@ -2081,6 +2081,18 @@ fn build_cloud_data_from_mount_graph(
 /// Re-init rebuilds the sidecar's ts-morph project; for a large monorepo this
 /// runs once per scoped service. A future optimization could load all service
 /// projects in a single init via the sidecar's monorepo builder.
+/// The root that file-based route derivation strips before matching a
+/// convention's root globs. Conventions declare app-root globs like `app` /
+/// `src/app`, which are SERVICE-relative: in a monorepo the app lives at e.g.
+/// `apps/web/app/**`, so stripping only the repo root would leave a path no
+/// glob matches and silently derive zero routes for every declared service.
+fn service_scan_root(repo_path: &str, service: &Config) -> std::path::PathBuf {
+    match &service.directory {
+        Some(dir) => Path::new(repo_path).join(dir),
+        None => Path::new(repo_path).to_path_buf(),
+    }
+}
+
 fn scope_sidecar_to_service(sidecar: Option<&TypeSidecar>, repo_path: &str, service: &Config) {
     let Some(sidecar) = sidecar else { return };
     if service.directory.is_none() && service.tsconfig.is_none() {
@@ -2822,12 +2834,13 @@ async fn analyze_current_repo(
 
     // 4. Run the complete multi-agent analysis
     let normalizer = UrlNormalizer::new(config);
+    let service_root = service_scan_root(repo_path, config);
     let analysis_result = orchestrator
         .run_complete_analysis(
             files.clone(),
             packages,
             &all_imported_symbols,
-            repo_path,
+            &service_root.to_string_lossy(),
             &graphql_producer_hints,
             &graphql_consumer_hints,
             &normalizer,
@@ -3495,6 +3508,24 @@ fn recreate_package_and_tsconfig(
 mod tests {
     use super::*;
     use crate::analyzer::ApiEndpointDetails;
+
+    #[test]
+    fn service_scan_root_joins_declared_directory() {
+        let flat = Config::default();
+        assert_eq!(
+            service_scan_root("/repo", &flat),
+            std::path::PathBuf::from("/repo")
+        );
+
+        let service = Config {
+            directory: Some("apps/web".to_string()),
+            ..Config::default()
+        };
+        assert_eq!(
+            service_scan_root("/repo", &service),
+            std::path::PathBuf::from("/repo/apps/web")
+        );
+    }
     use crate::cloud_storage::TypeEvidence;
     use crate::services::type_sidecar::{InferredType, SourceLocation};
     use crate::visitor::{OwnerType, TypeReference};

--- a/src/multi_agent_orchestrator.rs
+++ b/src/multi_agent_orchestrator.rs
@@ -81,7 +81,10 @@ impl MultiAgentOrchestrator {
         files: Vec<std::path::PathBuf>,
         packages: &Packages,
         imported_symbols: &HashMap<String, ImportedSymbol>,
-        repo_path: &str,
+        // Root for file-based route derivation: the SERVICE directory when
+        // carrick.json declares one, else the repo root (see
+        // `engine::service_scan_root`).
+        service_root: &str,
         graphql_producer_hints: &crate::graphql::GraphqlProducerHints,
         graphql_consumer_hints: &crate::graphql::GraphqlConsumerHints,
         normalizer: &UrlNormalizer,
@@ -126,7 +129,7 @@ impl MultiAgentOrchestrator {
                 &files,
                 &framework_guidance,
                 &framework_detection,
-                std::path::Path::new(repo_path),
+                std::path::Path::new(service_root),
                 graphql_producer_hints,
                 graphql_consumer_hints,
                 normalizer,

--- a/tests/file_based_routing_test.rs
+++ b/tests/file_based_routing_test.rs
@@ -96,6 +96,43 @@ fn nextjs_app_router_fixture_derives_expected_routes() {
     );
 }
 
+/// Monorepo trap: the app lives under `apps/web/app/**`, so deriving against
+/// the REPO root leaves paths (`apps/web/app/...`) that no convention root
+/// glob (`app`, `src/app`) matches — zero routes, silently. The engine must
+/// strip the SERVICE root (carrick.json `services[].directory`, here
+/// `apps/web`) instead; deriving against it yields the routes. The fixture
+/// also locks two export shapes route files use in the wild: a wrapped-const
+/// handler (`export const GET = wrapper({...})`) and a pure re-export route
+/// file whose handlers live outside the `app/` tree (the modules file itself
+/// derives nothing).
+#[test]
+fn nextjs_app_router_monorepo_derives_routes_relative_to_service_root() {
+    let conventions = builtin_conventions(&["Next.js".to_string()]);
+
+    let repo_root_relative = synthesized_routes("nextjs-app-monorepo", &conventions);
+    assert!(
+        repo_root_relative.is_empty(),
+        "repo-root-relative derivation must find nothing in a monorepo layout \
+         (this is why the engine strips the service root), got {repo_root_relative:?}"
+    );
+
+    let routes = synthesized_routes("nextjs-app-monorepo/apps/web", &conventions);
+    let expected: BTreeSet<String> = [
+        "GET /api/v1/client/:workspaceId/environment",
+        "POST /api/v2/client/:workspaceId/user",
+        "OPTIONS /api/v2/client/:workspaceId/user",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    assert_eq!(
+        routes, expected,
+        "service-root-relative derivation should yield the app routes: the \
+         wrapped-const GET, and the re-exported POST/OPTIONS at the app-side \
+         path (never the modules/ implementation path)"
+    );
+}
+
 #[test]
 fn astro_fixture_derives_expected_routes() {
     let routes = synthesized_routes("astro", &builtin_conventions(&["Astro".to_string()]));

--- a/tests/fixtures/nextjs-app-monorepo/apps/web/app/api/v1/client/[workspaceId]/environment/route.ts
+++ b/tests/fixtures/nextjs-app-monorepo/apps/web/app/api/v1/client/[workspaceId]/environment/route.ts
@@ -1,0 +1,7 @@
+// Wrapped-const export shape (the handler is built by a HOF, not declared as
+// `export async function GET`): the method must still come from the export name.
+const withApiWrapper = (opts: { handler: () => Promise<Response> }) => opts.handler;
+
+export const GET = withApiWrapper({
+  handler: async () => new Response(JSON.stringify({ ok: true })),
+});

--- a/tests/fixtures/nextjs-app-monorepo/apps/web/app/api/v2/client/[workspaceId]/user/route.ts
+++ b/tests/fixtures/nextjs-app-monorepo/apps/web/app/api/v2/client/[workspaceId]/user/route.ts
@@ -1,0 +1,3 @@
+// Pure re-export route file: the route path comes from THIS file's location;
+// the methods come from the re-exported names.
+export { POST, OPTIONS } from "../../../../../../modules/api/user/route";

--- a/tests/fixtures/nextjs-app-monorepo/apps/web/modules/api/user/route.ts
+++ b/tests/fixtures/nextjs-app-monorepo/apps/web/modules/api/user/route.ts
@@ -1,0 +1,9 @@
+// Handler implemented OUTSIDE the app/ tree; the app route file re-exports it.
+// This file itself must derive NO route (it is not under an app root).
+export async function POST(): Promise<Response> {
+  return new Response(JSON.stringify({ created: true }));
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null);
+}


### PR DESCRIPTION
## Problem

File-based route derivation (`derive_route`) matches convention root globs (`app`, `src/app`, ...) against paths relative to the scan root — and `analyze_files` received the **repo** root. In a monorepo where the app lives under a service directory (`apps/web/app/**`, declared via carrick.json `services[].directory`), `strip_root` never matches and every file-based route silently derives **zero endpoints**.

Observed live on an external Next.js monorepo (eval-oss run 29330510550): 120 `route.ts` files, 0 of the labeled producer routes derived; the only "endpoints" that surfaced came from other extraction paths, including filesystem-shaped noise like `POST /modules/ee/billing/api`.

## Fix

The engine now passes `service_scan_root` (repo root joined with the service's declared `directory`; the repo root itself for zero-config repos) to both `analyze_files` call sites — the incremental path and `run_complete_analysis`. `repo_path`/`service_root` had exactly one use in each callee (the route-derivation strip), so the change is contained.

## Tests

- `service_scan_root` unit test (flat config → repo root; declared directory → joined path).
- New `nextjs-app-monorepo` fixture + integration test asserting both halves: repo-root-relative derivation finds **nothing** (the trap that motivates the fix), service-root-relative derivation yields the routes. The fixture also locks two real-world route-file export shapes: a wrapped-const handler (`export const GET = wrapper({...})`) and a pure re-export route file whose handlers live outside `app/` (the `modules/` implementation file itself derives nothing).

Full pre-commit suite green (546 lib + 561 + integration tests). End-to-end confirmation will come from the next eval-oss run against the external monorepo with a services-declaring carrick.json injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)