### PR TITLE
spike: v2 capture prototype + sizing (do not merge)

### DIFF
--- a/src/sidecar/src/capture-v2.ts
+++ b/src/sidecar/src/capture-v2.ts
@@ -1,0 +1,473 @@
+/**
+ * SPIKE: type-compat v2 capture — "tsc as the serializer".
+ *
+ * Prototype of the v2 capture phase from
+ * docs/research/type-compat-synthetic-monorepo.md ("Capture phase", steps
+ * 1-2, 7, 8, plus the serialization/anchor-provenance tagging). Produces a
+ * types-only stub package for one service:
+ *
+ *   @carrick/<service>/
+ *   |- package.json            name, types entry, pinned deps (exact versions)
+ *   |- tsconfig.snapshot.json
+ *   |- carrick-manifest.json   per-alias records (spike stand-in for the
+ *   |                          descriptor that will ride CloudRepoData)
+ *   `- types/
+ *      |- surface.d.ts         entry: export type <alias> = import(...).<Symbol>
+ *      `- nested .d.ts tree    compiler-emitted declaration closure
+ *
+ * Deliberately NOT covered by the spike (see the sizing memo on #136):
+ * Awaited<ReturnType<...>> implicit anchors and their guards, the
+ * SymbolTracker node-builder fallback, tsconfig-paths specifier rewriting,
+ * global-augmentation inclusion, machinery unwrapping, per-alias closure
+ * attribution in the self-check (this file attributes at file granularity).
+ *
+ * The self-check here implements the amended rule from the design study:
+ * external-specifier resolution failures whose package is pinned in the
+ * stub's dependencies are ALLOWLISTED on bare checkouts (no node_modules at
+ * capture time) instead of decaying the alias to Unknown; the decay rule is
+ * kept for fully-internal failures. The check-phase probe gates
+ * (any/unknown/never, both sides) remain the backstop for aliases the
+ * allowlist lets through that still resolve to a top type at check time.
+ */
+
+import ts from 'typescript';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+export type AnchorOrigin = 'llm-symbol' | 'deterministic-infer' | 'anchor-backfill';
+
+export interface CaptureAnchorRequest {
+  /** Manifest alias, e.g. Endpoint_abc123_Response */
+  alias: string;
+  /** Exported symbol name in the producer repo */
+  symbol_name: string;
+  /** Declaring module, repo-root-relative, e.g. src/types/stock.ts */
+  source_file: string;
+  /** How the anchor was produced (design-doc amendment: fidelity ratchet
+   * must separate anchor-recall loss from serialization loss). */
+  anchor_origin: AnchorOrigin;
+}
+
+export type SelfCheckOutcome = 'ok' | 'allowlisted_external' | 'decayed_internal';
+
+export interface CaptureAliasRecord {
+  alias: string;
+  symbol_name: string;
+  source_file: string;
+  anchor_origin: AnchorOrigin;
+  /** Serialization tier. The spike only exercises the primary tier. */
+  serialization: 'emitted';
+  self_check: SelfCheckOutcome;
+  /** Human-readable reason when self_check is not 'ok'. */
+  self_check_detail?: string;
+  /** True when the alias resolved to any/unknown/never during self-check.
+   * With self_check === 'allowlisted_external' this is expected on a bare
+   * checkout and is NOT a decay; the probe gates own the final verdict. */
+  top_type_at_self_check: boolean;
+}
+
+export interface CaptureStubResult {
+  success: boolean;
+  stub_dir: string;
+  package_name: string;
+  /** Stub-relative paths of the emitted declaration tree. */
+  emitted_files: string[];
+  /** Exact-version pins for external packages referenced by the tree. */
+  pinned_dependencies: Record<string, string>;
+  /** External specifiers referenced by the tree but absent from the lockfile. */
+  unpinned_externals: string[];
+  aliases: CaptureAliasRecord[];
+  /** True when the source repo had no node_modules at capture time. */
+  bare_checkout: boolean;
+  ts_version: string;
+  errors: string[];
+}
+
+export interface CaptureStubOptions {
+  repoRoot: string;
+  serviceName: string;
+  anchors: CaptureAnchorRequest[];
+  /** Directory the stub package is written into (created if missing). */
+  outDir: string;
+  tsconfigPath?: string;
+}
+
+const SURFACE_ENTRY_BASENAME = '__carrick_surface__';
+
+/** Same normalization intent as bundle_file_stems on the Rust side. */
+export function sanitizeServiceName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function fail(stubDir: string, packageName: string, errors: string[]): CaptureStubResult {
+  return {
+    success: false,
+    stub_dir: stubDir,
+    package_name: packageName,
+    emitted_files: [],
+    pinned_dependencies: {},
+    unpinned_externals: [],
+    aliases: [],
+    bare_checkout: false,
+    ts_version: ts.version,
+    errors,
+  };
+}
+
+/** Extract every module specifier mentioned in a .d.ts text: `from "x"`,
+ * `import "x"`, and `import("x")` type references. */
+function collectSpecifiers(text: string): Set<string> {
+  const specs = new Set<string>();
+  const re = /(?:from\s+|import\s+|import\s*\(\s*)["']([^"']+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    specs.add(m[1]);
+  }
+  return specs;
+}
+
+function isRelative(spec: string): boolean {
+  return spec.startsWith('./') || spec.startsWith('../') || spec.startsWith('/');
+}
+
+/** zod -> zod, @scope/pkg/sub -> @scope/pkg, pkg/sub -> pkg */
+function packageNameOf(spec: string): string {
+  const parts = spec.split('/');
+  return spec.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+}
+
+/** Exact versions from package-lock.json (v2/v3 `packages` map, v1 fallback). */
+function lockfileVersions(repoRoot: string): Map<string, string> {
+  const versions = new Map<string, string>();
+  const lockPath = path.join(repoRoot, 'package-lock.json');
+  if (!fs.existsSync(lockPath)) return versions;
+  try {
+    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    if (lock.packages && typeof lock.packages === 'object') {
+      for (const [key, entry] of Object.entries<{ version?: string }>(lock.packages)) {
+        const idx = key.lastIndexOf('node_modules/');
+        if (idx === -1) continue;
+        const name = key.slice(idx + 'node_modules/'.length);
+        if (entry?.version && !versions.has(name)) versions.set(name, entry.version);
+      }
+    } else if (lock.dependencies && typeof lock.dependencies === 'object') {
+      for (const [name, entry] of Object.entries<{ version?: string }>(lock.dependencies)) {
+        if (entry?.version) versions.set(name, entry.version);
+      }
+    }
+  } catch {
+    // Unparseable lockfile: every external ends up in unpinned_externals.
+  }
+  return versions;
+}
+
+export function captureStub(opts: CaptureStubOptions): CaptureStubResult {
+  const repoRoot = path.resolve(opts.repoRoot);
+  const packageName = `@carrick/${sanitizeServiceName(opts.serviceName)}`;
+  const stubDir = path.resolve(opts.outDir);
+  const errors: string[] = [];
+
+  const configPath = opts.tsconfigPath
+    ? path.resolve(opts.tsconfigPath)
+    : path.join(repoRoot, 'tsconfig.json');
+  if (!fs.existsSync(configPath)) {
+    return fail(stubDir, packageName, [`tsconfig not found at ${configPath}`]);
+  }
+
+  const configHost: ts.ParseConfigFileHost = {
+    ...ts.sys,
+    onUnRecoverableConfigFileDiagnostic: (d) => {
+      throw new Error(ts.flattenDiagnosticMessageText(d.messageText, '\n'));
+    },
+  };
+  const parsed = ts.getParsedCommandLineOfConfigFile(configPath, {}, configHost);
+  if (!parsed) {
+    return fail(stubDir, packageName, [`failed to parse ${configPath}`]);
+  }
+
+  // The surface entry must live inside the effective rootDir (design doc
+  // Capture step 1: an entry at repo root with rootDir "src" fails TS6059).
+  const entryDir = parsed.options.rootDir
+    ? path.resolve(path.dirname(configPath), parsed.options.rootDir)
+    : repoRoot;
+  const entryPath = path.join(entryDir, `${SURFACE_ENTRY_BASENAME}.ts`);
+
+  const entryLines = ['// Generated by Carrick capture-v2 (spike). Deleted after emit.'];
+  for (const anchor of opts.anchors) {
+    const target = path.join(repoRoot, anchor.source_file).replace(/\.(ts|tsx|mts|cts)$/, '');
+    let rel = path.relative(entryDir, target).split(path.sep).join('/');
+    if (!rel.startsWith('.')) rel = `./${rel}`;
+    entryLines.push(
+      `export type ${anchor.alias} = import('${rel}').${anchor.symbol_name};`
+    );
+  }
+
+  // Emit into a staging dir so output paths are unambiguous, then relocate
+  // under <stub>/types/ with the entry renamed to surface.d.ts (same
+  // directory level, so its relative import specifiers stay valid).
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-capture-v2-'));
+  const emitted = new Map<string, string>();
+
+  try {
+    fs.writeFileSync(entryPath, entryLines.join('\n') + '\n');
+    const emitOptions: ts.CompilerOptions = {
+      ...parsed.options,
+      // The load-bearing trio: emit declarations without checking, so
+      // type-error-laden and bare (no node_modules) checkouts still emit.
+      noCheck: true,
+      declaration: true,
+      emitDeclarationOnly: true,
+      noEmit: false,
+      declarationMap: false,
+      composite: false,
+      incremental: false,
+      outDir: staging,
+      rootDir: entryDir,
+    };
+    const program = ts.createProgram([entryPath], emitOptions);
+    const emitResult = program.emit(
+      undefined,
+      (fileName, text) => emitted.set(fileName, text),
+      undefined,
+      /* emitOnlyDtsFiles */ true
+    );
+    if (emitResult.emitSkipped) {
+      return fail(stubDir, packageName, ['declaration emit was skipped']);
+    }
+    for (const d of emitResult.diagnostics) {
+      errors.push(ts.flattenDiagnosticMessageText(d.messageText, '\n'));
+    }
+  } catch (err) {
+    return fail(stubDir, packageName, [err instanceof Error ? err.message : String(err)]);
+  } finally {
+    if (fs.existsSync(entryPath)) fs.unlinkSync(entryPath);
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+
+  // ---- Relocate the emitted tree into the stub package ----
+  const typesDir = path.join(stubDir, 'types');
+  fs.rmSync(stubDir, { recursive: true, force: true });
+  fs.mkdirSync(typesDir, { recursive: true });
+
+  const emittedFiles: string[] = [];
+  const externalSpecs = new Set<string>();
+  let surfaceAbsPath = '';
+
+  for (const [fileName, text] of emitted) {
+    let rel = path.relative(staging, fileName).split(path.sep).join('/');
+    if (rel === `${SURFACE_ENTRY_BASENAME}.d.ts`) rel = 'surface.d.ts';
+    const dest = path.join(typesDir, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, text);
+    emittedFiles.push(`types/${rel}`);
+    if (rel === 'surface.d.ts') surfaceAbsPath = dest;
+    for (const spec of collectSpecifiers(text)) {
+      if (!isRelative(spec) && !spec.startsWith('node:')) {
+        externalSpecs.add(packageNameOf(spec));
+      }
+    }
+  }
+  if (!surfaceAbsPath) {
+    return fail(stubDir, packageName, ['no surface.d.ts produced by emit']);
+  }
+
+  // ---- Pin external deps from the producer repo's lockfile ----
+  const lockVersions = lockfileVersions(repoRoot);
+  const pinned: Record<string, string> = {};
+  const unpinned: string[] = [];
+  for (const name of [...externalSpecs].sort()) {
+    const version = lockVersions.get(name);
+    if (version) pinned[name] = version;
+    else unpinned.push(name);
+  }
+
+  fs.writeFileSync(
+    path.join(stubDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: packageName,
+        version: '0.0.0-carrick',
+        private: true,
+        types: './types/surface.d.ts',
+        dependencies: pinned,
+      },
+      null,
+      2
+    ) + '\n'
+  );
+  fs.writeFileSync(
+    path.join(stubDir, 'tsconfig.snapshot.json'),
+    JSON.stringify(
+      {
+        ts_version: ts.version,
+        strict: parsed.options.strict ?? false,
+        strictNullChecks: parsed.options.strictNullChecks ?? parsed.options.strict ?? false,
+        exactOptionalPropertyTypes: parsed.options.exactOptionalPropertyTypes ?? false,
+        module: parsed.options.module !== undefined ? ts.ModuleKind[parsed.options.module] : undefined,
+        target: parsed.options.target !== undefined ? ts.ScriptTarget[parsed.options.target] : undefined,
+      },
+      null,
+      2
+    ) + '\n'
+  );
+
+  // ---- Capture-time self-check (design doc Capture step 8, amended) ----
+  const bareCheckout = !fs.existsSync(path.join(repoRoot, 'node_modules'));
+  const aliases = selfCheck({
+    stubDir,
+    surfaceAbsPath,
+    anchors: opts.anchors,
+    pinned,
+    bareCheckout,
+  });
+
+  fs.writeFileSync(
+    path.join(stubDir, 'carrick-manifest.json'),
+    JSON.stringify({ package_name: packageName, ts_version: ts.version, aliases }, null, 2) + '\n'
+  );
+
+  return {
+    success: true,
+    stub_dir: stubDir,
+    package_name: packageName,
+    emitted_files: emittedFiles.sort(),
+    pinned_dependencies: pinned,
+    unpinned_externals: unpinned,
+    aliases,
+    bare_checkout: bareCheckout,
+    ts_version: ts.version,
+    errors,
+  };
+}
+
+/**
+ * Standalone typecheck of the stub tree, classifying each alias:
+ *
+ *   ok                    resolved to a concrete type
+ *   allowlisted_external  resolution failed only through external specifiers
+ *                         that are pinned in the stub's dependencies (bare
+ *                         checkout) — alias is KEPT at tier 'emitted'
+ *   decayed_internal      a dangling internal specifier or a top-type
+ *                         resolution not explained by a pinned external —
+ *                         alias decays to Unknown at capture time
+ *
+ * Spike limitation: attribution is per emitted FILE, not per alias closure.
+ * An alias is linked to an external failure if the file its surface entry
+ * points at (or the surface itself) mentions a failed specifier.
+ */
+function selfCheck(args: {
+  stubDir: string;
+  surfaceAbsPath: string;
+  anchors: CaptureAnchorRequest[];
+  pinned: Record<string, string>;
+  bareCheckout: boolean;
+}): CaptureAliasRecord[] {
+  const { stubDir, surfaceAbsPath, anchors, pinned, bareCheckout } = args;
+  const typesDir = path.join(stubDir, 'types');
+  const treeFiles: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.name.endsWith('.d.ts')) treeFiles.push(p);
+    }
+  };
+  walk(typesDir);
+
+  const program = ts.createProgram(treeFiles, {
+    noEmit: true,
+    strict: true,
+    // MUST be false: the whole stub tree is .d.ts, and skipLibCheck skips
+    // checking of declaration files entirely — with it on, unresolved
+    // specifiers produce zero diagnostics and the self-check is vacuous.
+    // (Same reason the design doc mandates skipLibCheck: false for stub
+    // trees at check time.)
+    skipLibCheck: false,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    types: [],
+  });
+  const checker = program.getTypeChecker();
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+
+  // Failed module specifiers, split external vs internal.
+  const failedExternalPinned = new Set<string>();
+  let internalFailure: string | undefined;
+  for (const d of diagnostics) {
+    if (d.code !== 2307 && d.code !== 2792) continue;
+    const msg = ts.flattenDiagnosticMessageText(d.messageText, ' ');
+    const m = /Cannot find module '([^']+)'/.exec(msg);
+    if (!m) continue;
+    const spec = m[1];
+    if (isRelative(spec)) {
+      internalFailure = internalFailure ?? spec;
+    } else if (pinned[packageNameOf(spec)]) {
+      failedExternalPinned.add(spec);
+    } else {
+      internalFailure = internalFailure ?? spec; // external but unpinned: treat as decay
+    }
+  }
+
+  const surfaceSource = program.getSourceFile(surfaceAbsPath);
+  const records: CaptureAliasRecord[] = [];
+
+  for (const anchor of anchors) {
+    let topType = true;
+    let targetFileText = '';
+    if (surfaceSource) {
+      for (const stmt of surfaceSource.statements) {
+        if (!ts.isTypeAliasDeclaration(stmt) || stmt.name.text !== anchor.alias) continue;
+        const type = checker.getTypeAtLocation(stmt.name);
+        topType = (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Never)) !== 0;
+        // Resolve the alias's import-type target file for coarse attribution.
+        if (ts.isImportTypeNode(stmt.type) && ts.isLiteralTypeNode(stmt.type.argument)) {
+          const lit = stmt.type.argument.literal;
+          if (ts.isStringLiteral(lit)) {
+            const base = path.resolve(path.dirname(surfaceAbsPath), lit.text);
+            for (const cand of [`${base}.d.ts`, path.join(base, 'index.d.ts')]) {
+              if (fs.existsSync(cand)) {
+                targetFileText = fs.readFileSync(cand, 'utf8');
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    let outcome: SelfCheckOutcome = 'ok';
+    let detail: string | undefined;
+    if (topType) {
+      const closureText = targetFileText + fs.readFileSync(surfaceAbsPath, 'utf8');
+      const blamedExternal = [...failedExternalPinned].find((spec) =>
+        closureText.includes(`"${spec}"`) || closureText.includes(`'${spec}'`)
+      );
+      if (bareCheckout && blamedExternal && !internalFailure) {
+        outcome = 'allowlisted_external';
+        detail =
+          `unresolved external '${blamedExternal}' is pinned ` +
+          `(${packageNameOf(blamedExternal)}@${pinned[packageNameOf(blamedExternal)]}); ` +
+          'kept at tier emitted on bare checkout; probe gates are the backstop';
+      } else {
+        outcome = 'decayed_internal';
+        detail = internalFailure
+          ? `dangling internal specifier '${internalFailure}'`
+          : 'alias resolved to a top type with no allowlisted external failure';
+      }
+    }
+
+    records.push({
+      alias: anchor.alias,
+      symbol_name: anchor.symbol_name,
+      source_file: anchor.source_file,
+      anchor_origin: anchor.anchor_origin,
+      serialization: 'emitted',
+      self_check: outcome,
+      self_check_detail: detail,
+      top_type_at_self_check: topType,
+    });
+  }
+
+  return records;
+}

--- a/src/sidecar/src/index.ts
+++ b/src/sidecar/src/index.ts
@@ -19,12 +19,14 @@ import { TypeBundler, SurfaceEmitter } from './bundler.js';
 import { TypeInferrer } from './type-inferrer.js';
 import { MonorepoBuilder } from './monorepo-builder.js';
 import { DefinitionResolver } from './definition-resolver.js';
+import { captureStub } from './capture-v2.js';
 import type {
   SidecarRequest,
   SidecarResponse,
   InitResponse,
   BundleResponse,
   EmitSurfaceResponse,
+  CaptureV2Response,
   InferResponse,
   BuildWorkspaceResponse,
   CheckCompatibilityResponse,
@@ -206,6 +208,38 @@ function handleEmitSurface(request: SidecarRequest & { action: 'emit_surface' })
     const error = err instanceof Error ? err.message : String(err);
     logError(`Surface emission failed: ${error}`);
 
+    return {
+      request_id: request.request_id,
+      status: 'error',
+      errors: [error],
+    };
+  }
+}
+
+/**
+ * SPIKE: handle the 'capture_v2' action - v2 "tsc as serializer" capture.
+ * Stateless by design: unlike bundle/infer it needs no init'd ts-morph
+ * project, only the repo's own tsconfig — this is the point of v2.
+ */
+function handleCaptureV2(request: SidecarRequest & { action: 'capture_v2' }): CaptureV2Response {
+  try {
+    log(`capture_v2 for service '${request.service_name}' (${request.anchors.length} anchor(s))`);
+    const result = captureStub({
+      repoRoot: request.repo_root,
+      serviceName: request.service_name,
+      anchors: request.anchors,
+      outDir: request.out_dir,
+      tsconfigPath: request.tsconfig_path,
+    });
+    return {
+      request_id: request.request_id,
+      status: result.success ? 'success' : 'error',
+      result,
+      errors: result.errors.length > 0 ? result.errors : undefined,
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    logError(`capture_v2 failed: ${error}`);
     return {
       request_id: request.request_id,
       status: 'error',
@@ -421,6 +455,8 @@ function handleRequest(request: SidecarRequest): SidecarResponse {
       return handleBundle(request);
     case 'emit_surface':
       return handleEmitSurface(request);
+    case 'capture_v2':
+      return handleCaptureV2(request);
     case 'infer':
       return handleInfer(request);
     case 'build_workspace':

--- a/src/sidecar/src/spike/run-capture-spike.ts
+++ b/src/sidecar/src/spike/run-capture-spike.ts
@@ -1,0 +1,151 @@
+/**
+ * SPIKE runner: v2 capture on the bare inventory-svc fixture, end to end.
+ *
+ *   cd src/sidecar && npm run build && node dist/src/spike/run-capture-spike.js
+ *
+ * Phase 1 (capture): run captureStub against
+ * tests/fixtures/xrepo-corpus-3/inventory-svc (a bare checkout — the fixture
+ * has no node_modules) and print the emitted stub, showing third-party
+ * annotations preserved as import references.
+ *
+ * Phase 2 (check-side smoke, needs network for one `npm install` into the
+ * stub): install the stub's pinned deps, generate v2-style probe files, run
+ * `tsc --noEmit`, and classify diagnostics into
+ * compatible / incompatible / unverifiable — demonstrating
+ *   - a clean pair verdicts compatible,
+ *   - a genuinely mismatched pair verdicts incompatible with the compiler's
+ *     elaborated error as the report,
+ *   - the alias that decayed to `any` on the bare checkout is caught by the
+ *     probe gates (TS2344) and verdicts unverifiable, never compatible.
+ */
+
+import ts from 'typescript';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { captureStub } from '../capture-v2.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// dist/src/spike -> repo root is five levels up
+const REPO_ROOT = path.join(__dirname, '..', '..', '..', '..', '..');
+const FIXTURE = path.join(REPO_ROOT, 'tests', 'fixtures', 'xrepo-corpus-3', 'inventory-svc');
+
+const GATE_PRELUDE = `
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type IsUnknown<T> = unknown extends T ? (0 extends 1 & T ? false : true) : false;
+type IsNever<T> = [T] extends [never] ? true : false;
+type Not<T extends boolean> = T extends true ? false : true;
+type Assert<T extends true> = T;
+`;
+
+function probe(sentImport: string, expectedDecl: string): string {
+  return `${sentImport}\n${expectedDecl}\n${GATE_PRELUDE}
+type _G1 = Assert<Not<IsAny<Sent>>>;
+type _G2 = Assert<Not<IsUnknown<Sent>>>;
+type _G3 = Assert<Not<IsNever<Sent>>>;
+type _G4 = Assert<Not<IsAny<Expected>>>;
+type _G5 = Assert<Not<IsUnknown<Expected>>>;
+type _G6 = Assert<Not<IsNever<Expected>>>;
+
+declare const sent: Sent;
+const expected: Expected = sent;
+`;
+}
+
+function classify(fileName: string, diags: readonly ts.Diagnostic[]): string {
+  const own = diags.filter((d) => d.file && path.basename(d.file.fileName) === fileName);
+  if (own.some((d) => d.code === 2344)) return 'unverifiable (gate fired: a side is any/unknown/never)';
+  if (own.some((d) => [2322, 2559, 2739, 2741].includes(d.code))) return 'incompatible';
+  if (own.length > 0) return `unverifiable (unexpected: ${own.map((d) => d.code).join(',')})`;
+  return 'compatible';
+}
+
+function main(): void {
+  console.log('=== Phase 1: capture (bare checkout) ===');
+  console.log(`fixture: ${FIXTURE}`);
+  console.log(`fixture node_modules present: ${fs.existsSync(path.join(FIXTURE, 'node_modules'))}`);
+
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-v2-spike-'));
+  const stubDir = path.join(workDir, 'stub');
+  const result = captureStub({
+    repoRoot: FIXTURE,
+    serviceName: 'inventory-svc',
+    outDir: stubDir,
+    anchors: [
+      { alias: 'Endpoint_stock_Response', symbol_name: 'StockLevel', source_file: 'src/types/stock.ts', anchor_origin: 'llm-symbol' },
+      { alias: 'Sub_stockadjust_Payload', symbol_name: 'StockAdjustCommand', source_file: 'src/types/stock.ts', anchor_origin: 'llm-symbol' },
+      { alias: 'Sub_priceupdated_Payload', symbol_name: 'PriceUpdatedEvent', source_file: 'src/types/stock.ts', anchor_origin: 'deterministic-infer' },
+    ],
+  });
+
+  console.log(JSON.stringify({ ...result, stub_dir: '<tmp>/stub' }, null, 2));
+  for (const rel of result.emitted_files) {
+    console.log(`\n--- ${rel} ---`);
+    console.log(fs.readFileSync(path.join(stubDir, rel), 'utf8').trimEnd());
+  }
+  if (!result.success) process.exit(1);
+
+  console.log('\n=== Phase 2: check-side smoke (probes against the stub) ===');
+  console.log(`npm install into stub (pinned: ${JSON.stringify(result.pinned_dependencies)}) ...`);
+  execSync('npm install --no-audit --no-fund --loglevel=error', { cwd: stubDir, stdio: 'inherit' });
+
+  const probesDir = path.join(workDir, 'probes');
+  fs.mkdirSync(probesDir);
+  const surface = path
+    .relative(probesDir, path.join(stubDir, 'types', 'surface'))
+    .split(path.sep)
+    .join('/');
+
+  const probes: Record<string, string> = {
+    // Compatible: consumer expects exactly what the producer sends.
+    'pair_ok.ts': probe(
+      `import type { Endpoint_stock_Response as Sent } from '${surface}';`,
+      `type Expected = { sku: string; warehouseId: string; onHand: number; reserved: number };`
+    ),
+    // Incompatible: consumer requires a field the producer does not send.
+    'pair_mismatch.ts': probe(
+      `import type { Endpoint_stock_Response as Sent } from '${surface}';`,
+      `type Expected = { sku: string; warehouseId: string; onHand: number; reserved: number; restockAt: string };`
+    ),
+    // Gate: the zod-inferred alias baked to any on the bare checkout —
+    // must classify unverifiable, never compatible.
+    'pair_gate.ts': probe(
+      `import type { Sub_stockadjust_Payload as Sent } from '${surface}';`,
+      `type Expected = { sku: string; delta: number; reason: string; orderId: string };`
+    ),
+  };
+  for (const [name, text] of Object.entries(probes)) {
+    fs.writeFileSync(path.join(probesDir, name), text);
+  }
+
+  const program = ts.createProgram(
+    Object.keys(probes).map((f) => path.join(probesDir, f)),
+    {
+      noEmit: true,
+      strict: true,
+      skipLibCheck: true,
+      noUnusedLocals: false,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      types: [],
+    }
+  );
+  const diags = ts.getPreEmitDiagnostics(program);
+
+  for (const name of Object.keys(probes)) {
+    console.log(`\n${name}: ${classify(name, diags)}`);
+    for (const d of diags.filter((d) => d.file && path.basename(d.file.fileName) === name)) {
+      const { line } = ts.getLineAndCharacterOfPosition(d.file!, d.start!);
+      console.log(
+        `  TS${d.code} @ line ${line + 1}: ` +
+          ts.flattenDiagnosticMessageText(d.messageText, '\n    ').slice(0, 500)
+      );
+    }
+  }
+
+  console.log(`\n(work dir kept for inspection: ${workDir})`);
+}
+
+main();

--- a/src/sidecar/src/types.ts
+++ b/src/sidecar/src/types.ts
@@ -217,6 +217,33 @@ export interface PayloadDefinition {
 }
 
 /**
+ * SPIKE: request to run the v2 "tsc as serializer" capture for one service.
+ * Produces a types-only stub package (compiler-emitted declaration tree +
+ * pinned deps) instead of a flattened structural string. See capture-v2.ts.
+ */
+export interface CaptureV2Request extends BaseRequest {
+  action: 'capture_v2';
+  /** Absolute path to the producer repo root */
+  repo_root: string;
+  /** Service name used for the @carrick/<service> stub package */
+  service_name: string;
+  /** Explicit-symbol anchors to alias in the surface entry */
+  anchors: import('./capture-v2.js').CaptureAnchorRequest[];
+  /** Directory to write the stub package into */
+  out_dir: string;
+  /** Optional explicit tsconfig path (defaults to <repo_root>/tsconfig.json) */
+  tsconfig_path?: string;
+}
+
+/**
+ * Response for the capture_v2 action (spike)
+ */
+export interface CaptureV2Response extends BaseResponse {
+  result?: import('./capture-v2.js').CaptureStubResult;
+  errors?: string[];
+}
+
+/**
  * Request to infer implicit types at specific locations
  */
 export interface InferRequest extends BaseRequest {
@@ -296,6 +323,7 @@ export type SidecarRequest =
   | InitRequest
   | BundleRequest
   | EmitSurfaceRequest
+  | CaptureV2Request
   | InferRequest
   | BuildWorkspaceRequest
   | CheckCompatibilityRequest
@@ -511,6 +539,7 @@ export type SidecarResponse =
   | InitResponse
   | BundleResponse
   | EmitSurfaceResponse
+  | CaptureV2Response
   | InferResponse
   | BuildWorkspaceResponse
   | CheckCompatibilityResponse

--- a/src/sidecar/src/validators.ts
+++ b/src/sidecar/src/validators.ts
@@ -221,6 +221,25 @@ export const EmitSurfaceRequestSchema = BaseRequestSchema.extend({
   output_path: z.string().min(1, 'Output path cannot be empty'),
 });
 
+/** SPIKE: v2 "tsc as serializer" capture (see capture-v2.ts). */
+export const CaptureV2RequestSchema = BaseRequestSchema.extend({
+  action: z.literal('capture_v2'),
+  repo_root: z.string().min(1, 'Repo root cannot be empty'),
+  service_name: z.string().min(1, 'Service name cannot be empty'),
+  anchors: z
+    .array(
+      z.object({
+        alias: z.string().min(1),
+        symbol_name: z.string().min(1),
+        source_file: z.string().min(1),
+        anchor_origin: z.enum(['llm-symbol', 'deterministic-infer', 'anchor-backfill']),
+      })
+    )
+    .min(1, 'At least one anchor is required'),
+  out_dir: z.string().min(1, 'Output dir cannot be empty'),
+  tsconfig_path: z.string().optional(),
+});
+
 export const InferRequestSchema = BaseRequestSchema.extend({
   action: z.literal('infer'),
   requests: z.array(InferRequestItemSchema).min(1, 'At least one infer request is required'),
@@ -264,6 +283,7 @@ export const SidecarRequestSchema = z.discriminatedUnion('action', [
   InitRequestSchema,
   BundleRequestSchema,
   EmitSurfaceRequestSchema,
+  CaptureV2RequestSchema,
   InferRequestSchema,
   BuildWorkspaceRequestSchema,
   CheckCompatibilityRequestSchema,

--- a/src/sidecar/test/capture-v2.test.ts
+++ b/src/sidecar/test/capture-v2.test.ts
@@ -1,0 +1,162 @@
+/**
+ * SPIKE: v2 capture ("tsc as serializer") — bare-checkout stdio test.
+ *
+ * Drives the sidecar over the same JSON-over-stdio wire the Rust client uses
+ * (the integration point for src/services/type_sidecar.rs), against the
+ * xrepo-corpus-3 inventory-svc fixture, which has NO node_modules — the bare
+ * checkout case from the v2 design study.
+ *
+ * What this pins:
+ *  1. `tsc --noCheck --declaration --emitDeclarationOnly` capture succeeds on
+ *     a bare checkout (exit clean, tree emitted).
+ *  2. Third-party type ANNOTATIONS survive as syntactic import references
+ *     (`import { z } from "zod"` + `z.infer<typeof StockAdjustSchema>`
+ *     verbatim in the emitted tree) where expandTypeStructural bakes `any`.
+ *  3. The amended self-check: the zod-dependent alias is ALLOWLISTED (kept at
+ *     tier 'emitted', not decayed to Unknown) because its unresolved external
+ *     specifier is pinned in the stub's dependencies.
+ *  4. The honest limitation: types INFERRED through the missing library
+ *     (`export declare const StockAdjustSchema: any`) bake to `any` on a bare
+ *     checkout; the check-phase probe gates are the backstop for those.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SidecarClient } from './helpers.js';
+import type { CaptureStubResult } from '../src/capture-v2.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// dist/test -> repo root is four levels up (dist/test -> dist -> sidecar -> src -> root)
+const FIXTURE = path.join(
+  __dirname, '..', '..', '..', '..',
+  'tests', 'fixtures', 'xrepo-corpus-3', 'inventory-svc'
+);
+
+interface CaptureV2ResponseShape {
+  request_id: string;
+  status: string;
+  result?: CaptureStubResult;
+  errors?: string[];
+}
+
+describe('capture_v2 (spike): bare-checkout tsc-as-serializer', () => {
+  const client = new SidecarClient();
+  let outDir: string;
+  let response: CaptureV2ResponseShape;
+
+  before(async () => {
+    assert.ok(fs.existsSync(FIXTURE), `fixture missing: ${FIXTURE}`);
+    assert.ok(
+      !fs.existsSync(path.join(FIXTURE, 'node_modules')),
+      'precondition: fixture must be a bare checkout (no node_modules)'
+    );
+    outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-capture-v2-test-'));
+    await client.start();
+    response = (await client.send({
+      request_id: 'capture-v2-spike-1',
+      action: 'capture_v2',
+      repo_root: FIXTURE,
+      service_name: 'inventory-svc',
+      out_dir: path.join(outDir, 'stub'),
+      anchors: [
+        {
+          alias: 'Endpoint_stock_Response',
+          symbol_name: 'StockLevel',
+          source_file: 'src/types/stock.ts',
+          anchor_origin: 'llm-symbol',
+        },
+        {
+          alias: 'Sub_stockadjust_Payload',
+          symbol_name: 'StockAdjustCommand',
+          source_file: 'src/types/stock.ts',
+          anchor_origin: 'llm-symbol',
+        },
+        {
+          alias: 'Sub_priceupdated_Payload',
+          symbol_name: 'PriceUpdatedEvent',
+          source_file: 'src/types/stock.ts',
+          anchor_origin: 'deterministic-infer',
+        },
+      ],
+    })) as CaptureV2ResponseShape;
+  });
+
+  after(async () => {
+    await client.stop();
+    fs.rmSync(outDir, { recursive: true, force: true });
+  });
+
+  it('succeeds on a bare checkout with clean emit', () => {
+    assert.strictEqual(response.status, 'success', JSON.stringify(response.errors));
+    assert.ok(response.result);
+    assert.strictEqual(response.result.bare_checkout, true);
+    assert.deepStrictEqual(response.result.errors, []);
+  });
+
+  it('emits the v2 stub package shape', () => {
+    const result = response.result!;
+    assert.strictEqual(result.package_name, '@carrick/inventory-svc');
+    assert.ok(result.emitted_files.includes('types/surface.d.ts'));
+    assert.ok(result.emitted_files.includes('types/src/types/stock.d.ts'));
+    assert.ok(fs.existsSync(path.join(result.stub_dir, 'package.json')));
+    assert.ok(fs.existsSync(path.join(result.stub_dir, 'tsconfig.snapshot.json')));
+    const pkg = JSON.parse(fs.readFileSync(path.join(result.stub_dir, 'package.json'), 'utf8'));
+    assert.strictEqual(pkg.types, './types/surface.d.ts');
+  });
+
+  it('preserves third-party annotations as import references (not any)', () => {
+    const result = response.result!;
+    const stockDts = fs.readFileSync(
+      path.join(result.stub_dir, 'types', 'src', 'types', 'stock.d.ts'),
+      'utf8'
+    );
+    // The exact loss expandTypeStructural forces today: these survive verbatim.
+    assert.ok(stockDts.includes('import { z } from "zod"'), stockDts);
+    assert.ok(stockDts.includes('z.infer<typeof StockAdjustSchema>'), stockDts);
+    // Honest limitation on bare checkouts: inference THROUGH the missing
+    // library still bakes any (annotations survive; inferred consts do not).
+    assert.ok(stockDts.includes('StockAdjustSchema: any'), stockDts);
+  });
+
+  it('pins referenced externals to exact lockfile versions', () => {
+    const result = response.result!;
+    assert.strictEqual(result.pinned_dependencies['zod'], '3.23.0');
+    assert.deepStrictEqual(result.unpinned_externals, []);
+    // Pruning: express/amqplib/nats are in the lockfile but not referenced
+    // by the emitted tree, so they must not be pinned into the stub.
+    assert.strictEqual(result.pinned_dependencies['express'], undefined);
+  });
+
+  it('self-check: plain internal types pass', () => {
+    const byAlias = new Map(response.result!.aliases.map((a) => [a.alias, a]));
+    for (const alias of ['Endpoint_stock_Response', 'Sub_priceupdated_Payload']) {
+      const rec = byAlias.get(alias)!;
+      assert.strictEqual(rec.self_check, 'ok', alias);
+      assert.strictEqual(rec.top_type_at_self_check, false, alias);
+      assert.strictEqual(rec.serialization, 'emitted');
+    }
+  });
+
+  it('self-check: pinned-external failure is allowlisted, not decayed (amendment 1)', () => {
+    const byAlias = new Map(response.result!.aliases.map((a) => [a.alias, a]));
+    const rec = byAlias.get('Sub_stockadjust_Payload')!;
+    assert.strictEqual(rec.self_check, 'allowlisted_external', rec.self_check_detail);
+    assert.strictEqual(rec.top_type_at_self_check, true);
+    // Still tier 'emitted': the alias is NOT downgraded to Unknown.
+    assert.strictEqual(rec.serialization, 'emitted');
+    assert.match(rec.self_check_detail ?? '', /zod@3\.23\.0/);
+  });
+
+  it('records anchor provenance separately from the serialization tier (amendment 2)', () => {
+    const byAlias = new Map(response.result!.aliases.map((a) => [a.alias, a]));
+    assert.strictEqual(byAlias.get('Endpoint_stock_Response')!.anchor_origin, 'llm-symbol');
+    assert.strictEqual(
+      byAlias.get('Sub_priceupdated_Payload')!.anchor_origin,
+      'deterministic-infer'
+    );
+  });
+});


### PR DESCRIPTION
## Do not merge

Sizing spike for type-compat v2 (design: `docs/research/type-compat-synthetic-monorepo.md`, PR #299). This branch exists to prove the capture path and price the remaining work. The full sizing memo is on #136; the two design-doc amendment drafts are on #299.

## What the prototype is

A minimal working "tsc as serializer" capture, wired to the sidecar's stdio seam (the same JSON-over-stdio wire `src/services/type_sidecar.rs` uses):

- `src/sidecar/src/capture-v2.ts`: surface entry generation inside the repo's effective rootDir, `noCheck` declaration-emit tree, stub package `@carrick/<service>` with lockfile-pinned deps pruned to referenced specifiers, tsconfig snapshot, and the amended capture self-check. Per-alias records carry the `serialization` tier plus `anchor_origin` provenance.
- `capture_v2` action in `validators.ts` / `types.ts` / `index.ts`. Notably stateless: unlike bundle/infer it needs no init'd ts-morph project, which simplifies the Rust call site.
- `src/sidecar/test/capture-v2.test.ts`: stdio-level test against `tests/fixtures/xrepo-corpus-3/inventory-svc`, which has no node_modules, pinning the bare-checkout claims.
- `src/sidecar/src/spike/run-capture-spike.ts`: end-to-end demo including a check-side smoke (probe files, diagnostic-code classification).

## What it proved on the bare fixture

- Emit exits clean on a checkout with zero node_modules (`emitSkipped: false`, 0 diagnostics).
- Third-party annotations survive as syntactic import references: `import { z } from "zod"` and `z.infer<typeof StockAdjustSchema>` ship verbatim where `expandTypeStructural` bakes `any` today.
- Honest limit: types inferred THROUGH the missing library bake to `any` (`export declare const StockAdjustSchema: any`). The probe gates catch these at check time (TS2344, classified unverifiable, never compatible). Verified in the smoke.
- Mismatch verdicts carry real type names: `TS2741: Property 'restockAt' is missing in type 'StockLevel' but required in type 'Expected'`. Today's output prints anonymous structural soup.
- Gotcha worth keeping: the self-check program must set `skipLibCheck: false`. With it on, checking of `.d.ts` files is skipped entirely and the self-check is vacuous. Same reason the design doc mandates it for stub trees at check time.

## Sizing (S = under a day, M = 2-4 days, L = 1-2 weeks)

| # | Workpackage | Size | Depends on | Spike status |
|---|---|---|---|---|
| WP1 | Capture core: all anchor forms incl. `Awaited<ReturnType>` guards, emit tree, tsconfig-paths rewrite, augmentation inclusion, per-alias self-check attribution, SymbolTracker node-builder fallback | L | none | emit tree, stub shape, pinning, self-check mechanics de-risked; node-builder fallback and paths rewrite still open |
| WP2 | Check core: scratch workspace, vendored pnpm, semver dedupe, probe generation with direction table, 4-bucket classifier, scrub pass, async install protocol | L | WP1 | probe pattern, gate backstop, classification de-risked; pnpm vendoring, dedupe, scrub, async protocol open |
| WP3 | Rust integration: sidecar request variants, pair-ID verdict join, formatter structured payload, re-point `resolve_per_endpoint_definitions` | M | WP1, WP2 | stdio seam proven; capture is stateless |
| WP4 | The seven string-decay compensation deletions | M | WP3 | mechanical once WP1-3 land; same release |
| WP5 | Wire change in carrick-cloud: content-addressed S3 tarballs, descriptors, presigned GETs, `artifact_version` gate (6MB sync-Lambda cap is the forcing constraint) | M | parallel; release prerequisite | not prototyped, out of spike scope, user-gated deploy |
| WP6 | Evals: new cases, surface-fidelity metric per tier and origin, checked-in verdict baseline assertion | M | WP1, WP2 | fixture patterns identified |
| WP7 | Release + fleet re-scan nudge | S | all above | user-gated |
| WP8 | ts_check/ deletion and packaging refs (#136) | M | WP3 | inventory already verified in #136 |

Biggest remaining unknown: the SymbolTracker-backed node-builder fallback for anonymous inferred types (silent failure modes, compiler-API-deep).

## Spike shortcuts, deliberately not fixed here

Explicit-symbol anchors only; self-check attribution is per emitted file, not per alias closure; no tsconfig-paths rewrite; no augmentation handling; `typescript` stays a devDependency (production wiring moves it to dependencies since the runtime now imports it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
