### PR TITLE
fix: classify call-site-only match pairs as shared external contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
 name = "carrick-match"
 version = "0.3.0"
 dependencies = [
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["crates/carrick-match"]
 
 [dependencies]
 async-trait = "0.1"
-carrick-match = { path = "crates/carrick-match" }
+carrick-match = { path = "crates/carrick-match", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5.0"
 futures = "0.3.32"

--- a/crates/carrick-match/Cargo.toml
+++ b/crates/carrick-match/Cargo.toml
@@ -14,9 +14,14 @@ crate-type = ["rlib", "cdylib"]
 # Adds wasm-bindgen exports for Node.js consumers. Default off so the native
 # scanner build pulls in zero new external dependencies.
 wasm = ["dep:wasm-bindgen"]
+# Adds serde derives to the classification enums so consumers that serialize
+# match output (the scanner's `CrossRepoMatch`) can embed them directly.
+# Default off so the bare crate stays dependency-free.
+serde = ["dep:serde"]
 
 [dependencies]
 # Pinned exactly: wasm-bindgen requires the CLI that generates the JS glue to
 # match this version. Bump the `cargo install wasm-bindgen-cli --version` pin
 # in .github/workflows/ci.yml in lockstep.
 wasm-bindgen = { version = "=0.2.126", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/carrick-match/src/lib.rs
+++ b/crates/carrick-match/src/lib.rs
@@ -1,10 +1,12 @@
 //! Path-matching primitives shared by every Carrick surface that compares
-//! HTTP route paths.
+//! HTTP route paths, plus the evidence-kind classification of what a matched
+//! pair means ([`classify_relationship`]).
 //!
 //! Extracted verbatim from the scanner's `MountGraph` (whose methods now
 //! delegate here) so the scanner and, via the optional `wasm` feature,
 //! Node.js consumers run the exact same matching semantics. Everything is a
-//! pure function over `&str`; the native build has zero dependencies.
+//! pure function; the default native build has zero dependencies (the
+//! optional `serde` feature adds derives on the classification enums).
 //!
 //! Two questions, two functions (#378/#381):
 //!
@@ -24,13 +26,73 @@
 //!
 //! The `wasm` feature (default off) adds wasm-bindgen exports for
 //! [`paths_match`], [`is_param_segment`], [`match_agreement`],
-//! [`path_literal_specificity`], and [`is_catch_all_path`]:
+//! [`path_literal_specificity`], [`is_catch_all_path`], and
+//! [`classify_relationship`]:
 //!
 //! ```text
 //! cargo build --target wasm32-unknown-unknown -p carrick-match --features wasm
 //! wasm-bindgen --target nodejs --out-dir <dir> \
 //!     target/wasm32-unknown-unknown/<profile>/carrick_match.wasm
 //! ```
+
+/// The kind of source evidence backing one side of a match: a route
+/// definition (a server declaring the operation) or a call site (a client
+/// invoking it).
+///
+/// Every match side is backed by one of these two. The distinction is what
+/// separates a real producer/consumer relationship from two clients that
+/// merely encode the same externally-hosted contract (#379).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum MatchEvidence {
+    /// The side declares/serves the operation (a route definition, an SDL
+    /// root field, a socket listener, a pub/sub subscriber).
+    #[default]
+    RouteDefinition,
+    /// The side invokes the operation (an outbound call expression). An
+    /// index entry that sits on the producer side but was derived from a
+    /// call expression carries this kind.
+    CallSite,
+}
+
+/// What a matched pair of operations means, classified purely by the
+/// evidence kind on each side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum MatchRelationship {
+    /// One side defines the route, the other calls it: a genuine
+    /// producer→consumer contract edge.
+    ProducerConsumer,
+    /// Both sides are call sites: nobody in the pair defines the route, so
+    /// the operations encode the same contract served outside the index.
+    /// Producer/consumer roles do not apply to this relationship.
+    SharedExternalContract,
+}
+
+/// Classify what a matched pair means from the evidence kind of each side.
+///
+/// A pair is a producer/consumer edge only when the producer-side entry is
+/// backed by a route definition. When the producer-side evidence is itself a
+/// call site, the "producer" role would be fabricated from a call expression
+/// (#379): both sides merely encode the same external contract.
+///
+/// The consumer side is accepted for symmetry (matchers know both sides);
+/// today's matchers always pass `CallSite` there, and its value does not
+/// change the classification — only the producer side's evidence decides.
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+pub fn classify_relationship(
+    producer_side: MatchEvidence,
+    _consumer_side: MatchEvidence,
+) -> MatchRelationship {
+    match producer_side {
+        MatchEvidence::RouteDefinition => MatchRelationship::ProducerConsumer,
+        MatchEvidence::CallSite => MatchRelationship::SharedExternalContract,
+    }
+}
 
 /// Whether a producer route path matches a consumer call path.
 ///
@@ -332,6 +394,31 @@ mod tests {
         assert!(!paths_match("/api/users/ ", "/api/users/:userId"));
         // Real values still match a param on the other side.
         assert!(agreement_with_params("/api/users/:id", "/api/users/123").is_some());
+    }
+
+    #[test]
+    fn test_classify_relationship_by_evidence_kind() {
+        // A route definition on the producer side is a real producer/consumer
+        // contract edge, regardless of the consumer side's evidence.
+        assert_eq!(
+            classify_relationship(MatchEvidence::RouteDefinition, MatchEvidence::CallSite),
+            MatchRelationship::ProducerConsumer
+        );
+        // Producer-side evidence that is itself a call site means nobody in
+        // the pair defines the route: the pair is two encodings of the same
+        // external contract, never a fabricated producer role (#379).
+        assert_eq!(
+            classify_relationship(MatchEvidence::CallSite, MatchEvidence::CallSite),
+            MatchRelationship::SharedExternalContract
+        );
+    }
+
+    #[test]
+    fn test_match_evidence_default_is_route_definition() {
+        // Index entries recorded before evidence kinds existed deserialize to
+        // the default; a producer-side entry defaults to a route definition so
+        // pre-existing matches keep their producer/consumer classification.
+        assert_eq!(MatchEvidence::default(), MatchEvidence::RouteDefinition);
     }
 
     #[test]

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -3175,6 +3175,10 @@ impl FileOrchestrator {
                         Path::new(file_path),
                         scan_root,
                     ),
+                    // Assumed a route definition here; reclassified to
+                    // `CallSite` by `classify_endpoint_evidence` when the same
+                    // source site was also extracted as a data call (#379).
+                    evidence: carrick_match::MatchEvidence::RouteDefinition,
                 });
             }
         }
