### PR TITLE
eval: capture analyzer I/O dump in eval-xrepo runs

### DIFF
--- a/.github/workflows/eval-xrepo.yml
+++ b/.github/workflows/eval-xrepo.yml
@@ -93,9 +93,22 @@ jobs:
           # term on large corpora (fresh eval runs never carry a prior scan's
           # content-hash cache). Skip them in eval scans.
           CARRICK_SKIP_INTENTS: "1"
+          # #359 capture mode: persist every file-analyzer request/response so
+          # the exact live prompt for any file can be replayed in the cloud
+          # prompt harness. The scanner child processes inherit this env.
+          CARRICK_EVAL_DUMP_DIR: ${{ github.workspace }}/target/eval-dump
         run: |
           cargo test --release --test eval_xrepo -- \
             --ignored xrepo_live_scorer --test-threads=1 --nocapture
+
+      # #359: raw analyzer I/O per file (input prompt + raw model response).
+      - name: Upload analyzer dump
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: analyzer-dump
+          path: target/eval-dump/
+          if-no-files-found: warn
 
       # Archive the cross-repo type-check artifacts so compat verdicts are
       # inspectable post-run. The release binary auto-discovers ts_check/ via


### PR DESCRIPTION
## What

Adds `CARRICK_EVAL_DUMP_DIR` to the eval-xrepo live scorer step and uploads the per-file analyzer request/response dump as an `analyzer-dump` workflow artifact (`if: always()`).

## Why

The #359 root-cause session showed the dump is the decisive diagnostic: with it, a single eval run yields the exact prompt and raw model output per file, which is what let a hit run be diffed against a miss run and the residual recall flake be pinned to the scanner's route-shape gate (#399). Capture is free (no extra LLM calls, ~350KB artifact on corpus-1), so it is on for every eval-xrepo run rather than behind an input.

The scanner child processes inherit the step env, so no Rust change is needed (`dump_eval_artifact` in `src/agents/file_analyzer_agent.rs` already gates on the env var).

## Testing

Exercised by five live capture runs on this branch (29677451581, 29677843395, 29677844107, 29677844809, 29677845609) — artifact contents drove the #359 diagnosis and the re-recorded carrick-cloud harness fixture.

Part of #359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)