### PR TITLE
feat: tag endpoint evidence with provenance (route vs mock/test handler)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -946,7 +946,7 @@ impl FileOrchestrator {
         debug!("  - Total data calls: {}", stats.total_data_calls);
 
         // STEP 5: Build aggregated mount graph from all file results
-        let mount_graph = self.build_mount_graph(&file_results, normalizer);
+        let mount_graph = self.build_mount_graph(&file_results, normalizer, service_root);
 
         Ok(FileCentricAnalysisResult {
             file_results,
@@ -3051,6 +3051,12 @@ impl FileOrchestrator {
         &self,
         file_results: &HashMap<String, FileAnalysisResult>,
         normalizer: &UrlNormalizer,
+        // Root the `file_results` keys are resolved against when classifying
+        // endpoint provenance (real route vs mock/test handler): the service
+        // scan root when keys are as-scanned paths, or `Path::new("")` when
+        // the keys are already repo-relative (the engine normalizes them
+        // before rebuilding the graph).
+        scan_root: &Path,
     ) -> MountGraph {
         let mut graph = MountGraph::new();
 
@@ -3163,6 +3169,12 @@ impl FileOrchestrator {
                     middleware_chain: Vec::new(),
                     repo_name: None,
                     service_name: None,
+                    // Structural classification from the source path: mock
+                    // trees keep producing endpoints, tagged as such (#380).
+                    provenance: crate::file_finder::endpoint_provenance(
+                        Path::new(file_path),
+                        scan_root,
+                    ),
                 });
             }
         }
@@ -3842,14 +3854,127 @@ mod tests {
             },
         );
 
-        let graph =
-            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
 
         assert_eq!(graph.mounts.len(), 1);
         assert_eq!(graph.endpoints.len(), 1);
         assert_eq!(graph.mounts[0].parent, "app");
         assert_eq!(graph.mounts[0].child, "userRouter");
         assert_eq!(graph.mounts[0].path_prefix, "/users");
+    }
+
+    #[test]
+    fn test_build_mount_graph_tags_mock_tree_endpoints_with_provenance() {
+        use crate::operation::EndpointProvenance;
+
+        let agent_service = AgentService::new();
+        let orchestrator = FileOrchestrator::new(agent_service);
+
+        let endpoint = |path: &str| EndpointResult {
+            candidate_id: "span:100-140".to_string(),
+            line_number: 5,
+            owner_node: "http".to_string(),
+            method: "GET".to_string(),
+            path: path.to_string(),
+            handler_name: "handler".to_string(),
+            pattern_matched: ".get(".to_string(),
+            call_expression_span_start: None,
+            call_expression_span_end: None,
+            payload_expression_text: None,
+            payload_expression_line: None,
+            response_expression_text: None,
+            response_expression_line: None,
+            emission_style: None,
+            primary_type_symbol: None,
+            type_import_source: None,
+        };
+        let file_result = |path: &str| FileAnalysisResult {
+            endpoints: vec![endpoint(path)],
+            ..Default::default()
+        };
+
+        let mut file_results = HashMap::new();
+        // MSW-style mock-service-worker handler tree: extracted, but tagged.
+        file_results.insert(
+            "src/mocks/handlers.ts".to_string(),
+            file_result("/api/widgets"),
+        );
+        // A real route registration in product source.
+        file_results.insert("src/routes/widgets.ts".to_string(), file_result("/widgets"));
+
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
+
+        assert_eq!(graph.endpoints.len(), 2);
+        let by_file = |needle: &str| {
+            graph
+                .endpoints
+                .iter()
+                .find(|e| e.file_location.starts_with(needle))
+                .unwrap_or_else(|| panic!("no endpoint from {needle}"))
+        };
+        assert_eq!(
+            by_file("src/mocks/").provenance,
+            EndpointProvenance::Mock,
+            "a mock-tree handler must be extracted with provenance=mock"
+        );
+        assert_eq!(
+            by_file("src/routes/").provenance,
+            EndpointProvenance::Route,
+            "a real route must be extracted with provenance=route"
+        );
+    }
+
+    #[test]
+    fn test_build_mount_graph_provenance_is_scan_root_relative() {
+        use crate::operation::EndpointProvenance;
+
+        let agent_service = AgentService::new();
+        let orchestrator = FileOrchestrator::new(agent_service);
+
+        let mut file_results = HashMap::new();
+        file_results.insert(
+            "tests/fixtures/mocks/service-a/src/index.ts".to_string(),
+            FileAnalysisResult {
+                endpoints: vec![EndpointResult {
+                    candidate_id: "span:1-2".to_string(),
+                    line_number: 1,
+                    owner_node: "app".to_string(),
+                    method: "GET".to_string(),
+                    path: "/health".to_string(),
+                    handler_name: "health".to_string(),
+                    pattern_matched: ".get(".to_string(),
+                    call_expression_span_start: None,
+                    call_expression_span_end: None,
+                    payload_expression_text: None,
+                    payload_expression_line: None,
+                    response_expression_text: None,
+                    response_expression_line: None,
+                    emission_style: None,
+                    primary_type_symbol: None,
+                    type_import_source: None,
+                }],
+                ..Default::default()
+            },
+        );
+
+        // A scan rooted inside a mock/test prefix (eval fixtures) must not tag
+        // everything under it as mock: only segments below the root count.
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new("tests/fixtures/mocks/service-a"),
+        );
+
+        assert_eq!(graph.endpoints.len(), 1);
+        assert_eq!(graph.endpoints[0].provenance, EndpointProvenance::Route);
     }
 
     #[test]
@@ -3897,8 +4022,11 @@ mod tests {
             },
         );
 
-        let graph =
-            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
 
         assert_eq!(graph.data_calls.len(), 1);
         assert_eq!(
@@ -3977,8 +4105,11 @@ mod tests {
             },
         );
 
-        let graph =
-            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
 
         let call_paths: Vec<&str> = graph
             .data_calls
@@ -4035,8 +4166,11 @@ mod tests {
             },
         );
 
-        let graph =
-            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
 
         let targets: Vec<&str> = graph
             .data_calls
@@ -4101,8 +4235,11 @@ mod tests {
             },
         );
 
-        let graph =
-            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
         let config = Config::default();
         let (_explicit, infer, _inline) =
             orchestrator.collect_type_requests(&file_results, ".", &graph, &config);
@@ -4143,8 +4280,11 @@ mod tests {
             },
         );
 
-        let graph =
-            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
         let config = Config::default();
         let (explicit, infer, inline) =
             orchestrator.collect_type_requests(&file_results, ".", &graph, &config);
@@ -4205,8 +4345,11 @@ mod tests {
             },
         );
 
-        let graph =
-            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
         let config = Config::default();
         let (_explicit, infer, _inline) =
             orchestrator.collect_type_requests(&file_results, ".", &graph, &config);
@@ -4261,8 +4404,11 @@ mod tests {
             },
         );
 
-        let graph =
-            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
         let config = Config::default();
         let (_explicit, infer, _inline) =
             orchestrator.collect_type_requests(&file_results, ".", &graph, &config);
@@ -4330,8 +4476,11 @@ mod tests {
                 pubsub_operations: vec![],
             },
         );
-        let graph =
-            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
         let config = Config::default();
         orchestrator.collect_type_requests(&file_results, ".", &graph, &config)
     }
@@ -4785,8 +4934,11 @@ mod tests {
             },
         );
 
-        let graph =
-            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
 
         // Should have the mount and both endpoints
         assert_eq!(graph.mounts.len(), 1);
@@ -5212,8 +5364,11 @@ export { routes };
 
         let mut file_results = HashMap::new();
         file_results.insert("src/app.ts".to_string(), result);
-        let graph =
-            orchestrator.build_mount_graph(&file_results, &UrlNormalizer::default_permissive());
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
 
         assert_eq!(graph.endpoints.len(), 1);
         assert_eq!(graph.endpoints[0].full_path, "/api/users");

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -34,10 +34,18 @@ static ARRAY_GENERIC_RE: LazyLock<regex::Regex> =
 
 // Type aliases to reduce complexity
 type RouteFieldMap = HashMap<OperationKey, Json>;
+/// A verified (matched) producer endpoint for the report: display label +
+/// name (`(method, path)` for HTTP) plus the producer's provenance so the
+/// verified table can mark mock/test handlers (#380).
+type VerifiedEndpointEntry = (String, String, crate::operation::EndpointProvenance);
 /// Result of `analyze_matches_with_mount_graph` and
 /// `analyze_exact_key_matches`: `(findings, verified_endpoints,
 /// cross_repo_matches)`.
