### PR TITLE
fix: match ignore patterns against path segments, not substrings

### DIFF
--- a/src/file_finder.rs
+++ b/src/file_finder.rs
@@ -76,7 +76,12 @@ fn is_test_path(path: &Path, root_dir: &Path) -> bool {
 /// (e.g. a service directory `packages/build`) still gets scanned — only its
 /// descendants can trigger the ignore.
 fn is_ignored(path: &Path, root_dir: &Path, ignore_patterns: &[&str]) -> bool {
-    let relative_path = path.strip_prefix(root_dir).unwrap_or(path);
+    // A path outside the scan root has no segments "below the root" to test;
+    // matching against the full (possibly absolute) path would let ignore
+    // patterns hit unrelated leading segments.
+    let Ok(relative_path) = path.strip_prefix(root_dir) else {
+        return false;
+    };
     relative_path.components().any(|component| {
         component
             .as_os_str()

--- a/src/file_finder.rs
+++ b/src/file_finder.rs
@@ -69,6 +69,23 @@ fn is_test_path(path: &Path, root_dir: &Path) -> bool {
     has_test_dir(path, root_dir) || has_test_suffix(path)
 }
 
+/// Whether any path segment BELOW the scan root matches an ignore pattern
+/// exactly. Matching whole segments (not substrings) keeps files like
+/// `src/buildkite.ts` or `lib/distances.ts` in scope, and stripping the root
+/// first means an explicitly configured scan root named after a pattern
+/// (e.g. a service directory `packages/build`) still gets scanned — only its
+/// descendants can trigger the ignore.
+fn is_ignored(path: &Path, root_dir: &Path, ignore_patterns: &[&str]) -> bool {
+    let relative_path = path.strip_prefix(root_dir).unwrap_or(path);
+    relative_path.components().any(|component| {
+        component
+            .as_os_str()
+            .to_str()
+            .map(|segment| ignore_patterns.contains(&segment))
+            .unwrap_or(false)
+    })
+}
+
 /// Find all JavaScript and TypeScript files in a directory
 /// Also looks for carrick.json configuration file
 /// Returns (js_ts_files, config_file_option)
@@ -92,10 +109,7 @@ pub fn find_files(
             continue;
         }
 
-        if ignore_patterns
-            .iter()
-            .any(|pattern| path.to_string_lossy().contains(pattern))
-        {
+        if is_ignored(path, root_path, ignore_patterns) {
             continue;
         }
 
@@ -271,6 +285,118 @@ mod tests {
         assert_eq!(files, vec![source_file]);
         assert_eq!(config, Some(config_path));
         assert_eq!(package, Some(package_path));
+    }
+
+    const ARTIFACT_IGNORES: &[&str] = &["node_modules", "dist", "build", ".next"];
+
+    #[test]
+    fn find_files_ignore_matches_segments_not_substrings() {
+        let tmp = tempdir().expect("temp dir");
+        let root = tmp.path();
+
+        fs::create_dir_all(root.join("src")).expect("src dir");
+        fs::create_dir_all(root.join("lib")).expect("lib dir");
+        fs::create_dir_all(root.join("builder")).expect("builder dir");
+
+        // Basenames and directory names that merely contain an ignore pattern
+        // as a substring must still be scanned.
+        let substring_in_basename = root.join("src").join("buildkite.ts");
+        let substring_in_basename_2 = root.join("lib").join("distances.ts");
+        let substring_in_dir = root.join("builder").join("plan.ts");
+
+        for f in [
+            &substring_in_basename,
+            &substring_in_basename_2,
+            &substring_in_dir,
+        ] {
+            File::create(f).expect("file");
+        }
+
+        let (mut files, _, _) = find_files(root.to_str().unwrap(), ARTIFACT_IGNORES);
+        files.sort();
+
+        let mut expected = vec![
+            substring_in_basename,
+            substring_in_basename_2,
+            substring_in_dir,
+        ];
+        expected.sort();
+        assert_eq!(files, expected);
+    }
+
+    #[test]
+    fn find_files_ignores_artifact_dirs_below_root() {
+        let tmp = tempdir().expect("temp dir");
+        let root = tmp.path();
+
+        fs::create_dir_all(root.join("src")).expect("src dir");
+        fs::create_dir_all(root.join("node_modules").join("dep")).expect("node_modules dir");
+        fs::create_dir_all(root.join("dist")).expect("dist dir");
+        fs::create_dir_all(root.join("build")).expect("build dir");
+        fs::create_dir_all(root.join(".next").join("server")).expect(".next dir");
+
+        let kept = root.join("src").join("app.ts");
+        File::create(&kept).expect("kept file");
+        File::create(root.join("node_modules/dep/index.ts")).expect("dep file");
+        File::create(root.join("node_modules/dep/package.json")).expect("dep package");
+        File::create(root.join("dist/app.js")).expect("dist file");
+        File::create(root.join("build/app.js")).expect("build file");
+        File::create(root.join(".next/server/page.js")).expect(".next file");
+
+        let (files, _, package) = find_files(root.to_str().unwrap(), ARTIFACT_IGNORES);
+
+        assert_eq!(files, vec![kept]);
+        // The package.json inside node_modules must not be picked up either.
+        assert_eq!(package, None);
+    }
+
+    #[test]
+    fn find_files_allows_root_dir_named_like_ignore_pattern() {
+        let tmp = tempdir().expect("temp dir");
+        // The explicitly configured scan root is named after an ignore
+        // pattern; only descendants below the root may trigger the ignore.
+        let root = tmp.path().join("packages").join("build");
+
+        fs::create_dir_all(root.join("src")).expect("src dir");
+        fs::create_dir_all(root.join("node_modules").join("dep")).expect("node_modules dir");
+
+        let kept = root.join("src").join("index.ts");
+        let pkg = root.join("package.json");
+        File::create(&kept).expect("kept file");
+        File::create(&pkg).expect("package file");
+        File::create(root.join("node_modules/dep/index.ts")).expect("dep file");
+
+        let (files, _, package) = find_files(root.to_str().unwrap(), ARTIFACT_IGNORES);
+
+        assert_eq!(files, vec![kept]);
+        assert_eq!(package, Some(pkg));
+    }
+
+    #[test]
+    fn find_service_files_scans_service_root_named_like_ignore_pattern() {
+        use crate::config::Config;
+
+        let tmp = tempdir().expect("temp dir");
+        let root = tmp.path();
+
+        fs::create_dir_all(root.join("packages/build/src")).expect("service dir");
+        fs::create_dir_all(root.join("packages/build/node_modules/dep")).expect("dep dir");
+
+        let kept = root.join("packages/build/src/index.ts");
+        let pkg = root.join("packages/build/package.json");
+        File::create(&kept).expect("kept file");
+        File::create(&pkg).expect("package file");
+        File::create(root.join("packages/build/node_modules/dep/index.ts")).expect("dep file");
+
+        let service = Config {
+            directory: Some("packages/build".to_string()),
+            ..Default::default()
+        };
+        let (files, package) =
+            find_service_files(root.to_str().unwrap(), &service, ARTIFACT_IGNORES);
+
+        assert_eq!(files, vec![kept]);
+        assert_eq!(package, Some(pkg));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #377

## Problem

`find_files` applied ignore patterns (`node_modules`, `dist`, `build`, `.next`) as bare substring matches over the whole path:

- Any path merely containing a pattern anywhere was skipped: `src/buildkite.ts`, `lib/distances.ts`, a `builder/` directory.
- A service whose configured `directory` was named after a pattern (e.g. `packages/build`) ignored every file inside itself and the scan failed loud with "No JS/TS source files found under service directory". Hit on a real monorepo during an eval-oss run.

## Fix

New `is_ignored` helper in `src/file_finder.rs`: ignore patterns now match whole path segments (component == pattern) and only segments below the scan root. The path is stripped of the root prefix first, so an explicitly configured service root named after a pattern still scans, and its own path segments never re-trigger the ignore. Build-artifact directories below the root are skipped exactly as before.

## Tests (written first, failing on main)

- `find_files_ignore_matches_segments_not_substrings` — `src/buildkite.ts`, `lib/distances.ts`, `builder/plan.ts` are scanned
- `find_files_ignores_artifact_dirs_below_root` — `node_modules/`, `dist/`, `build/`, `.next/` below the root are still ignored (including a `package.json` inside `node_modules`)
- `find_files_allows_root_dir_named_like_ignore_pattern` — a scan root at `packages/build` scans its own files
- `find_service_files_scans_service_root_named_like_ignore_pattern` — a service with `directory: "packages/build"` scans its files and finds its `package.json`

These run under the existing `cargo test --lib` CI step; no workflow change needed.

Full suite: all tests pass, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)