### PR TITLE
docs: user-scoped MCP install; refresh agent guidance to the workflow loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,28 +65,50 @@ Install hooks once per clone: `./scripts/install-hooks.sh`.
 ## Carrick
 
 This repo is part of the **carrick-tools / carrick-ci** Carrick
-project. Carrick indexes every service in the project — exported functions
-(with intent descriptions), dependencies, and API endpoints with real
+project. Carrick indexes every service in the project: exported functions
+with intent descriptions, dependencies, and API endpoints with their real
 request/response types.
 
 ### Connect the agent
 
 ```
-claude mcp add --transport http carrick https://api.carrick.tools/mcp
+claude mcp add --scope user --transport http carrick https://api.carrick.tools/mcp
 ```
 
 One install serves every project in the workspace. On Carrick tool calls
 from this repo, pass `project: "carrick-ci"` (or `repo: "<owner/repo>"`
 from the git remote) so Carrick queries the right system.
 
-### When to reach for Carrick
+### The loop for cross-service work
 
-- Before writing a helper/parser/validator/formatter: `search_by_intent` to
-  find an existing implementation in a sibling repo.
-- Before calling another service's API: `get_api_endpoints` +
-  `get_endpoint_types` instead of guessing the JSON shape.
-- Before changing a response shape, removing an endpoint, or renaming a path:
-  `check_compatibility` against each consumer.
-- Before adding/bumping an npm dependency: `get_service_dependencies`.
+1. Topology: `get_service_graph` shows who calls whom across the project.
+2. Prior art: `search_by_intent` with a plain-English description of what
+   you are about to write. Do this before writing any helper, parser,
+   validator, or domain function, even when you are sure it is new.
+3. Contracts: `get_endpoint_types` for the real request/response types of
+   anything you will call; `get_api_endpoints` first only when you don't
+   yet know which operations exist.
+4. Build.
+5. Consumers: `check_compatibility` against each consumer before changing
+   a response shape, removing an endpoint, or renaming a path.
+
+Also call `get_service_dependencies` before adding or bumping an npm
+package.
+
+### Building against a sibling before merge
+
+Pull the producer's contract with `get_endpoint_types`, code to it, done.
+The index at main is what production integrates against; your unmerged
+local state does not need to be visible to Carrick. All matching runs the
+same shared carrick-match code in the scanner, the cloud, and the MCP
+server (responses carry its `matcher_version`), so what the tools report
+is what the scan will compute.
+
+### Division of labor
+
+Write correct, idiomatic, explicitly typed code, and never contort code so
+the scanner can read it. If Carrick fails to extract something written
+normally, that is a Carrick bug to report, not a constraint to code
+around.
 
 Carrick is read-only; data reflects the most recent scan of each repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is the **public** Rust scanner for Carrick. Companion to the private `carri
 - Public (this repo): Rust scanner, AST/parser, agent orchestrators (thin), `ts_check/`, `src/sidecar/`, GitHub Action.
 - Private (`carrick-cloud`): all Lambdas, MCP server + tools, Terraform, prompts, wrapper-rule generation, future web dashboard.
 
-MCP is exposed exclusively as an HTTP endpoint at `https://api.carrick.tools/mcp`. Users add Carrick to their AI agent via `claude mcp add --transport http carrick https://api.carrick.tools/mcp`. There is no local-stdio install — the MCP tool implementations live in `carrick-cloud/lambdas/mcp-server/`.
+MCP is exposed exclusively as an HTTP endpoint at `https://api.carrick.tools/mcp`. Users add Carrick to their AI agent via `claude mcp add --scope user --transport http carrick https://api.carrick.tools/mcp`. There is no local-stdio install — the MCP tool implementations live in `carrick-cloud/lambdas/mcp-server/`.
 
 If you need to touch a Lambda, Terraform, or a prompt, the change goes in `carrick-cloud`.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The intent layer is the difference. It is what lets an agent answer "where do we
 The MCP endpoint lives at `https://api.carrick.tools/mcp`.
 
 ```bash
-claude mcp add --transport http carrick https://api.carrick.tools/mcp
+claude mcp add --scope user --transport http carrick https://api.carrick.tools/mcp
 ```
 
 The recommended authentication is sign-in-with-Carrick: your agent opens a browser, you click Approve once, and no API key changes hands. A manual key paste is available as a fallback. To get started, sign up at [app.carrick.tools](https://app.carrick.tools) — the full setup guide lives at [docs.carrick.tools](https://docs.carrick.tools).


### PR DESCRIPTION
Companion to carrick-tools/carrick-cloud#231 (MCP surface overhaul).

- `claude mcp add` defaults to per-project scope, so the documented install command made users reinstall Carrick in every repo. One connection serves the whole workspace, so `--scope user` is the right default (README, AGENTS.md, CLAUDE.md).
- AGENTS.md's Carrick section refreshed to the current scaffold template: the workflow loop (with `search_by_intent` as an explicit prior-art step), the pre-merge story, the `matcher_version` guarantee, and the division-of-labor rule.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)