### PR TITLE
docs: add estimation conventions in agent execution time to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,15 @@ Install hooks once per clone: `./scripts/install-hooks.sh`.
 - Follow Conventional Commits with optional scopes: `feat(sidecar): ...`, `fix: ...`, `docs: ...`, `refactor(phase4.1): ...`, `chore: ...`, `test: ...`.
 - PRs should include a short summary, rationale, test commands run, and links to relevant issues. Include sample Action output when it changes.
 
+## Estimation Conventions
+- Effort estimates in issues, plans, and design docs use S/M/L defined in agent execution time. Claude agents execute this repo's work, so estimates are not in human developer time.
+  - S: one agent, merged PR in under about an hour of wall clock. Implementation is minutes; CI (~5-10 min per push) and Copilot review dominate.
+  - M: one agent working session, roughly 1-3 hours to a merged PR, usually one or two review/rebase cycles.
+  - L: a sustained orchestrated session (parallel agents where the work decomposes), roughly a day.
+- Converting older docs or human-calibrated estimates: a human-week of focused work is roughly one L session; a human-month is roughly 3-5 sustained sessions spread over about a week of elapsed time.
+- Elapsed calendar time is set by the serialization points, not implementation speed: CI runs, review latency, dependency chains between workpackages, same-release bundles, batched paid eval gates, and owner-gated actions (terraform applies, deploys, releases, fleet re-scans). Estimates should name their serialization points.
+- Calibration (2026-07-18/19): nine scoped S/M tickets merged in one overnight session; a six-item tier including an L-sized prototype spike completed in about three hours of wall clock.
+
 ## Configuration & Infrastructure Notes
 - `carrick.json` is resolved by `Config::load_services` into one `Config` per service. A flat config (or none) is a single service rooted at the repo root; a `services` array fans out per directory (`directory`, `include`, `tsconfig` + the call-classification fields). The engine runs the analysis pipeline, per-service type extraction, and upload once per service. Multi-service index upload is gated on `CloudStorage::supports_multi_service`, driven by the cloud's `multiService` capability flag. See the README "Monorepos" section for the user-facing shape.
 - Runtime env vars: `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` (auto-set by GitHub Actions when the job grants `id-token: write`; the scanner mints an OIDC token from these and sends it as the `X-Carrick-OIDC` header — the cloud derives repo identity from the signed claims, so no API key is needed), `CARRICK_MOCK_ALL` (test-only, returns canned responses without hitting the cloud), `CARRICK_API_ENDPOINT` (override the default `https://api.carrick.tools` endpoint at build time; optional).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Install hooks once per clone: `./scripts/install-hooks.sh`.
   - M: one agent working session, roughly 1-3 hours to a merged PR, usually one or two review/rebase cycles.
   - L: a sustained orchestrated session (parallel agents where the work decomposes), roughly a day.
 - Converting older docs or human-calibrated estimates: a human-week of focused work is roughly one L session; a human-month is roughly 3-5 sustained sessions spread over about a week of elapsed time.
-- Elapsed calendar time is set by the serialization points, not implementation speed: CI runs, review latency, dependency chains between workpackages, same-release bundles, batched paid eval gates, and owner-gated actions (terraform applies, deploys, releases, fleet re-scans). Estimates should name their serialization points.
+- Elapsed calendar time is set by the serialization points, not implementation speed: CI runs, review latency, dependency chains between work packages, same-release bundles, batched paid eval gates, and owner-gated actions (terraform applies in carrick-cloud, deploys, releases, fleet re-scans). Estimates should name their serialization points.
 - Calibration (2026-07-18/19): nine scoped S/M tickets merged in one overnight session; a six-item tier including an L-sized prototype spike completed in about three hours of wall clock.
 
 ## Configuration & Infrastructure Notes


### PR DESCRIPTION
## Summary

Adds an "Estimation Conventions" section to AGENTS.md, between "Commit & Pull Request Guidelines" and "Configuration & Infrastructure Notes". All effort estimates in issues, plans, and design docs now use S/M/L defined in agent execution time, since Claude agents execute this repo's work.

The section covers:
- S/M/L definitions in agent wall-clock time (merged-PR endpoints, CI and review dominating)
- Conversions for reading older human-calibrated estimates
- Elapsed calendar time as a function of serialization points, which estimates should name
- A dated calibration one-liner from the 2026-07-18/19 sessions

## Rationale

Requested by the owner so future estimates stop defaulting to human developer time.

## Testing

Docs-only change to AGENTS.md; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)