### PR TITLE
fix(analyzer): drop HTTP producer==consumer self-pair edges

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -94,11 +94,13 @@ fn dependency_conflict_finding(conflict: &DependencyConflict) -> Finding {
 
 /// A structured producer→consumer edge captured at the matching site. This is
 /// the load-bearing cross-repo signal the eval scorer reads (contract §2): an
-/// endpoint in one repo matched by an outbound call in another repo, with the
-/// type-compatibility verdict for that producer endpoint. Same-identity pairs
-/// (producer_repo == consumer_repo on the `service_name ?? repo_name` id) are
-/// dropped by every matcher (#397): a service exercising its own contract is
-/// not a cross-service edge.
+/// endpoint owned by one service identity matched by an outbound call from
+/// another, with the type-compatibility verdict for that producer endpoint.
+/// Both sides are identified by the `service_name ?? repo_name` id (#368), so
+/// in a monorepo the two sides can be different services of ONE git repo and
+/// still form a real edge. Same-identity pairs (producer_repo ==
+/// consumer_repo) are dropped by every matcher (#397): a service exercising
+/// its own contract is not a cross-service edge.
 ///
 /// `type_compatible == None` is deliberate and load-bearing: it means compat
 /// was never evaluated for this edge (e.g. `ts_check_dir` was absent, so type

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -94,8 +94,11 @@ fn dependency_conflict_finding(conflict: &DependencyConflict) -> Finding {
 
 /// A structured producer→consumer edge captured at the matching site. This is
 /// the load-bearing cross-repo signal the eval scorer reads (contract §2): an
-/// endpoint in one repo matched by an outbound call in another (or the same)
-/// repo, with the type-compatibility verdict for that producer endpoint.
+/// endpoint in one repo matched by an outbound call in another repo, with the
+/// type-compatibility verdict for that producer endpoint. Same-identity pairs
+/// (producer_repo == consumer_repo on the `service_name ?? repo_name` id) are
+/// dropped by every matcher (#397): a service exercising its own contract is
+/// not a cross-service edge.
 ///
 /// `type_compatible == None` is deliberate and load-bearing: it means compat
 /// was never evaluated for this edge (e.g. `ts_check_dir` was absent, so type
@@ -1722,7 +1725,20 @@ impl Analyzer {
                         };
                         match edge.relationship {
                             carrick_match::MatchRelationship::ProducerConsumer => {
-                                cross_repo_matches.push(edge);
+                                // #397: a service calling its own endpoint
+                                // (through an env-var base; localhost
+                                // self-calls are dropped at extraction) is
+                                // real behaviour but not a cross-service
+                                // contract edge. Drop the self-pair on repo
+                                // identity alone, the same structural rule
+                                // `analyze_exact_key_matches` applies. The
+                                // endpoint was already marked matched above,
+                                // so it still surfaces as a verified
+                                // endpoint — only the degenerate self-edge
+                                // is dropped.
+                                if edge.producer_repo != edge.consumer_repo {
+                                    cross_repo_matches.push(edge);
+                                }
                             }
                             carrick_match::MatchRelationship::SharedExternalContract => {
                                 // Both sides are call-site encodings of the
@@ -5341,6 +5357,64 @@ mod tests {
             )]
         );
         assert!(findings.is_empty(), "got {findings:?}");
+    }
+
+    /// KILL (#397): a service calling its OWN endpoint through an env-var base
+    /// (localhost self-calls are dropped at extraction, so this is the shape
+    /// that reaches the matcher) must not emit a producer==consumer self-pair
+    /// edge — the same structural rule `analyze_exact_key_matches` applies.
+    /// The endpoint itself stays visible: it is verified by the self-call,
+    /// not orphaned. Pins the monorepo shape from the issue, where both
+    /// sides carry the same `service_name ?? repo_name` id (#368).
+    #[test]
+    fn http_self_pair_emits_no_edge_but_endpoint_stays_visible() {
+        let config = Config {
+            internal_env_vars: ["API_URL".to_string()].into_iter().collect(),
+            ..Config::default()
+        };
+        let cm = Lrc::new(SourceMap::default());
+        let mut analyzer = Analyzer::new(config, cm);
+
+        analyzer.calls.push(http_call(
+            "GET",
+            "ENV_VAR:API_URL:/api/self-status",
+            "apps/web/src/status.ts:7",
+        ));
+
+        let mut mount_graph = MountGraph::new();
+        // Producer: the `web` service of monorepo `acme-mono`.
+        let mut producer = resolved_in("GET", "/api/self-status", "acme-mono");
+        producer.service_name = Some("web".to_string());
+        mount_graph.endpoints.push(producer);
+        // Consumer: the SAME `web` service calling its own endpoint.
+        let mut consumer = data_call_in(
+            "GET",
+            "ENV_VAR:API_URL:/api/self-status",
+            "apps/web/src/status.ts:7",
+            "acme-mono",
+        );
+        consumer.service_name = Some("web".to_string());
+        mount_graph.data_calls.push(consumer);
+
+        let (findings, verified, edges) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
+
+        assert!(
+            edges.is_empty(),
+            "a producer==consumer pair is not a cross-repo edge, got {edges:?}"
+        );
+        assert_eq!(
+            verified,
+            vec![(
+                "GET".to_string(),
+                "/api/self-status".to_string(),
+                crate::operation::EndpointProvenance::Route
+            )],
+            "the endpoint stays visible as a verified endpoint"
+        );
+        assert!(
+            findings.is_empty(),
+            "matched means neither missing nor orphaned, got {findings:?}"
+        );
     }
 
     /// KEEP: literal paths keep pairing on their own signal — a

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -207,8 +207,10 @@ impl EvalProjection {
     /// on that key.
     ///
     /// HTTP ops are excluded — they get repo provenance from the mount graph, not
-    /// from `repo_name`, and localhost self-calls are already dropped at
-    /// extraction. A non-HTTP op with no repo attribution is skipped (self-loop is
+    /// from `repo_name`; localhost self-calls are already dropped at extraction,
+    /// and the HTTP matcher drops self-pair EDGES on repo identity (#397) while
+    /// keeping the ops visible as endpoint/call. A non-HTTP op with no repo
+    /// attribution is skipped (self-loop is
     /// undecidable without both repo ids), on both sides: it neither votes here
     /// nor gets dropped by the filter.
     fn intra_repo_self_loops(result: &ApiAnalysisResult) -> HashMap<String, String> {


### PR DESCRIPTION
Closes #397

## What

The HTTP matcher emitted a cross-repo match edge when a service called its own endpoint through an env-var base (localhost self-calls are already dropped at extraction). The exact-key matcher (`analyze_exact_key_matches`) already drops producer==consumer pairs structurally on repo identity, and the shared-external-contract arm carried the same guard. This aligns the remaining path.

## How

- `analyze_matches_with_mount_graph` (src/analyzer/mod.rs): the `ProducerConsumer` push now applies the same `producer_repo != consumer_repo` guard the `SharedExternalContract` arm uses. The guard sits after `matched_endpoints.insert`, so the endpoint still surfaces as a verified endpoint; only the degenerate self-edge is dropped. It is not reported as orphaned or missing either.
- The guard is on repo identity alone (the `service_name ?? repo_name` id from #368), never on topic-name, path, or library patterns, matching the exact-key rule.
- `CrossRepoMatch` doc no longer contemplates same-repo edges; every matcher now drops them.
- Eval projection (src/eval_output.rs): `intra_repo_self_loops` keeps excluding HTTP ops by design, so HTTP endpoints and calls stay visible in the projection's op sets; comment updated to record that the HTTP self-EDGE is now dropped at the matcher.

## Test

`http_self_pair_emits_no_edge_but_endpoint_stays_visible` pins the monorepo shape from the issue: the `web` service of `acme-mono` calling its own endpoint through a declared-internal env-var base yields no `cross_repo_matches` row, while the endpoint remains in the verified list and no findings are emitted.

## Expected corpus impact

None. Ground truth contains no self-pair edges, so corpus scores are expected not to move; this only removes rows that inflated `cross_repo_matches` in monorepos after #396 made both sides carry the same id.

Full cargo suite green locally (clippy and fmt clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)