### PR TITLE
feat: pub/sub payload type capture via expression locators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,12 @@ jobs:
       - name: Run ts_check unit tests
         run: cd ts_check && npm ci && npm test
 
+      # After the ts_check step: this test spawns the real binary over the
+      # pubsub-wrapper-monorepo fixture (cassette-mocked LLM, real sidecar) and
+      # the scan drives ts_check, so its node_modules must exist.
+      - name: Run pub/sub wrapper type-capture test
+        run: cargo test --test pubsub_wrapper_type_capture_test --verbose
+
       - name: Run library tests
         run: cargo test --lib --verbose
 

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -761,10 +761,7 @@ impl FileAnalyzerAgent {
                     Some(stripped.to_string())
                 };
             }
-            if op
-                .payload_expression_line
-                .is_some_and(|line| line <= 0)
-            {
+            if op.payload_expression_line.is_some_and(|line| line <= 0) {
                 op.payload_expression_line = None;
             }
             if op.payload_expression_text.is_none() {
@@ -1571,10 +1568,7 @@ mod tests {
                 Some("payload"),
             ]
         );
-        assert_eq!(
-            lines,
-            vec![Some(36), Some(13), Some(1), None, None, None]
-        );
+        assert_eq!(lines, vec![Some(36), Some(13), Some(1), None, None, None]);
     }
 
     #[test]

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -574,6 +574,40 @@ impl FileAnalyzerAgent {
             }
         }
 
