### PR TITLE
fix: hash repo-relative call-site paths so scanner output is machine-independent

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1177,6 +1177,7 @@ impl FileOrchestrator {
                 &file_path,
                 line_number,
                 &OperationKey::http(&method, path.clone()),
+                repo_path,
             );
             data_call_lookup
                 .entry((file_path, line_number))
@@ -1432,6 +1433,7 @@ impl FileOrchestrator {
                                 file_path,
                                 line_number,
                                 &OperationKey::http(&method_fallback, target_path.clone()),
+                                repo_path,
                             ),
                         )
                     });
@@ -1674,15 +1676,17 @@ impl FileOrchestrator {
                 // publishers (consumers) disambiguate by call site so fan-in
                 // publishers don't collide on one alias; subscribers (producers)
                 // stay plain. `build_call_site_id` MUST see the same (path, line,
-                // key) the manifest side passes — `path` is the raw `file_results`
-                // key on both sides — or the alias diverges and the resolution
-                // enrich-join silently drops the resolved payload type.
+                // key, repo_root) the manifest side passes — `path` is the raw
+                // `file_results` key on both sides and the id relativizes it
+                // against `repo_root` internally (#355) — or the alias diverges
+                // and the resolution enrich-join silently drops the resolved
+                // payload type.
                 let alias = match role {
                     ManifestRole::Consumer => {
                         // Same >= 1 clamp as the manifest side (see
                         // `append_pubsub_manifest_entries`) so the call_id matches.
                         let line = u32::try_from(op.line_number).unwrap_or(0).max(1);
-                        let call_id = build_call_site_id(path, line, &key);
+                        let call_id = build_call_site_id(path, line, &key, repo_path);
                         build_manifest_type_alias_with_call_id(
                             &key,
                             role,
@@ -1804,7 +1808,7 @@ impl FileOrchestrator {
                 let key = OperationKey::pubsub(op.topic.clone());
                 let alias = match role {
                     ManifestRole::Consumer => {
-                        let call_id = build_call_site_id(path, line, &key);
+                        let call_id = build_call_site_id(path, line, &key, repo_path);
                         build_manifest_type_alias_with_call_id(
                             &key,
                             role,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1158,13 +1158,14 @@ async fn analyze_current_repo_incremental(
             cloud_data.cache_version = Some(CACHE_VERSION);
 
             // Build type manifest
-            let mut manifest_entries = build_type_manifest_entries(&mount_graph, config);
+            let mut manifest_entries = build_type_manifest_entries(&mount_graph, config, repo_path);
             stamp_manifest_anchor_symbols(&mut manifest_entries, &merged_results);
             append_protocol_manifest_entries(&mut manifest_entries, &protocol_extractions);
             append_pubsub_manifest_entries(
                 &mut manifest_entries,
                 &merged_results,
                 &protocol_extractions.sockets,
+                repo_path,
             );
             if !manifest_entries.is_empty() {
                 cloud_data.type_manifest = Some(manifest_entries);
@@ -1658,6 +1659,7 @@ fn append_pubsub_manifest_entries(
     entries: &mut Vec<TypeManifestEntry>,
     file_results: &HashMap<String, crate::agents::file_analyzer_agent::FileAnalysisResult>,
     sockets: &crate::socket_io::SocketExtraction,
+    repo_root: &str,
 ) {
     use crate::operation::PubsubRole;
 
@@ -1696,7 +1698,7 @@ fn append_pubsub_manifest_entries(
             // Subscribers (producers) keep the plain alias: one definition per
             // topic per repo, exactly like an HTTP endpoint.
             let call_id = match role {
-                ManifestRole::Consumer => Some(build_call_site_id(path, line, &key)),
+                ManifestRole::Consumer => Some(build_call_site_id(path, line, &key, repo_root)),
                 ManifestRole::Producer => None,
             };
             add_protocol_manifest_entry(
@@ -2460,6 +2462,7 @@ fn resolve_per_endpoint_definitions(sidecar: &TypeSidecar, cloud_data: &mut Clou
 fn build_type_manifest_entries(
     mount_graph: &MountGraph,
     config: &Config,
+    repo_root: &str,
 ) -> Vec<TypeManifestEntry> {
     let normalizer = UrlNormalizer::new(config);
     let mut entries = Vec::new();
@@ -2529,15 +2532,14 @@ fn build_type_manifest_entries(
         // Only anchor types for a BARE route (internal/declared or relative
         // target). An external or unclassified call keeps its raw `${HOST}/path`
         // / full-URL canonical form: it has no internal producer to match, so a
-        // type anchor would be unused — and its `call_id` (a hash of the absolute
-        // file path) would make byte-compared goldens non-portable across
-        // machines. Mirrors main, where the raw projection key never joined an
-        // external call's `extract_path`-keyed manifest entry.
+        // type anchor would be unused. Mirrors main, where the raw projection
+        // key never joined an external call's `extract_path`-keyed manifest
+        // entry.
         if !path.starts_with('/') {
             continue;
         }
         let key = OperationKey::http(&method, path);
-        let call_id = build_call_site_id(&file_path, line_number, &key);
+        let call_id = build_call_site_id(&file_path, line_number, &key, repo_root);
 
         add_manifest_pair(
             &mut entries,
@@ -2930,13 +2932,15 @@ async fn analyze_current_repo(
         &analysis_result.file_results,
     );
 
-    let mut manifest_entries = build_type_manifest_entries(&analysis_result.mount_graph, config);
+    let mut manifest_entries =
+        build_type_manifest_entries(&analysis_result.mount_graph, config, repo_path);
     stamp_manifest_anchor_symbols(&mut manifest_entries, &analysis_result.file_results);
     append_protocol_manifest_entries(&mut manifest_entries, &protocol_extractions);
     append_pubsub_manifest_entries(
         &mut manifest_entries,
         &analysis_result.file_results,
         &protocol_extractions.sockets,
+        repo_path,
     );
     if !manifest_entries.is_empty() {
         cloud_data.type_manifest = Some(manifest_entries);
@@ -4534,7 +4538,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             ),
         ];
 
-        let entries = build_type_manifest_entries(&mount_graph, &config);
+        let entries = build_type_manifest_entries(&mount_graph, &config, ".");
 
         let consumer_paths: Vec<&str> = entries
             .iter()
@@ -4593,7 +4597,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             mk_endpoint("src/routes/orders.ts:42"),
         ];
 
-        let entries = build_type_manifest_entries(&mount_graph, &config);
+        let entries = build_type_manifest_entries(&mount_graph, &config, ".");
 
         let producer_aliases: Vec<&str> = entries
             .iter()
@@ -4655,7 +4659,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             repo_name: None,
         }];
 
-        let entries = build_type_manifest_entries(&mount_graph, &config);
+        let entries = build_type_manifest_entries(&mount_graph, &config, ".");
 
         assert!(
             entries.iter().all(|e| e.role != ManifestRole::Producer),
@@ -6558,6 +6562,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             &mut entries,
             &file_results,
             &crate::socket_io::SocketExtraction::default(),
+            ".",
         );
         let manifest_alias = entries
             .iter()
@@ -6635,6 +6640,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             &mut entries,
             &file_results,
             &crate::socket_io::SocketExtraction::default(),
+            ".",
         );
         let manifest_aliases: HashSet<String> = entries
             .iter()
@@ -6739,6 +6745,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             &mut entries,
             &file_results,
             &crate::socket_io::SocketExtraction::default(),
+            ".",
         );
         let manifest_aliases: HashMap<ManifestRole, String> = entries
             .iter()
@@ -6930,6 +6937,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             &mut entries,
             &file_results,
             &crate::socket_io::SocketExtraction::default(),
+            ".",
         );
 
         let producer = entries
@@ -7062,7 +7070,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
         // Manifest side folds identically: no orphan anchor for the folded op,
         // the real pub/sub op still anchors.
         let mut entries = Vec::new();
-        append_pubsub_manifest_entries(&mut entries, &file_results, &extractions.sockets);
+        append_pubsub_manifest_entries(&mut entries, &file_results, &extractions.sockets, ".");
         assert_eq!(
             entries
                 .iter()
@@ -7115,6 +7123,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             &mut entries,
             &file_results,
             &crate::socket_io::SocketExtraction::default(),
+            ".",
         );
 
         let untyped = entries

--- a/src/type_manifest.rs
+++ b/src/type_manifest.rs
@@ -50,8 +50,44 @@ pub fn build_manifest_type_alias(
     format!("Endpoint_{:016x}_{}", hash, type_label)
 }
 
-pub fn build_call_site_id(file_path: &str, line_number: u32, key: &OperationKey) -> String {
-    let hash_input = format!("{}|{}|{}", file_path, line_number, key.canonical());
+/// Reduce a source path to its repo-relative form for hashing: strip the
+/// repo-root prefix when present, then any leading `./`. Mirrors the cache-key
+/// normalization in `normalize_file_results_keys` so a full-scan absolute key
+/// (`/abs/repo/src/api.ts`) and an incremental repo-relative key (`src/api.ts`)
+/// reduce to the same string. A path outside the root passes through unchanged.
+fn repo_relative_source_path<'a>(file_path: &'a str, repo_root: &str) -> &'a str {
+    let root = repo_root.trim_end_matches('/');
+    let stripped = if root.is_empty() || root == "." {
+        file_path
+    } else {
+        file_path
+            .strip_prefix(root)
+            .and_then(|rest| rest.strip_prefix('/'))
+            .unwrap_or(file_path)
+    };
+    stripped.strip_prefix("./").unwrap_or(stripped)
+}
+
+/// Hash a consumer call site into the 16-hex id embedded in
+/// `Endpoint_<hash>_<Kind>_Call<id>` aliases. The id is a join key across the
+/// manifest, SymbolRequest, and infer-request sides, so every producer of it
+/// must call this function with the same `(path, line, key)` triple.
+///
+/// The path is reduced to its repo-relative form before hashing (issue #355):
+/// hashing the absolute path made every `_Call<id>` alias machine-specific,
+/// which broke byte-compared goldens across machines and any future
+/// output-determinism guarantee. Relativizing INSIDE this function (rather
+/// than at call sites) keeps the id identical at every join site regardless of
+/// whether the caller holds an absolute full-scan key or a repo-relative
+/// incremental key.
+pub fn build_call_site_id(
+    file_path: &str,
+    line_number: u32,
+    key: &OperationKey,
+    repo_root: &str,
+) -> String {
+    let relative = repo_relative_source_path(file_path, repo_root);
+    let hash_input = format!("{}|{}|{}", relative, line_number, key.canonical());
     format!("{:016x}", fnv1a_hash(&hash_input))
 }
 
@@ -122,7 +158,7 @@ mod tests {
         let key = OperationKey::http("GET", "/users");
         let base =
             build_manifest_type_alias(&key, ManifestRole::Consumer, ManifestTypeKind::Response);
-        let call_id = build_call_site_id("src/service.ts", 12, &key);
+        let call_id = build_call_site_id("src/service.ts", 12, &key, ".");
         let with_call = build_manifest_type_alias_with_call_id(
             &key,
             ManifestRole::Consumer,
@@ -132,6 +168,44 @@ mod tests {
 
         assert_ne!(base, with_call);
         assert!(with_call.contains("_Call"));
+    }
+
+    /// Issue #355 contract: the call-site id must not depend on WHERE the repo
+    /// is checked out. An absolute path under one root, the same path under
+    /// another root, and the already-relative incremental-cache form must all
+    /// hash to the same id.
+    #[test]
+    fn test_build_call_site_id_is_repo_root_invariant() {
+        let key = OperationKey::http("GET", "/users");
+        let from_abs_a =
+            build_call_site_id("/home/alice/repo/src/api.ts", 12, &key, "/home/alice/repo");
+        let from_abs_b = build_call_site_id("/ci/work/repo/src/api.ts", 12, &key, "/ci/work/repo/");
+        let from_rel = build_call_site_id("src/api.ts", 12, &key, ".");
+        let from_dot_rel = build_call_site_id("./src/api.ts", 12, &key, ".");
+
+        assert_eq!(from_abs_a, from_abs_b);
+        assert_eq!(from_abs_a, from_rel);
+        assert_eq!(from_abs_a, from_dot_rel);
+    }
+
+    /// A path outside the repo root must pass through unchanged, never be
+    /// mangled by a partial prefix match (`/repo` vs `/repo-other`).
+    #[test]
+    fn test_repo_relative_source_path_prefix_safety() {
+        assert_eq!(
+            repo_relative_source_path("/a/repo-other/src/x.ts", "/a/repo"),
+            "/a/repo-other/src/x.ts"
+        );
+        assert_eq!(
+            repo_relative_source_path("/a/repo/src/x.ts", "/a/repo"),
+            "src/x.ts"
+        );
+        assert_eq!(repo_relative_source_path("src/x.ts", "/a/repo"), "src/x.ts");
+        assert_eq!(repo_relative_source_path("./src/x.ts", "."), "src/x.ts");
+        assert_eq!(
+            repo_relative_source_path("/a/repo/src/x.ts", ""),
+            "/a/repo/src/x.ts"
+        );
     }
 
     #[test]

--- a/tests/fixtures/llm-mocked-api/__golden__.json
+++ b/tests/fixtures/llm-mocked-api/__golden__.json
@@ -92,9 +92,9 @@
       "response_type": null,
       "file": "tests/fixtures/llm-mocked-api/src/client.ts",
       "line": 4,
-      "type_alias": "Endpoint_4022e5b76e4552db_Response_Call0000000000000000",
+      "type_alias": "Endpoint_4022e5b76e4552db_Response_Calle64c9717ada550f1",
       "type_state": "Explicit",
-      "resolved_definition": "export interface Endpoint_4022e5b76e4552db_Response_Call0000000000000000 { id: number; userId: number; total: number; }",
+      "resolved_definition": "export interface Endpoint_4022e5b76e4552db_Response_Calle64c9717ada550f1 { id: number; userId: number; total: number; }",
       "expanded_definition": "{ id: number; userId: number; total: number; }",
       "is_explicit": true,
       "primary_type_symbol": "Order"

--- a/tests/llm_cassette_hard_gate_test.rs
+++ b/tests/llm_cassette_hard_gate_test.rs
@@ -19,39 +19,14 @@
 //!   CARRICK_MOCK_FIXTURE_DIR=tests/fixtures/llm-mocked-api/__llm__/ \
 //!   cargo run -- tests/fixtures/llm-mocked-api \
 //!   | sed "s#$(pwd)/##" \
-//!   | sed -E 's/_Call[0-9a-f]{16}/_Call0000000000000000/g' \
 //!   > tests/fixtures/llm-mocked-api/__golden__.json
 //! ```
 //!
-//! The second sed masks consumer call-site ids: `build_call_site_id` hashes the
-//! ABSOLUTE call-site file path (its uniqueness contract is per-run, so that is
-//! fine at runtime), which makes any `Endpoint_<hash>_<Kind>_Call<id>` alias
-//! machine-specific. The test applies the same mask to both sides, so the
-//! comparison is invariant to where the golden was recorded while still gating
-//! on everything semantic (keys, paths, resolved definitions, type states).
+//! `Endpoint_<hash>_<Kind>_Call<id>` aliases are compared verbatim:
+//! `build_call_site_id` hashes the REPO-RELATIVE call-site path (#355), so the
+//! ids are identical on every machine and need no masking.
 
 use std::process::Command;
-
-/// Mask the 16-hex call-site id in `_Call<id>` alias suffixes (see module doc).
-fn mask_call_site_ids(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut rest = s;
-    const TAG: &str = "_Call";
-    while let Some(idx) = rest.find(TAG) {
-        let after = &rest[idx + TAG.len()..];
-        let is_id = after.len() >= 16 && after.as_bytes()[..16].iter().all(u8::is_ascii_hexdigit);
-        if is_id {
-            out.push_str(&rest[..idx + TAG.len()]);
-            out.push_str("0000000000000000");
-            rest = &after[16..];
-        } else {
-            out.push_str(&rest[..idx + TAG.len()]);
-            rest = after;
-        }
-    }
-    out.push_str(rest);
-    out
-}
 
 #[test]
 fn cassette_hard_gate_llm_mocked_api() {
@@ -76,18 +51,15 @@ fn cassette_hard_gate_llm_mocked_api() {
     let stdout = String::from_utf8(output.stdout).expect("scanner stdout was not UTF-8");
     // Relativise the absolute repo root so the golden is portable across
     // machines / CI runners. The scanner is invoked with `{repo}/...`, so file
-    // paths in the projection are anchored at the same prefix.
-    // Mask machine-specific call-site ids on BOTH sides (see module doc): the
-    // id hashes the absolute file path, so it can never byte-match across
-    // machines/CI runners no matter where the golden was recorded.
-    let normalized = mask_call_site_ids(&stdout.replace(&format!("{repo}/"), ""));
+    // paths in the projection are anchored at the same prefix. Call-site ids
+    // need no masking: they hash the repo-relative path (#355).
+    let normalized = stdout.replace(&format!("{repo}/"), "");
 
     let actual: serde_json::Value =
         serde_json::from_str(&normalized).expect("scanner output was not valid JSON");
-    let golden: serde_json::Value = serde_json::from_str(&mask_call_site_ids(include_str!(
-        "fixtures/llm-mocked-api/__golden__.json"
-    )))
-    .expect("golden fixture was not valid JSON");
+    let golden: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/llm-mocked-api/__golden__.json"))
+            .expect("golden fixture was not valid JSON");
 
     assert_eq!(
         actual, golden,


### PR DESCRIPTION
## Problem (issue #355)

`build_call_site_id` hashed the ABSOLUTE call-site file path, so every `Endpoint_<hash>_<Kind>_Call<16hex>` alias differed per machine/runner for identical input. The cassette hard gate could never byte-match a re-recorded golden across machines, and PR #354 worked around it by masking the `_Call<16hex>` suffix to zeros on both sides of the comparison.

There was also a latent full-vs-incremental inconsistency: the full-analysis path keys `file_results` by absolute path while the incremental path normalizes keys to repo-relative (`normalize_file_results_keys`), so the same call site could hash differently depending on scan mode.

## Fix

The path is reduced to its repo-relative form INSIDE `build_call_site_id` (new `repo_root` parameter plus a `repo_relative_source_path` helper that mirrors `normalize_file_results_keys`: strip `{repo_root}/`, then a leading `./`, prefix-boundary safe so `/repo` never eats `/repo-other`). Relativizing inside the hash function rather than at call sites keeps the id identical at every join site by construction, whether the caller holds an absolute full-scan key or a repo-relative incremental key.

## Join sites audited

The alias is a join key across producer/consumer/sidecar sites. Every producer of the id was updated to pass the engine's canonical `repo_path` (the same string at every site within a run) and re-audited for byte-identity:

1. `src/engine/mod.rs` `build_type_manifest_entries` — HTTP consumer manifest entries (mount-graph `file_location`, which embeds the `file_results` key).
2. `src/engine/mod.rs` `append_pubsub_manifest_entries` — pub/sub publisher (consumer) manifest entries (raw `file_results` key).
3. `src/agents/file_orchestrator.rs` `collect_type_requests`, mount-graph loop — `data_call_lookup` ids handed to the SymbolRequest/infer side (parsed back out of the same `file_location`).
4. `src/agents/file_orchestrator.rs` `collect_type_requests`, per-file fallback — id recomputed from the raw `file_results` key when no lookup entry matches.
5. `src/agents/file_orchestrator.rs` `collect_pubsub_type_requests` — publisher SymbolRequest alias (raw `file_results` key).
6. `src/agents/file_orchestrator.rs` `collect_pubsub_infer_requests` — publisher infer-request alias (raw `file_results` key).

A repo-wide grep confirms these are the only `build_call_site_id` callers; `ts_check`, the sidecar, and `carrick-match` treat the alias as an opaque string and never parse the id. The existing alias byte-identity unit tests (manifest side vs request side) all still pass, now exercising the relativized ids.

## Gate mask removed

`tests/llm_cassette_hard_gate_test.rs` no longer masks `_Call<16hex>`: the `mask_call_site_ids` helper, the mask sed in the re-record recipe, and the mask rationale are gone, so the gate compares real ids again. The `llm-mocked-api` golden was re-recorded deterministically from the frozen cassettes (mock replay, `CARRICK_MOCK_ALL=1`, no model calls); the only diff against the previous golden is the masked id becoming the real one, verified byte-identical across two consecutive replays. The new id equals `fnv1a("src/client.ts|4|http|GET|/api/orders")`, independently recomputed, proving it derives from the repo-relative path only. CI matching this golden from a different checkout path is the end-to-end cross-machine proof.

## Tests

- New `test_build_call_site_id_is_repo_root_invariant`: same id for the same file under two different absolute roots and in relative/`./`-relative form.
- New `test_repo_relative_source_path_prefix_safety`: prefix-boundary and passthrough cases.
- Full `cargo test` (1200+ tests incl. cassette gate, sidecar integration, ts_check suite) green via the pre-commit hook.

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
