### PR TITLE
fix: name both sides of cross-repo match rows by the service-qualified id

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -3725,6 +3725,7 @@ impl FileOrchestrator {
                     file_location: format!("{}:{}", file_path, data_call.line_number),
                     call_kind: data_call.call_kind,
                     repo_name: None,
+                    service_name: None,
                 });
             }
         }

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -106,7 +106,9 @@ pub struct CrossRepoMatch {
     pub producer_repo: String,
     /// `OperationKey::canonical()` of the producer endpoint (mount-resolved path).
     pub producer_key: String,
-    /// Repo id of the consumer call.
+    /// Repo id of the consumer call (service_name ?? repo_name — the SAME
+    /// convention as `producer_repo`, so the two sides of an edge join on one
+    /// identity; #368).
     pub consumer_repo: String,
     /// `OperationKey::canonical()` of the consumer call (URL-normalized path).
     pub consumer_key: String,
@@ -1433,10 +1435,14 @@ impl Analyzer {
         type SharedGroup = (BTreeSet<String>, BTreeSet<String>);
         let mut shared_contract_groups: BTreeMap<(String, String), SharedGroup> = BTreeMap::new();
 
-        // Consumer repo lookup: a call's `(METHOD, canonical_path, file_location)`
-        // → owning repo. `merge_from_repos` tags each merged data call with its
-        // repo; `self.calls` carry only `(key, file_path)`, so this re-attaches
-        // the repo identity at the matching site. Keyed on `canonical_path` (NOT
+        // Consumer id lookup: a call's `(METHOD, canonical_path, file_location)`
+        // → owning `service_name ?? repo_name` id — the SAME id convention the
+        // producer side resolves through `endpoint.service_name ??
+        // endpoint.repo_name`, so both sides of an edge join on one identity
+        // (#368; a repo-only consumer id left monorepo rows asymmetric).
+        // `merge_from_repos` tags each merged data call with its repo and
+        // service; `self.calls` carry only `(key, file_path)`, so this
+        // re-attaches the identity at the matching site. Keyed on `canonical_path` (NOT
         // the raw `target_url`) because that is exactly the path the matcher looks
         // up with — `self.calls[].key` is `OperationKey::http(method,
         // canonical_path)`, so `build_cross_repo_match`'s `target` is the bare
@@ -1447,14 +1453,14 @@ impl Analyzer {
             .get_data_calls()
             .iter()
             .filter_map(|c| {
-                c.repo_name.as_ref().map(|repo| {
+                c.service_name.as_ref().or(c.repo_name.as_ref()).map(|id| {
                     (
                         (
                             c.method.to_uppercase(),
                             c.canonical_path.clone(),
                             c.file_location.clone(),
                         ),
-                        repo.clone(),
+                        id.clone(),
                     )
                 })
             })
@@ -1779,9 +1785,10 @@ impl Analyzer {
     }
 
     /// Build a [`CrossRepoMatch`] from a matched consumer call + producer
-    /// endpoint. Returns `None` only when the consumer's repo cannot be
-    /// attributed (no `repo_name` tag in the merged graph for this call) — an
-    /// edge without both repo ids is not useful to the scorer.
+    /// endpoint. Both sides carry the `service_name ?? repo_name` id (#368).
+    /// Returns `None` only when the consumer cannot be attributed (no
+    /// `service_name`/`repo_name` tag in the merged graph for this call) — an
+    /// edge without both ids is not useful to the scorer.
     ///
     /// `match_score` is `1.0`: every edge captured here is an exact
     /// normalized-key match (there is no finer scorer yet). `type_compatible`
@@ -3688,6 +3695,7 @@ mod tests {
             file_location: "client.ts:12".to_string(),
             call_kind: None,
             repo_name: Some("consumer-repo".to_string()),
+            service_name: None,
         });
 
         let (findings, verified, edges) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
@@ -3792,6 +3800,7 @@ mod tests {
             file_location: "src/widgets-client.ts:33".to_string(),
             call_kind: None,
             repo_name: Some("repo-beta".to_string()),
+            service_name: None,
         });
         analyzer
             .calls
@@ -3864,6 +3873,7 @@ mod tests {
             file_location: "src/widgets-client.ts:33".to_string(),
             call_kind: None,
             repo_name: Some("repo-beta".to_string()),
+            service_name: None,
         });
         analyzer
             .calls
@@ -3919,6 +3929,7 @@ mod tests {
             file_location: "operations/create-widget.ts:14".to_string(),
             call_kind: None,
             repo_name: Some("repo-alpha".to_string()),
+            service_name: None,
         });
         analyzer.calls.push(http_call(
             "POST",
@@ -4817,7 +4828,53 @@ mod tests {
             file_location: file.to_string(),
             call_kind: None,
             repo_name: Some(repo.to_string()),
+            service_name: None,
         }
+    }
+
+    /// Convention pin (#368): both sides of a cross-repo match row carry the
+    /// `service_name ?? repo_name` id. In a monorepo (carrick.json
+    /// `services[]`) producer AND consumer are named by service; a repo-only
+    /// consumer id left rows asymmetric (`web -> <repo>`), breaking every
+    /// join on edge identity — the eval scorer's owner attribution and the
+    /// cloud's `attach_compat_verdicts` consumer filter included.
+    #[test]
+    fn match_row_ids_are_service_qualified_on_both_sides() {
+        let cm = Lrc::new(SourceMap::default());
+        let mut analyzer = Analyzer::new(Config::default(), cm);
+
+        analyzer.calls.push(http_call(
+            "POST",
+            "/api/v2/client/:workspaceId/user",
+            "apps/web/src/client.ts:12",
+        ));
+
+        let mut mount_graph = MountGraph::new();
+        // Producer: the `api` service of monorepo `acme-mono`.
+        let mut producer = resolved_in("POST", "/api/v2/client/:workspaceId/user", "acme-mono");
+        producer.service_name = Some("api".to_string());
+        mount_graph.endpoints.push(producer);
+        // Consumer: the `web` service of the same monorepo.
+        let mut consumer = data_call_in(
+            "POST",
+            "/api/v2/client/:workspaceId/user",
+            "apps/web/src/client.ts:12",
+            "acme-mono",
+        );
+        consumer.service_name = Some("web".to_string());
+        mount_graph.data_calls.push(consumer);
+
+        let (_, _, edges) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
+
+        assert_eq!(edges.len(), 1, "expected one edge, got {edges:?}");
+        assert_eq!(
+            (
+                edges[0].producer_repo.as_str(),
+                edges[0].consumer_repo.as_str()
+            ),
+            ("api", "web"),
+            "both sides must carry the service-qualified id"
+        );
     }
 
     /// KILL (#381): a wildcard-only producer (`GET /*`, the SPA fallback

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4524,6 +4524,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
                 file_location: file.to_string(),
                 call_kind: None,
                 repo_name: None,
+                service_name: None,
             }
         };
         let mut mount_graph = MountGraph::new();