+        /// Strip balanced ENCLOSING parenthesis pairs from a locator string:
+        /// `(decision)` → `decision`, `(({ payload }))` → `{ payload }`.
+        /// Only strips when the leading `(` matches the trailing `)` around the
+        /// WHOLE string — `(a).b(c)` is untouched (its first paren closes
+        /// mid-string). Pure syntax normalization for the model's habit of
+        /// copying an arrow-function parameter with its parameter-list parens.
+        fn strip_enclosing_parens(text: &str) -> &str {
+            let mut current = text.trim();
+            loop {
+                let inner = current
+                    .strip_prefix('(')
+                    .and_then(|rest| rest.strip_suffix(')'));
+                let Some(inner) = inner else {
+                    return current;
+                };
+                // The stripped pair must enclose the whole string: scan the
+                // candidate inner text and reject if depth ever goes negative
+                // (that means the leading paren closed before the end).
+                let mut depth = 0i32;
+                let balanced = inner.chars().all(|ch| {
+                    match ch {
+                        '(' => depth += 1,
+                        ')' => depth -= 1,
+                        _ => {}
+                    }
+                    depth >= 0
+                }) && depth == 0;
+                if !balanced {
+                    return current;
+                }
+                current = inner.trim();
+            }
+        }
+
         fn is_suspicious_import_source(value: &str) -> bool {
             if value.contains("primary_type_symbol") || value.contains("type_import_source") {
                 return true;
@@ -712,6 +746,21 @@ impl FileAnalyzerAgent {
             // a locator without a positive 1-based line can't anchor the
             // sidecar's text search. Keep the pair consistent (text ⇔ line).
             normalize_optional_string(&mut op.payload_expression_text);
+            // The model frequently copies a subscriber handler's payload
+            // parameter WITH its arrow-parameter-list parens (`(decision)`,
+            // `({ time, run })`) — measured 12/20 on the wrapper-relay harness
+            // fixture. Enclosing parens are pure syntax, never part of the
+            // binding or expression the sidecar must locate, so strip balanced
+            // outer pairs deterministically here rather than fighting the
+            // model's copy granularity in the schema description.
+            if let Some(text) = op.payload_expression_text.take() {
+                let stripped = strip_enclosing_parens(&text);
+                op.payload_expression_text = if stripped.is_empty() {
+                    None
+                } else {
+                    Some(stripped.to_string())
+                };
+            }
             if op
                 .payload_expression_line
                 .is_some_and(|line| line <= 0)
@@ -1471,6 +1520,61 @@ mod tests {
         assert_eq!(data_call.method, Some("POST".to_string()));
         assert!(data_call.primary_type_symbol.is_none());
         assert!(data_call.type_import_source.is_none());
+    }
+
+    #[test]
+    fn sanitize_normalizes_pubsub_payload_locators() {
+        let op = |text: Option<&str>, line: Option<i32>| PubsubOperation {
+            topic: "itemArchived".to_string(),
+            role: Some(crate::operation::PubsubRole::Subscriber),
+            line_number: 13,
+            primary_type_symbol: None,
+            type_import_source: None,
+            broker: None,
+            payload_expression_text: text.map(String::from),
+            payload_expression_line: line,
+        };
+        let mut result = FileAnalysisResult {
+            pubsub_operations: vec![
+                // Arrow-param-list parens stripped (the measured 12/20 shape).
+                op(Some("(decision)"), Some(36)),
+                op(Some("({ time, item })"), Some(13)),
+                // Non-enclosing parens untouched.
+                op(Some("(a).b(c)"), Some(1)),
+                // Null-like text nulls the pair; line-only never survives alone.
+                op(Some("null"), Some(5)),
+                op(None, Some(7)),
+                // Non-positive line dropped, text kept.
+                op(Some("payload"), Some(0)),
+            ],
+            ..Default::default()
+        };
+        FileAnalyzerAgent::sanitize_result(&mut result);
+        let texts: Vec<Option<&str>> = result
+            .pubsub_operations
+            .iter()
+            .map(|o| o.payload_expression_text.as_deref())
+            .collect();
+        let lines: Vec<Option<i32>> = result
+            .pubsub_operations
+            .iter()
+            .map(|o| o.payload_expression_line)
+            .collect();
+        assert_eq!(
+            texts,
+            vec![
+                Some("decision"),
+                Some("{ time, item }"),
+                Some("(a).b(c)"),
+                None,
+                None,
+                Some("payload"),
+            ]
+        );
+        assert_eq!(
+            lines,
+            vec![Some(36), Some(13), Some(1), None, None, None]
+        );
     }
 
     #[test]

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -289,6 +289,17 @@ pub struct PubsubOperation {
     /// Not part of the operation's identity.
     #[serde(default)]
     pub broker: Option<String>,
+    /// Verbatim text of the value holding the decoded payload at this site: a
+    /// publisher's payload expression, or a subscriber handler's payload
+    /// parameter/binding. The locator for the sidecar's location-based
+    /// inference when `primary_type_symbol` is null (wrapper patterns whose
+    /// payload type is carried by a generic binding, never a bare identifier).
+    #[serde(default)]
+    pub payload_expression_text: Option<String>,
+    /// Line where the payload expression starts. Null whenever
+    /// `payload_expression_text` is null.
+    #[serde(default)]
+    pub payload_expression_line: Option<i32>,
 }
 
 /// Complete analysis result for a single file
@@ -697,6 +708,19 @@ impl FileAnalyzerAgent {
                 op.primary_type_symbol = None;
             }
             normalize_optional_string(&mut op.broker);
+            // Payload locator hygiene: a blank/null-like text is no locator, and
+            // a locator without a positive 1-based line can't anchor the
+            // sidecar's text search. Keep the pair consistent (text ⇔ line).
+            normalize_optional_string(&mut op.payload_expression_text);
+            if op
+                .payload_expression_line
+                .is_some_and(|line| line <= 0)
+            {
+                op.payload_expression_line = None;
+            }
+            if op.payload_expression_text.is_none() {
+                op.payload_expression_line = None;
+            }
             true
         });
 
@@ -970,7 +994,7 @@ primary_type_symbol, type_import_source
   - For payload_expression_text: copy the EXACT payload argument text if detected; emit null when the call sends no payload
   - For payload_expression_line: read the line number from the prefix; null whenever payload_expression_text is null
 
-For each pubsub_operation, include: topic, role, line_number, primary_type_symbol, type_import_source, broker
+For each pubsub_operation, include: topic, role, line_number, primary_type_symbol, type_import_source, broker, payload_expression_text, payload_expression_line
   - topic: the literal topic/channel/subject string (resolve a named const like TOPIC to its string literal)
   - role: "publisher" if the code SENDS a payload to a topic, "subscriber" if it REGISTERS a handler for a topic
   - line_number: read the line number from the prefix in the source code
@@ -1458,6 +1482,8 @@ mod tests {
             primary_type_symbol: None,
             type_import_source: None,
             broker: None,
+            payload_expression_text: None,
+            payload_expression_line: None,
         };
 
         let mut result = FileAnalysisResult {

--- a/src/agents/file_analyzer_agent.rs
+++ b/src/agents/file_analyzer_agent.rs
@@ -742,9 +742,15 @@ impl FileAnalyzerAgent {
                 op.primary_type_symbol = None;
             }
             normalize_optional_string(&mut op.broker);
-            // Payload locator hygiene: a blank/null-like text is no locator, and
-            // a locator without a positive 1-based line can't anchor the
-            // sidecar's text search. Keep the pair consistent (text ⇔ line).
+            // Payload locator hygiene: a blank/null-like text is no locator,
+            // and a non-positive line is not a valid 1-based anchor. The line
+            // is a PRECISION aid, not a prerequisite — the sidecar's text
+            // search runs file-wide without one — so a valid text with a
+            // missing/invalid line is kept, and the infer collector
+            // (`collect_pubsub_infer_requests`) anchors the search to the
+            // operation's own line instead (the payload expression starts at
+            // the publish call; the handler starts at the subscribe call). A
+            // line WITHOUT a text is meaningless, so that direction nulls.
             normalize_optional_string(&mut op.payload_expression_text);
             // The model frequently copies a subscriber handler's payload
             // parameter WITH its arrow-parameter-list parens (`(decision)`,

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1787,7 +1787,15 @@ impl FileOrchestrator {
                         span_start: None,
                         span_end: None,
                         expression_text: Some(text.clone()),
-                        expression_line,
+                        // Anchor the text search even when the model omitted the
+                        // expression's own line: the payload is an argument of
+                        // the publish call at the op's line, so it STARTS within
+                        // the sidecar's +/-5-line window of it. An unanchored
+                        // search scans the whole file and, for identical text at
+                        // multiple sites, has no proximity tie-break — a wrong
+                        // occurrence resolves a confidently wrong type, whereas
+                        // an anchored miss degrades to Unknown (recoverable).
+                        expression_line: expression_line.or(Some(line)),
                         infer_kind: InferKind::Expression,
                         alias: Some(alias),
                         param_name: None,

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1733,6 +1733,25 @@ impl FileOrchestrator {
                 let Some(text) = op.payload_expression_text.as_ref() else {
                     continue;
                 };
+                // Envelope guard (measured 10/20 on the wrapper-dispatch harness
+                // fixture): the model sometimes copies the whole options/envelope
+                // object or call instead of the payload value. When the locator
+                // text contains the op's own extracted topic literal, it
+                // demonstrably includes the ROUTING key — that text is the
+                // envelope or the call, never the decoded payload. Resolving it
+                // would put the envelope's type on the manifest and feed false
+                // compat verdicts; dropping it keeps the op Unknown, which is
+                // recoverable. Structural on purpose: keyed on this op's topic
+                // string alone, no property-name or library conventions.
+                if text.contains(op.topic.as_str()) {
+                    debug!(
+                        topic = %op.topic,
+                        file = %path,
+                        "pub/sub payload locator contains the topic literal; \
+                         treating as envelope copy and leaving the op unanchored"
+                    );
+                    continue;
+                }
                 let line = u32::try_from(op.line_number).unwrap_or(0).max(1);
                 let key = OperationKey::pubsub(op.topic.clone());
                 let alias = match role {

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1664,6 +1664,144 @@ impl FileOrchestrator {
         requests
     }
 
+    /// Build `InferRequestItem`s for pub/sub payloads whose type is NOT a bare
+    /// named symbol — the wrapper patterns where the payload type lives in a
+    /// generic binding (a topic→payload type map on a bus, a schema catalog's
+    /// `infer`, a handle factory's declaration-site type argument) and is
+    /// therefore invisible to the `primary_type_symbol` bundle path.
+    ///
+    /// Sibling of `collect_pubsub_type_requests`, mirroring the division the
+    /// HTTP family already uses: the LLM supplies a LOCATOR
+    /// (`payload_expression_text` + `payload_expression_line`), and the
+    /// sidecar's location-based inference resolves the type deterministically
+    /// with tsc — which has already instantiated the wrapper's generics at the
+    /// site. No library or method-name matching is involved anywhere.
+    ///
+    /// Routing is by role, not by syntax: a publisher's locator is a value
+    /// EXPRESSION (the payload argument / `payload:` property initializer), so
+    /// it takes `InferKind::Expression`; a subscriber's locator is the handler
+    /// parameter or destructured binding holding the payload, so it takes
+    /// `InferKind::FunctionParam` (the sidecar matches the param by name,
+    /// whole binding pattern, or binding element — see `inferFunctionParam`).
+    ///
+    /// Isolation guard (mirrors #268): an op that already carries a
+    /// `primary_type_symbol` bundles through the explicit-symbol path and must
+    /// never get a second, competing anchor here — every existing corpus pub/sub
+    /// fixture keeps its current path untouched.
+    ///
+    /// The alias MUST be byte-identical to the one
+    /// `append_pubsub_manifest_entries` stamped on the manifest entry — same
+    /// key, role, kind, and (for publishers) the same `build_call_site_id` over
+    /// the same raw `file_results` path and >=1-clamped line — or the
+    /// enrich-join silently fails to flip `Unknown` → `Implicit`. Guarded by a
+    /// unit test alongside the symbol-path alias test.
+    pub fn collect_pubsub_infer_requests(
+        &self,
+        file_results: &HashMap<String, FileAnalysisResult>,
+        repo_path: &str,
+    ) -> Vec<InferRequestItem> {
+        use crate::operation::{OperationKey, PubsubRole};
+
+        let repo_root = std::path::Path::new(repo_path);
+        let repo_root_absolute = if repo_root.is_absolute() {
+            repo_root.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(repo_root))
+                .unwrap_or_else(|_| repo_root.to_path_buf())
+                .canonicalize()
+                .unwrap_or_else(|_| repo_root.to_path_buf())
+        };
+
+        let mut requests: Vec<InferRequestItem> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        // Sorted walk for output determinism, same as the symbol collector.
+        let mut paths: Vec<&String> = file_results.keys().collect();
+        paths.sort();
+        for path in paths {
+            let result = &file_results[path];
+            for op in &result.pubsub_operations {
+                let role = match op.role {
+                    Some(PubsubRole::Subscriber) => ManifestRole::Producer,
+                    Some(PubsubRole::Publisher) => ManifestRole::Consumer,
+                    None => continue,
+                };
+                // Isolation guard: a named anchor already owns this op.
+                if op.primary_type_symbol.is_some() {
+                    continue;
+                }
+                let Some(text) = op.payload_expression_text.as_ref() else {
+                    continue;
+                };
+                let line = u32::try_from(op.line_number).unwrap_or(0).max(1);
+                let key = OperationKey::pubsub(op.topic.clone());
+                let alias = match role {
+                    ManifestRole::Consumer => {
+                        let call_id = build_call_site_id(path, line, &key);
+                        build_manifest_type_alias_with_call_id(
+                            &key,
+                            role,
+                            ManifestTypeKind::Response,
+                            Some(&call_id),
+                        )
+                    }
+                    ManifestRole::Producer => {
+                        build_manifest_type_alias(&key, role, ManifestTypeKind::Response)
+                    }
+                };
+                let file_abs = Self::to_absolute_path(path, &repo_root_absolute);
+                // The sidecar's text search anchors on the expression's own
+                // line when the model reported one, falling back to the
+                // operation line.
+                let expression_line = op
+                    .payload_expression_line
+                    .and_then(|l| u32::try_from(l).ok())
+                    .filter(|&l| l > 0);
+                let dedup_key = format!("{}|{}|{}", file_abs, text, alias);
+                if !seen.insert(dedup_key) {
+                    continue;
+                }
+                let request = match role {
+                    ManifestRole::Consumer => InferRequestItem {
+                        file_path: file_abs,
+                        line_number: line,
+                        span_start: None,
+                        span_end: None,
+                        expression_text: Some(text.clone()),
+                        expression_line,
+                        infer_kind: InferKind::Expression,
+                        alias: Some(alias),
+                        param_name: None,
+                    },
+                    ManifestRole::Producer => InferRequestItem {
+                        // Anchor the containing-function search on the payload
+                        // binding's own line when present (the handler may start
+                        // lines away from the subscribe call the op is keyed on).
+                        file_path: file_abs,
+                        line_number: expression_line.unwrap_or(line),
+                        span_start: None,
+                        span_end: None,
+                        // No expression_text: `resolveContainingFunction` treats
+                        // a failed text match as terminal, while the line-only
+                        // fallback tolerates ±2 lines — strictly more robust for
+                        // a locator that names a binding, not an expression.
+                        expression_text: None,
+                        expression_line: None,
+                        infer_kind: InferKind::FunctionParam,
+                        alias: Some(alias),
+                        param_name: Some(text.clone()),
+                    },
+                };
+                requests.push(request);
+            }
+        }
+        debug!(
+            "[FileOrchestrator] Collected {} pub/sub payload infer requests",
+            requests.len()
+        );
+        requests
+    }
+
     /// Build `SymbolRequest`s for GraphQL consumer result-type anchors (#248
     /// consumer side).
     ///
@@ -4947,6 +5085,8 @@ mod tests {
                     primary_type_symbol: Some("OrderPlacedEvent".to_string()),
                     type_import_source: Some("../types/events.ts".to_string()),
                     broker: None,
+                    payload_expression_text: None,
+                    payload_expression_line: None,
                 },
                 // (b) scoped-package source (no extension) -> untouched (canary safety).
                 PubsubOperation {
@@ -4956,6 +5096,8 @@ mod tests {
                     primary_type_symbol: Some("InternalAccount".to_string()),
                     type_import_source: Some("@metamask/keyring-internal-api".to_string()),
                     broker: None,
+                    payload_expression_text: None,
+                    payload_expression_line: None,
                 },
                 // (c) `.ts` whose stripped form is NOT in the import table -> left as-is
                 //     (we normalize only against evidence, never guess).
@@ -4966,6 +5108,8 @@ mod tests {
                     primary_type_symbol: Some("OrderPlacedEvent".to_string()),
                     type_import_source: Some("../wrong/path.ts".to_string()),
                     broker: None,
+                    payload_expression_text: None,
+                    payload_expression_line: None,
                 },
             ],
         };
@@ -5642,6 +5786,8 @@ export { routes };
             primary_type_symbol: Some(symbol.to_string()),
             type_import_source: None,
             broker: None,
+            payload_expression_text: None,
+            payload_expression_line: None,
         };
 
         // Three files, each contributing a typed op. The HashMap insertion order

--- a/src/agents/schemas.rs
+++ b/src/agents/schemas.rs
@@ -491,9 +491,19 @@ impl AgentSchemas {
                                 "type": "STRING",
                                 "nullable": true,
                                 "description": "Diagnostic only: the pub/sub library or transport the call uses if evident (e.g., 'redis'), or null. Not part of the operation's identity."
+                            },
+                            "payload_expression_text": {
+                                "type": "STRING",
+                                "nullable": true,
+                                "description": "Verbatim code text of the value that holds the DECODED payload at this operation, copied EXACTLY as it appears in the source code. For a `publisher`: the payload expression handed to the publish/send/enqueue call (e.g., 'event', '{ userId, plan }', or the initializer of a `payload:` property). For a `subscriber`: the handler parameter or destructured binding that holds the decoded payload (e.g., 'message', 'payload', '{ time, run }'). Emit this even when `primary_type_symbol` is null — it is how inline or generically-typed payloads get resolved. Null only when the operation carries no payload value."
+                            },
+                            "payload_expression_line": {
+                                "type": "INTEGER",
+                                "nullable": true,
+                                "description": "Line number where the payload expression starts (read from the line-number prefix in the source code). Null whenever `payload_expression_text` is null."
                             }
                         },
-                        "required": ["topic", "role", "line_number"]
+                        "required": ["topic", "role", "line_number", "payload_expression_text", "payload_expression_line"]
                     }
                 },
                 "graphql_consumer_locates": {
@@ -907,15 +917,29 @@ mod tests {
 
         assert_eq!(schema_values, serde_values);
 
-        // The three locating fields are always present; the type slots and the
-        // diagnostic broker stay optional/nullable.
+        // The locating fields are always present (required-but-nullable for the
+        // payload locator pair, same lever as data_calls: omission starves the
+        // sidecar); the type-judgment slots and the diagnostic broker stay
+        // optional/nullable.
         let required = schema["properties"]["pubsub_operations"]["items"]["required"]
             .as_array()
             .expect("pubsub_operations item required array must exist");
-        for field in ["topic", "role", "line_number"] {
+        for field in [
+            "topic",
+            "role",
+            "line_number",
+            "payload_expression_text",
+            "payload_expression_line",
+        ] {
             assert!(
                 required.iter().any(|v| v == field),
                 "pubsub_operations item required must contain {field}"
+            );
+        }
+        for field in ["primary_type_symbol", "type_import_source", "broker"] {
+            assert!(
+                !required.iter().any(|v| v == field),
+                "judgment/diagnostic field {field} must NOT be required on pubsub_operations"
             );
         }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1188,8 +1188,14 @@ async fn analyze_current_repo_incremental(
             // GraphQL producers take the infer path, not the bundle path: their
             // response contract is the resolver's expanded RETURN type, so they
             // become `FunctionReturn` infer requests (Stage B1).
-            let graphql_producer_infer = file_orchestrator
+            let mut protocol_infer = file_orchestrator
                 .collect_graphql_producer_infer_requests(&protocol_extractions.graphql, repo_path);
+            // Pub/sub payloads with no named symbol (wrapper patterns:
+            // topic-map emitters, schema-catalog workers, generic channel
+            // handles) resolve via the LLM-located payload expression through
+            // the same infer path.
+            protocol_infer
+                .extend(file_orchestrator.collect_pubsub_infer_requests(&merged_results, repo_path));
 
             // Type resolution via sidecar
             resolve_types_if_available(
@@ -1201,7 +1207,7 @@ async fn analyze_current_repo_incremental(
                 &mount_graph,
                 config,
                 &protocol_requests,
-                &graphql_producer_infer,
+                &protocol_infer,
                 &mut cloud_data,
             );
 
@@ -2966,8 +2972,14 @@ async fn analyze_current_repo(
     // GraphQL producers take the infer path, not the bundle path: their response
     // contract is the resolver's expanded RETURN type, so they become
     // `FunctionReturn` infer requests (Stage B1).
-    let graphql_producer_infer = file_orchestrator
+    let mut protocol_infer = file_orchestrator
         .collect_graphql_producer_infer_requests(&protocol_extractions.graphql, repo_path);
+    // Pub/sub payloads with no named symbol (wrapper patterns: topic-map
+    // emitters, schema-catalog workers, generic channel handles) resolve via
+    // the LLM-located payload expression through the same infer path.
+    protocol_infer.extend(
+        file_orchestrator.collect_pubsub_infer_requests(&analysis_result.file_results, repo_path),
+    );
 
     resolve_types_if_available(
         sidecar,
@@ -2978,7 +2990,7 @@ async fn analyze_current_repo(
         &analysis_result.mount_graph,
         config,
         &protocol_requests,
-        &graphql_producer_infer,
+        &protocol_infer,
         &mut cloud_data,
     );
 
@@ -5595,6 +5607,8 @@ mod tests {
             primary_type_symbol: symbol.map(String::from),
             type_import_source: source.map(String::from),
             broker: Some("redis".to_string()),
+            payload_expression_text: None,
+            payload_expression_line: None,
         }
     }
 
@@ -6258,6 +6272,122 @@ mod tests {
         );
     }
 
+    /// The same fragile alias contract for the pub/sub INFER path (wrapper
+    /// patterns whose payload type is generic-bound, never a named symbol):
+    /// the `InferRequestItem` alias produced by `collect_pubsub_infer_requests`
+    /// MUST byte-match the manifest entry's alias from
+    /// `append_pubsub_manifest_entries` — same plain alias for subscribers
+    /// (producers), same call-site-disambiguated alias for publishers
+    /// (consumers) — or the resolved payload type never joins back and the op
+    /// stays `Unknown`, silently. Also pins the role → InferKind routing and
+    /// the isolation guard (a named anchor suppresses the infer request).
+    #[test]
+    fn pubsub_infer_request_alias_matches_manifest_alias() {
+        use crate::operation::PubsubRole;
+        use crate::services::type_sidecar::InferKind;
+
+        let locator_op = |topic: &str, role: PubsubRole, line: i32, text: &str| {
+            crate::agents::file_analyzer_agent::PubsubOperation {
+                topic: topic.to_string(),
+                role: Some(role),
+                line_number: line,
+                primary_type_symbol: None,
+                type_import_source: None,
+                broker: None,
+                payload_expression_text: Some(text.to_string()),
+                payload_expression_line: Some(line),
+            }
+        };
+
+        let mut file_results: HashMap<String, FileAnalysisResult> = HashMap::new();
+        file_results.insert(
+            "relay/src/relay.ts".to_string(),
+            FileAnalysisResult {
+                pubsub_operations: vec![locator_op(
+                    "itemArchived",
+                    PubsubRole::Subscriber,
+                    13,
+                    "{ time, item }",
+                )],
+                ..Default::default()
+            },
+        );
+        file_results.insert(
+            "dispatch/src/dispatch.ts".to_string(),
+            FileAnalysisResult {
+                pubsub_operations: vec![
+                    locator_op("itemArchived", PubsubRole::Publisher, 9, "event"),
+                    // Named anchor present → the bundle path owns this op; the
+                    // infer collector must emit NOTHING for it.
+                    crate::agents::file_analyzer_agent::PubsubOperation {
+                        topic: "orders.placed".to_string(),
+                        role: Some(PubsubRole::Publisher),
+                        line_number: 30,
+                        primary_type_symbol: Some("OrderPlaced".to_string()),
+                        type_import_source: None,
+                        broker: None,
+                        payload_expression_text: Some("order".to_string()),
+                        payload_expression_line: Some(30),
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+
+        let mut entries = Vec::new();
+        append_pubsub_manifest_entries(
+            &mut entries,
+            &file_results,
+            &crate::socket_io::SocketExtraction::default(),
+        );
+        let manifest_aliases: HashMap<ManifestRole, String> = entries
+            .iter()
+            .filter(|e| e.key.canonical() == "pubsub|itemArchived")
+            .map(|e| (e.role, e.type_alias.clone()))
+            .collect();
+
+        let orchestrator = FileOrchestrator::new(AgentService::new());
+        let requests = orchestrator.collect_pubsub_infer_requests(&file_results, ".");
+
+        // Isolation guard: only the two locator-anchored itemArchived ops
+        // produce requests; the named-anchor op is excluded.
+        assert_eq!(requests.len(), 2, "requests: {requests:?}");
+        assert!(
+            !requests
+                .iter()
+                .any(|r| r.param_name.as_deref() == Some("order")
+                    || r.expression_text.as_deref() == Some("order")),
+            "an op with a primary_type_symbol must not also get an infer request"
+        );
+
+        // Subscriber (producer side): FunctionParam, param_name = locator text,
+        // plain alias byte-matching the manifest.
+        let subscriber = requests
+            .iter()
+            .find(|r| r.infer_kind == InferKind::FunctionParam)
+            .expect("subscriber infer request");
+        assert_eq!(subscriber.param_name.as_deref(), Some("{ time, item }"));
+        assert_eq!(
+            subscriber.alias.as_deref(),
+            manifest_aliases.get(&ManifestRole::Producer).map(|s| s.as_str()),
+            "subscriber infer alias must byte-match the Producer manifest alias"
+        );
+
+        // Publisher (consumer side): Expression, expression_text = locator
+        // text, call-site alias byte-matching the manifest.
+        let publisher = requests
+            .iter()
+            .find(|r| r.infer_kind == InferKind::Expression)
+            .expect("publisher infer request");
+        assert_eq!(publisher.expression_text.as_deref(), Some("event"));
+        assert_eq!(
+            publisher.alias.as_deref(),
+            manifest_aliases.get(&ManifestRole::Consumer).map(|s| s.as_str()),
+            "publisher infer alias must byte-match the Consumer manifest alias \
+             (same build_call_site_id over the same path/line/key)"
+        );
+    }
+
     /// PR-4: a subscriber pub/sub op carrying a decoded-payload
     /// `primary_type_symbol` reaches BOTH `cloud_data.endpoints` (via
     /// `append_pubsub_operations`, PR-3) AND the type manifest as a
@@ -6516,6 +6646,8 @@ mod tests {
                         primary_type_symbol: Some("Shipment".to_string()),
                         type_import_source: None,
                         broker: None,
+                        payload_expression_text: None,
+                        payload_expression_line: None,
                     },
                 ],
                 ..Default::default()

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1194,8 +1194,9 @@ async fn analyze_current_repo_incremental(
             // topic-map emitters, schema-catalog workers, generic channel
             // handles) resolve via the LLM-located payload expression through
             // the same infer path.
-            protocol_infer
-                .extend(file_orchestrator.collect_pubsub_infer_requests(&merged_results, repo_path));
+            protocol_infer.extend(
+                file_orchestrator.collect_pubsub_infer_requests(&merged_results, repo_path),
+            );
 
             // Type resolution via sidecar
             resolve_types_if_available(
@@ -6389,7 +6390,9 @@ mod tests {
         assert_eq!(subscriber.param_name.as_deref(), Some("{ time, item }"));
         assert_eq!(
             subscriber.alias.as_deref(),
-            manifest_aliases.get(&ManifestRole::Producer).map(|s| s.as_str()),
+            manifest_aliases
+                .get(&ManifestRole::Producer)
+                .map(|s| s.as_str()),
             "subscriber infer alias must byte-match the Producer manifest alias"
         );
 
@@ -6402,7 +6405,9 @@ mod tests {
         assert_eq!(publisher.expression_text.as_deref(), Some("event"));
         assert_eq!(
             publisher.alias.as_deref(),
-            manifest_aliases.get(&ManifestRole::Consumer).map(|s| s.as_str()),
+            manifest_aliases
+                .get(&ManifestRole::Consumer)
+                .map(|s| s.as_str()),
             "publisher infer alias must byte-match the Consumer manifest alias \
              (same build_call_site_id over the same path/line/key)"
         );

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -6413,6 +6413,49 @@ mod tests {
         );
     }
 
+    /// A publisher locator whose `payload_expression_line` the model omitted
+    /// must still anchor the sidecar's text search: the collector defaults
+    /// `expression_line` to the operation's own line. An unanchored request
+    /// searches the whole file, and identical locator text at another site
+    /// can resolve a confidently wrong type — an anchored miss degrades to
+    /// Unknown instead (see the sidecar's `matchByText` window/proximity
+    /// selection, pinned by `infer-expression-line-anchor.test.ts`).
+    #[test]
+    fn pubsub_publisher_locator_defaults_expression_line_to_op_line() {
+        use crate::operation::PubsubRole;
+        use crate::services::type_sidecar::InferKind;
+
+        let mut file_results: HashMap<String, FileAnalysisResult> = HashMap::new();
+        file_results.insert(
+            "dispatch/src/dispatch.ts".to_string(),
+            FileAnalysisResult {
+                pubsub_operations: vec![crate::agents::file_analyzer_agent::PubsubOperation {
+                    topic: "itemArchived".to_string(),
+                    role: Some(PubsubRole::Publisher),
+                    line_number: 9,
+                    primary_type_symbol: None,
+                    type_import_source: None,
+                    broker: None,
+                    payload_expression_text: Some("event".to_string()),
+                    payload_expression_line: None,
+                }],
+                ..Default::default()
+            },
+        );
+
+        let orchestrator = FileOrchestrator::new(AgentService::new());
+        let requests = orchestrator.collect_pubsub_infer_requests(&file_results, ".");
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
+        assert_eq!(request.infer_kind, InferKind::Expression);
+        assert_eq!(
+            request.expression_line,
+            Some(9),
+            "a missing payload_expression_line must default to the op's line, \
+             not fall through to an unanchored file-wide search"
+        );
+    }
+
     /// PR-4: a subscriber pub/sub op carrying a decoded-payload
     /// `primary_type_symbol` reaches BOTH `cloud_data.endpoints` (via
     /// `append_pubsub_operations`, PR-3) AND the type manifest as a

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -6329,6 +6329,17 @@ mod tests {
                         payload_expression_text: Some("order".to_string()),
                         payload_expression_line: Some(30),
                     },
+                    // Envelope-copy guard: the locator text contains the op's
+                    // own topic literal (the model copied the whole enqueue
+                    // options object), so it must be dropped — an envelope's
+                    // type on the manifest is a false compat verdict waiting
+                    // to happen; Unknown is recoverable.
+                    locator_op(
+                        "records.reindex",
+                        PubsubRole::Publisher,
+                        41,
+                        "{ id, job: \"records.reindex\", payload: { resourceId } }",
+                    ),
                 ],
                 ..Default::default()
             },
@@ -6349,8 +6360,9 @@ mod tests {
         let orchestrator = FileOrchestrator::new(AgentService::new());
         let requests = orchestrator.collect_pubsub_infer_requests(&file_results, ".");
 
-        // Isolation guard: only the two locator-anchored itemArchived ops
-        // produce requests; the named-anchor op is excluded.
+        // Isolation + envelope guards: only the two locator-anchored
+        // itemArchived ops produce requests; the named-anchor op and the
+        // topic-containing envelope copy are both excluded.
         assert_eq!(requests.len(), 2, "requests: {requests:?}");
         assert!(
             !requests
@@ -6358,6 +6370,14 @@ mod tests {
                 .any(|r| r.param_name.as_deref() == Some("order")
                     || r.expression_text.as_deref() == Some("order")),
             "an op with a primary_type_symbol must not also get an infer request"
+        );
+        assert!(
+            !requests.iter().any(|r| r
+                .expression_text
+                .as_deref()
+                .is_some_and(|t| t.contains("records.reindex"))),
+            "a locator containing the op's topic literal is an envelope copy \
+             and must be dropped, not resolved"
         );
 
         // Subscriber (producer side): FunctionParam, param_name = locator text,

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -28,6 +28,7 @@ import {
   type FunctionExpression,
   type MethodDeclaration,
   type CallExpression,
+  type ParameterDeclaration,
   type PropertyAssignment,
   type Type,
   type Symbol as TsSymbol,
@@ -432,26 +433,80 @@ export class TypeInferrer {
       return null;
     }
 
-    const param = func
-      .getParameters()
-      .find((p) => p.getName() === request.param_name);
+    const target = this.resolveParamTarget(func, request.param_name);
 
-    if (!param) {
+    if (!target) {
       this.log(
         `Parameter "${request.param_name}" not found at ${request.file_path}:${request.line_number}`
       );
       return null;
     }
 
-    const isExplicit = param.getTypeNode() !== undefined;
-    const typeString = typeText(param.getType(), param);
+    const isExplicit = target.param.getTypeNode() !== undefined;
+    const typeString = typeText(target.node.getType(), target.node);
 
     return this.createInferredType(
       request,
       typeString,
       isExplicit,
-      this.getNodeLocation(param)
+      this.getNodeLocation(target.node)
     );
+  }
+
+  /**
+   * Resolve a `function_param` locator against a function's parameter list.
+   * Three shapes, tried in order:
+   *
+   * 1. A parameter whose name matches exactly (`(payload) => …` ← "payload").
+   * 2. A parameter whose DESTRUCTURED BINDING PATTERN matches the locator
+   *    text under whitespace normalization (`({ time, run }) => …` ←
+   *    "{ time, run }") — the handler destructures the payload itself, so the
+   *    pattern's own type IS the payload type.
+   * 3. A named BINDING ELEMENT inside a destructured parameter
+   *    (`({ payload }) => …` ← "payload") — the payload is one property of an
+   *    envelope param, and the checker projects the element's type
+   *    (catalog-worker handlers: `params: { id, payload: Infer<…> }`).
+   *
+   * All three read the type off a node the checker has already instantiated,
+   * so generic wrappers (topic-map emitters, schema catalogs, channel handles)
+   * resolve without any named payload symbol existing anywhere.
+   */
+  private resolveParamTarget(
+    func: FunctionLike,
+    paramName: string
+  ): { param: ParameterDeclaration; node: Node } | undefined {
+    const params = func.getParameters();
+
+    // 1. Exact parameter name.
+    const byName = params.find((p) => p.getName() === paramName);
+    if (byName) {
+      return { param: byName, node: byName };
+    }
+
+    // 2. Whole binding pattern, whitespace-normalized.
+    const normalizedTarget = this.normalizeWhitespace(paramName);
+    for (const param of params) {
+      const nameNode = param.getNameNode();
+      if (
+        (Node.isObjectBindingPattern(nameNode) || Node.isArrayBindingPattern(nameNode)) &&
+        this.normalizeWhitespace(nameNode.getText()) === normalizedTarget
+      ) {
+        return { param, node: param };
+      }
+    }
+
+    // 3. Binding element inside a destructured parameter.
+    for (const param of params) {
+      const nameNode = param.getNameNode();
+      if (!Node.isObjectBindingPattern(nameNode)) continue;
+      for (const element of nameNode.getElements()) {
+        if (element.getName() === paramName) {
+          return { param, node: element };
+        }
+      }
+    }
+
+    return undefined;
   }
 
   private inferResponseBody(

--- a/src/sidecar/test/fixtures/sample-repo/src/pubsub-handlers.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/pubsub-handlers.ts
@@ -1,0 +1,48 @@
+// function_param locator shapes for pub/sub wrapper subscribers: the payload
+// type is carried by a generic binding (topic map / schema catalog / handle
+// factory), never a named annotation at the handler. Self-contained on
+// purpose — the wrapper is structural, not any library.
+
+type BusEvents = {
+  itemArchived: [
+    {
+      time: Date;
+      item: { id: string; status: string };
+    },
+  ];
+};
+
+interface TopicBus<Events extends Record<string, [unknown]>> {
+  on<K extends keyof Events>(
+    topic: K,
+    handler: (...payload: Events[K]) => void
+  ): void;
+}
+
+declare const bus: TopicBus<BusEvents>;
+
+export function watchArchives(): void {
+  // Whole destructured binding pattern: the param IS the payload.
+  bus.on("itemArchived", ({ time, item }) => {
+    console.log(time.toISOString(), item.id);
+  });
+}
+
+interface JobEnvelope<T> {
+  id: string;
+  payload: T;
+}
+
+interface JobRunner<T> {
+  register(handler: (params: JobEnvelope<T>) => Promise<void>): void;
+}
+
+declare const reindexRunner: JobRunner<{ resourceId: string; mode: "full" | "partial" }>;
+
+export function registerReindex(): void {
+  // Envelope param: the payload is ONE binding element of the destructured
+  // param — the locator names the element, and the checker projects its type.
+  reindexRunner.register(async ({ payload }) => {
+    console.log(payload.resourceId, payload.mode);
+  });
+}

--- a/src/sidecar/test/fixtures/sample-repo/src/pubsub-handlers.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/pubsub-handlers.ts
@@ -46,3 +46,30 @@ export function registerReindex(): void {
     console.log(payload.resourceId, payload.mode);
   });
 }
+
+// ---------------------------------------------------------------------------
+// Multi-occurrence disambiguation: the SAME locator text (`payloadValue`)
+// appears at two publish sites with different types. A line-anchored
+// expression search must resolve each site's own type; an unanchored search
+// has no proximity signal and can bind the wrong occurrence.
+// ---------------------------------------------------------------------------
+
+declare function send(topic: string, payload: unknown): boolean;
+
+export function publishFirst(): void {
+  const payloadValue = { kind: "first", n: 1 };
+  void send("first.topic", payloadValue);
+}
+
+// Spacer comments keep the two occurrences farther apart than the text
+// search's +/-5-line window, so each anchored request can only see its own
+// site's occurrences.
+//
+//
+//
+//
+
+export function publishSecond(): void {
+  const payloadValue = { kind: "second", s: "x" };
+  void send("second.topic", payloadValue);
+}

--- a/src/sidecar/test/infer-expression-line-anchor.test.ts
+++ b/src/sidecar/test/infer-expression-line-anchor.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Line-anchored expression resolution for pub/sub payload locators: the SAME
+ * locator text (`payloadValue`) occurs at two publish sites with different
+ * types (pubsub-handlers.ts lines 61 and 74, > the search window apart). The
+ * pub/sub infer collector always supplies an `expression_line` — the model's
+ * own line when reported, otherwise the operation's line — precisely so this
+ * search stays anchored: each request must resolve its OWN site's type. This
+ * pins the sidecar half of that contract.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const FIXTURE = path.join(FIXTURES_PATH, 'src/pubsub-handlers.ts');
+const noWs = (s: string) => s.replace(/\s/g, '');
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{ type_string: string; alias: string }>;
+  errors?: string[];
+}
+
+describe('expression infer resolves the line-anchored occurrence', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'ela-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('same text, two sites: each anchored request gets its own type', async () => {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'ela-1',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: 61,
+          expression_text: 'payloadValue',
+          expression_line: 61,
+          infer_kind: 'expression',
+          alias: 'ELA_First',
+        },
+        {
+          file_path: FIXTURE,
+          line_number: 74,
+          expression_text: 'payloadValue',
+          expression_line: 74,
+          infer_kind: 'expression',
+          alias: 'ELA_Second',
+        },
+      ],
+    });
+
+    const byAlias = new Map(
+      (response.inferred_types ?? []).map((t) => [t.alias, noWs(t.type_string)])
+    );
+    const first = byAlias.get('ELA_First');
+    const second = byAlias.get('ELA_Second');
+    assert.ok(first, 'first site should infer');
+    assert.ok(second, 'second site should infer');
+    assert.ok(
+      first!.includes('n:number') && !first!.includes('s:string'),
+      `first site must carry its own shape, got ${first}`
+    );
+    assert.ok(
+      second!.includes('s:string') && !second!.includes('n:number'),
+      `second site must carry its own shape, got ${second}`
+    );
+  });
+});

--- a/src/sidecar/test/infer-function-param-binding.test.ts
+++ b/src/sidecar/test/infer-function-param-binding.test.ts
@@ -1,0 +1,126 @@
+/**
+ * `function_param` locator resolution against destructured handler
+ * parameters (the pub/sub wrapper-subscriber shapes):
+ *
+ * 1. whole binding pattern (`{ time, item }`) — the handler destructures the
+ *    payload itself, so the pattern's type IS the payload type;
+ * 2. binding element (`payload`) inside an envelope param — the checker
+ *    projects the element's type out of the generic envelope.
+ *
+ * Both read types the checker has already instantiated from the wrapper's
+ * generics; no named payload symbol exists anywhere in the fixture.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const FIXTURE = path.join(FIXTURES_PATH, 'src/pubsub-handlers.ts');
+const noWs = (s: string) => s.replace(/\s/g, '');
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    type_string: string;
+    is_explicit: boolean;
+    infer_kind: string;
+    alias: string;
+  }>;
+  errors?: string[];
+}
+
+describe('function_param resolves destructured pub/sub handler payloads', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'fpb-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('matches a whole binding pattern and returns the payload type', async () => {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'fpb-1',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: 26,
+          infer_kind: 'function_param',
+          param_name: '{ time, item }',
+          alias: 'FPB_WholePattern',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.[0];
+    assert.ok(inferred, 'whole-pattern param should infer');
+    assert.strictEqual(inferred!.is_explicit, false);
+    const t = noWs(inferred!.type_string);
+    assert.ok(t.includes('time:Date'), `missing time member: ${inferred!.type_string}`);
+    assert.ok(
+      t.includes('id:string') && t.includes('status:string'),
+      `missing item members: ${inferred!.type_string}`
+    );
+  });
+
+  it('projects a named binding element out of an envelope param', async () => {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'fpb-2',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: 45,
+          infer_kind: 'function_param',
+          param_name: 'payload',
+          alias: 'FPB_BindingElement',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.[0];
+    assert.ok(inferred, 'binding-element locator should infer');
+    const t = noWs(inferred!.type_string);
+    assert.ok(
+      t.includes('resourceId:string'),
+      `missing resourceId: ${inferred!.type_string}`
+    );
+    assert.ok(
+      t.includes('"full"|"partial"'),
+      `missing mode union: ${inferred!.type_string}`
+    );
+    assert.ok(
+      !t.includes('id:string;payload'),
+      `must project the element, not the whole envelope: ${inferred!.type_string}`
+    );
+  });
+
+  it('still fails cleanly for a name that matches nothing', async () => {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'fpb-3',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: 26,
+          infer_kind: 'function_param',
+          param_name: 'nonexistent',
+          alias: 'FPB_Missing',
+        },
+      ],
+    });
+
+    assert.strictEqual(response.inferred_types?.length ?? 0, 0);
+  });
+});

--- a/tests/fixtures/pubsub-wrapper-monorepo/README.md
+++ b/tests/fixtures/pubsub-wrapper-monorepo/README.md
@@ -1,0 +1,34 @@
+# pubsub-wrapper-monorepo — generic wrapper-pattern pub/sub fixture
+
+An owned, dependency-free monorepo fixture for the pub/sub expression-locator
+path: three wrapper shapes whose payload types are **never a bare named symbol
+at any publish/subscribe site** — the type is carried by a generic binding in
+the shared `@fixture/contracts` workspace package:
+
+1. **Topic-map bus** (`TopicBus<Events>`): a typed event emitter over a
+   topic → payload-tuple map. Publisher emits an inline object literal;
+   subscriber destructures an unannotated handler param.
+2. **Schema-catalog worker** (`QueueWorker<Catalog>`): payload types derived
+   from value-level schemas via mapped/conditional types (`InferSchema`), the
+   way schema libraries do. Publisher's payload is a `payload:` property
+   initializer; subscriber's is a binding element inside the job envelope.
+3. **Channel-handle factory** (`channel<T>({ id })`): the payload type is a
+   declaration-site type argument; the pub/sub sites carry nothing.
+
+`carrick.json` splits the repo into two services (`dispatch` = publishers,
+`relay` = subscribers) so the topics form real cross-service edges rather than
+intra-repo self-loops (which the projection deliberately drops).
+
+The `__llm__/` cassettes replay the file-analyzer output offline, including
+the `payload_expression_text` / `payload_expression_line` locator fields; the
+sidecar resolves them deterministically with tsc (`expression` infer for
+publishers, `function_param` for subscribers). Driven by
+`tests/pubsub_wrapper_type_capture_test.rs`.
+
+Pre-fix baseline (why this fixture exists): all six ops extracted and matched,
+but `type_state=Unknown` on both sides of every edge — the named-symbol anchor
+(`primary_type_symbol`) is structurally unable to capture generically-bound
+payloads, and the schema correctly instructs null for them.
+
+Cassette line numbers reference exact source lines in `services/*/src/*.ts`;
+re-count them after any edit to those files.

--- a/tests/fixtures/pubsub-wrapper-monorepo/__llm__/analyze-file/dispatch.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/__llm__/analyze-file/dispatch.json
@@ -1,0 +1,37 @@
+{
+  "mounts": [],
+  "endpoints": [],
+  "data_calls": [],
+  "pubsub_operations": [
+    {
+      "topic": "itemArchived",
+      "role": "publisher",
+      "line_number": 9,
+      "primary_type_symbol": null,
+      "type_import_source": null,
+      "broker": null,
+      "payload_expression_text": "{ time: new Date(), item: { id: itemId, status: \"archived\", error: null } }",
+      "payload_expression_line": 9
+    },
+    {
+      "topic": "records.reindex",
+      "role": "publisher",
+      "line_number": 18,
+      "primary_type_symbol": null,
+      "type_import_source": null,
+      "broker": null,
+      "payload_expression_text": "{ resourceId, mode: \"full\" }",
+      "payload_expression_line": 21
+    },
+    {
+      "topic": "approval",
+      "role": "publisher",
+      "line_number": 33,
+      "primary_type_symbol": null,
+      "type_import_source": null,
+      "broker": null,
+      "payload_expression_text": "decision",
+      "payload_expression_line": 33
+    }
+  ]
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/__llm__/analyze-file/index.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/__llm__/analyze-file/index.json
@@ -1,0 +1,6 @@
+{
+  "mounts": [],
+  "endpoints": [],
+  "data_calls": [],
+  "pubsub_operations": []
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/__llm__/analyze-file/relay.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/__llm__/analyze-file/relay.json
@@ -1,0 +1,37 @@
+{
+  "mounts": [],
+  "endpoints": [],
+  "data_calls": [],
+  "pubsub_operations": [
+    {
+      "topic": "itemArchived",
+      "role": "subscriber",
+      "line_number": 13,
+      "primary_type_symbol": null,
+      "type_import_source": null,
+      "broker": null,
+      "payload_expression_text": "{ time, item }",
+      "payload_expression_line": 13
+    },
+    {
+      "topic": "records.reindex",
+      "role": "subscriber",
+      "line_number": 23,
+      "primary_type_symbol": null,
+      "type_import_source": null,
+      "broker": null,
+      "payload_expression_text": "payload",
+      "payload_expression_line": 23
+    },
+    {
+      "topic": "approval",
+      "role": "subscriber",
+      "line_number": 36,
+      "primary_type_symbol": null,
+      "type_import_source": null,
+      "broker": null,
+      "payload_expression_text": "decision",
+      "payload_expression_line": 36
+    }
+  ]
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/__llm__/framework-detect/framework-detect.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/__llm__/framework-detect/framework-detect.json
@@ -1,0 +1,6 @@
+{
+  "frameworks": [],
+  "data_fetchers": [],
+  "messaging_clients": ["@fixture/contracts", "@fixture/relay"],
+  "notes": "Monorepo with an in-house typed messaging layer in the contracts workspace package."
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/carrick.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/carrick.json
@@ -1,0 +1,6 @@
+{
+  "services": [
+    { "name": "dispatch", "directory": "services/dispatch" },
+    { "name": "relay", "directory": "services/relay" }
+  ]
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/package.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pubsub-wrapper-monorepo",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "workspaces": ["packages/*", "services/*"]
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/packages/contracts/package.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/packages/contracts/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/contracts",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/packages/contracts/src/index.ts
+++ b/tests/fixtures/pubsub-wrapper-monorepo/packages/contracts/src/index.ts
@@ -1,0 +1,151 @@
+// Shared messaging contracts for the wrapper-pattern monorepo fixture.
+//
+// Three wrapper shapes whose payload types are never a bare named symbol at
+// any publish/subscribe call site — the type is carried by a generic binding
+// established here:
+//   1. TopicBus<Events>: a typed event-emitter over a topic -> payload-tuple map
+//   2. QueueWorker<Catalog>: a job worker generic over a catalog of schemas,
+//      payload types derived via conditional/mapped types (InferSchema)
+//   3. channel<T>(): a handle factory whose payload type is a type argument at
+//      the declaration site only
+//
+// All code is fixture-owned and dependency-free on purpose: the pattern is
+// structural, not any particular library.
+
+// ---------------------------------------------------------------------------
+// Shape 1: typed event bus over a topic map
+// ---------------------------------------------------------------------------
+
+export interface TopicBus<Events extends Record<string, [unknown]>> {
+  emit<K extends keyof Events>(topic: K, ...payload: Events[K]): boolean;
+  on<K extends keyof Events>(
+    topic: K,
+    handler: (...payload: Events[K]) => void
+  ): this;
+}
+
+export function createBus<
+  Events extends Record<string, [unknown]>,
+>(): TopicBus<Events> {
+  const handlers = new Map<keyof Events, Array<(...args: never[]) => void>>();
+  return {
+    emit(topic, ...payload) {
+      const list = handlers.get(topic) ?? [];
+      for (const handler of list) {
+        (handler as (...args: unknown[]) => void)(...payload);
+      }
+      return list.length > 0;
+    },
+    on(topic, handler) {
+      const list = handlers.get(topic) ?? [];
+      list.push(handler as unknown as (...args: never[]) => void);
+      handlers.set(topic, list);
+      return this;
+    },
+  };
+}
+
+export type BusEvents = {
+  itemArchived: [
+    {
+      time: Date;
+      item: {
+        id: string;
+        status: string;
+        error: { code: string; message: string } | null;
+      };
+    },
+  ];
+  itemRestored: [{ time: Date; itemId: string }];
+};
+
+export const bus = createBus<BusEvents>();
+
+// ---------------------------------------------------------------------------
+// Shape 2: job worker generic over a schema catalog
+// ---------------------------------------------------------------------------
+
+type Prim = "string" | "number" | "boolean";
+
+type PrimToTs<P> = P extends "string"
+  ? string
+  : P extends "number"
+    ? number
+    : P extends "boolean"
+      ? boolean
+      : P extends readonly (infer L)[]
+        ? L
+        : never;
+
+export interface PayloadSchema<T> {
+  readonly shape: Record<string, unknown>;
+  readonly __out?: T;
+}
+
+/** Derive a payload type from a value-level shape, the way schema libraries do. */
+export function payloadSchema<
+  S extends Record<string, Prim | readonly string[]>,
+>(shape: S): PayloadSchema<{ [K in keyof S]: PrimToTs<S[K]> }> {
+  return { shape };
+}
+
+export type InferSchema<X> = X extends PayloadSchema<infer T> ? T : never;
+
+export type JobCatalog = {
+  [key: string]: { schema: PayloadSchema<unknown> };
+};
+
+export type JobHandler<C extends JobCatalog, K extends keyof C> = (params: {
+  id: string;
+  payload: InferSchema<C[K]["schema"]>;
+}) => Promise<void>;
+
+export class QueueWorker<C extends JobCatalog> {
+  constructor(
+    private readonly opts: {
+      catalog: C;
+      jobs: { [K in keyof C]: JobHandler<C, K> };
+    }
+  ) {}
+
+  async enqueue<K extends keyof C>(args: {
+    id: string;
+    job: K;
+    payload: InferSchema<C[K]["schema"]>;
+  }): Promise<void> {
+    await this.opts.jobs[args.job]({ id: args.id, payload: args.payload });
+  }
+}
+
+export const jobCatalog = {
+  "records.reindex": {
+    schema: payloadSchema({
+      resourceId: "string",
+      mode: ["full", "partial"],
+    } as const),
+  },
+} satisfies JobCatalog;
+
+// ---------------------------------------------------------------------------
+// Shape 3: generic channel-handle factory
+// ---------------------------------------------------------------------------
+
+export interface ChannelHandle<T> {
+  send(target: string, data: T): Promise<void>;
+  on(cb: (data: T) => void): void;
+}
+
+export function channel<T>(opts: { id: string }): ChannelHandle<T> {
+  const subscribers: Array<(data: T) => void> = [];
+  void opts;
+  return {
+    async send(_target: string, data: T) {
+      for (const cb of subscribers) {
+        cb(data);
+      }
+    },
+    on(cb: (data: T) => void) {
+      subscribers.push(cb);
+    },
+  };
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/services/dispatch/package.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/services/dispatch/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/dispatch",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/dispatch.ts"
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/services/dispatch/src/dispatch.ts
+++ b/tests/fixtures/pubsub-wrapper-monorepo/services/dispatch/src/dispatch.ts
@@ -1,0 +1,34 @@
+// Dispatch service: the PUBLISHER side of all three wrapper shapes. Every
+// payload is an inline object literal, a property initializer, or a local
+// variable — never a value with a named payload type.
+import { bus, channel } from "@fixture/contracts";
+import { worker } from "@fixture/relay";
+
+// Shape 1 producer: inline object literal payload on the typed bus.
+export function archiveItem(itemId: string): void {
+  bus.emit("itemArchived", {
+    time: new Date(),
+    item: { id: itemId, status: "archived", error: null },
+  });
+}
+
+// Shape 2 producer: the payload property initializer's type is derived from
+// the catalog schema; nothing at this site names it.
+export async function requestReindex(resourceId: string): Promise<void> {
+  await worker.enqueue({
+    id: `reindex-${resourceId}`,
+    job: "records.reindex",
+    payload: { resourceId, mode: "full" },
+  });
+}
+
+// Shape 3 producer: this service declares its own handle for the shared
+// channel id and sends a locally-typed value.
+const approvals = channel<{ approved: boolean; reviewer: string }>({
+  id: "approval",
+});
+
+export async function approveRun(runId: string): Promise<void> {
+  const decision = { approved: true, reviewer: "auto-policy" };
+  await approvals.send(runId, decision);
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/services/dispatch/tsconfig.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/services/dispatch/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../.."
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../packages/**/*.ts",
+    "../relay/src/**/*.ts"
+  ]
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/services/relay/package.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/services/relay/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/relay",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/relay.ts"
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/services/relay/src/relay.ts
+++ b/tests/fixtures/pubsub-wrapper-monorepo/services/relay/src/relay.ts
@@ -1,0 +1,39 @@
+// Relay service: the SUBSCRIBER side of all three wrapper shapes. Every
+// handler receives its payload through a generic binding — no payload type is
+// ever written as a named annotation at the subscribe site.
+import {
+  bus,
+  channel,
+  jobCatalog,
+  QueueWorker,
+} from "@fixture/contracts";
+
+// Shape 1 consumer: destructured, unannotated handler param on the typed bus.
+export function watchArchives(): void {
+  bus.on("itemArchived", ({ time, item }) => {
+    console.log(time.toISOString(), item.id, item.status, item.error?.code);
+  });
+}
+
+// Shape 2 consumer: the jobs-map handler destructures the payload out of the
+// worker envelope; its type is InferSchema<catalog["records.reindex"]["schema"]>.
+export const worker = new QueueWorker({
+  catalog: jobCatalog,
+  jobs: {
+    "records.reindex": async ({ payload }) => {
+      console.log(payload.resourceId, payload.mode);
+    },
+  },
+});
+
+// Shape 3 consumer: this service declares its own handle for the shared
+// channel id; the payload type is a declaration-site type argument.
+const approvals = channel<{ approved: boolean; reviewer: string }>({
+  id: "approval",
+});
+
+export function watchApprovals(): void {
+  approvals.on((decision) => {
+    console.log(decision.approved, decision.reviewer);
+  });
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/services/relay/tsconfig.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/services/relay/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../.."
+  },
+  "include": ["src/**/*.ts", "../../packages/**/*.ts"]
+}

--- a/tests/fixtures/pubsub-wrapper-monorepo/tsconfig.json
+++ b/tests/fixtures/pubsub-wrapper-monorepo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@fixture/contracts": ["packages/contracts/src/index.ts"],
+      "@fixture/relay": ["services/relay/src/relay.ts"]
+    }
+  },
+  "include": ["packages/**/*.ts", "services/**/*.ts"]
+}