-type MatcherOutput = (Vec<Finding>, Vec<(String, String)>, Vec<CrossRepoMatch>);
+type MatcherOutput = (
+    Vec<Finding>,
+    Vec<VerifiedEndpointEntry>,
+    Vec<CrossRepoMatch>,
+);
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum ConflictSeverity {
@@ -121,6 +129,13 @@ pub struct CrossRepoMatch {
     pub type_compatible: Option<bool>,
     /// `Some(..)` iff `type_compatible == Some(false)`; human-readable reason.
     pub mismatch_reason: Option<String>,
+    /// Whether the producer side of this edge is a real route or a mock/test
+    /// handler (#380). Carried from the producer endpoint's structural
+    /// classification so downstream surfaces can present a mismatch against a
+    /// mock with the right amount of trust. When several producers share one
+    /// exact key, route-wins (`EndpointProvenance::min`).
+    #[serde(default)]
+    pub producer_provenance: crate::operation::EndpointProvenance,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -155,6 +170,13 @@ pub struct ApiEndpointDetails {
     /// `serviceName`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_name: Option<String>,
+    /// For endpoints: whether the evidence is a real route or a mock/test
+    /// handler, classified structurally from the source path at extraction
+    /// (#380). For calls the field is meaningless and stays at its `Route`
+    /// default. `default` so index blobs written before the field existed
+    /// deserialize as `Route`.
+    #[serde(default)]
+    pub provenance: crate::operation::EndpointProvenance,
 }
 
 pub struct ApiAnalysisResult {
@@ -170,10 +192,11 @@ pub struct ApiAnalysisResult {
     /// major/unparseable.
     pub dependency_conflicts: Vec<DependencyConflict>,
     /// Endpoints that were successfully matched by at least one consumer
-    /// call, with their method + canonical path. Surfaced so users see
-    /// what *worked* in the PR comment, not just what's broken — clean
-    /// runs otherwise produce no positive signal.
-    pub verified_endpoints: Vec<(String, String)>,
+    /// call, with their method + canonical path + producer provenance (real
+    /// route vs mock/test handler). Surfaced so users see what *worked* in
+    /// the PR comment, not just what's broken — clean runs otherwise produce
+    /// no positive signal.
+    pub verified_endpoints: Vec<VerifiedEndpointEntry>,
     /// GraphQL libraries detected across all scanned repos (subset of
     /// `detected_data_fetchers`). When libraries are present but no
     /// operations were extracted, the formatter suggests committing an
@@ -763,6 +786,8 @@ impl Analyzer {
                 file_path: call.call_file.clone(),
                 repo_name: None,
                 service_name: None,
+                // Provenance is producer-side metadata; calls keep the default.
+                provenance: Default::default(),
             });
         }
     }
@@ -1582,12 +1607,17 @@ impl Analyzer {
         }
 
         // Find orphaned endpoints (not matched by any call), and capture
-        // verified matches as (method, path) tuples for the formatter.
-        let mut verified: Vec<(String, String)> = Vec::new();
+        // verified matches as (method, path, provenance) tuples for the
+        // formatter.
+        let mut verified: Vec<VerifiedEndpointEntry> = Vec::new();
         for endpoint in mount_graph.get_resolved_endpoints() {
             let key = format!("{}:{}", endpoint.method, endpoint.full_path);
             if matched_endpoints.contains(&key) {
-                verified.push((endpoint.method.clone(), endpoint.full_path.clone()));
+                verified.push((
+                    endpoint.method.clone(),
+                    endpoint.full_path.clone(),
+                    endpoint.provenance,
+                ));
             } else if !method_mismatched_producers.contains(&key)
                 && !carrick_match::is_catch_all_path(&endpoint.full_path)
                 && carrick_match::path_literal_specificity(&endpoint.full_path) > 0
@@ -1599,16 +1629,19 @@ impl Analyzer {
                 // design (#381), so "no consumer matched" is not a meaningful
                 // observation — they are routing infrastructure, not an
                 // unconsumed contract.
-                findings.push(Finding::orphaned_endpoint(
-                    endpoint.method.clone(),
-                    endpoint.full_path.clone(),
-                    // Prefer the monorepo service name, falling back to the repo
-                    // (matches the cloud's service_name ?? repo_name convention).
-                    endpoint
-                        .service_name
-                        .clone()
-                        .or_else(|| endpoint.repo_name.clone()),
-                ));
+                findings.push(
+                    Finding::orphaned_endpoint(
+                        endpoint.method.clone(),
+                        endpoint.full_path.clone(),
+                        // Prefer the monorepo service name, falling back to the repo
+                        // (matches the cloud's service_name ?? repo_name convention).
+                        endpoint
+                            .service_name
+                            .clone()
+                            .or_else(|| endpoint.repo_name.clone()),
+                    )
+                    .with_producer_provenance(endpoint.provenance),
+                );
             }
         }
         for ((env_var, method, path), sites) in env_var_calls {
@@ -1620,7 +1653,10 @@ impl Analyzer {
             ));
         }
         verified.sort();
-        verified.dedup();
+        // Collapse same (method, path) rows; sorting put `Route` first
+        // (`Route < Mock`), and `dedup_by` keeps the first of a run, so a key
+        // backed by both a real route and a mock reads as a route.
+        verified.dedup_by(|a, b| a.0 == b.0 && a.1 == b.1);
 
         // Deterministic order for the projection (mirrors verified.sort()): the
         // matcher iterates calls/endpoints in a non-deterministic order, so sort
@@ -1676,6 +1712,7 @@ impl Analyzer {
             match_score: 1.0,
             type_compatible: None,
             mismatch_reason: None,
+            producer_provenance: endpoint.provenance,
         })
     }
 
@@ -1706,11 +1743,15 @@ impl Analyzer {
         // Multiple producers can legitimately share one exact key — two services
         // exposing the same GraphQL field, or several listeners for one socket
         // event — and exact-key matching has no URL to disambiguate them. So
-        // collect ALL distinct producer repos (a `BTreeSet` for deterministic
+        // collect ALL distinct producer repos (a `BTreeMap` for deterministic
         // order) and emit one edge per producer↔consumer pair, rather than
-        // arbitrarily keeping the first by iteration order.
-        let mut producer_repos_by_key: HashMap<String, std::collections::BTreeSet<String>> =
-            HashMap::new();
+        // arbitrarily keeping the first by iteration order. Each repo carries
+        // the producer's provenance; when one repo has several producers on the
+        // same key, route-wins (`EndpointProvenance::min`, #380).
+        let mut producer_repos_by_key: HashMap<
+            String,
+            std::collections::BTreeMap<String, crate::operation::EndpointProvenance>,
+        > = HashMap::new();
         for endpoint in &self.endpoints {
             if endpoint.key.protocol() != protocol {
                 continue;
@@ -1723,7 +1764,9 @@ impl Analyzer {
                 producer_repos_by_key
                     .entry(endpoint.key.canonical())
                     .or_default()
-                    .insert(repo);
+                    .entry(repo)
+                    .and_modify(|provenance| *provenance = (*provenance).min(endpoint.provenance))
+                    .or_insert(endpoint.provenance);
             }
         }
 
@@ -1754,7 +1797,7 @@ impl Analyzer {
                 if let (Some(producer_repos), Some(consumer_repo)) =
                     (producer_repos_by_key.get(&canonical), consumer_repo)
                 {
-                    for producer_repo in producer_repos {
+                    for (producer_repo, producer_provenance) in producer_repos {
                         // Same-repo publisher↔subscriber (or listener↔emitter) is
                         // an intra-repo self-loop, not a cross-repo contract edge.
                         // Drop it structurally on repo identity alone (never on
@@ -1779,6 +1822,7 @@ impl Analyzer {
                             match_score: 1.0,
                             type_compatible: None,
                             mismatch_reason: None,
+                            producer_provenance: *producer_provenance,
                         });
                     }
                 }
@@ -1808,15 +1852,19 @@ impl Analyzer {
             }
             let (label, name) = endpoint.key.display_labels();
             if matched.contains(&endpoint.key) {
-                verified.push((label, name));
+                verified.push((label, name, endpoint.provenance));
             } else {
                 // GraphQL/socket producers are not repo-tagged at this layer, so
                 // the owning service is unknown.
-                findings.push(Finding::orphaned_endpoint(label, name, None));
+                findings.push(
+                    Finding::orphaned_endpoint(label, name, None)
+                        .with_producer_provenance(endpoint.provenance),
+                );
             }
         }
         verified.sort();
-        verified.dedup();
+        // Route-wins per (label, name), mirroring the HTTP matcher's dedup.
+        verified.dedup_by(|a, b| a.0 == b.0 && a.1 == b.1);
 
         (findings, verified, cross_repo_matches)
     }
@@ -2052,7 +2100,9 @@ impl Analyzer {
             cross_repo_matches.extend(protocol_cross_repo_matches);
         }
         verified_endpoints.sort();
-        verified_endpoints.dedup();
+        // Route-wins per (method, path): sorted order puts `Route` first and
+        // `dedup_by` keeps the first of each run.
+        verified_endpoints.dedup_by(|a, b| a.0 == b.0 && a.1 == b.1);
         // Re-sort/dedup over the combined HTTP + non-HTTP edge set so the final
         // ordering is stable regardless of which matcher produced an edge.
         sort_dedup_cross_repo_matches(&mut cross_repo_matches);
@@ -2356,17 +2406,47 @@ impl Analyzer {
                     .and_then(|c| c.as_str())
                     .map(|loc| vec![strip_ci_workspace_prefix(loc).to_string()])
                     .unwrap_or_default();
-                Some(Finding::type_mismatch(
-                    method,
-                    path,
-                    None,
-                    call_sites,
-                    self.clean_type_string(producer, &display_names),
-                    self.clean_type_string(consumer, &display_names),
-                    &self.clean_error_message(error, &display_names),
-                ))
+                let producer_provenance = self.producer_provenance_for(&method, &path);
+                Some(
+                    Finding::type_mismatch(
+                        method,
+                        path,
+                        None,
+                        call_sites,
+                        self.clean_type_string(producer, &display_names),
+                        self.clean_type_string(consumer, &display_names),
+                        &self.clean_error_message(error, &display_names),
+                    )
+                    .with_producer_provenance(producer_provenance),
+                )
             })
             .collect()
