### PR TITLE
fix: collapse inline env-var fallbacks in data-call targets

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -1066,6 +1066,16 @@ impl FileOrchestrator {
 
                     let mut adjusted = result;
                     Self::apply_candidate_map(&mut adjusted, &pf.candidate_map, &pf.path_str);
+                    // Collapse inline env-var fallbacks the model rendered
+                    // verbatim (`${A ?? "http://localhost"}/p` -> `${A}/p`,
+                    // carrick#399) BEFORE alias resolution: a local alias with
+                    // a rendered fallback must become the bare `${alias}` for
+                    // the alias-map lookup to rewrite it. This fold is the
+                    // single entry point for LLM data calls, so every
+                    // downstream reader (route-shape gate, canonical call key,
+                    // env-var classification, uploads) sees one normalized
+                    // form.
+                    Self::normalize_fallback_targets(&mut adjusted);
                     Self::resolve_env_var_aliases(&mut adjusted, &pf.env_alias_map);
                     Self::validate_type_hints(&mut adjusted, &pf.symbol_table);
                     Self::normalize_unusable_types(&mut adjusted, &framework_detection.frameworks);
@@ -3090,6 +3100,30 @@ impl FileOrchestrator {
         });
     }
 
+    /// Collapse inline env-var fallbacks in data-call targets (carrick#399):
+    /// `${A ?? <expr>}` / `${A || <expr>}` -> `${A}`. The model intermittently
+    /// (~1/3 of scans, guidance-correlated) copies the template literal
+    /// verbatim including its fallback; the whitespace inside the
+    /// interpolation then fails `is_valid_route_shape` and the call is
+    /// silently dropped — the residual #359 recall flake. The env-var NAME is
+    /// the classification signal (#294); the fallback expression is noise.
+    /// Pure string normalization, no re-parse; see
+    /// [`crate::analyzer::normalize_env_fallback_target`] for the exact rules
+    /// (non-fallback expressions stay verbatim and stay rejected).
+    fn normalize_fallback_targets(result: &mut FileAnalysisResult) {
+        for data_call in &mut result.data_calls {
+            if let Some(normalized) =
+                crate::analyzer::normalize_env_fallback_target(&data_call.target)
+            {
+                debug!(
+                    "Collapsed inline fallback in data-call target: {} -> {}",
+                    data_call.target, normalized
+                );
+                data_call.target = normalized;
+            }
+        }
+    }
+
     fn resolve_env_var_aliases(result: &mut FileAnalysisResult, env_alias_map: &EnvAliasMap) {
         if env_alias_map.is_empty() {
             return;
@@ -4688,6 +4722,89 @@ mod tests {
             "https://api.example.com/data"
         );
         assert_eq!(graph.data_calls[0].method, "POST");
+    }
+
+    /// Pre-fix-failing case for carrick#399 (eval run 29677844107): the model
+    /// rendered the audit call target verbatim with its inline fallback, the
+    /// whitespace inside the interpolation failed `is_valid_route_shape`, and
+    /// the fifth-pass gate silently dropped the call. After the fold-time
+    /// collapse, the call survives with the same canonical key the clean
+    /// `${AUDIT_WEBHOOK_URL}/audit/events` rendering produces.
+    #[test]
+    fn test_fallback_target_survives_graph_build_with_clean_canonical_key() {
+        let agent_service = AgentService::new();
+        let orchestrator = FileOrchestrator::new(agent_service);
+
+        let make_result = |target: &str| FileAnalysisResult {
+            data_calls: vec![DataCallResult {
+                call_kind: None,
+                candidate_id: "span:1002-1107".to_string(),
+                line_number: 42,
+                target: target.to_string(),
+                method: Some("POST".to_string()),
+                pattern_matched: "axios.post(".to_string(),
+                call_expression_span_start: None,
+                call_expression_span_end: None,
+                call_expression_text: None,
+                call_expression_line: None,
+                payload_expression_text: None,
+                payload_expression_line: None,
+                primary_type_symbol: None,
+                type_import_source: None,
+            }],
+            ..Default::default()
+        };
+
+        let config = Config {
+            internal_env_vars: ["AUDIT_WEBHOOK_URL"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            ..Config::default()
+        };
+        let normalizer = UrlNormalizer::new(&config);
+
+        let build = |result: FileAnalysisResult| {
+            let mut file_results = HashMap::new();
+            file_results.insert("lib/audit.ts".to_string(), result);
+            orchestrator.build_mount_graph(&file_results, &normalizer, Path::new(""))
+        };
+
+        // The verbatim rendering, run through the fold-time normalization the
+        // orchestrator applies to every LLM result.
+        let mut verbatim =
+            make_result(r#"${AUDIT_WEBHOOK_URL ?? "http://localhost:3099"}/audit/events"#);
+        FileOrchestrator::normalize_fallback_targets(&mut verbatim);
+        let graph = build(verbatim);
+        assert_eq!(
+            graph.data_calls.len(),
+            1,
+            "normalized fallback target must survive the route-shape gate"
+        );
+        assert_eq!(
+            graph.data_calls[0].target_url,
+            "${AUDIT_WEBHOOK_URL}/audit/events"
+        );
+        assert_eq!(graph.data_calls[0].canonical_path, "/audit/events");
+
+        // The clean rendering keys identically (fallback vs clean is the only
+        // difference between the hit and miss eval runs).
+        let clean = build(make_result("${AUDIT_WEBHOOK_URL}/audit/events"));
+        assert_eq!(
+            clean.data_calls[0].canonical_path,
+            graph.data_calls[0].canonical_path
+        );
+        assert_eq!(
+            clean.data_calls[0].target_url,
+            graph.data_calls[0].target_url
+        );
+
+        // A non-fallback whitespace target stays dropped: normalization does
+        // not touch it and the guard still rejects it.
+        let mut junk = make_result("${base + path}/audit/events");
+        FileOrchestrator::normalize_fallback_targets(&mut junk);
+        let graph = build(junk);
+        assert!(graph.data_calls.is_empty());
     }
 
     /// A data call to the service's OWN endpoint (same mount graph) is a

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -3116,7 +3116,7 @@ impl FileOrchestrator {
                 crate::analyzer::normalize_env_fallback_target(&data_call.target)
             {
                 debug!(
-                    "Collapsed inline fallback in data-call target: {} -> {}",
+                    "Collapsed inline fallback in data-call target: {:?} -> {:?}",
                     data_call.target, normalized
                 );
                 data_call.target = normalized;

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -609,16 +609,21 @@ pub fn normalize_env_fallback_target(target: &str) -> Option<String> {
 }
 
 /// Byte index of the `}` closing an interpolation whose `${` was already
-/// consumed. Brace-depth and quote aware, so a `}` inside a quoted fallback
-/// string or a nested `${...}` inside a backtick template does not terminate
-/// the scan early.
+/// consumed. Brace-depth, quote, and escape aware, so a `}` inside a quoted
+/// fallback string (including behind an escaped quote, `"\"}"`) or a nested
+/// `${...}` inside a backtick template does not terminate the scan early.
 fn interpolation_end(s: &str) -> Option<usize> {
     let mut depth = 1usize;
     let mut quote: Option<char> = None;
+    let mut escaped = false;
     for (i, c) in s.char_indices() {
         match quote {
             Some(q) => {
-                if c == q {
+                if escaped {
+                    escaped = false;
+                } else if c == '\\' {
+                    escaped = true;
+                } else if c == q {
                     quote = None;
                 }
             }
@@ -655,17 +660,24 @@ fn fallback_reference(content: &str) -> Option<&str> {
 }
 
 /// Byte index of the first `??` or `||` outside quotes and outside any
-/// bracket/paren/brace nesting. Single `?`/`|` (ternary, optional chaining,
-/// bitwise-or) never match.
+/// bracket/paren/brace nesting. Escape aware inside quotes, so an escaped
+/// quote never ends the string early and a `??`/`||` inside a string literal
+/// never counts. Single `?`/`|` (ternary, optional chaining, bitwise-or)
+/// never match.
 fn top_level_fallback_op(s: &str) -> Option<usize> {
     let bytes = s.as_bytes();
     let mut depth = 0usize;
     let mut quote: Option<u8> = None;
+    let mut escaped = false;
     for i in 0..bytes.len() {
         let b = bytes[i];
         match quote {
             Some(q) => {
-                if b == q {
+                if escaped {
+                    escaped = false;
+                } else if b == b'\\' {
+                    escaped = true;
+                } else if b == q {
                     quote = None;
                 }
             }
@@ -2968,6 +2980,10 @@ mod tests {
             ("${BASE ?? `http://localhost:${PORT}`}/p", "${BASE}/p"),
             // Quoted `}` and `||` inside the fallback string are inert.
             (r#"${BASE ?? "a||b}c"}/p"#, "${BASE}/p"),
+            // Escaped quote inside the fallback string does not end the
+            // string early, so the `}` and `||` behind it stay inert.
+            (r#"${BASE ?? "it\"s}fine"}/p"#, "${BASE}/p"),
+            (r#"${BASE ?? "\" || junk"}/p"#, "${BASE}/p"),
             // Backtick-wrapped template with a mid-path param: only the
             // fallback interpolation collapses, the `${id}` param survives.
             (

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -555,6 +555,138 @@ fn dedup_findings(findings: &mut Vec<Finding>) {
 /// `unknown`) — is rejected. Pure string-shape logic: it names no framework,
 /// client, or SDK. The shape-blind residue (a bare `${TABLE_NAME}` that is
 /// really a datastore resource, not a base URL) is handled on the prompt side.
+/// Collapse an inline fallback inside a template interpolation to the bare
+/// reference: `${A ?? <expr>}` / `${A || <expr>}` -> `${A}` (equivalently
+/// `${process.env.A ?? <expr>}` and dotted alias forms like
+/// `${config.baseUrl || <expr>}`). Applies to every interpolation in the
+/// target, so a mid-path `${id ?? 0}` also collapses to the plain `${id}`
+/// param form.
+///
+/// The file-analyzer LLM sometimes renders a call target verbatim with its
+/// source-level fallback (`${AUDIT_WEBHOOK_URL ?? "http://localhost:3099"}
+/// /audit/events`, carrick#399); the whitespace inside the interpolation then
+/// fails [`is_valid_route_shape`] and the call is silently dropped. The
+/// env-var NAME is the classification signal (carrick#294) and the fallback
+/// expression is noise, so both observed renderings of the same call site
+/// normalize to the identical canonical key.
+///
+/// Deliberately tight: the collapse happens only when the left-hand side of a
+/// top-level `??`/`||` (outside quotes, brackets, and parens) is a clean
+/// reference (ASCII alphanumerics, `_`, `$`, `.`). Anything else — call
+/// expressions, concatenation, plain whitespace junk — is left verbatim so
+/// [`is_valid_route_shape`] still rejects it.
+///
+/// Returns `Some(normalized)` when at least one interpolation was collapsed,
+/// `None` when the target has no collapsible fallback.
+pub fn normalize_env_fallback_target(target: &str) -> Option<String> {
+    let mut out = String::with_capacity(target.len());
+    let mut rest = target;
+    let mut changed = false;
+    while let Some(start) = rest.find("${") {
+        let (before, after) = rest.split_at(start);
+        out.push_str(before);
+        let inner = &after[2..];
+        let Some(end) = interpolation_end(inner) else {
+            // Unterminated interpolation: keep the tail verbatim.
+            out.push_str(after);
+            rest = "";
+            break;
+        };
+        let content = &inner[..end];
+        match fallback_reference(content) {
+            Some(reference) => {
+                out.push_str("${");
+                out.push_str(reference);
+                out.push('}');
+                changed = true;
+            }
+            None => out.push_str(&after[..end + 3]),
+        }
+        rest = &inner[end + 1..];
+    }
+    out.push_str(rest);
+    changed.then_some(out)
+}
+
+/// Byte index of the `}` closing an interpolation whose `${` was already
+/// consumed. Brace-depth and quote aware, so a `}` inside a quoted fallback
+/// string or a nested `${...}` inside a backtick template does not terminate
+/// the scan early.
+fn interpolation_end(s: &str) -> Option<usize> {
+    let mut depth = 1usize;
+    let mut quote: Option<char> = None;
+    for (i, c) in s.char_indices() {
+        match quote {
+            Some(q) => {
+                if c == q {
+                    quote = None;
+                }
+            }
+            None => match c {
+                '"' | '\'' | '`' => quote = Some(c),
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(i);
+                    }
+                }
+                _ => {}
+            },
+        }
+    }
+    None
+}
+
+/// If the interpolation content is `<reference> ?? <expr>` or
+/// `<reference> || <expr>` with the operator at the top level, return the
+/// trimmed reference. `None` means "not a collapsible fallback" — the caller
+/// keeps the content verbatim.
+fn fallback_reference(content: &str) -> Option<&str> {
+    let op = top_level_fallback_op(content)?;
+    let reference = content[..op].trim();
+    let expr = content[op + 2..].trim();
+    (!reference.is_empty()
+        && !expr.is_empty()
+        && reference
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '$' | '.')))
+    .then_some(reference)
+}
+
+/// Byte index of the first `??` or `||` outside quotes and outside any
+/// bracket/paren/brace nesting. Single `?`/`|` (ternary, optional chaining,
+/// bitwise-or) never match.
+fn top_level_fallback_op(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut depth = 0usize;
+    let mut quote: Option<u8> = None;
+    for i in 0..bytes.len() {
+        let b = bytes[i];
+        match quote {
+            Some(q) => {
+                if b == q {
+                    quote = None;
+                }
+            }
+            None => match b {
+                b'"' | b'\'' | b'`' => quote = Some(b),
+                b'{' | b'(' | b'[' => depth += 1,
+                b'}' | b')' | b']' => depth = depth.saturating_sub(1),
+                b'?' | b'|' if depth == 0 && bytes.get(i + 1) == Some(&b) => {
+                    // Match only the START of a `??`/`||` run.
+                    if i > 0 && bytes[i - 1] == b {
+                        continue;
+                    }
+                    return Some(i);
+                }
+                _ => {}
+            },
+        }
+    }
+    None
+}
+
 pub fn is_valid_route_shape(route: &str) -> bool {
     let route = route.trim();
     if route.is_empty() {
@@ -2807,6 +2939,130 @@ mod tests {
                 "expected route to be kept: {route:?}"
             );
         }
+    }
+
+    /// carrick#399: the file-analyzer sometimes renders a call target verbatim
+    /// with its inline fallback; the collapse must yield the exact clean form
+    /// so both renderings of the same call site produce one canonical key.
+    #[test]
+    fn normalize_env_fallback_collapses_inline_fallbacks() {
+        let cases = [
+            // The exact verbatim rendering from the #399 evidence
+            // (eval run 29677844107).
+            (
+                r#"${AUDIT_WEBHOOK_URL ?? "http://localhost:3099"}/audit/events"#,
+                "${AUDIT_WEBHOOK_URL}/audit/events",
+            ),
+            ("${A || 'x'}/p", "${A}/p"),
+            (
+                r#"${process.env.AUDIT_WEBHOOK_URL ?? "http://localhost:3099"}/audit/events"#,
+                "${process.env.AUDIT_WEBHOOK_URL}/audit/events",
+            ),
+            // Dotted config-alias form (#218 shape) with a fallback.
+            (
+                r#"${config.catalogUrl ?? "http://localhost:4001"}/api/products"#,
+                "${config.catalogUrl}/api/products",
+            ),
+            // Fallback expression carrying a nested interpolation inside a
+            // backtick template: the inner `${PORT}` must not end the scan.
+            ("${BASE ?? `http://localhost:${PORT}`}/p", "${BASE}/p"),
+            // Quoted `}` and `||` inside the fallback string are inert.
+            (r#"${BASE ?? "a||b}c"}/p"#, "${BASE}/p"),
+            // Backtick-wrapped template with a mid-path param: only the
+            // fallback interpolation collapses, the `${id}` param survives.
+            (
+                "`${ORDERS_BASE || 'http://localhost:3001'}/orders/${id}`",
+                "`${ORDERS_BASE}/orders/${id}`",
+            ),
+            // Mid-path param fallback collapses to the plain param form.
+            ("/orders/${id ?? 0}", "/orders/${id}"),
+            // Chained fallback keeps the first reference.
+            ("${A ?? B ?? C}/p", "${A}/p"),
+        ];
+        for (raw, want) in cases {
+            assert_eq!(
+                normalize_env_fallback_target(raw).as_deref(),
+                Some(want),
+                "for {raw:?}"
+            );
+        }
+        // The collapsed forms are valid route shapes; the verbatim forms are
+        // not (that rejection was the #359 recall flake).
+        assert!(!is_valid_route_shape(
+            r#"${AUDIT_WEBHOOK_URL ?? "http://localhost:3099"}/audit/events"#
+        ));
+        assert!(is_valid_route_shape("${AUDIT_WEBHOOK_URL}/audit/events"));
+        assert!(is_valid_route_shape("${A}/p"));
+        assert!(is_valid_route_shape(
+            "${process.env.AUDIT_WEBHOOK_URL}/audit/events"
+        ));
+    }
+
+    /// The whitespace guard in `is_valid_route_shape` exists for a reason:
+    /// only clean-reference fallbacks become valid. Everything else stays
+    /// verbatim and stays rejected.
+    #[test]
+    fn normalize_env_fallback_leaves_non_fallback_expressions_rejected() {
+        let untouched_and_rejected = [
+            // Plain whitespace junk: no fallback operator at all.
+            "${a b}/p",
+            // Call-expression left-hand side is not an env reference.
+            r#"${getUrl() ?? "x"}/p"#,
+            // Concatenation is not a fallback.
+            "${base + path}/p",
+            // Optional chaining on the left-hand side is not a clean reference.
+            "${cfg?.url ?? 'x'}/p",
+            // Fallback with an empty right-hand side is not collapsible.
+            "${A ??}/p",
+            // Operator OUTSIDE the interpolation (historical dropped case).
+            "${API_KEYS_TABLE}||CarrickApiKeys",
+        ];
+        for target in untouched_and_rejected {
+            assert_eq!(
+                normalize_env_fallback_target(target),
+                None,
+                "expected no normalization for {target:?}"
+            );
+            assert!(
+                !is_valid_route_shape(target),
+                "expected route to stay dropped: {target:?}"
+            );
+        }
+        // Already-clean targets are untouched (no-op, not Some(identical)).
+        for target in ["${AUDIT_WEBHOOK_URL}/audit/events", "/plain/path"] {
+            assert_eq!(normalize_env_fallback_target(target), None);
+        }
+    }
+
+    /// Acceptance from carrick#399: feeding the run-29677844107 verbatim target
+    /// through the consumer-call path yields canonical `/audit/events` with
+    /// env-var base `AUDIT_WEBHOOK_URL` — byte-identical to the clean
+    /// `${AUDIT_WEBHOOK_URL}/audit/events` rendering's key.
+    #[test]
+    fn normalized_fallback_target_produces_the_clean_canonical_key() {
+        let config = crate::config::Config {
+            internal_env_vars: ["AUDIT_WEBHOOK_URL"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            ..crate::config::Config::default()
+        };
+        let normalizer = crate::url_normalizer::UrlNormalizer::new(&config);
+
+        let verbatim = r#"${AUDIT_WEBHOOK_URL ?? "http://localhost:3099"}/audit/events"#;
+        let clean = "${AUDIT_WEBHOOK_URL}/audit/events";
+
+        let normalized = normalize_env_fallback_target(verbatim).expect("collapses");
+        assert!(is_valid_route_shape(&normalized));
+        assert_eq!(
+            normalizer.consumer_call_path(&normalized),
+            normalizer.consumer_call_path(clean)
+        );
+        assert_eq!(normalizer.consumer_call_path(&normalized), "/audit/events");
+        assert_eq!(
+            Analyzer::extract_env_var_name(&normalized),
+            "AUDIT_WEBHOOK_URL"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #399

## Problem

The residual #359 corpus-1 recall flake: the file-analyzer intermittently (~1/3 of runs, guidance-correlated) renders a call target verbatim with its source-level fallback:

```
${AUDIT_WEBHOOK_URL ?? "http://localhost:3099"}/audit/events
```

The whitespace inside the interpolation fails `is_valid_route_shape` (src/analyzer/mod.rs), so the fifth-pass gate in `build_mount_graph` silently dropped the call (debug-level log only). Extraction presence was 5/5 live and 20/20 in the harness; the loss was entirely post-extraction validation. Full evidence in the #359 results comment (eval run 29677844107).

## Fix

Deterministic engine-side normalization, no prompt or schema text changes.

- New `analyzer::normalize_env_fallback_target`: quote- and brace-aware collapse of `${A ?? <expr>}` / `${A || <expr>}` to the bare `${A}`, covering `process.env.A` and dotted alias forms (`config.catalogUrl`), every interpolation in the target (so a mid-path `${id ?? 0}` becomes the plain `${id}` param), nested interpolations and quoted `}`/`||` inside the fallback expression.
- Applied once at the PHASE 3 fold in `FileOrchestrator` (the single entry point for LLM data calls into `file_results`), before `resolve_env_var_aliases` so a local alias with a rendered fallback still resolves through the alias map. Every downstream reader of the target then sees the same normalized form: the route-shape gate, `consumer_call_path` canonical keys, env-var classification (#294 model: env-var NAME is the classification signal), mount-graph merge keys, the engine's GraphQL transport fold, and uploads.
- The collapse is deliberately tight: only a top-level `??`/`||` whose left side is a clean reference (alphanumerics, `_`, `$`, `.`) qualifies. Call expressions, optional chaining, concatenation, and plain whitespace junk stay verbatim and stay rejected, so the guard's purpose is preserved.

## Acceptance criteria coverage

- `${A ?? "http://x"}/p`, `${A || 'x'}/p`, and the `process.env.A ?? "x"` form all normalize to the plain `${A}`-style route and produce the same canonical key as the clean rendering (unit tests in `analyzer::tests`).
- The pre-fix-failing case: the run-29677844107 verbatim target now survives `build_mount_graph` with canonical path `/audit/events` and env-var base `AUDIT_WEBHOOK_URL`, byte-identical to the clean form's key (`test_fallback_target_survives_graph_build_with_clean_canonical_key`, verified failing with the normalization disabled).
- Non-fallback whitespace/expression targets remain rejected (regression tests reuse the historical dropped-values list).

Live confirmation (corpus-1 eval call F1 holding 1.00 across repeated runs, the #359 exit criterion) is deferred to a batched owner-approved run.

## Testing

- Full `cargo test`: 22 suites green locally (cassette tests replay recordings), plus clippy and fmt clean.
- New tests run in CI via the existing `cargo test --lib` step; no new test file, so no allowlist change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)