--- a/tests/pubsub_wrapper_type_capture_test.rs
+++ b/tests/pubsub_wrapper_type_capture_test.rs
@@ -109,9 +109,9 @@ fn find_op<'a>(
         .iter()
         .filter(|op| {
             op["key"].as_str() == Some(key)
-                && op["file"]
-                    .as_str()
-                    .is_some_and(|f| Path::new(f).ends_with(file_suffix) || f.ends_with(file_suffix))
+                && op["file"].as_str().is_some_and(|f| {
+                    Path::new(f).ends_with(file_suffix) || f.ends_with(file_suffix)
+                })
         })
         .collect();
     assert!(
@@ -162,12 +162,22 @@ fn pubsub_wrapper_payloads_resolve_on_both_sides() {
 
     // Shape 2: schema-catalog queue worker (payload via mapped/conditional types).
     assert_resolved(
-        find_op(&projection, "calls", "pubsub|records.reindex", "dispatch.ts"),
+        find_op(
+            &projection,
+            "calls",
+            "pubsub|records.reindex",
+            "dispatch.ts",
+        ),
         "worker.enqueue publisher",
         &["resourceId", "mode"],
     );
     assert_resolved(
-        find_op(&projection, "endpoints", "pubsub|records.reindex", "relay.ts"),
+        find_op(
+            &projection,
+            "endpoints",
+            "pubsub|records.reindex",
+            "relay.ts",
+        ),
         "jobs-map subscriber (envelope binding element)",
         &["resourceId", "mode"],
     );

--- a/tests/pubsub_wrapper_type_capture_test.rs
+++ b/tests/pubsub_wrapper_type_capture_test.rs
@@ -1,0 +1,186 @@
+//! Pub/sub wrapper-pattern type capture (expression-locator path).
+//!
+//! Drives the real scanner binary — offline, cassette-mocked LLM, real
+//! sidecar — over `tests/fixtures/pubsub-wrapper-monorepo/`, a monorepo whose
+//! messaging layer is built from three generic wrapper shapes:
+//!
+//! 1. a typed event bus parameterised by a topic → payload-tuple map,
+//! 2. a queue worker generic over a schema catalog (payload types derived via
+//!    mapped/conditional types),
+//! 3. a channel-handle factory whose payload type is a declaration-site type
+//!    argument.
+//!
+//! In all three, the payload type is never a bare named symbol at any
+//! publish/subscribe site, so the `primary_type_symbol` anchor channel cannot
+//! capture it (the schema correctly instructs null for inline payloads). The
+//! cassettes instead carry the `payload_expression_text`/`payload_expression_line`
+//! LOCATOR fields, and the scanner routes them through the sidecar's
+//! location-based inference (`expression` for publishers, `function_param`
+//! for subscribers) — the same LLM-locator + deterministic-tsc division the
+//! HTTP family uses.
+//!
+//! Pre-fix baseline: every one of the six ops (3 shapes × 2 roles) reported
+//! `type_state: "Unknown"` with no resolved definition. This test asserts the
+//! post-fix state (`Implicit` + a structurally-correct expanded definition),
+//! so it FAILS on the pre-fix scanner by construction.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixture_dir() -> PathBuf {
+    repo_root().join("tests/fixtures/pubsub-wrapper-monorepo")
+}
+
+/// Same ambient-CI stripping as `xrepo_harness_test.rs`: keeps repo identity
+/// tied to the scanned fixture dir and `should_upload_data()` deterministic.
+fn strip_ci_env(cmd: &mut Command) -> &mut Command {
+    for var in [
+        "GITHUB_REPOSITORY",
+        "GITHUB_REF",
+        "GITHUB_EVENT_NAME",
+        "GITHUB_SHA",
+        "GITHUB_RUN_ID",
+        "GITHUB_ACTIONS",
+        "GITHUB_WORKSPACE",
+        "CI",
+        "ACTIONS_ID_TOKEN_REQUEST_URL",
+        "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+    ] {
+        cmd.env_remove(var);
+    }
+    cmd
+}
+
+fn carrick_bin() -> PathBuf {
+    let bin = PathBuf::from(env!("CARGO_BIN_EXE_carrick"));
+    assert!(bin.exists(), "carrick binary not built: {}", bin.display());
+    bin
+}
+
+/// One isolated offline scan of the fixture; returns the parsed projection.
+fn scan_fixture() -> serde_json::Value {
+    let cache = tempfile::tempdir().expect("temp cache dir");
+    let cassettes = fixture_dir().join("__llm__");
+    assert!(cassettes.exists(), "fixture cassette dir missing");
+
+    let mut cmd = Command::new(carrick_bin());
+    cmd.arg(fixture_dir())
+        .env("CARRICK_LOCAL_STORAGE_DIR", cache.path())
+        .env("CARRICK_LOCAL_STORAGE_ISOLATE", "1")
+        .env("CARRICK_MOCK_ALL", "1")
+        .env(
+            "CARRICK_MOCK_FIXTURE_DIR",
+            format!("{}/", cassettes.display()),
+        )
+        .env("CARRICK_OUTPUT_JSON", "1");
+    strip_ci_env(&mut cmd);
+    let output = cmd.output().expect("failed to spawn carrick");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "fixture scan exited non-zero:\n{stderr}"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json_start = stdout
+        .find('{')
+        .unwrap_or_else(|| panic!("no JSON in scanner stdout:\n{stdout}"));
+    serde_json::from_str(&stdout[json_start..])
+        .unwrap_or_else(|e| panic!("projection parse failed: {e}\n{stdout}"))
+}
+
+/// Find the single op for `key` whose `file` ends with `file_suffix`, in the
+/// given projection array (`endpoints` for subscribers, `calls` for
+/// publishers).
+fn find_op<'a>(
+    projection: &'a serde_json::Value,
+    side: &str,
+    key: &str,
+    file_suffix: &str,
+) -> &'a serde_json::Value {
+    let ops = projection[side]
+        .as_array()
+        .unwrap_or_else(|| panic!("projection has no `{side}` array"));
+    let matched: Vec<&serde_json::Value> = ops
+        .iter()
+        .filter(|op| {
+            op["key"].as_str() == Some(key)
+                && op["file"]
+                    .as_str()
+                    .is_some_and(|f| Path::new(f).ends_with(file_suffix) || f.ends_with(file_suffix))
+        })
+        .collect();
+    assert!(
+        !matched.is_empty(),
+        "no `{side}` op with key `{key}` in `{file_suffix}`; keys present: {:?}",
+        ops.iter().map(|o| &o["key"]).collect::<Vec<_>>()
+    );
+    matched[0]
+}
+
+/// Assert an op's payload type resolved through the locator path: state
+/// `Implicit` (location-inferred, not annotated) and an expanded definition
+/// carrying the structural members of the payload.
+fn assert_resolved(op: &serde_json::Value, label: &str, expect_members: &[&str]) {
+    let state = op["type_state"].as_str();
+    assert_eq!(
+        state,
+        Some("Implicit"),
+        "{label}: expected type_state Implicit, got {state:?} (op: {op})"
+    );
+    let expanded = op["expanded_definition"]
+        .as_str()
+        .or_else(|| op["resolved_definition"].as_str())
+        .unwrap_or_else(|| panic!("{label}: no resolved/expanded definition (op: {op})"));
+    for member in expect_members {
+        assert!(
+            expanded.contains(member),
+            "{label}: expanded definition missing `{member}`:\n{expanded}"
+        );
+    }
+}
+
+#[test]
+fn pubsub_wrapper_payloads_resolve_on_both_sides() {
+    let projection = scan_fixture();
+
+    // Shape 1: typed event bus over a topic map.
+    assert_resolved(
+        find_op(&projection, "calls", "pubsub|itemArchived", "dispatch.ts"),
+        "bus.emit publisher",
+        &["time", "item", "status", "error"],
+    );
+    assert_resolved(
+        find_op(&projection, "endpoints", "pubsub|itemArchived", "relay.ts"),
+        "bus.on subscriber",
+        &["time", "item", "status", "error"],
+    );
+
+    // Shape 2: schema-catalog queue worker (payload via mapped/conditional types).
+    assert_resolved(
+        find_op(&projection, "calls", "pubsub|records.reindex", "dispatch.ts"),
+        "worker.enqueue publisher",
+        &["resourceId", "mode"],
+    );
+    assert_resolved(
+        find_op(&projection, "endpoints", "pubsub|records.reindex", "relay.ts"),
+        "jobs-map subscriber (envelope binding element)",
+        &["resourceId", "mode"],
+    );
+
+    // Shape 3: generic channel handle (declaration-site type argument).
+    assert_resolved(
+        find_op(&projection, "calls", "pubsub|approval", "dispatch.ts"),
+        "channel send publisher",
+        &["approved", "reviewer"],
+    );
+    assert_resolved(
+        find_op(&projection, "endpoints", "pubsub|approval", "relay.ts"),
+        "channel on subscriber",
+        &["approved", "reviewer"],
+    );
+}