+    }
+
+    /// Provenance of the producer behind a ts_check verdict, joined against
+    /// the mount graph's resolved endpoints by `(METHOD, path)` — the same
+    /// param-name-agnostic path normalization the compat overlay uses. When
+    /// several producers share the key, route-wins (`.min()`); an unmatched
+    /// key (non-HTTP labels, no mount graph) conservatively reads as `Route`.
+    fn producer_provenance_for(
+        &self,
+        method: &str,
+        path: &str,
+    ) -> crate::operation::EndpointProvenance {
+        let Some(mount_graph) = self.mount_graph.as_ref() else {
+            return Default::default();
+        };
+        let want = normalize_compat_path(path);
+        mount_graph
+            .get_resolved_endpoints()
+            .iter()
+            .filter(|endpoint| {
+                endpoint.method.eq_ignore_ascii_case(method)
+                    && normalize_compat_path(&endpoint.full_path) == want
+            })
+            .map(|endpoint| endpoint.provenance)
+            .min()
+            .unwrap_or_default()
     }
 
     fn clean_type_string(&self, type_str: &str, display_names: &HashMap<String, String>) -> String {
@@ -2854,6 +2934,7 @@ mod tests {
             file_path: PathBuf::from(file),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         }
     }
 
@@ -2892,7 +2973,14 @@ mod tests {
         let (findings, verified, _edges) =
             analyzer.analyze_exact_key_matches(crate::operation::Protocol::Graphql);
 
-        assert_eq!(verified, vec![("QUERY".to_string(), "user".to_string())]);
+        assert_eq!(
+            verified,
+            vec![(
+                "QUERY".to_string(),
+                "user".to_string(),
+                crate::operation::EndpointProvenance::Route
+            )]
+        );
         assert_eq!(
             findings,
             vec![
@@ -2961,8 +3049,16 @@ mod tests {
         assert_eq!(
             verified,
             vec![
-                ("CLIENT->SERVER".to_string(), "chat:message".to_string()),
-                ("SERVER->CLIENT".to_string(), "chat:broadcast".to_string()),
+                (
+                    "CLIENT->SERVER".to_string(),
+                    "chat:message".to_string(),
+                    crate::operation::EndpointProvenance::Route
+                ),
+                (
+                    "SERVER->CLIENT".to_string(),
+                    "chat:broadcast".to_string(),
+                    crate::operation::EndpointProvenance::Route
+                ),
             ]
         );
         assert_eq!(
@@ -3206,6 +3302,7 @@ mod tests {
             file_path: PathBuf::from("test.ts"),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         });
 
         // 2. Unclassified env var (not in internal/external list)
@@ -3221,6 +3318,7 @@ mod tests {
             file_path: PathBuf::from("test.ts"),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         });
 
         // 3. Process.env pattern (should be detected as env var)
@@ -3236,6 +3334,7 @@ mod tests {
             file_path: PathBuf::from("test.ts"),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         });
 
         // 4. Raw code pattern with UPPERCASE var (common in legacy code)
@@ -3252,6 +3351,7 @@ mod tests {
             file_path: PathBuf::from("test.ts"),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         });
 
         let mount_graph = MountGraph::new(); // Empty graph
@@ -3315,6 +3415,7 @@ mod tests {
             file_path: PathBuf::from("client.ts:12"),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         });
 
         let mut mount_graph = MountGraph::new();
@@ -3328,6 +3429,7 @@ mod tests {
             middleware_chain: vec![],
             repo_name: Some("api".to_string()),
             service_name: None,
+            provenance: Default::default(),
         });
 
         let (findings, verified, _edges) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
@@ -3368,6 +3470,7 @@ mod tests {
             file_path: PathBuf::from("client.ts:3"),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         });
 
         let mut mount_graph = MountGraph::new();
@@ -3381,6 +3484,7 @@ mod tests {
             middleware_chain: vec![],
             repo_name: Some("api".to_string()),
             service_name: None,
+            provenance: Default::default(),
         });
 
         let (findings, _, _) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
@@ -3391,6 +3495,133 @@ mod tests {
                 Finding::missing_endpoint("GET", "/api/missing", None, vec!["client.ts:3".into()]),
                 Finding::orphaned_endpoint("POST", "/api/orders", Some("api".to_string())),
             ]
+        );
+    }
+
+    /// A matched wire whose producer is a mock/test handler must expose that
+    /// provenance on the edge, the verified entry, and — when unmatched — the
+    /// orphan finding (#380).
+    #[test]
+    fn test_matched_wire_exposes_mock_producer_provenance() {
+        use crate::mount_graph::{DataFetchingCall, ResolvedEndpoint};
+        use crate::operation::EndpointProvenance;
+
+        let cm = Lrc::new(SourceMap::default());
+        let mut analyzer = Analyzer::new(Config::default(), cm);
+
+        analyzer.calls.push(ApiEndpointDetails {
+            owner: None,
+            key: OperationKey::http("GET", "/api/widgets"),
+            params: vec![],
+            request_body: None,
+            response_body: None,
+            handler_name: None,
+            request_type: None,
+            response_type: None,
+            file_path: PathBuf::from("client.ts:12"),
+            repo_name: Some("consumer-repo".to_string()),
+            service_name: None,
+            provenance: Default::default(),
+        });
+
+        let mut mount_graph = MountGraph::new();
+        // The matched producer: an MSW-style handler under a mock tree.
+        mount_graph.endpoints.push(ResolvedEndpoint {
+            method: "GET".to_string(),
+            path: "/api/widgets".to_string(),
+            full_path: "/api/widgets".to_string(),
+            handler: None,
+            owner: "http".to_string(),
+            file_location: "src/mocks/handlers.ts:5".to_string(),
+            middleware_chain: vec![],
+            repo_name: Some("producer-repo".to_string()),
+            service_name: None,
+            provenance: EndpointProvenance::Mock,
+        });
+        // An unmatched mock producer: must orphan WITH the mock tag.
+        mount_graph.endpoints.push(ResolvedEndpoint {
+            method: "POST".to_string(),
+            path: "/api/widgets".to_string(),
+            full_path: "/api/widgets".to_string(),
+            handler: None,
+            owner: "http".to_string(),
+            file_location: "src/mocks/handlers.ts:9".to_string(),
+            middleware_chain: vec![],
+            repo_name: Some("producer-repo".to_string()),
+            service_name: None,
+            provenance: EndpointProvenance::Mock,
+        });
+        mount_graph.data_calls.push(DataFetchingCall {
+            method: "GET".to_string(),
+            target_url: "/api/widgets".to_string(),
+            canonical_path: "/api/widgets".to_string(),
+            client: "fetch".to_string(),
+            file_location: "client.ts:12".to_string(),
+            call_kind: None,
+            repo_name: Some("consumer-repo".to_string()),
+        });
+
+        let (findings, verified, edges) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
+
+        assert_eq!(edges.len(), 1, "one matched wire expected, got {edges:?}");
+        assert_eq!(edges[0].producer_repo, "producer-repo");
+        assert_eq!(
+            edges[0].producer_provenance,
+            EndpointProvenance::Mock,
+            "the matched wire must expose the producer's mock provenance"
+        );
+        assert_eq!(
+            verified,
+            vec![(
+                "GET".to_string(),
+                "/api/widgets".to_string(),
+                EndpointProvenance::Mock
+            )],
+            "the verified entry must carry the mock tag"
+        );
+        assert_eq!(
+            findings,
+            vec![
+                Finding::orphaned_endpoint("POST", "/api/widgets", Some("producer-repo".into()))
+                    .with_producer_provenance(EndpointProvenance::Mock)
+            ],
+            "the orphaned mock must carry the mock tag"
+        );
+    }
+
+    /// Exact-key protocols thread producer provenance onto the edge the same
+    /// way the HTTP matcher does (#380).
+    #[test]
+    fn test_exact_key_edge_carries_producer_provenance() {
+        use crate::operation::EndpointProvenance;
+
+        let cm = Lrc::new(SourceMap::default());
+        let mut analyzer = Analyzer::new(Config::default(), cm);
+
+        let mut producer = op_details_in_repo(
+            OperationKey::pubsub("orders.created"),
+            "svc/src/mocks/bus.ts:4",
+            "producer-repo",
+        );
+        producer.provenance = EndpointProvenance::Mock;
+        analyzer.endpoints.push(producer);
+        analyzer.calls.push(op_details_in_repo(
+            OperationKey::pubsub("orders.created"),
+            "worker/src/publish.ts:9",
+            "consumer-repo",
+        ));
+
+        let (_, verified, edges) =
+            analyzer.analyze_exact_key_matches(crate::operation::Protocol::Pubsub);
+        assert_eq!(edges.len(), 1, "one pub/sub edge expected, got {edges:?}");
+        assert_eq!(edges[0].producer_provenance, EndpointProvenance::Mock);
+        assert_eq!(
+            verified,
+            vec![(
+                "PUBSUB".to_string(),
+                "orders.created".to_string(),
+                EndpointProvenance::Mock
+            )]
         );
     }
 