@@ -3225,6 +3229,17 @@ impl FileOrchestrator {
         // Sixth pass: resolve full paths for endpoints
         self.resolve_endpoint_paths(&mut graph);
 
+        // Evidence classification (#379): an "endpoint" whose exact source
+        // site was ALSO extracted as a data call is a client call expression
+        // the extraction double-classified (an integration/SDK operation
+        // definition), not a route this service defines. Mark it as call-site
+        // evidence so the cross-repo matcher reports a pair against it as a
+        // shared external contract instead of fabricating a producer role.
+        // Must run BEFORE the self-call suppression below: suppression deletes
+        // the twin data call (the fabricated endpoint matches it), destroying
+        // the evidence.
+        Self::classify_endpoint_evidence(&mut graph);
+
         // Seventh pass: suppress self-calls. A data call whose (method, canonical
         // path) matches one of THIS service's own resolved endpoints is the
         // service hitting its own HTTP surface (e.g. a cron/reindex job fetching
@@ -3244,18 +3259,28 @@ impl FileOrchestrator {
             .data_calls
             .iter()
             .map(|call| {
-                // A zero-agreement routing match (#381) — this service's own
-                // catch-all fallback (`GET /*`) absorbing the call — is not
-                // evidence of a self-call: it would suppress every one of the
-                // service's real outgoing calls. Only a producer that shares
-                // literal path signal with the call counts.
+                // Two guards on what counts as a self-call, composed:
+                // - A zero-agreement routing match (#381) — this service's own
+                //   catch-all fallback (`GET /*`) absorbing the call — is not
+                //   evidence of a self-call: it would suppress every one of
+                //   the service's real outgoing calls. Only a producer that
+                //   shares literal path signal with the call counts.
+                // - Only route-definition evidence counts (#379): a call whose
+                //   only match is a call-site-evidence endpoint (its own
+                //   double-extracted twin) is a call to an EXTERNAL contract,
+                //   not the service hitting its own surface — keep it so the
+                //   shared-external-contract group can form cross-repo.
                 let is_self_call = graph
                     .find_matching_endpoints(&call.canonical_path, &call.method)
                     .iter()
                     .any(|endpoint| {
-                        carrick_match::match_agreement(&endpoint.full_path, &call.canonical_path)
+                        endpoint.evidence == carrick_match::MatchEvidence::RouteDefinition
+                            && carrick_match::match_agreement(
+                                &endpoint.full_path,
+                                &call.canonical_path,
+                            )
                             .unwrap_or(0)
-                            > 0
+                                > 0
                     });
                 if is_self_call {
                     debug!(
@@ -3360,6 +3385,40 @@ impl FileOrchestrator {
         for endpoint in &mut graph.endpoints {
             if let Some(prefix) = owner_prefixes.get(&endpoint.owner) {
                 endpoint.full_path = Self::join_paths(prefix, &endpoint.path);
+            }
+        }
+    }
+
+    /// Reclassify endpoints whose evidence is actually a client call
+    /// expression (#379).
+    ///
+    /// An endpoint is call-site evidence when a data call in the SAME graph
+    /// shares its exact source site (`file:line`), its method, and a matching
+    /// path — the extraction emitted one call expression as BOTH an endpoint
+    /// and a data call (e.g. an integration platform's request-descriptor
+    /// `perform` operation). The triple gate is deliberately strict, purely
+    /// structural, and framework-agnostic: a genuine route definition never
+    /// shares its exact line, verb, AND path with an outbound call. Known
+    /// limitation (logged at debug level via the reclassification message
+    /// only): a fabricated endpoint whose twin call was emitted at a
+    /// different line is not caught and keeps route-definition evidence.
+    ///
+    /// Runs after `resolve_endpoint_paths` (so `full_path` is final) and
+    /// before self-call suppression (which deletes the twin call).
+    fn classify_endpoint_evidence(graph: &mut MountGraph) {
+        for endpoint in &mut graph.endpoints {
+            let twinned = graph.data_calls.iter().any(|call| {
+                call.file_location == endpoint.file_location
+                    && call.method.eq_ignore_ascii_case(&endpoint.method)
+                    && carrick_match::paths_match(&endpoint.full_path, &call.canonical_path)
+            });
+            if twinned {
+                debug!(
+                    "Endpoint {} {} at {} is a double-extracted call expression; \
+                     reclassifying as call-site evidence",
+                    endpoint.method, endpoint.full_path, endpoint.file_location
+                );
+                endpoint.evidence = carrick_match::MatchEvidence::CallSite;
             }
         }
     }
@@ -4122,6 +4181,116 @@ mod tests {
             "self-call must be suppressed, surviving calls: {call_paths:?}"
         );
         assert_eq!(graph.data_calls[0].canonical_path, "/catalog/:id");
+    }
+
+    /// #379: an "endpoint" whose exact source site (file:line), method, and
+    /// path were ALSO extracted as a data call is a double-extracted client
+    /// call expression, not a route definition. It must be reclassified to
+    /// call-site evidence, and its twin call must SURVIVE self-call
+    /// suppression (the call targets an external contract, not the service's
+    /// own surface). A genuine route definition in the same file keeps
+    /// route-definition evidence, and a call matching THAT one is still
+    /// suppressed as a self-call.
+    #[test]
+    fn test_build_mount_graph_reclassifies_double_extracted_call_as_call_site_evidence() {
+        let agent_service = AgentService::new();
+        let orchestrator = FileOrchestrator::new(agent_service);
+
+        let mk_endpoint = |line: u32, method: &str, path: &str| EndpointResult {
+            candidate_id: format!("span:{line}"),
+            line_number: line as i32,
+            owner_node: "app".to_string(),
+            method: method.to_string(),
+            path: path.to_string(),
+            handler_name: "handler".to_string(),
+            pattern_matched: ".request(".to_string(),
+            call_expression_span_start: None,
+            call_expression_span_end: None,
+            payload_expression_text: None,
+            payload_expression_line: None,
+            response_expression_text: None,
+            response_expression_line: None,
+            emission_style: None,
+            primary_type_symbol: None,
+            type_import_source: None,
+        };
+        let mk_call = |line: u32, method: &str, target: &str| DataCallResult {
+            call_kind: None,
+            candidate_id: format!("call:{line}"),
+            line_number: line as i32,
+            target: target.to_string(),
+            method: Some(method.to_string()),
+            pattern_matched: "request(".to_string(),
+            call_expression_span_start: None,
+            call_expression_span_end: None,
+            call_expression_text: None,
+            call_expression_line: None,
+            payload_expression_text: None,
+            payload_expression_line: None,
+            primary_type_symbol: None,
+            type_import_source: None,
+        };
+
+        let mut file_results = HashMap::new();
+        file_results.insert(
+            "operations/create-widget.ts".to_string(),
+            FileAnalysisResult {
+                graphql_consumer_locates: vec![],
+                mounts: vec![],
+                endpoints: vec![
+                    // Double-extracted client call: same line, verb, and path
+                    // as the data call below → call-site evidence.
+                    mk_endpoint(14, "POST", "/v2/widgets"),
+                    // Genuine route definition at a different site.
+                    mk_endpoint(40, "GET", "/health"),
+                ],
+                data_calls: vec![
+                    mk_call(14, "POST", "/v2/widgets"),
+                    // Self-call to the genuine route: still suppressed.
+                    mk_call(52, "GET", "/health"),
+                ],
+                graphql_operations: vec![],
+                pubsub_operations: vec![],
+            },
+        );
+
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+        );
+
+        let evidence_of = |method: &str| {
+            graph
+                .endpoints
+                .iter()
+                .find(|e| e.method == method)
+                .expect("endpoint present")
+                .evidence
+        };
+        assert_eq!(
+            evidence_of("POST"),
+            carrick_match::MatchEvidence::CallSite,
+            "double-extracted call expression must be call-site evidence"
+        );
+        assert_eq!(
+            evidence_of("GET"),
+            carrick_match::MatchEvidence::RouteDefinition,
+            "a genuine route definition keeps route-definition evidence"
+        );
+
+        // The twin call survives (external contract encoding); the genuine
+        // self-call is still suppressed.
+        let surviving: Vec<&str> = graph
+            .data_calls
+            .iter()
+            .map(|c| c.canonical_path.as_str())
+            .collect();
+        assert_eq!(
+            surviving,
+            vec!["/v2/widgets"],
+            "twin call must survive; self-call to the real route must not"
+        );
     }
 
     /// #307 (class 1): a wrapper-internal call whose canonical path is nothing

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -133,9 +133,25 @@ pub struct CrossRepoMatch {
     /// handler (#380). Carried from the producer endpoint's structural
     /// classification so downstream surfaces can present a mismatch against a
     /// mock with the right amount of trust. When several producers share one
-    /// exact key, route-wins (`EndpointProvenance::min`).
+    /// exact key, route-wins (`EndpointProvenance::min`). Orthogonal to
+    /// `relationship`: provenance says where the producer-side entry was
+    /// written; relationship says what the pair means. A
+    /// shared-external-contract edge still carries the producer side's
+    /// provenance (a mock call-site is conceivable and the tags compose).
     #[serde(default)]
     pub producer_provenance: crate::operation::EndpointProvenance,
+    /// What this pair means, classified by evidence kind
+    /// (`carrick_match::classify_relationship`, #379). `ProducerConsumer` is
+    /// the ordinary case: the producer side is a route definition. For
+    /// `SharedExternalContract` the producer side's evidence was itself a
+    /// call site — both sides encode the same externally-served contract, and
+    /// the `producer_*`/`consumer_*` field names carry NO role meaning (they
+    /// only say which side sat in the endpoint index vs the call index);
+    /// renderers must not label either side producer or consumer, and
+    /// ts_check verdicts are never overlaid on these edges (they would be
+    /// request-vs-request comparisons mislabelled as producer-contract
+    /// verdicts).
+    pub relationship: carrick_match::MatchRelationship,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -415,6 +431,16 @@ fn apply_compat_verdicts(result: &serde_json::Value, matches: &mut [CrossRepoMat
     }
 
     for edge in matches.iter_mut() {
+        // A shared-external-contract edge has no producer contract to verify:
+        // both sides are call sites, so any ts_check comparison keyed on the
+        // same (method, path, consumer) would be request-vs-request — and the
+        // optimistic `Some(true)` fallback below would otherwise fabricate a
+        // "compatible" verdict for a check that never ran. These edges are
+        // verdict-exempt: `type_compatible` stays `None` (#379).
+        if edge.relationship != carrick_match::MatchRelationship::ProducerConsumer {
+            edge.type_compatible = None;
+            continue;
+        }
         // Recover the join key from the producer_key. ts_check type-checks HTTP
         // (`http|METHOD|path`), socket (`socket|DIRECTION|event`), and graphql
         // (`graphql|KIND|field`), so all three join here. A key for any other
@@ -455,6 +481,15 @@ fn apply_compat_verdicts(result: &serde_json::Value, matches: &mut [CrossRepoMat
 /// identity so two distinct call sites in one consumer repo against the same
 /// producer endpoint stay separate edges (each carries its own verdict).
 fn sort_dedup_cross_repo_matches(matches: &mut Vec<CrossRepoMatch>) {
+    // Relationship is part of edge identity: one repo can index BOTH a real
+    // route definition and a call-site-evidence entry on the same key, and
+    // the resulting producer/consumer and shared-external-contract edges are
+    // distinct facts. Ordered as a stable tiebreaker (ProducerConsumer <
+    // SharedExternalContract via the discriminant), never collapsed.
+    let relationship_rank = |m: &CrossRepoMatch| match m.relationship {
+        carrick_match::MatchRelationship::ProducerConsumer => 0u8,
+        carrick_match::MatchRelationship::SharedExternalContract => 1u8,
+    };
     matches.sort_by(|a, b| {
         (
             &a.producer_repo,
@@ -462,6 +497,7 @@ fn sort_dedup_cross_repo_matches(matches: &mut Vec<CrossRepoMatch>) {
             &a.consumer_repo,
             &a.consumer_key,
             &a.consumer_location,
+            relationship_rank(a),
         )
             .cmp(&(
                 &b.producer_repo,
@@ -469,6 +505,7 @@ fn sort_dedup_cross_repo_matches(matches: &mut Vec<CrossRepoMatch>) {
                 &b.consumer_repo,
                 &b.consumer_key,
                 &b.consumer_location,
+                relationship_rank(b),
             ))
     });
     matches.dedup_by(|a, b| {
@@ -477,6 +514,7 @@ fn sort_dedup_cross_repo_matches(matches: &mut Vec<CrossRepoMatch>) {
             && a.consumer_repo == b.consumer_repo
             && a.consumer_key == b.consumer_key
             && a.consumer_location == b.consumer_location
+            && a.relationship == b.relationship
     });
 }
 
@@ -1383,6 +1421,14 @@ impl Analyzer {
         let mut method_mismatched_producers: HashSet<String> = HashSet::new();
         // Structured producer→consumer edges for the eval projection.
         let mut cross_repo_matches: Vec<CrossRepoMatch> = Vec::new();
+        // Shared-external-contract groups (#379): (METHOD, path) → (repo ids,
+        // call sites) for matches whose "producer" side is itself call-site
+        // evidence — no one in the pair defines the route, so the repos merely
+        // encode the same externally-served contract. BTree-keyed for
+        // deterministic emission; reported as one group finding per contract,
+        // with no producer/consumer roles.
+        type SharedGroup = (BTreeSet<String>, BTreeSet<String>);
+        let mut shared_contract_groups: BTreeMap<(String, String), SharedGroup> = BTreeMap::new();
 
         // Consumer repo lookup: a call's `(METHOD, canonical_path, file_location)`
         // → owning repo. `merge_from_repos` tags each merged data call with its
@@ -1511,15 +1557,39 @@ impl Analyzer {
                         }
                         let key = format!("{}:{}", endpoint.method, endpoint.full_path);
                         matched_endpoints.insert(key);
-                        if let Some(edge) = Self::build_cross_repo_match(
+                        let Some(edge) = Self::build_cross_repo_match(
                             call,
                             method,
                             target,
                             &normalized_path,
                             endpoint,
                             &consumer_repo_by_call,
-                        ) {
-                            cross_repo_matches.push(edge);
+                        ) else {
+                            continue;
+                        };
+                        match edge.relationship {
+                            carrick_match::MatchRelationship::ProducerConsumer => {
+                                cross_repo_matches.push(edge);
+                            }
+                            carrick_match::MatchRelationship::SharedExternalContract => {
+                                // Both sides are call-site encodings of the
+                                // same external contract (#379): record group
+                                // membership for the report. The edge's
+                                // producer_/consumer_ fields carry no roles
+                                // (see `CrossRepoMatch::relationship`); a
+                                // same-repo pair (a repo re-matching its own
+                                // double-extracted site) still counts toward
+                                // the group but emits no self edge.
+                                let (repos, sites) = shared_contract_groups
+                                    .entry((method.to_string(), normalized_path.clone()))
+                                    .or_default();
+                                repos.insert(edge.producer_repo.clone());
+                                repos.insert(edge.consumer_repo.clone());
+                                sites.insert(call_site.clone());
+                                if edge.producer_repo != edge.consumer_repo {
+                                    cross_repo_matches.push(edge);
+                                }
+                            }
                         }
                     }
                 }
@@ -1532,9 +1602,17 @@ impl Analyzer {
                     // connectivity gap). A wildcard-only collision — e.g.
                     // `POST /users/:id` while `GET /users/list` is missing —
                     // stays a missing endpoint.
-                    let path_matches = mount_graph
+                    // Only route-definition evidence can back "the producer
+                    // expects METHOD": a call-site-evidence entry (#379) is
+                    // not a producer, so naming it here would fabricate the
+                    // same role the shared-external-contract classification
+                    // exists to remove.
+                    let mut path_matches = mount_graph
                         .find_exact_path_matches_any_method(&lookup_url, &normalizer)
                         .unwrap_or_default();
+                    path_matches.retain(|endpoint| {
+                        endpoint.evidence == carrick_match::MatchEvidence::RouteDefinition
+                    });
                     if path_matches.is_empty() {
                         missing
                             .entry((method.to_string(), miss_path))
@@ -1611,6 +1689,13 @@ impl Analyzer {
         // formatter.
         let mut verified: Vec<VerifiedEndpointEntry> = Vec::new();
         for endpoint in mount_graph.get_resolved_endpoints() {
+            // Call-site-evidence entries are not producers (#379): matched or
+            // not, they are neither "verified endpoints" (nothing was served)
+            // nor "orphaned endpoints" (nothing was defined). Their matches
+            // surface as shared-external-contract groups instead.
+            if endpoint.evidence == carrick_match::MatchEvidence::CallSite {
+                continue;
+            }
             let key = format!("{}:{}", endpoint.method, endpoint.full_path);
             if matched_endpoints.contains(&key) {
                 verified.push((
@@ -1649,6 +1734,22 @@ impl Analyzer {
                 method,
                 path,
                 env_var,
+                sites.into_iter().collect(),
+            ));
+        }
+        // Shared-external-contract groups (#379): only groups spanning ≥2
+        // repos are reported — "N repos encode the same external contract" is
+        // signal; a single repo's own encoding (every SDK operation would
+        // qualify) is noise, and unattributed single-repo runs collect no repo
+        // ids at all.
+        for ((method, path), (repos, sites)) in shared_contract_groups {
+            if repos.len() < 2 {
+                continue;
+            }
+            findings.push(Finding::shared_external_contract(
+                method,
+                path,
+                repos.into_iter().collect(),
                 sites.into_iter().collect(),
             ));
         }
@@ -1704,6 +1805,13 @@ impl Analyzer {
             producer_key: producer_key.canonical(),
             consumer_repo,
             consumer_key: consumer_key.canonical(),
+            // Classified by evidence kind (#379): the consumer side is always
+            // a call site here; the producer side is whatever evidence backs
+            // the matched endpoint entry.
+            relationship: carrick_match::classify_relationship(
+                endpoint.evidence,
+                carrick_match::MatchEvidence::CallSite,
+            ),
             // The consumer call's source location — the per-pair join key for the
             // compat verdict (#260). Shares the consumer manifest entry's source
             // (both come from this call's `file_location`), so the overlay can
@@ -1814,6 +1922,14 @@ impl Analyzer {
                             producer_key: canonical.clone(),
                             consumer_repo: consumer_repo.clone(),
                             consumer_key: canonical.clone(),
+                            // Exact-key producers are definition-side entries
+                            // (SDL root fields, socket listeners, pub/sub
+                            // subscribers), so the pair is a real
+                            // producer/consumer edge.
+                            relationship: carrick_match::classify_relationship(
+                                carrick_match::MatchEvidence::RouteDefinition,
+                                carrick_match::MatchEvidence::CallSite,
+                            ),
                             // Exact-key protocols (GraphQL/socket) ARE type-checked
                             // by ts_check now, so this consumer location feeds the
                             // compat overlay (`apply_compat_verdicts`) and also keeps
@@ -3430,6 +3546,7 @@ mod tests {
             repo_name: Some("api".to_string()),
             service_name: None,
             provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         });
 
         let (findings, verified, _edges) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
@@ -3485,6 +3602,7 @@ mod tests {
             repo_name: Some("api".to_string()),
             service_name: None,
             provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         });
 
         let (findings, _, _) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
@@ -3537,6 +3655,7 @@ mod tests {
             repo_name: Some("producer-repo".to_string()),
             service_name: None,
             provenance: EndpointProvenance::Mock,
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         });
         // An unmatched mock producer: must orphan WITH the mock tag.
         mount_graph.endpoints.push(ResolvedEndpoint {
@@ -3550,6 +3669,7 @@ mod tests {
             repo_name: Some("producer-repo".to_string()),
             service_name: None,
             provenance: EndpointProvenance::Mock,
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         });
         mount_graph.data_calls.push(DataFetchingCall {
             method: "GET".to_string(),
@@ -3625,6 +3745,182 @@ mod tests {
         );
     }
 
+    /// #379: when the producer-side entry is call-site evidence (a client
+    /// call double-extracted as an endpoint), a match against another repo's
+    /// identical call is a shared-external-contract pair: the edge carries
+    /// the relationship, the report gets one role-free group finding naming
+    /// both repos, and no producer role is fabricated (the entry is neither
+    /// verified nor orphaned, and there is no missing-endpoint gap).
+    #[test]
+    fn test_call_site_evidence_pair_reports_shared_external_contract() {
+        use crate::mount_graph::{DataFetchingCall, ResolvedEndpoint};
+
+        let cm = Lrc::new(SourceMap::default());
+        let mut analyzer = Analyzer::new(Config::default(), cm);
+
+        // repo-alpha: a client call expression the extraction double-emitted;
+        // reclassified to call-site evidence at scan time.
+        let mut mount_graph = MountGraph::new();
+        mount_graph.endpoints.push(ResolvedEndpoint {
+            method: "POST".to_string(),
+            path: "/v2/widgets".to_string(),
+            full_path: "/v2/widgets".to_string(),
+            handler: None,
+            owner: "app".to_string(),
+            file_location: "operations/create-widget.ts:14".to_string(),
+            middleware_chain: vec![],
+            repo_name: Some("repo-alpha".to_string()),
+            service_name: None,
+            provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::CallSite,
+        });
+        // repo-beta: the identical call to the same external endpoint.
+        mount_graph.data_calls.push(DataFetchingCall {
+            method: "POST".to_string(),
+            target_url: "https://api.vendor.example/v2/widgets".to_string(),
+            canonical_path: "/v2/widgets".to_string(),
+            client: "fetch".to_string(),
+            file_location: "src/widgets-client.ts:33".to_string(),
+            call_kind: None,
+            repo_name: Some("repo-beta".to_string()),
+        });
+        analyzer
+            .calls
+            .push(http_call("POST", "/v2/widgets", "src/widgets-client.ts:33"));
+
+        let (findings, verified, edges) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
+
+        // One edge, classified — with NO producer role asserted beyond the
+        // side names (see CrossRepoMatch::relationship).
+        assert_eq!(edges.len(), 1, "edges: {edges:?}");
+        assert_eq!(
+            edges[0].relationship,
+            carrick_match::MatchRelationship::SharedExternalContract
+        );
+        assert_eq!(edges[0].producer_repo, "repo-alpha");
+        assert_eq!(edges[0].consumer_repo, "repo-beta");
+
+        // One role-free group finding; no gaps, no fabricated producer.
+        assert_eq!(
+            findings,
+            vec![Finding::shared_external_contract(
+                "POST",
+                "/v2/widgets",
+                vec!["repo-alpha".to_string(), "repo-beta".to_string()],
+                vec!["src/widgets-client.ts:33".to_string()],
+            )],
+            "the pair must surface once, as a shared-external-contract group"
+        );
+        assert!(
+            verified.is_empty(),
+            "a call-site-evidence entry is never a verified producer"
+        );
+    }
+
+    /// #379 control: a real route definition matched by another repo's call
+    /// stays a plain producer/consumer edge — verified endpoint (with its
+    /// provenance, #380), no shared group, no behaviour change.
+    #[test]
+    fn test_route_definition_pair_stays_producer_consumer() {
+        use crate::mount_graph::{DataFetchingCall, ResolvedEndpoint};
+
+        let cm = Lrc::new(SourceMap::default());
+        let mut analyzer = Analyzer::new(Config::default(), cm);
+
+        let mut mount_graph = MountGraph::new();
+        mount_graph.endpoints.push(ResolvedEndpoint {
+            method: "POST".to_string(),
+            path: "/v2/widgets".to_string(),
+            full_path: "/v2/widgets".to_string(),
+            handler: Some("createWidget".to_string()),
+            owner: "app".to_string(),
+            file_location: "src/server.ts:14".to_string(),
+            middleware_chain: vec![],
+            repo_name: Some("repo-alpha".to_string()),
+            service_name: None,
+            provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
+        });
+        mount_graph.data_calls.push(DataFetchingCall {
+            method: "POST".to_string(),
+            target_url: "/v2/widgets".to_string(),
+            canonical_path: "/v2/widgets".to_string(),
+            client: "fetch".to_string(),
+            file_location: "src/widgets-client.ts:33".to_string(),
+            call_kind: None,
+            repo_name: Some("repo-beta".to_string()),
+        });
+        analyzer
+            .calls
+            .push(http_call("POST", "/v2/widgets", "src/widgets-client.ts:33"));
+
+        let (findings, verified, edges) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
+
+        assert_eq!(edges.len(), 1);
+        assert_eq!(
+            edges[0].relationship,
+            carrick_match::MatchRelationship::ProducerConsumer
+        );
+        assert!(findings.is_empty(), "findings: {findings:?}");
+        assert_eq!(
+            verified,
+            vec![(
+                "POST".to_string(),
+                "/v2/widgets".to_string(),
+                crate::operation::EndpointProvenance::Route
+            )]
+        );
+    }
+
+    /// #379: a repo re-matching its OWN call-site-evidence entry (the twin
+    /// call kept by scan-time suppression) is not signal — no self edge, and
+    /// a group confined to one repo is not reported.
+    #[test]
+    fn test_same_repo_call_site_pair_emits_no_edge_or_group() {
+        use crate::mount_graph::{DataFetchingCall, ResolvedEndpoint};
+
+        let cm = Lrc::new(SourceMap::default());
+        let mut analyzer = Analyzer::new(Config::default(), cm);
+
+        let mut mount_graph = MountGraph::new();
+        mount_graph.endpoints.push(ResolvedEndpoint {
+            method: "POST".to_string(),
+            path: "/v2/widgets".to_string(),
+            full_path: "/v2/widgets".to_string(),
+            handler: None,
+            owner: "app".to_string(),
+            file_location: "operations/create-widget.ts:14".to_string(),
+            middleware_chain: vec![],
+            repo_name: Some("repo-alpha".to_string()),
+            service_name: None,
+            provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::CallSite,
+        });
+        mount_graph.data_calls.push(DataFetchingCall {
+            method: "POST".to_string(),
+            target_url: "/v2/widgets".to_string(),
+            canonical_path: "/v2/widgets".to_string(),
+            client: "request".to_string(),
+            file_location: "operations/create-widget.ts:14".to_string(),
+            call_kind: None,
+            repo_name: Some("repo-alpha".to_string()),
+        });
+        analyzer.calls.push(http_call(
+            "POST",
+            "/v2/widgets",
+            "operations/create-widget.ts:14",
+        ));
+
+        let (findings, verified, edges) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
+
+        assert!(edges.is_empty(), "no self edge: {edges:?}");
+        assert!(
+            findings.is_empty(),
+            "single-repo group is noise: {findings:?}"
+        );
+        assert!(verified.is_empty());
+    }
+
     /// Bare HTTP consumer call for the mount-graph matcher tests.
     fn http_call(method: &str, path: &str, file: &str) -> ApiEndpointDetails {
         graphql_details(OperationKey::http(method, path.to_string()), file)
@@ -3643,6 +3939,7 @@ mod tests {
             repo_name: Some("api".to_string()),
             service_name: None,
             provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         }
     }
 
@@ -3826,6 +4123,7 @@ mod tests {
             type_compatible: None,
             mismatch_reason: None,
             producer_provenance: Default::default(),
+            relationship: carrick_match::MatchRelationship::ProducerConsumer,
         }
     }
 
@@ -3867,6 +4165,35 @@ mod tests {
             "a producer absent from the mismatch list is compatible (verdict reached)"
         );
         assert!(matches[1].mismatch_reason.is_none());
+    }
+
+    /// #379: a shared-external-contract edge is verdict-exempt. Both sides
+    /// are call sites, so any ts_check comparison on the same key would be
+    /// request-vs-request — and without the guard the overlay's optimistic
+    /// fallback would stamp `Some(true)` on an edge ts_check never verified
+    /// as a producer contract.
+    #[test]
+    fn apply_compat_verdicts_leaves_shared_external_contract_edges_unevaluated() {
+        // No mismatch entry for this key: the fallback would say Some(true).
+        let results: serde_json::Value = serde_json::from_str(
+            r#"{ "mismatches": [], "totalChecked": 1, "compatibleCount": 1 }"#,
+        )
+        .unwrap();
+
+        let mut shared = edge("http|POST|/v2/widgets");
+        shared.relationship = carrick_match::MatchRelationship::SharedExternalContract;
+        let mut matches = vec![shared, edge("http|POST|/v2/widgets")];
+        apply_compat_verdicts(&results, &mut matches);
+
+        assert_eq!(
+            matches[0].type_compatible, None,
+            "shared-external-contract edges are verdict-exempt"
+        );
+        assert_eq!(
+            matches[1].type_compatible,
+            Some(true),
+            "the producer/consumer edge on the same key still gets its verdict"
+        );
     }
 
     /// PR-comment polish (#337): the risk row's call site must not leak the CI

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -436,9 +436,12 @@ fn apply_compat_verdicts(result: &serde_json::Value, matches: &mut [CrossRepoMat
         // same (method, path, consumer) would be request-vs-request — and the
         // optimistic `Some(true)` fallback below would otherwise fabricate a
         // "compatible" verdict for a check that never ran. These edges are
-        // verdict-exempt: `type_compatible` stays `None` (#379).
+        // verdict-exempt: `type_compatible` stays `None` (#379), and the
+        // reason is cleared with it — `mismatch_reason` is only ever present
+        // alongside `type_compatible == Some(false)`.
         if edge.relationship != carrick_match::MatchRelationship::ProducerConsumer {
             edge.type_compatible = None;
+            edge.mismatch_reason = None;
             continue;
         }
         // Recover the join key from the producer_key. ts_check type-checks HTTP
@@ -1586,6 +1589,12 @@ impl Analyzer {
                                 repos.insert(edge.producer_repo.clone());
                                 repos.insert(edge.consumer_repo.clone());
                                 sites.insert(call_site.clone());
+                                // The endpoint-side entry is ITSELF a call
+                                // site (that is what made the pair shared) —
+                                // its source location is a group member too,
+                                // so the report shows where every encoding
+                                // lives, including the double-extracted one.
+                                sites.insert(endpoint.file_location.clone());
                                 if edge.producer_repo != edge.consumer_repo {
                                     cross_repo_matches.push(edge);
                                 }
@@ -3800,14 +3809,20 @@ mod tests {
         assert_eq!(edges[0].producer_repo, "repo-alpha");
         assert_eq!(edges[0].consumer_repo, "repo-beta");
 
-        // One role-free group finding; no gaps, no fabricated producer.
+        // One role-free group finding; no gaps, no fabricated producer. The
+        // call sites name BOTH encodings — repo-beta's call AND repo-alpha's
+        // double-extracted site — so the report shows where every encoding
+        // of the contract lives.
         assert_eq!(
             findings,
             vec![Finding::shared_external_contract(
                 "POST",
                 "/v2/widgets",
                 vec!["repo-alpha".to_string(), "repo-beta".to_string()],
-                vec!["src/widgets-client.ts:33".to_string()],
+                vec![
+                    "operations/create-widget.ts:14".to_string(),
+                    "src/widgets-client.ts:33".to_string(),
+                ],
             )],
             "the pair must surface once, as a shared-external-contract group"
         );
@@ -4182,12 +4197,20 @@ mod tests {
 
         let mut shared = edge("http|POST|/v2/widgets");
         shared.relationship = carrick_match::MatchRelationship::SharedExternalContract;
+        // A stale reason (e.g. from an earlier overlay pass) must be cleared
+        // along with the verdict: `mismatch_reason` is only ever present
+        // alongside `type_compatible == Some(false)`.
+        shared.mismatch_reason = Some("stale request-vs-request reason".to_string());
         let mut matches = vec![shared, edge("http|POST|/v2/widgets")];
         apply_compat_verdicts(&results, &mut matches);
 
         assert_eq!(
             matches[0].type_compatible, None,
             "shared-external-contract edges are verdict-exempt"
+        );
+        assert_eq!(
+            matches[0].mismatch_reason, None,
+            "a verdict-exempt edge carries no mismatch reason"
         );
         assert_eq!(
             matches[1].type_compatible,

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -556,6 +556,7 @@ mod tests {
             repo_name: None,
             service_name: None,
             provenance: EndpointProvenance::Mock,
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         });
 
         let (endpoints, _calls) = mount_graph_to_api_details(&graph);
@@ -616,6 +617,7 @@ mod tests {
             type_compatible,
             mismatch_reason: mismatch_reason.map(String::from),
             producer_provenance: Default::default(),
+            relationship: carrick_match::MatchRelationship::ProducerConsumer,
         }
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2471,6 +2471,15 @@ fn build_type_manifest_entries(
         if !is_http_method(&method) {
             continue;
         }
+        // Call-site-evidence entries (#379) never anchor Producer types: they
+        // are client encodings of an external contract, and a producer
+        // manifest entry would make ts_check run a request-vs-request
+        // comparison mislabelled as a producer-contract verdict. Their pairs
+        // are verdict-exempt at the source; the site's Consumer entry is
+        // still emitted from the twin data call below.
+        if endpoint.evidence == carrick_match::MatchEvidence::CallSite {
+            continue;
+        }
         let path = endpoint.full_path.clone();
         if !path.starts_with('/') {
             continue;
@@ -4175,6 +4184,7 @@ mod tests {
             repo_name: None,
             service_name: None,
             provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         };
         let mut mount_graph = MountGraph::new();
         mount_graph.endpoints = vec![
@@ -4211,6 +4221,53 @@ mod tests {
             .expect("one producer entry expected");
         assert_eq!(survivor.file_path, "src/routes/orders.ts");
         assert_eq!(survivor.line_number, 11);
+    }
+
+    /// #379: a call-site-evidence entry never anchors Producer manifest
+    /// types — a producer entry would make ts_check run a request-vs-request
+    /// comparison mislabelled as a producer-contract verdict. The twin data
+    /// call's Consumer entries are unaffected.
+    #[test]
+    fn test_call_site_evidence_endpoint_emits_no_producer_manifest_entries() {
+        let config = Config::default();
+        let mut mount_graph = MountGraph::new();
+        mount_graph.endpoints = vec![crate::mount_graph::ResolvedEndpoint {
+            method: "POST".to_string(),
+            path: "/v2/widgets".to_string(),
+            full_path: "/v2/widgets".to_string(),
+            handler: None,
+            owner: "app".to_string(),
+            file_location: "operations/create-widget.ts:14".to_string(),
+            middleware_chain: vec![],
+            repo_name: None,
+            service_name: None,
+            provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::CallSite,
+        }];
+        mount_graph.data_calls = vec![crate::mount_graph::DataFetchingCall {
+            method: "POST".to_string(),
+            target_url: "/v2/widgets".to_string(),
+            canonical_path: "/v2/widgets".to_string(),
+            client: "request".to_string(),
+            file_location: "operations/create-widget.ts:14".to_string(),
+            call_kind: None,
+            repo_name: None,
+        }];
+
+        let entries = build_type_manifest_entries(&mount_graph, &config);
+
+        assert!(
+            entries.iter().all(|e| e.role != ManifestRole::Producer),
+            "call-site evidence must not produce Producer manifest entries: {:?}",
+            entries
+                .iter()
+                .map(|e| (&e.role, &e.type_alias))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            entries.iter().any(|e| e.role == ManifestRole::Consumer),
+            "the twin call's Consumer entries are still emitted"
+        );
     }
 
     #[test]
@@ -4684,6 +4741,7 @@ mod tests {
             type_compatible: Some(false),
             mismatch_reason: Some("y".repeat(400)),
             producer_provenance: Default::default(),
+            relationship: carrick_match::MatchRelationship::ProducerConsumer,
         }];
         crate::cloud_storage::attach_compat_verdicts(&mut payloads, &matches);
         assert!(

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -92,6 +92,19 @@ pub struct CrossRepoMatch {
     /// `Some(..)` iff `type_compatible == Some(false)`; omitted otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mismatch_reason: Option<String>,
+    /// Additive (#379): `"producer_consumer"` or `"shared_external_contract"`
+    /// (`carrick_match::MatchRelationship`'s serde wire values). For
+    /// shared-external-contract edges the `producer_*`/`consumer_*` names
+    /// carry no roles — both sides are call-site encodings of the same
+    /// external contract. Defaults to producer/consumer so projections
+    /// recorded before this field existed keep their meaning.
+    #[serde(default = "default_relationship")]
+    pub relationship: String,
+}
+
+/// The pre-#379 implied relationship of every edge.
+fn default_relationship() -> String {
+    "producer_consumer".to_string()
 }
 
 /// A dependency version conflict (contract §4). `versions` is sorted ascending
@@ -449,6 +462,13 @@ impl CrossRepoMatch {
             match_score: m.match_score,
             type_compatible: m.type_compatible,
             mismatch_reason: m.mismatch_reason.clone(),
+            relationship: match m.relationship {
+                carrick_match::MatchRelationship::ProducerConsumer => "producer_consumer",
+                carrick_match::MatchRelationship::SharedExternalContract => {
+                    "shared_external_contract"
+                }
+            }
+            .to_string(),
         }
     }
 }
@@ -761,6 +781,7 @@ mod tests {
                 type_compatible: Some(true),
                 mismatch_reason: None,
                 producer_provenance: Default::default(),
+                relationship: carrick_match::MatchRelationship::ProducerConsumer,
             },
             // Compat evaluated, incompatible.
             AnalyzerCrossRepoMatch {
@@ -773,6 +794,7 @@ mod tests {
                 type_compatible: Some(false),
                 mismatch_reason: Some("id: number vs string".to_string()),
                 producer_provenance: Default::default(),
+                relationship: carrick_match::MatchRelationship::ProducerConsumer,
             },
             // Compat NOT evaluated (the load-bearing None).
             AnalyzerCrossRepoMatch {
@@ -785,6 +807,7 @@ mod tests {
                 type_compatible: None,
                 mismatch_reason: None,
                 producer_provenance: Default::default(),
+                relationship: carrick_match::MatchRelationship::ProducerConsumer,
             },
         ];
 
@@ -844,6 +867,8 @@ mod tests {
         assert_eq!(compatible["consumer_repo"], "payments-svc");
         assert_eq!(compatible["match_score"], 1.0);
         assert_eq!(compatible["type_compatible"], true);
+        // Additive #379 field: the evidence-kind classification travels.
+        assert_eq!(compatible["relationship"], "producer_consumer");
         // mismatch_reason omitted when None.
         assert!(compatible.get("mismatch_reason").is_none());
 

--- a/src/findings.rs
+++ b/src/findings.rs
@@ -128,6 +128,18 @@ pub enum Finding {
         tier: String,
         versions: Vec<PackageVersionRef>,
     },
+    /// Multiple repos encode the same external contract (#379): every side of
+    /// the match is a call site, so no indexed service defines the route and
+    /// producer/consumer roles do not apply. Advisory signal — "these N repos
+    /// speak the same external API" — never a contract verdict.
+    SharedExternalContract {
+        method: String,
+        path: String,
+        /// Repo ids (service_name ?? repo_name) that encode this contract,
+        /// sorted; always ≥2 (single-repo groups are not emitted).
+        repos: Vec<String>,
+        call_sites: Vec<String>,
+    },
 }
 
 impl Finding {
@@ -238,6 +250,20 @@ impl Finding {
         }
     }
 
+    pub fn shared_external_contract(
+        method: impl Into<String>,
+        path: impl Into<String>,
+        repos: Vec<String>,
+        call_sites: Vec<String>,
+    ) -> Self {
+        Finding::SharedExternalContract {
+            method: method.into(),
+            path: path.into(),
+            repos,
+            call_sites,
+        }
+    }
+
     /// The wire `kind` tag.
     pub fn kind(&self) -> &'static str {
         match self {
@@ -247,6 +273,7 @@ impl Finding {
             Finding::OrphanedEndpoint { .. } => "orphaned_endpoint",
             Finding::EnvVarCall { .. } => "env_var_call",
             Finding::DependencyConflict { .. } => "dependency_conflict",
+            Finding::SharedExternalContract { .. } => "shared_external_contract",
         }
     }
 
@@ -257,7 +284,9 @@ impl Finding {
         match self {
             Finding::TypeMismatch { .. } | Finding::MethodMismatch { .. } => Severity::Risk,
             Finding::MissingEndpoint { .. } | Finding::OrphanedEndpoint { .. } => Severity::Gap,
-            Finding::EnvVarCall { .. } => Severity::Advisory,
+            Finding::EnvVarCall { .. } | Finding::SharedExternalContract { .. } => {
+                Severity::Advisory
+            }
             Finding::DependencyConflict { tier, .. } => {
                 if tier == tier::MAJOR {
                     Severity::Gap
@@ -351,6 +380,17 @@ impl Serialize for Finding {
                 map.serialize_entry("package_name", package_name)?;
                 map.serialize_entry("tier", tier)?;
                 map.serialize_entry("versions", versions)?;
+            }
+            Finding::SharedExternalContract {
+                method,
+                path,
+                repos,
+                call_sites,
+            } => {
+                map.serialize_entry("method", method)?;
+                map.serialize_entry("path", path)?;
+                map.serialize_entry("repos", repos)?;
+                map.serialize_entry("call_sites", wire_call_sites(call_sites))?;
             }
         }
         map.end()
@@ -594,6 +634,12 @@ mod tests {
                     }],
                 ),
                 Finding::dependency_conflict("typescript", tier::UNPARSEABLE, vec![]),
+                Finding::shared_external_contract(
+                    "POST",
+                    "/v2/widgets",
+                    vec!["repo-alpha".to_string(), "repo-beta".to_string()],
+                    vec!["src/widgets-client.ts:33".to_string()],
+                ),
             ],
             delta: Some(PrDelta {
                 new_endpoints: vec![EndpointRef {
@@ -719,6 +765,19 @@ mod tests {
         // Unparseable tier downgrades the severity to advisory.
         assert_eq!(findings[6]["severity"], "advisory");
         assert_eq!(findings[6]["tier"], "unparseable");
+        // Shared external contract (#379): role-free — repos, never a
+        // producer/consumer or service attribution.
+        assert_eq!(
+            findings[7],
+            json!({
+                "kind": "shared_external_contract",
+                "severity": "advisory",
+                "method": "POST",
+                "path": "/v2/widgets",
+                "repos": ["repo-alpha", "repo-beta"],
+                "call_sites": ["src/widgets-client.ts:33"],
+            })
+        );
     }
 
     /// An empty `run_id` is omitted, not sent as `""` — the cloud validates

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -146,6 +146,12 @@ pub fn format_analysis_results(
         output.push_str(&format_configuration_section(&categorized.configuration));
         output.push_str("\n\n");
     }
+    if !categorized.shared_contracts.is_empty() {
+        output.push_str(&format_shared_contract_section(
+            &categorized.shared_contracts,
+        ));
+        output.push_str("\n\n");
+    }
     if !result.verified_endpoints.is_empty() {
         output.push_str(&format_verified_section(&result.verified_endpoints));
         output.push_str("\n\n");
@@ -279,6 +285,13 @@ fn format_verdict(
             "{} configuration suggestion{}",
             categorized.configuration.len(),
             plural(categorized.configuration.len())
+        ));
+    }
+    if !categorized.shared_contracts.is_empty() {
+        parts.push(format!(
+            "{} shared external contract{}",
+            categorized.shared_contracts.len(),
+            plural(categorized.shared_contracts.len())
         ));
     }
 
@@ -427,6 +440,10 @@ struct CategorizedFindings<'a> {
     /// `unparseable` is advisory.
     major_dependencies: Vec<&'a Finding>,
     unparseable_dependencies: Vec<&'a Finding>,
+    /// Shared external contracts (#379): groups of repos whose call sites
+    /// encode the same externally-served API. Advisory; carries no
+    /// producer/consumer roles.
+    shared_contracts: Vec<&'a Finding>,
 }
 
 impl CategorizedFindings<'_> {
@@ -465,6 +482,7 @@ fn categorize_findings(findings: &[Finding]) -> CategorizedFindings<'_> {
     let mut env_var_calls = Vec::new();
     let mut major_dependencies = Vec::new();
     let mut unparseable_dependencies = Vec::new();
+    let mut shared_contracts = Vec::new();
 
     for finding in findings {
         match finding {
@@ -479,6 +497,7 @@ fn categorize_findings(findings: &[Finding]) -> CategorizedFindings<'_> {
                     unparseable_dependencies.push(finding);
                 }
             }
+            Finding::SharedExternalContract { .. } => shared_contracts.push(finding),
         }
     }
 
@@ -489,6 +508,7 @@ fn categorize_findings(findings: &[Finding]) -> CategorizedFindings<'_> {
         configuration: group_env_var_suggestions(&env_var_calls),
         major_dependencies,
         unparseable_dependencies,
+        shared_contracts,
     }
 }
 
@@ -732,6 +752,54 @@ fn format_configuration_section(issues: &[EnvVarSuggestionGroup]) -> String {
     output
 }
 
+/// Render the shared-external-contract groups (#379): repos whose call sites
+/// all target the same route that no indexed service defines. Deliberately
+/// role-free wording — none of the repos is a producer, and no contract
+/// verdict is implied.
+fn format_shared_contract_section(shared: &[&Finding]) -> String {
+    let mut output = String::new();
+
+    output.push_str(&format!(
+        "<details>\n<summary><strong>Shared external contracts ({})</strong></summary>\n\n",
+        shared.len()
+    ));
+    output.push_str(
+        "> These repos call the same API, but no indexed service defines it — they encode the same external contract. Useful as a change-impact signal; no producer exists in the index, so no contract verdict is implied.\n\n",
+    );
+    output.push_str("| Method | Path | Encoded by | Call sites |\n| :--- | :--- | :--- | :--- |\n");
+    for finding in shared {
+        let Finding::SharedExternalContract {
+            method,
+            path,
+            repos,
+            call_sites,
+        } = finding
+        else {
+            // categorize_findings only routes SharedExternalContract here.
+            continue;
+        };
+        let repo_list = repos
+            .iter()
+            .map(|r| format!("`{}`", code_cell(r)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sites = if call_sites.is_empty() {
+            "-".to_string()
+        } else {
+            format!("`{}`", code_cell(&call_sites.join(", ")))
+        };
+        output.push_str(&format!(
+            "| `{}` | `{}` | {} | {} |\n",
+            code_cell(method),
+            code_cell(path),
+            repo_list,
+            sites
+        ));
+    }
+    output.push_str("\n</details>");
+    output
+}
+
 fn format_dependency_section(major: &[&Finding], unparseable: &[&Finding]) -> String {
     let mut output = String::new();
 
@@ -853,6 +921,38 @@ mod tests {
             graphql_operations_indexed: false,
             cross_repo_matches: vec![],
         }
+    }
+
+    /// #379: a shared-external-contract group renders as its own role-free
+    /// advisory section — named repos, no producer/consumer labels, no
+    /// headline issue counted, and no connectivity framing.
+    #[test]
+    fn shared_external_contract_renders_role_free_group() {
+        let result = result_with(vec![Finding::shared_external_contract(
+            "POST",
+            "/v2/widgets",
+            vec!["repo-alpha".to_string(), "repo-beta".to_string()],
+            vec!["src/widgets-client.ts:33".to_string()],
+        )]);
+        let output = format_analysis_results(result, &topology_baseline(), None);
+
+        assert!(
+            output.contains("Shared external contracts (1)"),
+            "missing section: {output}"
+        );
+        assert!(output.contains("`repo-alpha`") && output.contains("`repo-beta`"));
+        assert!(output.contains("`POST`") && output.contains("`/v2/widgets`"));
+        // Advisory: never a headline issue.
+        assert!(
+            output.contains("<!-- CARRICK_ISSUE_COUNT:0 -->"),
+            "shared contracts must not count as issues: {output}"
+        );
+        // Role-free table: repos are "Encoded by", never a Producer/Consumer
+        // column.
+        assert!(output.contains("| Method | Path | Encoded by | Call sites |"));
+        assert!(!output.contains("| Producer") && !output.contains("| Consumer"));
+        // The verdict mentions the group.
+        assert!(output.contains("1 shared external contract"));
     }
 
     fn type_mismatch_finding() -> Finding {

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -47,9 +47,23 @@ pub struct ResolvedEndpoint {
     /// Where this endpoint's evidence comes from — a real route or a mock/test
     /// handler — classified structurally from the source path when the graph
     /// is built (`file_finder::endpoint_provenance`). `default` so graphs
-    /// serialized before the field existed read as `Route`.
+    /// serialized before the field existed read as `Route`. Orthogonal to
+    /// `evidence`: provenance describes WHERE the entry was written (route vs
+    /// mock tree), evidence describes WHAT KIND of expression backs it (a
+    /// definition vs a client call) — a mock call-site carries both tags.
     #[serde(default)]
     pub provenance: crate::operation::EndpointProvenance,
+    /// What kind of source evidence backs this entry (#379). Endpoints are
+    /// route definitions by construction, but extraction can fabricate one
+    /// from a client call expression (the same site double-extracted as an
+    /// endpoint AND a data call — see
+    /// `FileOrchestrator::classify_endpoint_evidence`). A `CallSite` entry is
+    /// not a producer: a consumer call matching it is classified as a
+    /// shared-external-contract pair, not producer/consumer. Defaults to
+    /// `RouteDefinition` so index data recorded before this field existed
+    /// keeps its meaning.
+    #[serde(default)]
+    pub evidence: carrick_match::MatchEvidence,
 }
 
 /// Represents a data-fetching call with its target
@@ -452,6 +466,7 @@ mod tests {
             repo_name: None,
             service_name: None,
             provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         });
 
         // Create config with internal domain
@@ -727,6 +742,7 @@ mod tests {
             repo_name: None,
             service_name: None,
             provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         });
 
         let config = Config {
@@ -769,6 +785,7 @@ mod tests {
             repo_name: None,
             service_name: None,
             provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         });
 
         let config = Config {
@@ -802,6 +819,7 @@ mod tests {
             repo_name: None,
             service_name: None,
             provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         });
 
         let config = Config::default();
@@ -835,6 +853,7 @@ mod tests {
                 repo_name: None,
                 service_name: None,
                 provenance: Default::default(),
+                evidence: carrick_match::MatchEvidence::RouteDefinition,
             });
         }
         let normalizer = UrlNormalizer::default_permissive();
@@ -885,6 +904,7 @@ mod tests {
             repo_name: None,
             service_name: None,
             provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
         });
         crate::cloud_storage::CloudRepoData {
             repo_name: repo.to_string(),


### PR DESCRIPTION
Fixes #379

## Problem

When two repos both CALL the same external endpoint (no in-org route definition exists), the matcher paired them and labelled one side producer. Root cause: extraction can double-emit one client call expression as BOTH an endpoint and a data call (e.g. an integration platform's request-descriptor operation). The fabricated endpoint entered the producer index, scan-time self-call suppression then deleted its twin call (destroying the evidence), and cross-repo another repo's identical call matched it — producing a producer/consumer edge, a "verified endpoint", Producer manifest entries, and a ts_check request-vs-request comparison labelled as a producer-contract verdict.

## Approach: classify by evidence kind

The shared `carrick-match` crate gains the classification, so scanner, cloud, and MCP share one definition:

- `MatchEvidence`: `route_definition` | `call_site` — what backs a match side.
- `MatchRelationship`: `producer_consumer` | `shared_external_contract`.
- `classify_relationship(producer_side, consumer_side)`: producer-side evidence that is itself a call site means nobody in the pair defines the route → `shared_external_contract`, never a fabricated producer role.

Both enums are exported for wasm consumers; serde derives sit behind a new optional `serde` feature (default native build stays dependency-free).

## Output-shape change

`CrossRepoMatch` (analyzer) and the eval projection edge both gain a `relationship` field. For `shared_external_contract` edges the `producer_*`/`consumer_*` field names carry NO role meaning (they only record which side sat in the endpoint index vs the call index); the projection field is an additive string defaulting to `producer_consumer` for old projections.

## Scanner plumbing

- `ResolvedEndpoint.evidence` (serde-default `route_definition`, so previously indexed data keeps its meaning). At mount-graph build time an endpoint is reclassified to call-site evidence when a data call in the same graph shares its exact source site (file:line), verb, and a matching path — a purely structural, framework-agnostic gate. Known limitation (documented in code): a fabricated endpoint whose twin call was emitted at a different line is not caught.
- Self-call suppression now only counts route-definition matches, so the twin call survives as the repo's own encoding of the external contract.
- Matcher: call-site-evidence entries are neither verified nor orphaned, never named as the expected-verb producer in method-mismatch risks, and their matches accumulate into role-free groups reported as a new `shared_external_contract` finding kind (advisory): "these N repos encode the same external contract". Groups spanning <2 repos are suppressed as noise; same-repo self-pairs emit no edge.

## ts_check semantics

The request-vs-request comparison is dropped rather than relabelled: call-site-evidence entries emit no Producer manifest entries, so ts_check never pairs them, and the compat overlay additionally leaves `shared_external_contract` edges verdict-exempt (`type_compatible: None`) — without that guard the overlay's optimistic fallback would stamp `Some(true)` on a check that never ran.

## What carrick-cloud will need (not touched here)

- The `post-pr-result` payload can now carry a `shared_external_contract` finding kind (`method`, `path`, `repos[]`, `call_sites[]`, severity `advisory`); the cloud comment renderer should render it as a role-free group and must not fail on the unknown kind meanwhile.
- Persisted cross-repo match edges / MCP match responses will carry the `relationship` field once the cloud consumes the updated carrick-match wasm artifact; `shared_external_contract` edges must not be rendered with producer/consumer labels or compat verdicts.

## Tests

- `carrick-match`: `test_classify_relationship_by_evidence_kind`, `test_match_evidence_default_is_route_definition`.
- Analyzer: `test_call_site_evidence_pair_reports_shared_external_contract` (two client repos, same external endpoint → shared group, no producer role), `test_route_definition_pair_stays_producer_consumer` (control: unchanged), `test_same_repo_call_site_pair_emits_no_edge_or_group`, `apply_compat_verdicts_leaves_shared_external_contract_edges_unevaluated`.
- Orchestrator: `test_build_mount_graph_reclassifies_double_extracted_call_as_call_site_evidence`.
- Engine: `test_call_site_evidence_endpoint_emits_no_producer_manifest_entries`.
- Findings/formatter: wire-shape and role-free rendering assertions.

Mutation-checked: reverting the classification to always-`producer_consumer` makes the new analyzer test fail.

All tests live in existing CI-covered targets (`cargo test --lib`, `cargo test -p carrick-match`) — no workflow allowlist change needed. Full `cargo test` green locally (cassette hard gate passes byte-identical: this fixture produces no cross-repo matches, so the golden needed no re-record). `cargo clippy --all-targets` clean; wasm target builds.

Rebased onto main after #383 (path-specificity gating) and #384 (endpoint provenance) merged; the three changes compose: #383 decides WHICH candidates pair (its zero-agreement guard runs before this classification, and self-call suppression now requires literal agreement AND route-definition evidence), #384 describes the producer side's provenance (a shared_external_contract edge still carries producer_provenance — the tags are orthogonal and a mock call-site is representable), and this PR classifies the relationship and gates roles/verdicts. #384's mock-provenance tests and verified 3-tuples are preserved unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