--- a/tests/pubsub_wrapper_type_capture_test.rs
+++ b/tests/pubsub_wrapper_type_capture_test.rs
@@ -114,9 +114,13 @@ fn find_op<'a>(
                 })
         })
         .collect();
-    assert!(
-        !matched.is_empty(),
-        "no `{side}` op with key `{key}` in `{file_suffix}`; keys present: {:?}",
+    assert_eq!(
+        matched.len(),
+        1,
+        "expected exactly one `{side}` op with key `{key}` in `{file_suffix}` \
+         (multi-site keys would make the assertions nondeterministic); \
+         found {}; keys present: {:?}",
+        matched.len(),
         ops.iter().map(|o| &o["key"]).collect::<Vec<_>>()
     );
     matched[0]


### PR DESCRIPTION
Closes the pub/sub type-capture gap for wrapper patterns whose payload types are carried by a generic binding — typed topic-map emitters, schema-catalog workers, and generic channel/stream handles — where no bare named payload symbol exists anywhere, so the `primary_type_symbol` anchor structurally cannot capture the type and every edge reports `type_state=unknown` on both sides.

## Approach

Same division of labor as the HTTP family: the LLM supplies a LOCATOR (`payload_expression_text` + `payload_expression_line`, required-nullable), and the sidecar resolves it deterministically with tsc, which has already instantiated the wrapper's generics at the site. No library or method-name matching anywhere in the new path.

- **Schema**: two locator fields added to `pubsub_operations` (existing descriptions untouched).
- **Scanner**: `collect_pubsub_infer_requests` — publishers route through `InferKind::Expression`, subscribers through `InferKind::FunctionParam`, gated on `primary_type_symbol.is_none()` (named anchors and all existing corpus fixtures keep the bundle path). Alias byte-identical to `append_pubsub_manifest_entries` so the existing enrich join flips Unknown → Implicit.
- **Sidecar**: `function_param` now resolves destructured handler params — whole binding-pattern match and binding-element projection (the catalog envelope shape).
- **Hardening** (measured pass^20): balanced enclosing parens stripped from locators deterministically; a locator containing the op's own topic literal is treated as an envelope copy and dropped (Unknown is recoverable, a wrong verdict is not).

## Fixture reproduces the generic topic-map / catalog / stream-handle patterns

`tests/fixtures/pubsub-wrapper-monorepo/` — owned, dependency-free two-service monorepo with the contract types in a shared workspace package; driven offline (cassette LLM, real sidecar, real ts_check) by `tests/pubsub_wrapper_type_capture_test.rs`. On the pre-fix scanner the test fails with `type_state=Unknown` on all six ops (3 shapes × 2 roles); with this PR all six resolve Implicit with correct structural payloads. New CI step added (test-suite allowlist).

## Validation

- Full deterministic suite green (cargo test incl. new E2E, clippy clean, sidecar 116 tests, ts_check).
- pass^20 sweep (16 pub/sub-affected harness fixtures): all c2/c3 broker fixtures and all postmessage fixtures 20/20 — no mainstream regression. Known shifts on the in-process messenger family are documented in the harness PR (channel shift with correct locator emitted 20/20; one true recall residual on no-payload template topics).
- Live evals, one run per corpus: c1 **100%**, c2 **99%**, c3 **99%** — type-resolution 1.00 and compat-verdict 1.00 on every corpus; every itemized pub/sub edge resolved with the correct anchor and verdict.

## Known residuals

- Catalog-envelope publishers: the model copies the whole options object ~10/20; the topic-literal guard degrades those to Unknown rather than wrong. Follow-up is schema-side wording (gated behind a sweep) or a corpus-4 pattern.
- Subscriber envelope binding `{ payload }` at pattern- vs element-granularity (~7/20): resolves the envelope type; same follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)