### PR TITLE
fix: backfill payload-less pub/sub ops from deterministic AST anchors

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -2579,12 +2579,16 @@ impl FileOrchestrator {
 
     /// Merge deterministically-anchored pub/sub operations (carrick#387) into a
     /// file's extraction, adding only the ops the LLM pass missed. An anchor is
-    /// considered covered — and skipped — when the extraction already has an op
-    /// at the same line (the LLM extracted this site, possibly with different
-    /// topic text; its judgment wins) or with the same (topic, role) pair (the
-    /// operation is already on the right side of the topic). Backfilled ops are
-    /// payload-less by construction, so every judgment field is `None`: there is
-    /// no type to capture and no locator to emit — pure topic recall.
+    /// considered covered — and skipped — exactly when the extraction already
+    /// carries its contribution: an op with the same (topic, role) pair, at any
+    /// line (the matching join is topic-keyed; one op per side suffices). Line
+    /// numbers deliberately play no part in coverage: a line can carry several
+    /// pub/sub ops, and an extracted op that shares the anchor's line but not
+    /// its topic (e.g. a template the model kept verbatim) does not put the
+    /// resolved topic on the wire — the anchor still must (Copilot review on
+    /// #389). Backfilled ops are payload-less by construction, so every
+    /// judgment field is `None`: there is no type to capture and no locator to
+    /// emit — pure topic recall.
     fn merge_pubsub_anchor_ops(
         result: &mut FileAnalysisResult,
         anchor_ops: Vec<PubsubAnchorOp>,
@@ -2592,9 +2596,10 @@ impl FileOrchestrator {
         let mut added = 0;
         for anchor in anchor_ops {
             let line = i32::try_from(anchor.line_number).unwrap_or(i32::MAX);
-            let covered = result.pubsub_operations.iter().any(|op| {
-                op.line_number == line || (op.topic == anchor.topic && op.role == Some(anchor.role))
-            });
+            let covered = result
+                .pubsub_operations
+                .iter()
+                .any(|op| op.topic == anchor.topic && op.role == Some(anchor.role));
             if covered {
                 continue;
             }
@@ -6309,8 +6314,9 @@ const ESCALATE_MUTATION = gql`
 
     /// carrick#387: a deterministically-anchored payload-less pub/sub op the
     /// LLM extraction missed is backfilled with all judgment fields `None`;
-    /// anchors the extraction already covers (same line, or same topic+role)
-    /// are skipped so the LLM's judgment is never duplicated or overridden.
+    /// an anchor is covered — and skipped — exactly when the extraction
+    /// already carries its (topic, role) contribution. Line numbers play no
+    /// part in coverage: a line is not an operation identity.
     #[test]
     fn merge_pubsub_anchor_ops_backfills_only_missed_ops() {
         use crate::agents::file_analyzer_agent::PubsubOperation;
@@ -6330,23 +6336,24 @@ const ESCALATE_MUTATION = gql`
 
         let mut result = FileAnalysisResult {
             pubsub_operations: vec![
-                // Covers anchor (a) by exact line — even though the LLM's topic
-                // text differs (kept the template verbatim), its judgment wins.
-                llm_op("${name}:pollingStarted", 182),
-                // Covers anchor (b) by topic+role at a different line.
+                // Covers anchor (a): identical (topic, role) at the same site.
+                llm_op("PollController:pollingStarted", 182),
+                // Covers anchor (b) by (topic, role) at a different line — the
+                // topic is already on the publisher side, one op per side is
+                // all the matching join needs.
                 llm_op("PollController:stateChange", 90),
             ],
             ..Default::default()
         };
 
         let anchors = vec![
-            // (a) same line as an extracted op -> skipped.
+            // (a) same (topic, role) as an extracted op -> skipped.
             PubsubAnchorOp {
                 topic: "PollController:pollingStarted".to_string(),
                 role: PubsubRole::Publisher,
                 line_number: 182,
             },
-            // (b) same topic+role as an extracted op -> skipped.
+            // (b) same (topic, role) as an extracted op at another line -> skipped.
             PubsubAnchorOp {
                 topic: "PollController:stateChange".to_string(),
                 role: PubsubRole::Publisher,
@@ -6376,6 +6383,78 @@ const ESCALATE_MUTATION = gql`
         assert_eq!(backfilled.broker, None);
         assert_eq!(backfilled.payload_expression_text, None);
         assert_eq!(backfilled.payload_expression_line, None);
+    }
+
+    /// Copilot review on #389: an extracted op on the same LINE must not mask
+    /// a missing (topic, role) contribution — a line can carry several pub/sub
+    /// ops (`bus.publish('a'); bus.subscribe('b')` minified onto one line), and
+    /// the extraction may have produced only one of them, or one with a
+    /// different topic entirely (e.g. a template kept verbatim). Coverage is
+    /// keyed on (topic, role) alone.
+    #[test]
+    fn merge_pubsub_anchor_ops_same_line_does_not_mask_missing_ops() {
+        use crate::agents::file_analyzer_agent::PubsubOperation;
+        use crate::operation::PubsubRole;
+        use crate::swc_scanner::PubsubAnchorOp;
+
+        let mut result = FileAnalysisResult {
+            pubsub_operations: vec![PubsubOperation {
+                topic: "jobs.retry".to_string(),
+                role: Some(PubsubRole::Publisher),
+                line_number: 7,
+                primary_type_symbol: None,
+                type_import_source: None,
+                broker: None,
+                payload_expression_text: None,
+                payload_expression_line: None,
+            }],
+            ..Default::default()
+        };
+
+        let anchors = vec![
+            // Publisher+subscriber share line 7; only the publisher was
+            // extracted -> the subscriber must backfill despite the shared line.
+            PubsubAnchorOp {
+                topic: "jobs.retry".to_string(),
+                role: PubsubRole::Publisher,
+                line_number: 7,
+            },
+            PubsubAnchorOp {
+                topic: "jobs.completed".to_string(),
+                role: PubsubRole::Subscriber,
+                line_number: 7,
+            },
+            // Same line, same role, DIFFERENT topic (the extraction kept a
+            // template verbatim, say) -> the resolved-topic anchor must
+            // backfill; the resolved literal is the joinable key.
+            PubsubAnchorOp {
+                topic: "jobs.failed".to_string(),
+                role: PubsubRole::Publisher,
+                line_number: 7,
+            },
+        ];
+
+        let added = FileOrchestrator::merge_pubsub_anchor_ops(&mut result, anchors);
+        assert_eq!(
+            added, 2,
+            "line-sharing must not mask the subscriber or the different-topic anchor"
+        );
+        assert!(
+            result
+                .pubsub_operations
+                .iter()
+                .any(|op| op.topic == "jobs.completed"
+                    && op.role == Some(PubsubRole::Subscriber)
+                    && op.line_number == 7),
+            "subscriber sharing the publisher's line must be backfilled"
+        );
+        assert!(
+            result
+                .pubsub_operations
+                .iter()
+                .any(|op| op.topic == "jobs.failed" && op.role == Some(PubsubRole::Publisher)),
+            "different-topic anchor on the same line must be backfilled"
+        );
     }
 
     /// Same topic on the OTHER side is not coverage: a publisher extraction

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -20,7 +20,7 @@ use crate::{
     agent_service::AgentService,
     agents::{
         file_analyzer_agent::{
-            EmissionStyle, EndpointResult, FileAnalysisResult, FileAnalyzerAgent,
+            EmissionStyle, EndpointResult, FileAnalysisResult, FileAnalyzerAgent, PubsubOperation,
         },
         framework_guidance_agent::ProtocolGuidance,
     },
@@ -36,7 +36,7 @@ use crate::{
         ExtractionConfig, InferKind, InferRequestItem, SymbolRequest, TypeResolutionResult,
         TypeSidecar,
     },
-    swc_scanner::{CandidateTarget, RouteDescriptorEndpoint, SwcScanner},
+    swc_scanner::{CandidateTarget, PubsubAnchorOp, RouteDescriptorEndpoint, SwcScanner},
     type_manifest::{
         build_call_site_id, build_manifest_type_alias, build_manifest_type_alias_with_call_id,
         is_http_method, normalize_manifest_method, parse_file_location,
@@ -96,6 +96,11 @@ pub struct ProcessingStats {
     /// (`{ method, path, handler }` in a registry array) rather than from the
     /// file-analyzer LLM. A subset of `total_endpoints`. See #234.
     pub route_descriptor_endpoints: usize,
+    /// Pub/sub operations asserted deterministically from the AST and merged in
+    /// because the file-analyzer's extraction omitted them (carrick#387). The
+    /// anchors themselves are computed for every gated file; only the ones the
+    /// LLM missed are counted here.
+    pub pubsub_anchor_backfills: usize,
     pub total_data_calls: usize,
     pub errors: Vec<String>,
 }
@@ -415,6 +420,10 @@ impl FileOrchestrator {
             /// user message so call sites of an imported wrapper can be emitted
             /// as resolved data calls. Empty for files with no such imports.
             wrapper_context: Vec<String>,
+            /// Pub/sub operations asserted deterministically from the AST
+            /// (carrick#387), merged in after the LLM pass so an extraction
+            /// omission cannot lose them. Empty when Signal 7's gates are off.
+            pubsub_anchor_ops: Vec<PubsubAnchorOp>,
         }
 
         /// A zero-candidate file whose skip decision is deferred until the
@@ -697,6 +706,7 @@ impl FileOrchestrator {
                 graphql_producer_hints: graphql_producer_hints.lines.clone(),
                 graphql_consumer_hints: graphql_consumer_hints.lines.clone(),
                 wrapper_context: Vec::new(),
+                pubsub_anchor_ops: scan_result.pubsub_anchor_ops,
             });
         }
 
@@ -826,6 +836,9 @@ impl FileOrchestrator {
                 graphql_producer_hints: graphql_producer_hints.lines.clone(),
                 graphql_consumer_hints: graphql_consumer_hints.lines.clone(),
                 wrapper_context: ctx,
+                // Rescued zero-candidate files by definition raised no Signal 7
+                // candidate, so they can carry no anchor ops either.
+                pubsub_anchor_ops: Vec::new(),
             });
         }
 
@@ -904,6 +917,14 @@ impl FileOrchestrator {
                     // for such routes (#234).
                     stats.route_descriptor_endpoints +=
                         Self::merge_file_based_endpoints(&mut adjusted, pf.descriptor_endpoints);
+
+                    // Merge deterministically-anchored pub/sub operations the
+                    // LLM pass didn't already produce (carrick#387). A
+                    // payload-less publish/subscribe with a resolvable literal
+                    // topic is a structural fact — an extraction omission must
+                    // not lose the operation.
+                    stats.pubsub_anchor_backfills +=
+                        Self::merge_pubsub_anchor_ops(&mut adjusted, pf.pubsub_anchor_ops);
 
                     stats.total_mounts += adjusted.mounts.len();
                     stats.total_endpoints += adjusted.endpoints.len();
@@ -2552,6 +2573,46 @@ impl FileOrchestrator {
                 result.endpoints.push(ep);
                 added += 1;
             }
+        }
+        added
+    }
+
+    /// Merge deterministically-anchored pub/sub operations (carrick#387) into a
+    /// file's extraction, adding only the ops the LLM pass missed. An anchor is
+    /// considered covered — and skipped — when the extraction already has an op
+    /// at the same line (the LLM extracted this site, possibly with different
+    /// topic text; its judgment wins) or with the same (topic, role) pair (the
+    /// operation is already on the right side of the topic). Backfilled ops are
+    /// payload-less by construction, so every judgment field is `None`: there is
+    /// no type to capture and no locator to emit — pure topic recall.
+    fn merge_pubsub_anchor_ops(
+        result: &mut FileAnalysisResult,
+        anchor_ops: Vec<PubsubAnchorOp>,
+    ) -> usize {
+        let mut added = 0;
+        for anchor in anchor_ops {
+            let line = i32::try_from(anchor.line_number).unwrap_or(i32::MAX);
+            let covered = result.pubsub_operations.iter().any(|op| {
+                op.line_number == line || (op.topic == anchor.topic && op.role == Some(anchor.role))
+            });
+            if covered {
+                continue;
+            }
+            debug!(
+                "Backfilling pub/sub op the extraction missed: {} ({:?}) at line {}",
+                anchor.topic, anchor.role, line
+            );
+            result.pubsub_operations.push(PubsubOperation {
+                topic: anchor.topic,
+                role: Some(anchor.role),
+                line_number: line,
+                primary_type_symbol: None,
+                type_import_source: None,
+                broker: None,
+                payload_expression_text: None,
+                payload_expression_line: None,
+            });
+            added += 1;
         }
         added
     }
@@ -6243,6 +6304,117 @@ const ESCALATE_MUTATION = gql`
         assert_eq!(
             keys.get("ESCALATE_MUTATION").map(String::as_str),
             Some("graphql|mutation|escalateTicket")
+        );
+    }
+
+    /// carrick#387: a deterministically-anchored payload-less pub/sub op the
+    /// LLM extraction missed is backfilled with all judgment fields `None`;
+    /// anchors the extraction already covers (same line, or same topic+role)
+    /// are skipped so the LLM's judgment is never duplicated or overridden.
+    #[test]
+    fn merge_pubsub_anchor_ops_backfills_only_missed_ops() {
+        use crate::agents::file_analyzer_agent::PubsubOperation;
+        use crate::operation::PubsubRole;
+        use crate::swc_scanner::PubsubAnchorOp;
+
+        let llm_op = |topic: &str, line: i32| PubsubOperation {
+            topic: topic.to_string(),
+            role: Some(PubsubRole::Publisher),
+            line_number: line,
+            primary_type_symbol: None,
+            type_import_source: None,
+            broker: None,
+            payload_expression_text: None,
+            payload_expression_line: None,
+        };
+
+        let mut result = FileAnalysisResult {
+            pubsub_operations: vec![
+                // Covers anchor (a) by exact line — even though the LLM's topic
+                // text differs (kept the template verbatim), its judgment wins.
+                llm_op("${name}:pollingStarted", 182),
+                // Covers anchor (b) by topic+role at a different line.
+                llm_op("PollController:stateChange", 90),
+            ],
+            ..Default::default()
+        };
+
+        let anchors = vec![
+            // (a) same line as an extracted op -> skipped.
+            PubsubAnchorOp {
+                topic: "PollController:pollingStarted".to_string(),
+                role: PubsubRole::Publisher,
+                line_number: 182,
+            },
+            // (b) same topic+role as an extracted op -> skipped.
+            PubsubAnchorOp {
+                topic: "PollController:stateChange".to_string(),
+                role: PubsubRole::Publisher,
+                line_number: 95,
+            },
+            // (c) genuinely missed -> backfilled.
+            PubsubAnchorOp {
+                topic: "PollController:pollingStopped".to_string(),
+                role: PubsubRole::Publisher,
+                line_number: 201,
+            },
+        ];
+
+        let added = FileOrchestrator::merge_pubsub_anchor_ops(&mut result, anchors);
+        assert_eq!(added, 1, "only the missed anchor must be backfilled");
+        assert_eq!(result.pubsub_operations.len(), 3);
+
+        let backfilled = result
+            .pubsub_operations
+            .iter()
+            .find(|op| op.topic == "PollController:pollingStopped")
+            .expect("missed anchor must be present after the merge");
+        assert_eq!(backfilled.role, Some(PubsubRole::Publisher));
+        assert_eq!(backfilled.line_number, 201);
+        assert_eq!(backfilled.primary_type_symbol, None);
+        assert_eq!(backfilled.type_import_source, None);
+        assert_eq!(backfilled.broker, None);
+        assert_eq!(backfilled.payload_expression_text, None);
+        assert_eq!(backfilled.payload_expression_line, None);
+    }
+
+    /// Same topic on the OTHER side is not coverage: a publisher extraction
+    /// does not cover a subscriber anchor for the same topic.
+    #[test]
+    fn merge_pubsub_anchor_ops_role_disambiguates_coverage() {
+        use crate::agents::file_analyzer_agent::PubsubOperation;
+        use crate::operation::PubsubRole;
+        use crate::swc_scanner::PubsubAnchorOp;
+
+        let mut result = FileAnalysisResult {
+            pubsub_operations: vec![PubsubOperation {
+                topic: "jobs.retry".to_string(),
+                role: Some(PubsubRole::Publisher),
+                line_number: 10,
+                primary_type_symbol: None,
+                type_import_source: None,
+                broker: None,
+                payload_expression_text: None,
+                payload_expression_line: None,
+            }],
+            ..Default::default()
+        };
+
+        let added = FileOrchestrator::merge_pubsub_anchor_ops(
+            &mut result,
+            vec![PubsubAnchorOp {
+                topic: "jobs.retry".to_string(),
+                role: PubsubRole::Subscriber,
+                line_number: 25,
+            }],
+        );
+        assert_eq!(added, 1);
+        assert!(
+            result
+                .pubsub_operations
+                .iter()
+                .any(|op| op.topic == "jobs.retry" && op.role == Some(PubsubRole::Subscriber)),
+            "subscriber anchor must be backfilled alongside the publisher extraction"
         );
     }
 }

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -14,7 +14,7 @@
 //! of the compiler sidecar architecture migration.
 
 use serde::Serialize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use swc_common::{
     SourceMap, SourceMapper, Spanned,
@@ -25,7 +25,7 @@ use swc_ecma_ast::*;
 use swc_ecma_parser::{EsSyntax, TsSyntax};
 use swc_ecma_visit::{Visit, VisitWith};
 
-use crate::operation::Protocol;
+use crate::operation::{Protocol, PubsubRole};
 use crate::parser::parse_file;
 
 /// A candidate API call site detected by the SWC scanner.
@@ -100,6 +100,34 @@ pub struct ScanResult {
     /// without re-parsing, whether a zero-candidate file imports a recognized
     /// messaging-client package and should be force-analyzed (pub/sub Part B).
     pub import_sources: Vec<String>,
+    /// Pub/sub operations whose identity is fully derivable from the AST
+    /// (carrick#387). Merged into the file's LLM extraction after the analyzer
+    /// pass so an extraction-recall flake cannot lose the operation — the same
+    /// authoritative-structural-facts contract as file-based route endpoints.
+    /// Empty whenever Signal 7's messaging-client gates are off.
+    pub pubsub_anchor_ops: Vec<PubsubAnchorOp>,
+}
+
+/// A pub/sub operation asserted deterministically from the AST (carrick#387):
+/// a statement/initializer-position member call literally named `publish` or
+/// `subscribe` whose ONLY argument resolves to a literal topic string (inline
+/// literal, top-level const-string reference, or a template literal whose every
+/// interpolation is such a reference). Payload-less by construction — a call
+/// with a payload argument stays on the LLM path so the type-capture judgment
+/// (locators, envelope unwrapping) is never preempted. The measured gap this
+/// closes: the file-analyzer sometimes omits no-payload template-literal-topic
+/// ops entirely (4/20 passes on the messenger-template-topic-nopayload
+/// fixture), and with no payload there is no judgment left for the LLM to add —
+/// the topic, role, and line are structural facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PubsubAnchorOp {
+    /// The fully resolved literal topic string (e.g. "PollController:pollingStarted").
+    pub topic: String,
+    /// publish -> Publisher, subscribe -> Subscriber (the protocol vocabulary
+    /// is the only method-name shape the anchor accepts).
+    pub role: PubsubRole,
+    /// 1-based line number of the call site.
+    pub line_number: usize,
 }
 
 /// A value exported from a module. Used by file-based routing to recover the
@@ -189,6 +217,7 @@ impl SwcScanner {
                     candidates: Vec::new(),
                     parse_failed: true,
                     import_sources: Vec::new(),
+                    pubsub_anchor_ops: Vec::new(),
                 };
             }
         };
@@ -199,16 +228,16 @@ impl SwcScanner {
         let repo_has_messaging_clients = !messaging_clients.is_empty();
         // Const-string topic bindings are only needed for the gated Signal 7, so
         // skip the pre-pass entirely when both gate tiers are off.
-        let const_string_bindings = if imports_messaging_client || repo_has_messaging_clients {
-            collect_const_string_bindings(&module)
+        let const_string_values = if imports_messaging_client || repo_has_messaging_clients {
+            collect_const_string_values(&module)
         } else {
-            HashSet::new()
+            HashMap::new()
         };
         let mut visitor = CandidateVisitor::new(
             self.source_map.clone(),
             network_import_locals(&module, data_fetchers),
             imports_messaging_client,
-            const_string_bindings,
+            const_string_values,
             repo_has_messaging_clients,
         );
         module.visit_with(&mut visitor);
@@ -217,6 +246,7 @@ impl SwcScanner {
             candidates: visitor.candidates,
             parse_failed: false,
             import_sources,
+            pubsub_anchor_ops: visitor.pubsub_anchor_ops,
         }
     }
 
@@ -295,6 +325,7 @@ impl SwcScanner {
                     candidates: Vec::new(),
                     parse_failed: true,
                     import_sources: Vec::new(),
+                    pubsub_anchor_ops: Vec::new(),
                 };
             }
         };
@@ -313,16 +344,16 @@ impl SwcScanner {
         let repo_has_messaging_clients = !messaging_clients.is_empty();
         // Const-string topic bindings are only needed for the gated Signal 7, so
         // skip the pre-pass entirely when both gate tiers are off.
-        let const_string_bindings = if imports_messaging_client || repo_has_messaging_clients {
-            collect_const_string_bindings(&module)
+        let const_string_values = if imports_messaging_client || repo_has_messaging_clients {
+            collect_const_string_values(&module)
         } else {
-            HashSet::new()
+            HashMap::new()
         };
         let mut visitor = CandidateVisitor::new(
             file_source_map,
             network_import_locals(&module, data_fetchers),
             imports_messaging_client,
-            const_string_bindings,
+            const_string_values,
             repo_has_messaging_clients,
         );
         module.visit_with(&mut visitor);
@@ -331,6 +362,7 @@ impl SwcScanner {
             candidates: visitor.candidates,
             parse_failed: false,
             import_sources,
+            pubsub_anchor_ops: visitor.pubsub_anchor_ops,
         }
     }
 
@@ -597,12 +629,14 @@ struct CandidateVisitor {
     /// messaging client, so socket files never gate in and the signal stays inert
     /// there. Empty `messaging_clients` → always false → Signal 7 never fires.
     file_imports_messaging_client: bool,
-    /// Top-level `const <id> = "<literal>"` bindings, so a pub/sub call whose
-    /// topic is referenced by name (`const SUBJECT = "user.registered"; …
-    /// nc.publish(SUBJECT, …)`) still counts as having a string-literal topic
-    /// for the Signal 7 first-arg check. Only string-literal initializers are
+    /// Top-level `const <id> = "<literal>"` bindings (name -> literal value),
+    /// so a pub/sub call whose topic is referenced by name (`const SUBJECT =
+    /// "user.registered"; … nc.publish(SUBJECT, …)`) still counts as having a
+    /// string-literal topic for the Signal 7 first-arg check, and so the
+    /// anchor-op path (carrick#387) can resolve const-ref and template-literal
+    /// topics to their literal strings. Only string-literal initializers are
     /// recorded; this is a recall booster, not a full constant-folder.
-    const_string_bindings: HashSet<String>,
+    const_string_values: HashMap<String, String>,
     /// True while visiting a call expression that sits directly in a
     /// statement-expression (`nc.publish(SUBJECT, payload);`) or a variable
     /// initializer (`const sub = nc.subscribe("topic");`). Signal 7 only fires
@@ -617,6 +651,11 @@ struct CandidateVisitor {
     /// named `publish`/`subscribe`, the protocol vocabulary itself, so
     /// `logger.info('msg')` / `socket.emit('evt')` stay inert (carrick#317).
     repo_has_messaging_clients: bool,
+    /// Deterministically asserted pub/sub operations (carrick#387): the
+    /// payload-less publish/subscribe sites whose topic resolves to a literal
+    /// string. Collected alongside the Signal 7 candidates (same gates, same
+    /// position rule) and merged into the file's extraction after the LLM pass.
+    pubsub_anchor_ops: Vec<PubsubAnchorOp>,
 }
 
 impl CandidateVisitor {
@@ -624,7 +663,7 @@ impl CandidateVisitor {
         source_map: Lrc<SourceMap>,
         network_import_locals: HashSet<String>,
         file_imports_messaging_client: bool,
-        const_string_bindings: HashSet<String>,
+        const_string_values: HashMap<String, String>,
         repo_has_messaging_clients: bool,
     ) -> Self {
         Self {
@@ -635,9 +674,10 @@ impl CandidateVisitor {
             seen_spans: HashSet::new(),
             await_depth: 0,
             file_imports_messaging_client,
-            const_string_bindings,
+            const_string_values,
             in_pubsub_call_position: false,
             repo_has_messaging_clients,
+            pubsub_anchor_ops: Vec::new(),
         }
     }
 
@@ -815,8 +855,43 @@ impl CandidateVisitor {
     fn first_arg_is_stringish_or_const_string(&self, call: &CallExpr) -> bool {
         match call.args.first().map(|a| &*a.expr) {
             Some(Expr::Lit(Lit::Str(_))) | Some(Expr::Tpl(_)) => true,
-            Some(Expr::Ident(ident)) => self.const_string_bindings.contains(ident.sym.as_ref()),
+            Some(Expr::Ident(ident)) => self.const_string_values.contains_key(ident.sym.as_ref()),
             _ => false,
+        }
+    }
+
+    /// Resolve a topic expression to its literal string, or `None` when it is
+    /// not deterministically resolvable (carrick#387 anchor-op path). Handles
+    /// exactly the shapes the const-string pre-pass supports: an inline string
+    /// literal, a reference to a top-level `const <id> = "<literal>"`, and a
+    /// template literal whose every interpolation is such a reference
+    /// (`` `${name}:pollingStarted` `` with `export const name = '...'`).
+    /// Anything else — call results, member expressions, parameters — returns
+    /// `None` and the site stays on the LLM path.
+    fn resolve_topic_string(&self, expr: &Expr) -> Option<String> {
+        match expr {
+            Expr::Lit(Lit::Str(s)) => Some(s.value.to_string()),
+            Expr::Ident(ident) => self.const_string_values.get(ident.sym.as_ref()).cloned(),
+            Expr::Tpl(tpl) => {
+                let mut resolved = String::new();
+                for (i, quasi) in tpl.quasis.iter().enumerate() {
+                    match &quasi.cooked {
+                        Some(cooked) => resolved.push_str(cooked),
+                        // A quasi with no cooked value contains an invalid
+                        // escape — not a resolvable literal.
+                        None => return None,
+                    }
+                    if let Some(interp) = tpl.exprs.get(i) {
+                        let Expr::Ident(ident) = &**interp else {
+                            return None;
+                        };
+                        let value = self.const_string_values.get(ident.sym.as_ref())?;
+                        resolved.push_str(value);
+                    }
+                }
+                Some(resolved)
+            }
+            _ => None,
         }
     }
 
@@ -1377,6 +1452,33 @@ impl Visit for CandidateVisitor {
             if gates_in {
                 let obj_name = Self::extract_callee_object(&member.obj)
                     .unwrap_or_else(|| "<pubsub>".to_string());
+
+                // Anchor-op path (carrick#387), a strict subset of the sites
+                // gated in above: when the call is literally named
+                // publish/subscribe (the protocol vocabulary — stricter than
+                // tier 1's any-method candidate), carries NO payload argument,
+                // and its only argument resolves to a literal topic, the whole
+                // operation is a structural fact. Assert it deterministically
+                // so an LLM extraction omission cannot lose it; payload-carrying
+                // calls stay LLM-owned (locator judgment, envelope unwrapping).
+                let role = match method.as_deref() {
+                    Some("publish") => Some(PubsubRole::Publisher),
+                    Some("subscribe") => Some(PubsubRole::Subscriber),
+                    _ => None,
+                };
+                if let Some(role) = role
+                    && call.args.len() == 1
+                    && call.args[0].spread.is_none()
+                    && let Some(topic) = self.resolve_topic_string(&call.args[0].expr)
+                {
+                    let line_number = self.get_line_number(call.span);
+                    self.pubsub_anchor_ops.push(PubsubAnchorOp {
+                        topic,
+                        role,
+                        line_number,
+                    });
+                }
+
                 self.push_candidate(call, obj_name, method);
             }
         }
@@ -1427,15 +1529,17 @@ fn file_imports_messaging_client(import_sources: &[String], messaging_clients: &
     })
 }
 
-/// Collect top-level `const <id> = "<string-literal>"` binding names so a
-/// pub/sub call whose topic is a const reference (`const SUBJECT =
-/// "user.registered"; nc.publish(SUBJECT, …)`) still counts as having a
-/// string-literal topic for Signal 7. Only module-body `const` declarators with
-/// an identifier pattern and a bare string-literal initializer are recorded —
-/// this is a targeted recall booster, not a general constant-folder, so
-/// template literals, member exprs, and nested scopes are intentionally ignored.
-fn collect_const_string_bindings(module: &Module) -> HashSet<String> {
-    let mut bindings = HashSet::new();
+/// Collect top-level `const <id> = "<string-literal>"` bindings (name ->
+/// literal value) so a pub/sub call whose topic is a const reference (`const
+/// SUBJECT = "user.registered"; nc.publish(SUBJECT, …)`) still counts as having
+/// a string-literal topic for Signal 7, and so the anchor-op path (carrick#387)
+/// can resolve const-ref and template-literal topics to their literal strings.
+/// Only module-body `const` declarators with an identifier pattern and a bare
+/// string-literal initializer are recorded — this is a targeted recall booster,
+/// not a general constant-folder, so template literals, member exprs, and
+/// nested scopes are intentionally ignored.
+fn collect_const_string_values(module: &Module) -> HashMap<String, String> {
+    let mut bindings = HashMap::new();
     for item in &module.body {
         let var = match item {
             ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
@@ -1453,9 +1557,9 @@ fn collect_const_string_bindings(module: &Module) -> HashSet<String> {
                 continue;
             };
             if let Some(init) = &decl.init
-                && let Expr::Lit(Lit::Str(_)) = &**init
+                && let Expr::Lit(Lit::Str(value)) = &**init
             {
-                bindings.insert(ident.id.sym.to_string());
+                bindings.insert(ident.id.sym.to_string(), value.value.to_string());
             }
         }
     }
@@ -2479,6 +2583,106 @@ export class NetworkMonitor {
             inert.candidates.is_empty(),
             "with no detected messaging clients the file must surface 0 candidates, got {:?}",
             inert.candidates
+        );
+    }
+
+    /// carrick#387: a payload-less publish/subscribe with a deterministically
+    /// resolvable topic is a structural fact — emit it as an anchor op so an
+    /// LLM extraction omission cannot lose the operation. The template-literal
+    /// case (`` this.messenger.publish(`${name}:started`) `` with
+    /// `export const name = '...'`) is the measured 4/20 recall gap.
+    #[test]
+    fn pubsub_anchor_ops_resolve_template_and_literal_topics() {
+        use crate::operation::PubsubRole;
+
+        let src = r#"
+export const name = 'PollController';
+const CHANNEL = 'jobs.retry';
+export class PollController {
+  start() {
+    this.messenger.publish(`${name}:pollingStarted`);
+  }
+  stop() {
+    this.messenger.publish('PollController:stopped');
+  }
+  listen() {
+    const sub = this.messenger.subscribe(CHANNEL);
+  }
+}
+"#;
+        let scanner = SwcScanner::new();
+        let result = scanner.scan_content(
+            &PathBuf::from("poll.ts"),
+            src,
+            &[],
+            &["fakebus".to_string()],
+        );
+        let ops = &result.pubsub_anchor_ops;
+        assert_eq!(ops.len(), 3, "expected 3 anchor ops, got {ops:?}");
+        assert!(
+            ops.iter()
+                .any(|op| op.topic == "PollController:pollingStarted"
+                    && op.role == PubsubRole::Publisher
+                    && op.line_number == 6),
+            "template topic with exported same-file const must resolve, got {ops:?}"
+        );
+        assert!(
+            ops.iter().any(|op| op.topic == "PollController:stopped"
+                && op.role == PubsubRole::Publisher
+                && op.line_number == 9),
+            "inline string-literal topic must resolve, got {ops:?}"
+        );
+        assert!(
+            ops.iter().any(|op| op.topic == "jobs.retry"
+                && op.role == PubsubRole::Subscriber
+                && op.line_number == 12),
+            "const-ref topic in initializer position must resolve, got {ops:?}"
+        );
+    }
+
+    /// The anchor path only asserts what is structurally certain: gated off with
+    /// no detected messaging clients; never for payload-carrying calls (those
+    /// stay LLM-owned so the type-capture path is undisturbed); never for
+    /// unresolvable or non-publish/subscribe-named calls; never in nested
+    /// (non-statement/initializer) positions.
+    #[test]
+    fn pubsub_anchor_ops_stay_inert_outside_the_guarded_shape() {
+        let src = r#"
+export const name = 'PollController';
+import { bus } from 'fakebus';
+function localTopic(): string { return 'x'; }
+export function run(payload: object, dynamic: string) {
+  bus.publish('with.payload', payload);
+  bus.publish(`${dynamic}:started`);
+  bus.emit('not.protocol.vocab');
+  wrap(bus.publish('nested.position'));
+  bus.publish(localTopic());
+}
+"#;
+        let scanner = SwcScanner::new();
+        let gated_in = scanner.scan_content(
+            &PathBuf::from("guarded.ts"),
+            src,
+            &[],
+            &["fakebus".to_string()],
+        );
+        assert!(
+            gated_in.pubsub_anchor_ops.is_empty(),
+            "payload-carrying / unresolvable / nested / non-vocab calls must not anchor, got {:?}",
+            gated_in.pubsub_anchor_ops
+        );
+
+        // Gate off entirely: no messaging clients detected.
+        let no_payload_src = r#"
+import { bus } from 'fakebus';
+bus.publish('plain.topic');
+"#;
+        let gated_out =
+            scanner.scan_content(&PathBuf::from("guarded.ts"), no_payload_src, &[], &[]);
+        assert!(
+            gated_out.pubsub_anchor_ops.is_empty(),
+            "empty messaging_clients must keep the anchor path inert, got {:?}",
+            gated_out.pubsub_anchor_ops
         );
     }
 }

--- a/tests/file_centric_analysis_test.rs
+++ b/tests/file_centric_analysis_test.rs
@@ -276,6 +276,7 @@ fn test_processing_stats_tracking() {
         total_endpoints: 10,
         file_based_endpoints: 2,
         route_descriptor_endpoints: 1,
+        pubsub_anchor_backfills: 0,
         total_data_calls: 4,
         errors: vec!["Test error".to_string()],
     };


### PR DESCRIPTION
Scanner side of #387 — the 4/20 TRUE recall loss the pass^20 sweep measured after the #386 pubsub locator-field addition: the file-analyzer sometimes omits a no-payload template-literal-topic publish entirely (the messenger-template-topic-nopayload shape). Per the issue's next-steps, this is closed with a deterministic scanner-side guard, not schema/prompt iteration (schema text changes are sweep-gated).

## What

A payload-less publish/subscribe whose topic resolves to a literal string is a structural fact — there is no locator to emit and no type to capture, so nothing is left for LLM judgment. The scanner now asserts these operations itself and backfills any the extraction missed:

- **`PubsubAnchorOp` collection** (swc_scanner): collected alongside Signal 7, under the same messaging-client gates and the same statement/initializer position rule, but strictly narrower — the member call must be literally named `publish`/`subscribe` (the protocol vocabulary, matching tier 2's constraint even under tier 1), carry exactly one argument (no payload), and that argument must resolve deterministically: inline string literal, top-level const-string reference, or a template literal whose every interpolation is such a reference (the measured miss shape: `` this.messenger.publish(`${name}:pollingStarted`) `` with `export const name = '...'`). The const-string pre-pass now records name → value instead of only names.
- **`merge_pubsub_anchor_ops`** (file_orchestrator): mirrors the file-based-endpoint merge contract — merged after the LLM pass, adding only ops the extraction missed. An anchor is covered (skipped) when an extracted op sits at the same line (the LLM's topic judgment wins) or carries the same (topic, role). Backfilled ops have `None` in every judgment field: pure topic recall, manifest entry stays Unknown (recoverable), so the #386 locator/type-capture path is never preempted.

Empty `messaging_clients` keeps the whole path inert, exactly like Signal 7 — zero new exposure for socket.io/logger shapes.

## Why not the schema

The regression was A/B-attributed to the locator-field schema addition, and schema descriptions are sweep-gated (a text edit collapses unrelated fixtures). The deterministic anchor recovers the op regardless of what the model does, which also hardens every future schema evolution against this failure mode.

## Tests

- `pubsub_anchor_ops_resolve_template_and_literal_topics` / `pubsub_anchor_ops_stay_inert_outside_the_guarded_shape` (swc_scanner): template/const/literal resolution, role + line assertions; inert for payload-carrying, unresolvable, nested-position, non-vocabulary calls and when gates are off.
- `merge_pubsub_anchor_ops_backfills_only_missed_ops` / `merge_pubsub_anchor_ops_role_disambiguates_coverage` (file_orchestrator): backfill only on true misses; same-line and same-(topic, role) coverage; role disambiguation.
- Full suite: 1301 passed, 0 failed (incl. cassette hard gate); `cargo fmt` clean, `clippy --all-targets` zero warnings.

Companion PR in carrick-cloud fixes the sweep's other 10/20 (omitted-vs-null scorer artifact).

Closes #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)