@@ -3411,6 +3642,7 @@ mod tests {
             middleware_chain: vec![],
             repo_name: Some("api".to_string()),
             service_name: None,
+            provenance: Default::default(),
         }
     }
 
@@ -3505,7 +3737,14 @@ mod tests {
                 Finding::orphaned_endpoint("GET", "/b", Some("api".to_string())),
             ]
         );
-        assert_eq!(verified, vec![("GET".to_string(), "/a".to_string())]);
+        assert_eq!(
+            verified,
+            vec![(
+                "GET".to_string(),
+                "/a".to_string(),
+                crate::operation::EndpointProvenance::Route
+            )]
+        );
     }
 
     /// When every exact-path producer is verified, fall back to the first in
@@ -3534,7 +3773,14 @@ mod tests {
                 "GET",
             )]
         );
-        assert_eq!(verified, vec![("GET".to_string(), "/a".to_string())]);
+        assert_eq!(
+            verified,
+            vec![(
+                "GET".to_string(),
+                "/a".to_string(),
+                crate::operation::EndpointProvenance::Route
+            )]
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -3579,6 +3825,7 @@ mod tests {
             match_score: 1.0,
             type_compatible: None,
             mismatch_reason: None,
+            producer_provenance: Default::default(),
         }
     }
 
@@ -4305,7 +4552,11 @@ mod tests {
         assert_eq!(edges[0].consumer_repo, "web-client");
         assert_eq!(
             verified,
-            vec![("GET".to_string(), "/api/v1/chat/new".to_string())],
+            vec![(
+                "GET".to_string(),
+                "/api/v1/chat/new".to_string(),
+                crate::operation::EndpointProvenance::Route
+            )],
             "the catch-all is not verified by a call it lost"
         );
         assert!(
@@ -4404,7 +4655,11 @@ mod tests {
         assert_eq!(edges[0].consumer_key, "http|POST|/oauth/token");
         assert_eq!(
             verified,
-            vec![("POST".to_string(), "/oauth/token".to_string())]
+            vec![(
+                "POST".to_string(),
+                "/oauth/token".to_string(),
+                crate::operation::EndpointProvenance::Route
+            )]
         );
         assert!(findings.is_empty(), "got {findings:?}");
     }
@@ -4493,7 +4748,14 @@ mod tests {
 
         assert_eq!(edges.len(), 1, "got {edges:?}");
         assert_eq!(edges[0].producer_repo, "files-svc");
-        assert_eq!(verified, vec![("GET".to_string(), "/files/**".to_string())]);
+        assert_eq!(
+            verified,
+            vec![(
+                "GET".to_string(),
+                "/files/**".to_string(),
+                crate::operation::EndpointProvenance::Route
+            )]
+        );
         assert!(findings.is_empty(), "got {findings:?}");
     }
 }

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -308,6 +308,7 @@ pub fn mount_graph_to_api_details(
             file_path: PathBuf::from(&endpoint.file_location),
             repo_name: None,
             service_name: None,
+            provenance: endpoint.provenance,
         })
         .collect();
 
@@ -326,6 +327,8 @@ pub fn mount_graph_to_api_details(
             file_path: PathBuf::from(&call.file_location),
             repo_name: None,
             service_name: None,
+            // Provenance is producer-side metadata; calls keep the default.
+            provenance: Default::default(),
         })
         .collect();
 
@@ -533,6 +536,37 @@ mod tests {
         assert_eq!(back.key, key);
     }
 