@@ -4657,6 +4658,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             file_location: "operations/create-widget.ts:14".to_string(),
             call_kind: None,
             repo_name: None,
+            service_name: None,
         }];
 
         let entries = build_type_manifest_entries(&mount_graph, &config, ".");
@@ -5840,6 +5842,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             file_location: file_location.to_string(),
             call_kind: None,
             repo_name: None,
+            service_name: None,
         }
     }
 
@@ -5890,6 +5893,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             file_location: "src/gql.ts:25".to_string(),
             call_kind: None,
             repo_name: None,
+            service_name: None,
         }];
         let graphql = crate::graphql::GraphqlExtraction {
             producers: vec![],

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -77,6 +77,12 @@ pub struct EvalOp {
 }
 
 /// A structured producer→consumer edge (contract §2 FROZEN field set).
+///
+/// `producer_repo` and `consumer_repo` both carry the `service_name ??
+/// repo_name` id — one convention on BOTH sides (#368). In a plain repo that
+/// is the repo name; in a monorepo with carrick.json `services[]` it is the
+/// service name, on the producer AND the consumer, so a join on edge identity
+/// never sees a service on one side and a repo on the other.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CrossRepoMatch {
     pub producer_repo: String,

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -87,6 +87,13 @@ pub struct DataFetchingCall {
     /// `None` until merge (single-repo graphs don't carry it).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repo_name: Option<String>,
+    /// Owning service (monorepo carrick.json serviceName), tagged during
+    /// cross-repo merge exactly like `repo_name`. Carried so a matched
+    /// consumer resolves to the same `service_name ?? repo_name` id the
+    /// producer side uses — without it, monorepo match rows named the
+    /// producer by service but the consumer by repo (#368).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_name: Option<String>,
 }
 
 /// The complete mount and endpoint graph
@@ -411,14 +418,16 @@ impl MountGraph {
                 }
 
                 // Merge data calls (deduplicate by method + target_url + file_location).
-                // Tag each consumer with its owning repo (symmetric with the
-                // endpoint tagging above) so a matched call can be attributed to
-                // its repo for cross-repo edge capture.
+                // Tag each consumer with its owning repo AND (monorepo) service
+                // (symmetric with the endpoint tagging above) so a matched call
+                // resolves to the same `service_name ?? repo_name` id producers
+                // carry when cross-repo edges are captured (#368).
                 for call in &mount_graph.data_calls {
                     let key = format!("{}:{}:{}", call.method, call.target_url, call.file_location);
                     if seen_data_calls.insert(key) {
                         let mut tagged_call = call.clone();
                         tagged_call.repo_name = Some(repo_data.repo_name.clone());
+                        tagged_call.service_name = repo_data.service_name.clone();
                         merged.data_calls.push(tagged_call);
                     }
                 }
@@ -973,5 +982,32 @@ mod tests {
             .filter(|e| e.full_path == "/health")
             .count();
         assert_eq!(health, 2, "endpoints from different repos must be kept");
+    }
+
+    #[test]
+    fn test_merge_tags_data_calls_with_repo_and_service() {
+        // Consumer calls must be tagged with BOTH repo and service, so the
+        // matcher resolves them to the same `service_name ?? repo_name` id
+        // producers carry (#368) — repo-only tagging left match rows naming
+        // the producer by service but the consumer by repo.
+        let mut repo = cloud_repo_with_health("platform", Some("web"));
+        repo.mount_graph
+            .as_mut()
+            .unwrap()
+            .data_calls
+            .push(DataFetchingCall {
+                method: "GET".to_string(),
+                target_url: "/api/orders".to_string(),
+                canonical_path: "/api/orders".to_string(),
+                client: "fetch".to_string(),
+                file_location: "apps/web/src/orders.ts:4".to_string(),
+                call_kind: None,
+                repo_name: None,
+                service_name: None,
+            });
+        let merged = MountGraph::merge_from_repos(&[repo]);
+        assert_eq!(merged.data_calls.len(), 1);
+        assert_eq!(merged.data_calls[0].repo_name.as_deref(), Some("platform"));
+        assert_eq!(merged.data_calls[0].service_name.as_deref(), Some("web"));
     }
 }


