### PR TITLE
fix: carry the member property on URL-scheme and awaited-call candidates

### DIFF
--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -1062,7 +1062,6 @@ impl CandidateVisitor {
         })
     }
 
-    /// Extract callee object name from expression
     /// Property name of a member-expression callee (`axios.post(...)` ->
     /// "post", `w['post'](...)` -> "post"). `None` for non-member callees and
     /// non-literal computed properties. Used by the structural signals (URL
@@ -1086,6 +1085,7 @@ impl CandidateVisitor {
         }
     }
 
+    /// Extract callee object name from expression
     fn extract_callee_object(expr: &Expr) -> Option<String> {
         match expr {
             Expr::Ident(ident) => Some(ident.sym.to_string()),
@@ -1300,13 +1300,10 @@ impl Visit for CandidateVisitor {
             && let Some(root) = Self::callee_root_ident(callee_expr)
             && self.network_import_locals.contains(&root)
         {
-            let property = match &**callee_expr {
-                Expr::Member(member) => match &member.prop {
-                    MemberProp::Ident(id) => Some(id.sym.to_string()),
-                    _ => None,
-                },
-                _ => None,
-            };
+            // Same member-property extraction as Signals 3/4 (incl. computed
+            // string properties like `client["post"](url)`), so every signal
+            // that can emit this span first labels it identically.
+            let property = Self::callee_member_prop(callee_expr);
             self.push_candidate(call, root, property);
         }
 
@@ -1705,6 +1702,26 @@ export async function record(event: unknown): Promise<void> {
         let b = pick(&without_fetcher);
         assert_eq!(a, b, "candidate must not depend on data_fetchers");
         assert_eq!(a.2.as_deref(), Some("post"));
+    }
+
+    #[test]
+    fn imported_fetcher_computed_property_call_carries_property() {
+        // Signal 2 (import-gated) must extract computed string properties the
+        // same way Signals 3/4 do, so whichever signal emits a span first
+        // labels it identically.
+        let content = r#"
+import client from "client-lib";
+export async function load() {
+  await client["post"]("/things", {});
+}
+"#;
+        let result = scan_test_content_with_fetchers(content, &["client-lib".to_string()]);
+        let c = result
+            .candidates
+            .iter()
+            .find(|c| c.callee_object == "client")
+            .expect("imported-fetcher candidate must be emitted");
+        assert_eq!(c.callee_property.as_deref(), Some("post"));
     }
 
     #[test]

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -1063,6 +1063,29 @@ impl CandidateVisitor {
     }
 
     /// Extract callee object name from expression
+    /// Property name of a member-expression callee (`axios.post(...)` ->
+    /// "post", `w['post'](...)` -> "post"). `None` for non-member callees and
+    /// non-literal computed properties. Used by the structural signals (URL
+    /// scheme, awaited stringish call) so the candidate hint carries the full
+    /// `object.property` callee even when the package is absent from the
+    /// LLM-detected `data_fetchers` list — without this, the same call site's
+    /// hint flips between `axios.post` and bare `axios` depending on a per-run
+    /// LLM detection output, which is exactly the kind of prompt variance the
+    /// candidate layer exists to prevent.
+    fn callee_member_prop(expr: &Expr) -> Option<String> {
+        let Expr::Member(member) = expr else {
+            return None;
+        };
+        match &member.prop {
+            MemberProp::Ident(id) => Some(id.sym.to_string()),
+            MemberProp::Computed(c) => match &*c.expr {
+                Expr::Lit(Lit::Str(s)) => Some(s.value.to_string()),
+                _ => None,
+            },
+            MemberProp::PrivateName(_) => None,
+        }
+    }
+
     fn extract_callee_object(expr: &Expr) -> Option<String> {
         match expr {
             Expr::Ident(ident) => Some(ident.sym.to_string()),
@@ -1289,24 +1312,26 @@ impl Visit for CandidateVisitor {
 
         // Signal 3: first argument is a URL with a network scheme.
         if Self::first_arg_has_url_scheme(call) {
-            let obj = match &call.callee {
-                Callee::Expr(e) => {
-                    Self::extract_callee_object(e).unwrap_or_else(|| "<url-call>".to_string())
-                }
-                _ => "<url-call>".to_string(),
+            let (obj, prop) = match &call.callee {
+                Callee::Expr(e) => (
+                    Self::extract_callee_object(e).unwrap_or_else(|| "<url-call>".to_string()),
+                    Self::callee_member_prop(e),
+                ),
+                _ => ("<url-call>".to_string(), None),
             };
-            self.push_candidate(call, obj, None);
+            self.push_candidate(call, obj, prop);
         }
 
         // Signal 4: awaited call with a string/template argument.
         if self.await_depth > 0 && Self::first_arg_is_stringish(call) {
-            let obj = match &call.callee {
-                Callee::Expr(e) => {
-                    Self::extract_callee_object(e).unwrap_or_else(|| "<awaited-call>".to_string())
-                }
-                _ => "<awaited-call>".to_string(),
+            let (obj, prop) = match &call.callee {
+                Callee::Expr(e) => (
+                    Self::extract_callee_object(e).unwrap_or_else(|| "<awaited-call>".to_string()),
+                    Self::callee_member_prop(e),
+                ),
+                _ => ("<awaited-call>".to_string(), None),
             };
-            self.push_candidate(call, obj, None);
+            self.push_candidate(call, obj, prop);
         }
 
         // Signal 5 (existing): method calls matching the API name heuristics.
@@ -1641,6 +1666,64 @@ mod tests {
         let healthy = scan_test_content("const x = 1;");
         assert!(!healthy.parse_failed);
         assert!(healthy.candidates.is_empty());
+    }
+
+    #[test]
+    fn candidate_hint_is_stable_across_data_fetcher_detection() {
+        // carrick#359: the candidate for a member call must carry the same
+        // `object.property` callee whether or not the package appears in the
+        // LLM-detected data_fetchers list. Before this guard, `axios.post`
+        // (Signal 2, import-gated) degraded to bare `axios` with a null
+        // property (Signal 4, awaited-stringish) whenever a scan's detect
+        // output omitted axios — a per-run LLM output mutating the candidate
+        // hint the file-analyzer prompt presents.
+        let content = r#"
+import axios from "axios";
+export async function record(event: unknown): Promise<void> {
+  await axios.post(`${process.env.HOOK_URL ?? "http://localhost:3099"}/audit/events`, event);
+}
+"#;
+
+        let with_fetcher = scan_test_content_with_fetchers(content, &["axios".to_string()]);
+        let without_fetcher = scan_test_content(content);
+
+        let pick = |r: &ScanResult| {
+            let c = r
+                .candidates
+                .iter()
+                .find(|c| c.callee_object == "axios")
+                .expect("axios candidate must be emitted")
+                .clone();
+            (
+                c.candidate_id.clone(),
+                c.callee_object.clone(),
+                c.callee_property.clone(),
+                c.path_snippet.clone(),
+            )
+        };
+        let a = pick(&with_fetcher);
+        let b = pick(&without_fetcher);
+        assert_eq!(a, b, "candidate must not depend on data_fetchers");
+        assert_eq!(a.2.as_deref(), Some("post"));
+    }
+
+    #[test]
+    fn url_scheme_candidate_carries_member_property() {
+        // Signal 3 (URL-scheme first arg) on a member callee that is neither a
+        // known API object nor a detected data-fetcher import: the hint should
+        // still name the full callee, not just the root object.
+        let content = r#"
+export function ping(myTransport: { fire(u: string): void }) {
+  myTransport.fire("https://example.com/ping");
+}
+"#;
+        let result = scan_test_content(content);
+        let c = result
+            .candidates
+            .iter()
+            .find(|c| c.callee_object == "myTransport")
+            .expect("url-scheme candidate must be emitted");
+        assert_eq!(c.callee_property.as_deref(), Some("fire"));
     }
 
     #[test]


### PR DESCRIPTION
## What

The SWC candidate for a member call like `axios.post(url, body)` only carried its full `object.property` callee when the package appeared in the LLM-detected `data_fetchers` list (Signal 2, import-gated). When a scan's detect output omitted the package, the awaited-stringish signal (Signal 4) or the URL-scheme signal (Signal 3) emitted the same span first with a bare root object and `callee_property: null`. The span dedup in `push_candidate` keeps the first emission, so the hint and candidate-context JSON the file-analyzer prompt presents for one call site flipped between `axios.post` and bare `axios` depending on a per-run LLM output.

This PR extracts the member property structurally (`callee_member_prop`) for Signals 3 and 4, making the candidate presentation independent of detection.

## Why

Diagnostic pass on #359 (full evidence in the issue comment): AST candidate extraction and per-file prompt assembly are byte-deterministic across 25 independent process invocations, so the live ~1/3 recall miss on the `audit.ts` axios call is not a scanner-ordering bug. The detect-dependent hint degradation found here was the one reproducible source of live prompt variance for exactly that call site, and only the favourable `axios.post` variant was ever exercised by the prompt harness. After this change the no-fetchers and with-fetchers candidate outputs for the payments-svc corpus fixture are byte-identical (25/25 runs).

## Testing

- New unit tests: `candidate_hint_is_stable_across_data_fetcher_detection` and `url_scheme_candidate_carries_member_property` (src/swc_scanner.rs).
- Full `cargo test` suite green, including the cassette hard gate (fixed LLM inputs, exact golden match), clippy and fmt clean.

Live confirmation is deferred to the morning paid eval batch; this PR does not claim to close the flake on its own.

Part of #359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