+    /// The uploaded index (extraction output) must carry each endpoint's
+    /// provenance so downstream matching/rendering can tell a mock producer
+    /// from a real route (#380). Calls keep the `Route` default.
+    #[test]
+    fn mount_graph_projection_carries_endpoint_provenance() {
+        use crate::mount_graph::ResolvedEndpoint;
+        use crate::operation::EndpointProvenance;
+
+        let mut graph = MountGraph::new();
+        graph.endpoints.push(ResolvedEndpoint {
+            method: "GET".to_string(),
+            path: "/api/widgets".to_string(),
+            full_path: "/api/widgets".to_string(),
+            handler: Some("handler".to_string()),
+            owner: "http".to_string(),
+            file_location: "src/mocks/handlers.ts:5".to_string(),
+            middleware_chain: vec![],
+            repo_name: None,
+            service_name: None,
+            provenance: EndpointProvenance::Mock,
+        });
+
+        let (endpoints, _calls) = mount_graph_to_api_details(&graph);
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].provenance, EndpointProvenance::Mock);
+
+        // And it is on the serialized wire (the index blob).
+        let json = serde_json::to_value(&endpoints[0]).unwrap();
+        assert_eq!(json["provenance"], "mock");
+    }
+
     use crate::analyzer::CrossRepoMatch;
 
     fn empty_repo(repo_name: &str, service_name: Option<&str>) -> CloudRepoData {
@@ -581,6 +615,7 @@ mod tests {
             match_score: 1.0,
             type_compatible,
             mismatch_reason: mismatch_reason.map(String::from),
+            producer_provenance: Default::default(),
         }
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -499,10 +499,13 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         verified: results
             .verified_endpoints
             .iter()
-            .map(|(method, path)| crate::findings::VerifiedEndpoint {
-                method: method.clone(),
-                path: path.clone(),
-            })
+            .map(
+                |(method, path, provenance)| crate::findings::VerifiedEndpoint {
+                    method: method.clone(),
+                    path: path.clone(),
+                    provenance: *provenance,
+                },
+            )
             .collect(),
         graphql: crate::findings::GraphqlStatus {
             libraries: results.detected_graphql_libraries.clone(),
@@ -1083,8 +1086,13 @@ async fn analyze_current_repo_incremental(
 
             // Rebuild mount graph from full merged results
             let graph_orchestrator = FileOrchestrator::new(agent_service.clone());
-            let mut mount_graph =
-                graph_orchestrator.build_mount_graph(&merged_results, &normalizer);
+            // `merged_results` keys were normalized to repo-relative paths
+            // above, so provenance classification resolves against "" here.
+            let mut mount_graph = graph_orchestrator.build_mount_graph(
+                &merged_results,
+                &normalizer,
+                std::path::Path::new(""),
+            );
 
             // Deterministic protocol scans run BEFORE the graph is projected:
             // the GraphQL consumer file set folds transport data calls out of
@@ -1423,6 +1431,10 @@ fn append_deterministic_protocol_operations(
         file_path: PathBuf::from(format!("{}:{}", file_path.display(), line)),
         repo_name: None,
         service_name: None,
+        // Provenance classification is HTTP-only today (#380): non-HTTP op
+        // paths are not root-stripped here, and segment-matching an
+        // un-relativized path would misfire on scan-prefix directories.
+        provenance: Default::default(),
     };
 
     let graphql = &extractions.graphql;
@@ -3849,6 +3861,7 @@ mod tests {
             handler_name: Some("testHandler".to_string()),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         };
 
         let test_data = CloudRepoData {
@@ -3967,6 +3980,7 @@ mod tests {
             handler_name: Some("testHandler".to_string()),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         };
 
         let test_data = vec![CloudRepoData {
@@ -4160,6 +4174,7 @@ mod tests {
             middleware_chain: vec![],
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         };
         let mut mount_graph = MountGraph::new();
         mount_graph.endpoints = vec![
@@ -4668,6 +4683,7 @@ mod tests {
             match_score: 1.0,
             type_compatible: Some(false),
             mismatch_reason: Some("y".repeat(400)),
+            producer_provenance: Default::default(),
         }];
         crate::cloud_storage::attach_compat_verdicts(&mut payloads, &matches);
         assert!(
@@ -6237,6 +6253,7 @@ mod tests {
             file_path: PathBuf::from(format!("{}:{}", file_path.display(), line)),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         };
         append_pubsub_operations(
             &mut cloud_data,

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -593,6 +593,7 @@ mod tests {
             file_path: PathBuf::from(file_line),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         }
     }
 
@@ -609,6 +610,7 @@ mod tests {
             file_path: PathBuf::from(file_line),
             repo_name: Some(repo.to_string()),
             service_name: None,
+            provenance: Default::default(),
         }
     }
 
@@ -758,6 +760,7 @@ mod tests {
                 match_score: 1.0,
                 type_compatible: Some(true),
                 mismatch_reason: None,
+                producer_provenance: Default::default(),
             },
             // Compat evaluated, incompatible.
             AnalyzerCrossRepoMatch {
@@ -769,6 +772,7 @@ mod tests {
                 match_score: 1.0,
                 type_compatible: Some(false),
                 mismatch_reason: Some("id: number vs string".to_string()),
+                producer_provenance: Default::default(),
             },
             // Compat NOT evaluated (the load-bearing None).
             AnalyzerCrossRepoMatch {
@@ -780,6 +784,7 @@ mod tests {
                 match_score: 1.0,
                 type_compatible: None,
                 mismatch_reason: None,
+                producer_provenance: Default::default(),
             },
         ];
 
@@ -941,6 +946,7 @@ mod tests {
             file_path: PathBuf::from("src/socket.ts:12"),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         };
 
         let result = ApiAnalysisResult {
@@ -1012,6 +1018,7 @@ mod tests {
                 file_path: PathBuf::from("web/src/orders.ts:7"),
                 repo_name: None,
                 service_name: None,
+                provenance: Default::default(),
             }],
             findings: vec![],
             dependency_conflicts: vec![],
@@ -1149,6 +1156,7 @@ mod tests {
             file_path: PathBuf::from("src/billing.client.ts:19"),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         };
         let result = ApiAnalysisResult {
             endpoints: vec![],
@@ -1208,6 +1216,7 @@ mod tests {
             file_path: PathBuf::from(file_line),
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         };
         let result = ApiAnalysisResult {
             endpoints: vec![],

--- a/src/file_finder.rs
+++ b/src/file_finder.rs
@@ -128,6 +128,12 @@ fn is_ignored(path: &Path, root_dir: &Path, ignore_patterns: &[&str]) -> bool {
 /// dev-dependency placement of the registering import or reachability from
 /// runtime entry points is follow-up work.
 pub fn endpoint_provenance(path: &Path, root_dir: &Path) -> EndpointProvenance {
+    // A path outside the scan root has no segments below the root to
+    // classify; is_test_path's suffix check alone would still fire on it,
+    // contradicting the conservative guarantee above.
+    if path.strip_prefix(root_dir).is_err() {
+        return EndpointProvenance::Route;
+    }
     if has_dir_named(path, root_dir, MOCK_DIR_NAMES) || is_test_path(path, root_dir) {
         EndpointProvenance::Mock
     } else {
@@ -481,6 +487,16 @@ mod tests {
         // A FILE named after the convention is not a mock tree.
         assert_eq!(
             endpoint_provenance(Path::new("src/api/mocks.ts"), root),
+            EndpointProvenance::Route
+        );
+    }
+
+    #[test]
+    fn endpoint_provenance_outside_scan_root_stays_route() {
+        // A test-suffixed file OUTSIDE the scan root must not classify as
+        // Mock via the suffix check alone.
+        assert_eq!(
+            endpoint_provenance(Path::new("elsewhere/foo.spec.ts"), Path::new("service")),
             EndpointProvenance::Route
         );
     }

--- a/src/file_finder.rs
+++ b/src/file_finder.rs
@@ -1,3 +1,4 @@
+use crate::operation::EndpointProvenance;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -32,25 +33,40 @@ const TEST_FILE_SUFFIXES: &[&str] = &[
     ".stories.jsx",
 ];
 
-fn has_test_dir(path: &Path, root_dir: &Path) -> bool {
-    // We only check for test directories relative to the root directory being scanned.
-    // This allows scanning a directory that is itself inside a "tests" folder (e.g. fixtures).
+/// Directory-name conventions that mark a subtree as mock/test-double code
+/// while still being product-adjacent source (so its files ARE scanned, unlike
+/// [`TEST_DIR_NAMES`] trees, which `find_files` skips entirely). The canonical
+/// case is a mock-service-worker handler tree under `src/mocks/`. These are
+/// ecosystem-wide path conventions, deliberately NOT a mock-framework package
+/// list — provenance must hold for any registration idiom.
+const MOCK_DIR_NAMES: &[&str] = &["mocks", "mock"];
+
+/// Whether any directory segment of `path`, relative to the scanned
+/// `root_dir`, matches one of `dir_names` (case-insensitive). Only checked
+/// relative to the root so a scan whose root itself sits inside such a
+/// directory (e.g. eval fixtures under `tests/fixtures/`) is unaffected;
+/// a path outside `root_dir` conservatively returns false.
+fn has_dir_named(path: &Path, root_dir: &Path, dir_names: &[&str]) -> bool {
     let relative_path = match path.strip_prefix(root_dir) {
         Ok(p) => p,
         Err(_) => return false,
     };
 
-    relative_path.ancestors().any(|ancestor| {
+    relative_path.ancestors().skip(1).any(|ancestor| {
         ancestor
             .file_name()
             .and_then(|name| name.to_str())
             .map(|name| {
-                TEST_DIR_NAMES
+                dir_names
                     .iter()
                     .any(|pattern| name.eq_ignore_ascii_case(pattern))
             })
             .unwrap_or(false)
     })
+}
+
+fn has_test_dir(path: &Path, root_dir: &Path) -> bool {
+    has_dir_named(path, root_dir, TEST_DIR_NAMES)
 }
 
 fn has_test_suffix(path: &Path) -> bool {
@@ -89,6 +105,34 @@ fn is_ignored(path: &Path, root_dir: &Path, ignore_patterns: &[&str]) -> bool {
             .map(|segment| ignore_patterns.contains(&segment))
             .unwrap_or(false)
     })
+}
+
+/// Classify where an endpoint's evidence comes from, structurally, from its
+/// source path relative to the scanned root: a file under a mock tree
+/// ([`MOCK_DIR_NAMES`]) — or any test path per [`is_test_path`], should one
+/// ever reach extraction via a custom include — yields
+/// [`EndpointProvenance::Mock`]; everything else is a real
+/// [`EndpointProvenance::Route`].
+///
+/// This is the `is_test_path` classification extended to mock trees (#380):
+/// test trees are excluded from scanning outright, while mock trees are kept
+/// — their handlers often encode the canonical contract — and tagged so
+/// matching and the report can say "this producer shape comes from a mock".
+///
+/// Conservative by construction: a path that cannot be resolved relative to
+/// `root_dir` (e.g. an `include` root outside the service directory) is left
+/// as `Route` rather than risking segment matches against prefix directories
+/// the scan never chose (the same guard `has_test_dir` uses). Known
+/// limitation, logged in #380: mock servers living outside a conventionally
+/// named tree are not detected; composing structural signals such as
+/// dev-dependency placement of the registering import or reachability from
+/// runtime entry points is follow-up work.
+pub fn endpoint_provenance(path: &Path, root_dir: &Path) -> EndpointProvenance {
+    if has_dir_named(path, root_dir, MOCK_DIR_NAMES) || is_test_path(path, root_dir) {
+        EndpointProvenance::Mock
+    } else {
+        EndpointProvenance::Route
+    }
 }
 
 /// Find all JavaScript and TypeScript files in a directory
@@ -402,6 +446,69 @@ mod tests {
 
         assert_eq!(files, vec![kept]);
         assert_eq!(package, Some(pkg));
+    }
+
+    #[test]
+    fn endpoint_provenance_tags_mock_trees_and_test_paths() {
+        use crate::operation::EndpointProvenance;
+
+        let root = Path::new("");
+        // The observed real-world shape: an MSW-style handler tree.
+        assert_eq!(
+            endpoint_provenance(Path::new("src/mocks/handlers.ts"), root),
+            EndpointProvenance::Mock
+        );
+        // Case-insensitive segment match, any depth, singular variant.
+        assert_eq!(
+            endpoint_provenance(Path::new("src/testing/Mock/server.ts"), root),
+            EndpointProvenance::Mock
+        );
+        // Test-path classification is folded in (defensive: such files are
+        // normally excluded from scanning entirely).
+        assert_eq!(
+            endpoint_provenance(Path::new("src/__mocks__/api.ts"), root),
+            EndpointProvenance::Mock
+        );
+        assert_eq!(
+            endpoint_provenance(Path::new("src/api/server.spec.ts"), root),
+            EndpointProvenance::Mock
+        );
+        // Real product routes stay routes.
+        assert_eq!(
+            endpoint_provenance(Path::new("src/routes/users.ts"), root),
+            EndpointProvenance::Route
+        );
+        // A FILE named after the convention is not a mock tree.
+        assert_eq!(
+            endpoint_provenance(Path::new("src/api/mocks.ts"), root),
+            EndpointProvenance::Route
+        );
+    }
+
+    #[test]
+    fn endpoint_provenance_is_relative_to_scan_root() {
+        use crate::operation::EndpointProvenance;
+
+        // A scan rooted INSIDE a mocks/tests prefix (e.g. eval fixtures under
+        // tests/fixtures/) must not tag everything mock: only segments below
+        // the root count.
+        let root = Path::new("tests/fixtures/mocks/repo-a");
+        assert_eq!(
+            endpoint_provenance(Path::new("tests/fixtures/mocks/repo-a/src/app.ts"), root),
+            EndpointProvenance::Route
+        );
+        assert_eq!(
+            endpoint_provenance(
+                Path::new("tests/fixtures/mocks/repo-a/src/mocks/handlers.ts"),
+                root
+            ),
+            EndpointProvenance::Mock
+        );
+        // A path outside the root cannot be classified — conservative Route.
+        assert_eq!(
+            endpoint_provenance(Path::new("elsewhere/mocks/handlers.ts"), root),
+            EndpointProvenance::Route
+        );
     }
 
     #[test]

--- a/src/findings.rs
+++ b/src/findings.rs
@@ -5,6 +5,7 @@
 //! source of truth: the cloud renders the PR comment/check run from this
 //! JSON and never re-parses prose.
 
+use crate::operation::EndpointProvenance;
 use serde::{Serialize, Serializer, ser::SerializeMap};
 
 /// Wire cap on `call_sites` entries per finding. Applied when serializing
@@ -79,6 +80,11 @@ pub enum Finding {
         consumer_type: String,
         /// Compiler error, pre-truncated to [`MAX_DETAIL_CHARS`] chars.
         detail: String,
+        /// Whether the producer shape comes from a real route or a mock/test
+        /// handler (#380) — a mismatch against a mock is often still real
+        /// (mocks frequently encode the canonical contract) but should be
+        /// presented with that caveat.
+        producer_provenance: EndpointProvenance,
     },
     /// A consumer call matched a producer path but not its method. `method`
     /// is the consumer's attempt; `expected_method` is the producer's.
@@ -101,6 +107,10 @@ pub enum Finding {
         method: String,
         path: String,
         service: Option<String>,
+        /// Whether this producer is a real route or a mock/test handler
+        /// (#380). Orphaned mocks are expected (most mock handlers have no
+        /// scanned consumer), so surfaces can de-noise on this.
+        provenance: EndpointProvenance,
     },
     /// A call whose URL is built from an env var not classified in
     /// carrick.json (`internalEnvVars` / `externalEnvVars`).
@@ -138,6 +148,7 @@ impl Finding {
             producer_type: producer_type.into(),
             consumer_type: consumer_type.into(),
             detail: truncate_chars(detail, MAX_DETAIL_CHARS),
+            producer_provenance: EndpointProvenance::default(),
         }
     }
 
@@ -180,7 +191,25 @@ impl Finding {
             method: method.into(),
             path: path.into(),
             service,
+            provenance: EndpointProvenance::default(),
         }
+    }
+
+    /// Attach producer-side provenance (real route vs mock/test handler) to a
+    /// finding that has a producer side. Constructors default to `Route`, so
+    /// existing call sites stay unchanged; the matchers chain this where the
+    /// producer's classification is known. No-op for kinds without a
+    /// producer-side provenance field.
+    pub fn with_producer_provenance(mut self, producer: EndpointProvenance) -> Self {
+        match &mut self {
+            Finding::TypeMismatch {
+                producer_provenance,
+                ..
+            } => *producer_provenance = producer,
+            Finding::OrphanedEndpoint { provenance, .. } => *provenance = producer,
+            _ => {}
+        }
+        self
     }
 
     pub fn env_var_call(
@@ -257,6 +286,7 @@ impl Serialize for Finding {
                 producer_type,
                 consumer_type,
                 detail,
+                producer_provenance,
             } => {
                 map.serialize_entry("method", method)?;
                 map.serialize_entry("path", path)?;
@@ -265,6 +295,7 @@ impl Serialize for Finding {
                 map.serialize_entry("producer_type", producer_type)?;
                 map.serialize_entry("consumer_type", consumer_type)?;
                 map.serialize_entry("detail", detail)?;
+                map.serialize_entry("producer_provenance", producer_provenance)?;
             }
             Finding::MethodMismatch {
                 method,
@@ -294,10 +325,12 @@ impl Serialize for Finding {
                 method,
                 path,
                 service,
+                provenance,
             } => {
                 map.serialize_entry("method", method)?;
                 map.serialize_entry("path", path)?;
                 map.serialize_entry("service", service)?;
+                map.serialize_entry("provenance", provenance)?;
             }
             Finding::EnvVarCall {
                 method,
@@ -373,6 +406,9 @@ pub struct ScanStats {
 pub struct VerifiedEndpoint {
     pub method: String,
     pub path: String,
+    /// Real route vs mock/test handler (#380); route-wins when several
+    /// producers share the (method, path) key.
+    pub provenance: EndpointProvenance,
 }
 
 /// GraphQL coverage signal: libraries detected vs operations actually
@@ -463,6 +499,32 @@ mod tests {
     }
 
     #[test]
+    fn producer_provenance_defaults_to_route_and_serializes() {
+        // Constructors default to `route`; the wire always carries the field
+        // so the cloud renderer never has to infer it (#380).
+        let mismatch = Finding::type_mismatch("GET", "/x", None, vec![], "A", "B", "boom");
+        let v = serde_json::to_value(&mismatch).unwrap();
+        assert_eq!(v["producer_provenance"], json!("route"));
+
+        let mismatch = mismatch.with_producer_provenance(EndpointProvenance::Mock);
+        let v = serde_json::to_value(&mismatch).unwrap();
+        assert_eq!(v["producer_provenance"], json!("mock"));
+
+        let orphan = Finding::orphaned_endpoint("GET", "/x", None)
+            .with_producer_provenance(EndpointProvenance::Mock);
+        let v = serde_json::to_value(&orphan).unwrap();
+        assert_eq!(v["provenance"], json!("mock"));
+
+        // No-op on kinds without a producer-side field.
+        let missing = Finding::missing_endpoint("GET", "/x", None, vec![])
+            .with_producer_provenance(EndpointProvenance::Mock);
+        assert_eq!(
+            missing,
+            Finding::missing_endpoint("GET", "/x", None, vec![])
+        );
+    }
+
+    #[test]
     fn detail_truncated_at_construction() {
         let long = "☕".repeat(500);
         let finding = Finding::type_mismatch("GET", "/x", None, vec![], "A", "B", &long);
@@ -548,6 +610,7 @@ mod tests {
             verified: vec![VerifiedEndpoint {
                 method: "GET".to_string(),
                 path: "/api/users".to_string(),
+                provenance: Default::default(),
             }],
             graphql: GraphqlStatus {
                 libraries: vec![],
@@ -575,7 +638,7 @@ mod tests {
         );
         assert_eq!(
             v["verified"],
-            json!([{ "method": "GET", "path": "/api/users" }])
+            json!([{ "method": "GET", "path": "/api/users", "provenance": "route" }])
         );
         assert_eq!(
             v["graphql"],
@@ -595,6 +658,7 @@ mod tests {
                 "producer_type": "UserResponse",
                 "consumer_type": "User[]",
                 "detail": "Property 'role' is missing",
+                "producer_provenance": "route",
             })
         );
         assert_eq!(
@@ -628,6 +692,7 @@ mod tests {
                 "method": "GET",
                 "path": "/legacy/ping",
                 "service": "billing",
+                "provenance": "route",
             })
         );
         assert_eq!(

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -357,7 +357,9 @@ fn format_no_issues(
 /// at least one consumer call successfully matched. Surfaced so PR comments
 /// communicate what's *working*, not just what's broken — without it, a
 /// clean cross-repo run produces no positive signal at all.
-fn format_verified_section(verified: &[(String, String)]) -> String {
+fn format_verified_section(
+    verified: &[(String, String, crate::operation::EndpointProvenance)],
+) -> String {
     let mut output = String::new();
     output.push_str(&format!(
         "<details>\n<summary><strong>Verified ({})</strong></summary>\n\n",
@@ -367,8 +369,15 @@ fn format_verified_section(verified: &[(String, String)]) -> String {
         "> Endpoints with at least one matching consumer call. Types were resolved and compared by the TypeScript compiler pass.\n\n",
     );
     output.push_str("| Method | Path |\n| :--- | :--- |\n");
-    for (method, path) in verified {
-        output.push_str(&format!("| `{}` | `{}` |\n", method, path));
+    for (method, path, provenance) in verified {
+        // A producer whose evidence is a mock/test handler is marked so the
+        // match is trusted accordingly (#380).
+        let marker = if provenance.is_mock() {
+            " (mock handler)"
+        } else {
+            ""
+        };
+        output.push_str(&format!("| `{}` | `{}`{} |\n", method, path, marker));
     }
     output.push_str("\n</details>");
     output
@@ -501,12 +510,22 @@ fn format_critical_section(risks: &[&Finding]) -> String {
                 producer_type,
                 consumer_type,
                 detail,
+                producer_provenance,
                 ..
             } => (
                 format!("{} {}", method, path),
                 format!(
-                    "producer `{}` vs consumer `{}`: {}",
-                    producer_type, consumer_type, detail
+                    "producer `{}`{} vs consumer `{}`: {}",
+                    producer_type,
+                    // The producer shape comes from a mock/test handler —
+                    // often still the canonical contract, but say so (#380).
+                    if producer_provenance.is_mock() {
+                        " (mock handler)"
+                    } else {
+                        ""
+                    },
+                    consumer_type,
+                    detail
                 ),
             ),
             Finding::MethodMismatch {
@@ -617,13 +636,25 @@ fn format_connectivity_section(
 
     if !orphaned.is_empty() {
         output.push_str(&format!("**Orphaned ({})**\n\n", orphaned.len()));
-        fn orphan_row(finding: &Finding) -> Option<(&String, &String, &Option<String>)> {
+        type OrphanRow<'a> = (&'a String, &'a String, &'a Option<String>, &'static str);
+        fn orphan_row(finding: &Finding) -> Option<OrphanRow<'_>> {
             match finding {
                 Finding::OrphanedEndpoint {
                     method,
                     path,
                     service,
-                } => Some((method, path, service)),
+                    provenance,
+                } => {
+                    // Mark mock/test-handler producers: an orphaned mock is
+                    // expected (its consumers are usually not scanned), so the
+                    // row should not read like a dead product route (#380).
+                    let marker = if provenance.is_mock() {
+                        " (mock handler)"
+                    } else {
+                        ""
+                    };
+                    Some((method, path, service, marker))
+                }
                 _ => None,
             }
         }
@@ -632,10 +663,10 @@ fn format_connectivity_section(
         if orphaned
             .iter()
             .filter_map(|f| orphan_row(f))
-            .any(|(_, _, service)| service.is_some())
+            .any(|(_, _, service, _)| service.is_some())
         {
             output.push_str("| Method | Path | Service |\n| :--- | :--- | :--- |\n");
-            for (method, path, service) in orphaned.iter().filter_map(|f| orphan_row(f)) {
+            for (method, path, service, marker) in orphaned.iter().filter_map(|f| orphan_row(f)) {
                 // A row can be unattributed even when the column is shown (e.g.
                 // a GraphQL orphan alongside an attributed HTTP one); use a dash
                 // rather than an empty cell.
@@ -644,19 +675,21 @@ fn format_connectivity_section(
                     .map(|s| format!("`{}`", code_cell(s)))
                     .unwrap_or_else(|| "-".to_string());
                 output.push_str(&format!(
-                    "| `{}` | `{}` | {} |\n",
+                    "| `{}` | `{}`{} | {} |\n",
                     code_cell(method),
                     code_cell(path),
+                    marker,
                     service
                 ));
             }
         } else {
             output.push_str("| Method | Path |\n| :--- | :--- |\n");
-            for (method, path, _) in orphaned.iter().filter_map(|f| orphan_row(f)) {
+            for (method, path, _, marker) in orphaned.iter().filter_map(|f| orphan_row(f)) {
                 output.push_str(&format!(
-                    "| `{}` | `{}` |\n",
+                    "| `{}` | `{}`{} |\n",
                     code_cell(method),
-                    code_cell(path)
+                    code_cell(path),
+                    marker
                 ));
             }
         }
@@ -787,6 +820,7 @@ fn group_env_var_suggestions(findings: &[&Finding]) -> Vec<EnvVarSuggestionGroup
 mod tests {
     use super::*;
     use crate::findings::{EndpointRef, Finding, PackageVersionRef, tier};
+    use crate::operation::EndpointProvenance;
 
     /// A poly-repo topology with peers, so connectivity findings are
     /// conclusive (has_baseline == true).
@@ -958,8 +992,16 @@ mod tests {
     fn test_verified_section_renders_when_matches_present() {
         let mut result = result_with(vec![]);
         result.verified_endpoints = vec![
-            ("GET".to_string(), "/api/users".to_string()),
-            ("POST".to_string(), "/api/orders".to_string()),
+            (
+                "GET".to_string(),
+                "/api/users".to_string(),
+                EndpointProvenance::Route,
+            ),
+            (
+                "POST".to_string(),
+                "/api/orders".to_string(),
+                EndpointProvenance::Route,
+            ),
         ];
 
         let output = format_analysis_results(result, &topology_baseline(), None);
@@ -970,9 +1012,69 @@ mod tests {
     }
 
     #[test]
+    fn test_verified_section_marks_mock_producers() {
+        let mut result = result_with(vec![]);
+        result.verified_endpoints = vec![
+            (
+                "GET".to_string(),
+                "/api/users".to_string(),
+                EndpointProvenance::Route,
+            ),
+            (
+                "GET".to_string(),
+                "/api/widgets".to_string(),
+                EndpointProvenance::Mock,
+            ),
+        ];
+
+        let output = format_analysis_results(result, &topology_baseline(), None);
+
+        assert!(output.contains("`GET` | `/api/users` |"));
+        assert!(
+            output.contains("`GET` | `/api/widgets` (mock handler) |"),
+            "mock producer must be marked in the verified table: {output}"
+        );
+    }
+
+    #[test]
+    fn test_orphaned_and_mismatch_rows_mark_mock_producers() {
+        use crate::operation::EndpointProvenance;
+
+        let findings = vec![
+            Finding::type_mismatch(
+                "GET",
+                "/api/widgets",
+                None,
+                vec!["client.ts:3".into()],
+                "Widget",
+                "Gadget",
+                "boom",
+            )
+            .with_producer_provenance(EndpointProvenance::Mock),
+            Finding::orphaned_endpoint("POST", "/api/widgets", None)
+                .with_producer_provenance(EndpointProvenance::Mock),
+        ];
+        let result = result_with(findings);
+        let output = format_analysis_results(result, &topology_baseline(), None);
+
+        assert!(
+            output.contains("producer `Widget` (mock handler) vs consumer `Gadget`"),
+            "type-mismatch row must mark a mock producer: {output}"
+        );
+        assert!(
+            output.contains("`/api/widgets` (mock handler)"),
+            "orphaned row must mark a mock producer: {output}"
+        );
+    }
+
+    #[test]
     fn test_verified_section_singular_label() {
         let mut result = result_with(vec![]);
-        result.verified_endpoints = vec![("GET".to_string(), "/api/users".to_string())];
+        result.verified_endpoints = vec![(
+            "GET".to_string(),
+            "/api/users".to_string(),
+            EndpointProvenance::Route,
+        )];
         let output = format_analysis_results(result, &topology_baseline(), None);
         assert!(output.contains("Verified (1)"));
     }
@@ -983,7 +1085,11 @@ mod tests {
         // matches must surface them — that's the whole point of the
         // section. Pre-fix, `format_no_issues` ignored verified entirely.
         let mut result = result_with(vec![]);
-        result.verified_endpoints = vec![("GET".to_string(), "/api/users".to_string())];
+        result.verified_endpoints = vec![(
+            "GET".to_string(),
+            "/api/users".to_string(),
+            EndpointProvenance::Route,
+        )];
         let output = format_analysis_results(result, &topology_baseline(), None);
 
         assert!(output.contains("All cross-service calls match the indexed contracts"));

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -44,6 +44,12 @@ pub struct ResolvedEndpoint {
     /// during cross-repo merge so findings can name the owning service.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_name: Option<String>,
+    /// Where this endpoint's evidence comes from — a real route or a mock/test
+    /// handler — classified structurally from the source path when the graph
+    /// is built (`file_finder::endpoint_provenance`). `default` so graphs
+    /// serialized before the field existed read as `Route`.
+    #[serde(default)]
+    pub provenance: crate::operation::EndpointProvenance,
 }
 
 /// Represents a data-fetching call with its target
@@ -445,6 +451,7 @@ mod tests {
             middleware_chain: vec![],
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         });
 
         // Create config with internal domain
@@ -719,6 +726,7 @@ mod tests {
             middleware_chain: vec![],
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         });
 
         let config = Config {
@@ -760,6 +768,7 @@ mod tests {
             middleware_chain: vec![],
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         });
 
         let config = Config {
@@ -792,6 +801,7 @@ mod tests {
             middleware_chain: vec![],
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         });
 
         let config = Config::default();
@@ -824,6 +834,7 @@ mod tests {
                 middleware_chain: vec![],
                 repo_name: None,
                 service_name: None,
+                provenance: Default::default(),
             });
         }
         let normalizer = UrlNormalizer::default_permissive();
@@ -873,6 +884,7 @@ mod tests {
             middleware_chain: vec![],
             repo_name: None,
             service_name: None,
+            provenance: Default::default(),
         });
         crate::cloud_storage::CloudRepoData {
             repo_name: repo.to_string(),

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -77,6 +77,41 @@ impl CallKind {
     }
 }
 
+/// Where a producer endpoint's evidence comes from: a real runtime route, or
+/// a handler registered in a mock/test tree (e.g. a mock-service-worker style
+/// `http.get(...)` under `src/mocks/`).
+///
+/// Classified STRUCTURALLY from the endpoint's source path (directory-name
+/// conventions shared across the ecosystem — see
+/// [`crate::file_finder::endpoint_provenance`]), never from a
+/// framework/package name list. Mock endpoints are still extracted and
+/// matched — a mock frequently encodes the org's canonical contract, so
+/// mismatches against it are real — but the tag travels through matching into
+/// findings and the report so a consumer mismatch whose producer shape comes
+/// from a mock can be presented with the right amount of trust.
+///
+/// `Ord` is deliberate: `Route < Mock`, so `.min()` over several candidate
+/// producers implements "route-wins" when a real route and a mock share one
+/// operation key.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum EndpointProvenance {
+    /// A route registration in product source.
+    #[default]
+    Route,
+    /// A handler registered under a mock/test tree (`mocks/`, `__mocks__/`,
+    /// test directories, or test-suffixed files).
+    Mock,
+}
+
+impl EndpointProvenance {
+    pub fn is_mock(&self) -> bool {
+        matches!(self, EndpointProvenance::Mock)
+    }
+}
+
 /// Which side of a pub/sub topic an operation sits on. A subscriber registers a
 /// handler for a topic and is the contract producer (endpoint); a publisher
 /// sends to a topic and is the contract consumer (call). Assigned by the


### PR DESCRIPTION
Fixes #380

MSW-style mock handlers (`http.get(...)` in a `src/mocks/` tree) were extracted as endpoint producers indistinguishable from real routes. This keeps extracting them — the observed real-world mock carried the org's canonical OpenAPI-codegen response type, so mismatches against it were real — but tags endpoint evidence with provenance and carries the tag through matching into the report.

## How classification works

Structural, never a mock-framework package list. `file_finder::endpoint_provenance(path, scan_root)` extends the existing `is_test_path` path-segment classification:

- a directory segment named `mocks`, `mock`, or any of the existing test-dir names (`__mocks__`, `__tests__`, `tests`, …), **relative to the scan root**, or a test/story file suffix, classifies the file's endpoints as `mock`;
- everything else is `route`;
- conservative by construction: a path that cannot be resolved against the scan root (e.g. an `include` root outside the service directory) stays `route`, and a scan rooted *inside* a mock/test prefix (eval fixtures under `tests/fixtures/…`) is unaffected because only segments below the root count.

Test trees are already excluded from scanning outright, so in practice the live signal is a mock tree in product source — exactly the shape from the issue.

## Schema changes (no back-compat constraints)

- `operation::EndpointProvenance { route, mock }` (`Ord`: route < mock, so `.min()` = route-wins when several producers share a key).
- `ResolvedEndpoint.provenance` — stamped at mount-graph build (`build_mount_graph` now takes the scan root; the engine's incremental path passes `""` because its keys are already repo-relative).
- `ApiEndpointDetails.provenance` — projected into the uploaded index (`CloudRepoData.endpoints`); `serde(default)` so pre-existing blobs read as `route`.
- `CrossRepoMatch.producer_provenance` — filled by both the HTTP matcher (from the matched `ResolvedEndpoint`) and the exact-key matcher (per producer repo, route-wins).
- PR-result wire (`findings.rs`, the schema source of truth for the cloud renderer): `Finding::TypeMismatch.producer_provenance`, `Finding::OrphanedEndpoint.provenance`, `VerifiedEndpoint.provenance` — always emitted (`"route"` / `"mock"`).

## Report surfacing (this repo)

The local/PR markdown marks mock producers with `(mock handler)` in the contract-risk rows (after the producer type), the orphaned table, and the verified table.

Downstream renderers (cloud PR comment / dashboard / MCP) now receive the fields above and should render an equivalent producer-side mock marker; nothing in other repos is touched here.

## Deliberately not done (logged limitations)

- **No prompt/schema sync needed**: provenance is derived scanner-side from the file path; the file-analyzer LLM response schema and prompts are untouched.
- **Non-HTTP ops** (GraphQL/socket/pub-sub deterministic extraction) currently always tag `route`: their op paths are not root-stripped at projection time, and segment-matching an un-relativized path would misfire on scan-prefix directories. The field is threaded, so extending classification there is mechanical.
- **Mock servers outside conventionally named trees** are not detected. Stronger structural signals (dev-dependency placement of the registering import, reachability from runtime entry points) compose cleanly with this field but are follow-up work.
- The frozen eval projection (contract §2) is untouched; the cassette hard gate passes against the existing golden.
- `crates/carrick-match` is untouched: it contains only pure path-matching predicates (no evidence structs), so there was nothing to thread there; matched wires (`CrossRepoMatch`) live in the scanner.

## Tests

- `file_finder`: `endpoint_provenance_tags_mock_trees_and_test_paths`, `endpoint_provenance_is_relative_to_scan_root`
- `file_orchestrator`: `test_build_mount_graph_tags_mock_tree_endpoints_with_provenance` (MSW-style handler → `mock`, real route → `route`), `test_build_mount_graph_provenance_is_scan_root_relative`
- `analyzer`: `test_matched_wire_exposes_mock_producer_provenance` (edge + verified + orphan all carry the tag), `test_exact_key_edge_carries_producer_provenance`
- `cloud_storage`: `mount_graph_projection_carries_endpoint_provenance` (index wire shows `"provenance":"mock"`)
- `findings`: `producer_provenance_defaults_to_route_and_serializes`
- `formatter`: `test_verified_section_marks_mock_producers`, `test_orphaned_and_mismatch_rows_mark_mock_producers`

All in existing files already covered by the CI test-suite allowlist. Full `cargo test`: 1249 tests, 0 failures (incl. the cassette hard gate); `cargo clippy --all-targets` clean. No live LLM calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)