### PR DESCRIPTION
Closes #368.

## Problem

Cross-repo match rows named the producer by the service-qualified id (`service_name ?? repo_name`) but the consumer by repo only. In a monorepo scan with carrick.json `services[]` that produced rows like `web -> <repo>`, so any consumer joining edges on one identity broke, including the eval scorer's expected-match comparison and owner attribution.

## Convention decided

Both sides carry `service_name ?? repo_name`. This is the convention the rest of the system already commits to:

- `CompatVerdict` (the persisted cloud contract) documents exactly this id on both key fields; the cloud reconstructs pair identity from it, so the scanner cannot emit anything else without breaking that join.
- The exact-key matcher (GraphQL, socket, pub/sub) already resolves both sides this way.
- `attach_compat_verdicts` filters consumer edges with `consumer_repo != (service_name ?? repo_name)`.

Repo-only naming was rejected because a repo id is lossy in monorepos: one repo holds several services, so a repo-only consumer id cannot be mapped back to the service that made the call, and intra-monorepo cross-service edges (the Formbricks shape) would collapse into apparent self-loops.

## Root cause and fix

`DataFetchingCall` had no `service_name` field at all, so the HTTP consumer side could only ever be attributed by repo:

- `src/mount_graph.rs`: add `service_name` to `DataFetchingCall`; `merge_from_repos` now tags consumers with repo and service, symmetric with endpoint tagging.
- `src/analyzer/mod.rs`: the `consumer_repo_by_call` lookup now resolves `service_name ?? repo_name`, the same id the producer side resolves through `endpoint.service_name ?? endpoint.repo_name`.
- Doc comments on both `CrossRepoMatch` structs (analyzer and eval projection) now pin the convention.

Side effect worth naming: `attach_compat_verdicts` previously dropped every HTTP compat verdict for monorepo service consumers, because `consumer_repo` (repo) never equalled `service_id` (service). Those verdicts now attach.

## Join sites audited

Following the #294 lesson, every reader of these rows was grepped and checked:

1. `src/analyzer/mod.rs` `consumer_repo_by_call` + `build_cross_repo_match` (HTTP consumer side): fixed, now `service_name ?? repo_name`.
2. `src/analyzer/mod.rs` `analyze_exact_key_matches` (GraphQL/socket/pub-sub): already used `service_name ?? repo_name` on both sides; unchanged.
3. `src/analyzer/mod.rs` shared-external-contract grouping and its `producer_repo != consumer_repo` self-pair guard: now compares like ids instead of service-vs-repo.
4. `src/analyzer/mod.rs` orphaned-endpoint finding attribution: already `service_name ?? repo_name`; unchanged.
5. `src/mount_graph.rs` `merge_from_repos` consumer tagging: fixed, tags service alongside repo.
6. `src/eval_output.rs` projection pass-through, deterministic sort keys, and `intra_repo_self_loops` (non-HTTP, `service_name ?? repo_name` on ops): consistent with the edge ids.
7. `src/cloud_storage/mod.rs` `attach_compat_verdicts` consumer filter: joins again for monorepo HTTP consumers (see above).
8. `src/cloud_storage/mod.rs` `CompatVerdict` persisted keys: the documented convention now actually holds for HTTP consumer rows, so no cloud-side change is required.
9. `tests/eval_xrepo.rs` scorer: joins expected and actual rows as opaque string tuples; the corpora declare no `services[]`, so emitted values there are unchanged.
10. `ts_check/`, `crates/carrick-match`, `src/formatter`: no readers of these fields.

## Tests

- `analyzer::tests::match_row_ids_are_service_qualified_on_both_sides` pins the convention on the issue's exact shape (monorepo `api` service producer, `web` service consumer, `POST /api/v2/client/:workspaceId/user`).
- `mount_graph::tests::test_merge_tags_data_calls_with_repo_and_service` pins the merge tagging.
- Existing tests (helpers construct calls with `service_name: None`) pin the repo fallback.
- Full `cargo test` green, including the cassette hard gate. The cassette golden is byte-identical before and after the change (verified by diffing scanner output on the frozen fixture against a pristine origin/main run), so single-service scans are provably unaffected.

Live owner-accuracy confirmation on the monorepo scan is deferred to the morning batched eval run; no paid LLM calls were made for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
