### PR TITLE
feat(scanner): two-anchor arbitration for pub/sub payload anchors (witnessed borrow demotion)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -321,6 +321,76 @@ impl Visit for BindingTypeCollector {
     }
 }
 
+/// Collects the per-binding annotation evidence the pub/sub borrow witness
+/// checks an explicit `primary_type_symbol` against (#413): for every
+/// annotated binding in the file (params and typed `const`/`let`), the set of
+/// type symbols MENTIONED at any nesting depth in that binding's annotation.
+///
+/// Mention-based on purpose, mirroring `call_annotated_syms` in the HTTP
+/// sibling: `envelope: Envelope<OrderPlaced>` credits BOTH `Envelope` and
+/// `OrderPlaced` to `envelope`, so an explicit anchor that correctly names
+/// the INNER contract type of a wrapped payload is never witnessed as a
+/// borrow by its own wrapper annotation (the corpus-2 `order.placed`
+/// publisher is exactly this shape). Primary-symbol equality would misfire
+/// there; membership cannot.
+#[derive(Default)]
+struct AnnotationMentionsCollector {
+    /// binding identifier -> every type symbol mentioned in its annotation.
+    /// An annotation mentioning no named type (`payload: string`) yields an
+    /// empty set — the binding still counts as annotated.
+    mentions_by_binding: HashMap<String, HashSet<String>>,
+}
+
+impl Visit for AnnotationMentionsCollector {
+    fn visit_binding_ident(&mut self, n: &BindingIdent) {
+        if let Some(type_ann) = &n.type_ann {
+            let syms = self
+                .mentions_by_binding
+                .entry(n.id.sym.to_string())
+                .or_default();
+            type_ann
+                .type_ann
+                .visit_with(&mut TypeRefIdentCollector { syms });
+        }
+        n.visit_children_with(self);
+    }
+}
+
+/// Deterministic borrow witness for a pub/sub explicit anchor (#413): AST
+/// evidence that `symbol` structurally cannot be the type of the payload the
+/// op's locator names. The pub/sub analogue of
+/// `suppress_borrowed_request_types`' binding-type check.
+///
+/// Fires only when BOTH hold:
+/// 1. The payload binding itself is annotated, and that annotation never
+///    mentions `symbol` at any depth — the file's own contract for the
+///    payload contradicts the emitted anchor. An unannotated payload proves
+///    nothing and never witnesses.
+/// 2. `symbol` IS mentioned in the annotation of a DIFFERENT binding in the
+///    file — the place the model plausibly borrowed it from.
+///
+/// A qualified symbol (`api.AuditEvent`) is compared by its rightmost ident,
+/// matching what `TypeRefIdentCollector` records. No witness means no
+/// demotion downstream (`demote_witnessed_borrowed_anchors`), so every
+/// failure mode here — unparseable file, destructured payload, missing
+/// annotation — fails closed to the current explicit-anchor behavior.
+fn pubsub_payload_borrow_witness(
+    mentions_by_binding: &HashMap<String, HashSet<String>>,
+    payload_ident: &str,
+    symbol: &str,
+) -> bool {
+    let leaf = symbol.rsplit('.').next().unwrap_or(symbol);
+    let Some(payload_mentions) = mentions_by_binding.get(payload_ident) else {
+        return false;
+    };
+    if payload_mentions.contains(leaf) {
+        return false;
+    }
+    mentions_by_binding
+        .iter()
+        .any(|(binding, syms)| binding != payload_ident && syms.contains(leaf))
+}
+
 /// Collects the textual witnesses `suppress_phantom_pubsub_topics` checks an
 /// LLM-emitted pub/sub topic against (carrick#311): every string-literal value
 /// in the file, plus the static-part shape of every composed string (template
@@ -1237,6 +1307,7 @@ impl FileOrchestrator {
                         source_file,
                         alias,
                         array_depth: None,
+                        payload_borrow_witness: false,
                     });
                 }
             };
@@ -1752,6 +1823,7 @@ impl FileOrchestrator {
                     source_file,
                     alias: Some(alias),
                     array_depth: None,
+                    payload_borrow_witness: false,
                 });
             }
         };
@@ -1797,6 +1869,13 @@ impl FileOrchestrator {
     /// already dropped from `cloud_data` and has no manifest entry to join to).
     /// An absent `type_import_source` means the symbol is declared in the op's
     /// own file, so it resolves against that file's absolute path.
+    ///
+    /// Each request additionally carries the deterministic borrow witness
+    /// (#413, `pubsub_payload_borrow_witness`): AST evidence that the emitted
+    /// symbol structurally cannot be the type of the payload the op's locator
+    /// names. The witness alone changes nothing — it only licenses
+    /// `demote_witnessed_borrowed_anchors` to prefer the locator's
+    /// tsc-resolved root over the explicit symbol when the two disagree.
     pub fn collect_pubsub_type_requests(
         &self,
         file_results: &HashMap<String, FileAnalysisResult>,
@@ -1824,6 +1903,12 @@ impl FileOrchestrator {
         paths.sort();
         for path in paths {
             let result = &file_results[path];
+            let file_abs = Self::to_absolute_path(path, &repo_root_absolute);
+            // Lazy per-file annotation-mention evidence for the borrow
+            // witness (#413): parsed at most once per file, and only when an
+            // op actually carries both anchors (an explicit symbol AND a
+            // payload locator the infer collector will accept).
+            let mut annotation_mentions: Option<Option<AnnotationMentionsCollector>> = None;
             for op in &result.pubsub_operations {
                 // Mirror the manifest-side role mapping in
                 // `append_pubsub_manifest_entries`: subscriber = producer,
@@ -1836,12 +1921,47 @@ impl FileOrchestrator {
                 let Some(symbol) = op.primary_type_symbol.as_ref() else {
                     continue;
                 };
-                let file_abs = Self::to_absolute_path(path, &repo_root_absolute);
                 let source_file = match op.type_import_source.as_ref() {
                     Some(import_source) => Self::resolve_import_path(&file_abs, import_source),
                     // No import → same-file declaration: resolve against the file.
-                    None => file_abs,
+                    None => file_abs.clone(),
                 };
+                // Borrow witness (#413): computed only against locators the
+                // sibling infer collector will actually resolve — a bare
+                // identifier that does not contain the op's own topic (the
+                // envelope-copy guard) — because arbitration in
+                // `demote_witnessed_borrowed_anchors` needs the second
+                // anchor's inference to exist for the same alias.
+                let payload_borrow_witness = op
+                    .payload_expression_text
+                    .as_deref()
+                    .filter(|text| !text.contains(op.topic.as_str()))
+                    .and_then(payload_bare_ident)
+                    .is_some_and(|payload_ident| {
+                        let collector = annotation_mentions.get_or_insert_with(|| {
+                            let cm: Lrc<SourceMap> = Default::default();
+                            let handler = Handler::with_tty_emitter(
+                                ColorConfig::Never,
+                                false,
+                                false,
+                                Some(cm.clone()),
+                            );
+                            parse_file(std::path::Path::new(&file_abs), &cm, &handler).map(
+                                |module| {
+                                    let mut mentions = AnnotationMentionsCollector::default();
+                                    module.visit_with(&mut mentions);
+                                    mentions
+                                },
+                            )
+                        });
+                        collector.as_ref().is_some_and(|mentions| {
+                            pubsub_payload_borrow_witness(
+                                &mentions.mentions_by_binding,
+                                payload_ident,
+                                symbol,
+                            )
+                        })
+                    });
                 let key = OperationKey::pubsub(op.topic.clone());
                 // Mirror the manifest side (`append_pubsub_manifest_entries`):
                 // publishers (consumers) disambiguate by call site so fan-in
@@ -1876,6 +1996,7 @@ impl FileOrchestrator {
                         source_file,
                         alias: Some(alias),
                         array_depth: None,
+                        payload_borrow_witness,
                     });
                 }
             }
@@ -1907,10 +2028,17 @@ impl FileOrchestrator {
     /// `InferKind::FunctionParam` (the sidecar matches the param by name,
     /// whole binding pattern, or binding element — see `inferFunctionParam`).
     ///
-    /// Isolation guard (mirrors #268): an op that already carries a
-    /// `primary_type_symbol` bundles through the explicit-symbol path and must
-    /// never get a second, competing anchor here — every existing corpus pub/sub
-    /// fixture keeps its current path untouched.
+    /// Two-anchor co-emission (#413, replacing the former #268-style isolation
+    /// guard): an op that already carries a `primary_type_symbol` still emits
+    /// an infer request when it has a usable payload locator. The explicit
+    /// bundle remains authoritative for the alias — a same-alias inference
+    /// never shadows a bundled definition in `resolve_all_types` — EXCEPT
+    /// when the scanner attached a deterministic borrow witness to the
+    /// explicit request and the inferred payload root disagrees with the
+    /// emitted symbol, in which case `demote_witnessed_borrowed_anchors`
+    /// drops the explicit anchor and the inference becomes the alias's
+    /// definition (the wrong-symbol borrow class, measured 13/20 on the
+    /// honest c1 decoy fixture).
     ///
     /// The alias MUST be byte-identical to the one
     /// `append_pubsub_manifest_entries` stamped on the manifest entry — same
@@ -1949,10 +2077,15 @@ impl FileOrchestrator {
                     Some(PubsubRole::Publisher) => ManifestRole::Consumer,
                     None => continue,
                 };
-                // Isolation guard: a named anchor already owns this op.
-                if op.primary_type_symbol.is_some() {
-                    continue;
-                }
+                // No isolation guard for named anchors (#413): an op that
+                // carries a `primary_type_symbol` ALSO emits an infer request
+                // when it has a usable payload locator, so the sidecar
+                // resolves both anchors and `demote_witnessed_borrowed_anchors`
+                // can arbitrate a witnessed wrong symbol against the
+                // tsc-resolved payload root. Without a borrow witness the
+                // explicit bundle still wins unconditionally — the combine
+                // step in `resolve_all_types` never lets a same-alias
+                // inference shadow a bundled alias.
                 let Some(text) = op.payload_expression_text.as_ref() else {
                     continue;
                 };
@@ -2135,6 +2268,7 @@ impl FileOrchestrator {
                     source_file,
                     alias: Some(alias),
                     array_depth: None,
+                    payload_borrow_witness: false,
                 });
             }
         }
@@ -2178,6 +2312,7 @@ impl FileOrchestrator {
                     source_file,
                     alias: Some(alias),
                     array_depth,
+                    payload_borrow_witness: false,
                 });
             }
         }
@@ -6786,6 +6921,157 @@ export { routes };
             symbols,
             vec!["UserSignedUp", "PageViewEvent", "OrderCreated"]
         );
+    }
+
+    // ---- #413 pub/sub borrow witness ----
+
+    /// One file exercising every witness verdict: `evt: OrderPlaced` is the
+    /// annotated payload, `record: AuditRecord` is the borrow source, and
+    /// `envelope: Envelope<OrderPlaced>` is the wrapper whose annotation
+    /// MENTIONS the inner contract type.
+    fn write_witness_fixture(dir: &std::path::Path) {
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(
+            dir.join("src/pub.ts"),
+            r#"
+import type { OrderPlaced, Envelope, AuditRecord } from "./types";
+
+export function handleOrder(evt: OrderPlaced): void {
+  void evt;
+}
+
+export function auditIt(record: AuditRecord): void {
+  void record;
+}
+
+export function publishWrapped(order: OrderPlaced): void {
+  const envelope: Envelope<OrderPlaced> = { v: 1, data: order };
+  void envelope;
+}
+"#,
+        )
+        .unwrap();
+    }
+
+    fn witness_requests(
+        dir: &std::path::Path,
+        ops: Vec<crate::agents::file_analyzer_agent::PubsubOperation>,
+    ) -> Vec<crate::services::type_sidecar::SymbolRequest> {
+        let mut file_results = HashMap::new();
+        file_results.insert("src/pub.ts".to_string(), pubsub_only_result(ops));
+        let orchestrator = FileOrchestrator::new(AgentService::new());
+        orchestrator.collect_pubsub_type_requests(&file_results, dir.to_str().unwrap())
+    }
+
+    /// The witness fires exactly when the payload binding's annotation
+    /// contradicts the emitted symbol AND the symbol is anchored to a
+    /// different binding — and stays off in every agreement, wrapper-mention,
+    /// unannotated, non-bare-locator, and envelope-copy shape.
+    #[test]
+    fn test_pubsub_borrow_witness_verdicts() {
+        use crate::operation::PubsubRole;
+
+        let dir = tempfile::tempdir().unwrap();
+        write_witness_fixture(dir.path());
+
+        let sub = |topic: &str, symbol: &str, locator: Option<&str>| {
+            pubsub_op(topic, PubsubRole::Subscriber, Some(symbol), None, locator)
+        };
+        let requests = witness_requests(
+            dir.path(),
+            vec![
+                // Borrow: payload `evt: OrderPlaced` never mentions
+                // AuditRecord, and AuditRecord annotates `record`.
+                sub("t.borrow", "AuditRecord", Some("evt")),
+                // Agreement: the symbol IS the payload annotation.
+                sub("t.agree", "OrderPlaced", Some("evt")),
+                // Wrapper mention: `envelope: Envelope<OrderPlaced>` mentions
+                // the inner contract type at depth — never a borrow, even
+                // though the primary symbol of the annotation is `Envelope`.
+                sub("t.wrapped", "OrderPlaced", Some("envelope")),
+                // Unannotated/unknown payload binding: proves nothing.
+                sub("t.unannotated", "AuditRecord", Some("mystery")),
+                // Symbol anchored to no other binding: no borrow source.
+                sub("t.ghost", "GhostType", Some("evt")),
+                // Non-bare-ident locator: the infer path can't be attributed
+                // to a binding, so no witness.
+                sub("t.encoded", "AuditRecord", Some("jc.encode(evt)")),
+                // Envelope-copy locator (contains the topic): the infer
+                // collector drops it, so there is no second anchor to
+                // arbitrate against.
+                sub(
+                    "t.copy",
+                    "AuditRecord",
+                    Some("{ topic: \"t.copy\", data: evt }"),
+                ),
+                // No locator at all.
+                sub("t.nolocator", "AuditRecord", None),
+            ],
+        );
+
+        // Every op carries a symbol, so all eight anchor a request, in op
+        // order (a single file's ops walk in vec order).
+        let witnesses: Vec<bool> = requests.iter().map(|r| r.payload_borrow_witness).collect();
+        assert_eq!(
+            witnesses,
+            vec![
+                true,  // t.borrow: witnessed borrow
+                false, // t.agree: agreement
+                false, // t.wrapped: wrapper annotation mentions the symbol
+                false, // t.unannotated: payload binding not annotated
+                false, // t.ghost: symbol anchored to no other binding
+                false, // t.encoded: non-bare-ident locator
+                false, // t.copy: envelope-copy locator (contains the topic)
+                false, // t.nolocator: no locator at all
+            ],
+            "requests: {requests:?}"
+        );
+    }
+
+    /// An unparseable (or absent) file yields no annotation evidence, so the
+    /// witness fails closed to `false` — never blocking the explicit path.
+    #[test]
+    fn test_pubsub_borrow_witness_fails_closed_without_a_parseable_file() {
+        use crate::operation::PubsubRole;
+
+        let dir = tempfile::tempdir().unwrap();
+        // No src/pub.ts on disk at all.
+        let requests = witness_requests(
+            dir.path(),
+            vec![pubsub_op(
+                "t.borrow",
+                PubsubRole::Subscriber,
+                Some("AuditRecord"),
+                None,
+                Some("evt"),
+            )],
+        );
+        assert_eq!(requests.len(), 1);
+        assert!(!requests[0].payload_borrow_witness);
+    }
+
+    /// Pure-map witness check: qualified symbols compare by rightmost ident.
+    #[test]
+    fn test_pubsub_borrow_witness_qualified_symbol_leaf() {
+        let mut mentions: HashMap<String, HashSet<String>> = HashMap::new();
+        mentions.insert(
+            "evt".to_string(),
+            ["OrderPlaced".to_string()].into_iter().collect(),
+        );
+        mentions.insert(
+            "record".to_string(),
+            ["AuditRecord".to_string()].into_iter().collect(),
+        );
+        assert!(pubsub_payload_borrow_witness(
+            &mentions,
+            "evt",
+            "api.AuditRecord"
+        ));
+        assert!(!pubsub_payload_borrow_witness(
+            &mentions,
+            "evt",
+            "api.OrderPlaced"
+        ));
     }
 
     // ---- #361 deterministic extraction-flake guards ----

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -5587,6 +5587,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             infer_kind: InferKind::CallResult,
             primary_type_symbol: None,
             array_depth: None,
+            primary_type_symbol_source: None,
         });
 
         enrich_manifest_with_type_resolution(&mut manifest, &resolution, None);
@@ -5615,6 +5616,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             infer_kind: InferKind::CallResult,
             primary_type_symbol: None,
             array_depth: None,
+            primary_type_symbol_source: None,
         });
 
         enrich_manifest_with_type_resolution(&mut manifest, &resolution, None);
@@ -5643,6 +5645,7 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             infer_kind: InferKind::ResponseBody,
             primary_type_symbol: Some(symbol.to_string()),
             array_depth: None,
+            primary_type_symbol_source: None,
         }
     }
 
@@ -6781,8 +6784,9 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
     /// `append_pubsub_manifest_entries` — same plain alias for subscribers
     /// (producers), same call-site-disambiguated alias for publishers
     /// (consumers) — or the resolved payload type never joins back and the op
-    /// stays `Unknown`, silently. Also pins the role → InferKind routing and
-    /// the isolation guard (a named anchor suppresses the infer request).
+    /// stays `Unknown`, silently. Also pins the role → InferKind routing, the
+    /// two-anchor co-emission (#413: a named anchor no longer suppresses the
+    /// infer request — the sidecar arbitrates), and the envelope-copy guard.
     #[test]
     fn pubsub_infer_request_alias_matches_manifest_alias() {
         use crate::operation::PubsubRole;
@@ -6819,8 +6823,11 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
             FileAnalysisResult {
                 pubsub_operations: vec![
                     locator_op("itemArchived", PubsubRole::Publisher, 9, "event"),
-                    // Named anchor present → the bundle path owns this op; the
-                    // infer collector must emit NOTHING for it.
+                    // Named anchor present WITH a usable locator → the op
+                    // co-emits an infer request (#413) so the sidecar can
+                    // arbitrate the two anchors; the explicit bundle still
+                    // wins unless a borrow witness plus a root disagreement
+                    // demotes it.
                     crate::agents::file_analyzer_agent::PubsubOperation {
                         topic: "orders.placed".to_string(),
                         role: Some(PubsubRole::Publisher),
@@ -6863,16 +6870,16 @@ npm error peer typescript@\">=4.2\" from ts-node@10.9.2
         let orchestrator = FileOrchestrator::new(AgentService::new());
         let requests = orchestrator.collect_pubsub_infer_requests(&file_results, ".");
 
-        // Isolation + envelope guards: only the two locator-anchored
-        // itemArchived ops produce requests; the named-anchor op and the
-        // topic-containing envelope copy are both excluded.
-        assert_eq!(requests.len(), 2, "requests: {requests:?}");
+        // Co-emission + envelope guard: the two locator-anchored itemArchived
+        // ops AND the named-anchor orders.placed op produce requests (#413);
+        // only the topic-containing envelope copy is excluded.
+        assert_eq!(requests.len(), 3, "requests: {requests:?}");
         assert!(
-            !requests
+            requests
                 .iter()
-                .any(|r| r.param_name.as_deref() == Some("order")
-                    || r.expression_text.as_deref() == Some("order")),
-            "an op with a primary_type_symbol must not also get an infer request"
+                .any(|r| r.expression_text.as_deref() == Some("order")),
+            "an op with a primary_type_symbol and a usable locator must ALSO \
+             emit an infer request so the sidecar can arbitrate the anchors"
         );
         assert!(
             !requests.iter().any(|r| r

--- a/src/services/type_sidecar.rs
+++ b/src/services/type_sidecar.rs
@@ -20,7 +20,7 @@ use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
-use tracing::debug;
+use tracing::{debug, info};
 
 // ============================================================================
 // Sidecar State
@@ -128,6 +128,19 @@ pub struct SymbolRequest {
     /// bundles the symbol as-is (the HTTP/socket/consumer default).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub array_depth: Option<u32>,
+    /// Deterministic borrow witness from the scanner's AST pre-pass (pub/sub
+    /// two-anchor arbitration, #413 / the #403/#359 borrow-class lineage):
+    /// `true` means the file's own annotations testify that `symbol_name`
+    /// structurally cannot be the payload this request's alias stands for —
+    /// the payload binding is annotated with a type that never mentions the
+    /// symbol, while the symbol annotates a DIFFERENT binding in the same
+    /// file (where the model borrowed it from). Only
+    /// `collect_pubsub_type_requests` ever sets this; HTTP/socket/GraphQL
+    /// requests always carry `false`, so `demote_witnessed_borrowed_anchors`
+    /// is structurally inert for every non-pub/sub path. Scanner-internal:
+    /// never serialized to the sidecar.
+    #[serde(skip)]
+    pub payload_borrow_witness: bool,
 }
 
 /// Request for type inference at a specific location
@@ -261,6 +274,14 @@ pub struct InferredType {
     /// of the bare element. Absent when 0 or when there is no anchor symbol.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub array_depth: Option<u32>,
+    /// Declaration file (absolute path) of `primary_type_symbol`, reported by
+    /// the pub/sub infer kinds (`function_param`, `expression`) only (#413).
+    /// `demote_witnessed_borrowed_anchors` uses it to re-aim a demoted
+    /// explicit `SymbolRequest`: the bundler resolves a symbol only against
+    /// declarations IN the request's `source_file`, and the inference is the
+    /// only party that knows where the tsc-witnessed payload type lives.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_type_symbol_source: Option<String>,
 }
 
 /// Information about a symbol that failed to resolve
@@ -701,13 +722,24 @@ impl TypeSidecar {
             }
         }
 
+        // Two-anchor arbitration (#413, pub/sub only): a request carrying the
+        // scanner's deterministic borrow witness whose alias the inference
+        // resolved to a DIFFERENT named root is demoted here — re-aimed at
+        // the tsc-witnessed root so the bundler defines the alias from the
+        // inferred payload type instead of the borrowed symbol. This must
+        // happen BEFORE the bundle runs: compat verdicts are computed from
+        // the bundled dts, so a post-hoc flag flip in
+        // `enrich_manifest_with_type_resolution` could never undo a wrong
+        // explicit definition.
+        let explicit = demote_witnessed_borrowed_anchors(explicit, &result.inferred_types);
+
         // Bundle explicit types. An LLM-extracted anchor is a bare identifier
         // by schema contract (`User[]` → `User`), so bundling it as-is erases
         // the use-site's array-ness and an array-vs-scalar mismatch scores
         // compatible (#306). Copy the inference-resolved depth onto each
         // matching request so the bundler's array_depth wrap (#248) restores
         // the `[]` levels.
-        let explicit = apply_inferred_array_depth(explicit, &result.inferred_types);
+        let explicit = apply_inferred_array_depth(&explicit, &result.inferred_types);
         if !explicit.is_empty() {
             let bundle_response = self.resolve_types(&explicit)?;
             result.dts_content = bundle_response.dts_content;
@@ -945,6 +977,130 @@ impl TypeSidecar {
     }
 }
 
+/// Two-anchor arbitration for pub/sub payload anchors (#413, the #403/#359
+/// borrow-class lineage): demote a witnessed-borrowed explicit request when
+/// the same alias's location-based inference resolved a DIFFERENT named root.
+///
+/// A pub/sub op can carry two independent anchors: the LLM's explicit
+/// `primary_type_symbol` (a judgment, measured wrong 13/20 on the honest
+/// borrow fixture) and the payload locator, which the sidecar resolves
+/// deterministically with tsc. When both resolve, the per-alias inferred root
+/// symbol is compared against the explicit request's symbol — the same
+/// alias+symbol join `apply_inferred_array_depth` performs. On a named-root
+/// disagreement the explicit request is demoted: re-aimed at the inferred
+/// root (symbol, declaration file, and array depth all from the inference),
+/// so the bundler defines the alias from the tsc-witnessed payload type
+/// instead of the borrowed one. Re-aiming rather than dropping keeps the
+/// alias's dts definition self-contained — the inferred type_string keeps
+/// named types as names (`OrderPlaced`), which would dangle if pasted in as
+/// a standalone `export type` — while still making the inferred type the
+/// alias's definition.
+///
+/// Demotion is gated on the scanner's deterministic borrow witness
+/// (`payload_borrow_witness`, computed from the file's AST in
+/// `collect_pubsub_type_requests`): no witness, no demotion — a bare
+/// tsc-vs-LLM disagreement without AST evidence keeps the explicit symbol,
+/// so a mis-anchored inference (wrong text occurrence, envelope resolution)
+/// can never displace a correct explicit anchor on its own.
+///
+/// Anonymous inferred types are NOT arbitrated: when the inference returns a
+/// structural type with no root symbol (`primary_type_symbol: None` — object
+/// literals, encoded payloads, lib-global roots), the named-root-disagreement
+/// rule cannot fire and the explicit symbol is kept, witness or not. There is
+/// deliberately no resolution for that case — a structural shape carries no
+/// identity to disagree with, and inventing a comparison (e.g. shape
+/// equality) would demote on formatting noise.
+///
+/// Further keeps, all deliberate:
+/// - an alias carried by more than one explicit request (fan-in ambiguity —
+///   the inference cannot be attributed to either request);
+/// - an inference whose type_string is not the bare named form of its own
+///   root (`Root`, `Root[]`, …): a generic instantiation
+///   (`Envelope<Order>`) or an expanded structural shape cannot be
+///   reproduced by bundling the bare root symbol, so re-aiming would change
+///   the type;
+/// - a root with no reported declaration file (the bundler could not resolve
+///   it), or a framework envelope root (demotion must never install
+///   machinery as a payload);
+/// - requests without the witness flag — every HTTP/socket/GraphQL request,
+///   making this function structurally inert outside pub/sub.
+fn demote_witnessed_borrowed_anchors(
+    explicit: &[SymbolRequest],
+    inferred: &[InferredType],
+) -> Vec<SymbolRequest> {
+    // First inference per alias wins, mirroring `apply_inferred_array_depth`
+    // and the `or_insert` join in `enrich_manifest_with_type_resolution`.
+    let mut inferred_by_alias: HashMap<&str, &InferredType> = HashMap::new();
+    for inf in inferred {
+        inferred_by_alias.entry(inf.alias.as_str()).or_insert(inf);
+    }
+
+    let mut alias_counts: HashMap<&str, usize> = HashMap::new();
+    for req in explicit {
+        if let Some(alias) = req.alias.as_deref() {
+            *alias_counts.entry(alias).or_insert(0) += 1;
+        }
+    }
+
+    explicit
+        .iter()
+        .map(|req| {
+            if !req.payload_borrow_witness {
+                return req.clone();
+            }
+            let Some(alias) = req.alias.as_deref() else {
+                return req.clone();
+            };
+            if alias_counts.get(alias).copied().unwrap_or(0) > 1 {
+                return req.clone();
+            }
+            let Some(inf) = inferred_by_alias.get(alias) else {
+                return req.clone();
+            };
+            // Anonymous inferred type: no root to disagree with — keep.
+            let Some(root) = inf.primary_type_symbol.as_deref() else {
+                return req.clone();
+            };
+            if root == req.symbol_name {
+                return req.clone();
+            }
+            // Re-aiming needs the root's declaration file.
+            let Some(root_source) = inf.primary_type_symbol_source.as_deref() else {
+                return req.clone();
+            };
+            // Never install machinery as a payload.
+            if TypeSidecar::is_untyped_response_type(root) {
+                return req.clone();
+            }
+            // The inference must BE the bare named form of its root (modulo
+            // array suffixes), or bundling the root would change the type.
+            let mut named_form = inf.type_string.trim();
+            while let Some(stripped) = named_form.strip_suffix("[]") {
+                named_form = stripped.trim_end();
+            }
+            if named_form != root {
+                return req.clone();
+            }
+            info!(
+                alias = %alias,
+                explicit_symbol = %req.symbol_name,
+                inferred_root = %root,
+                inferred_root_source = %root_source,
+                "[type_sidecar] pub/sub anchor arbitration: witnessed borrowed \
+                 symbol disagrees with the tsc-resolved payload root; demoting \
+                 the explicit anchor to the inferred type"
+            );
+            SymbolRequest {
+                symbol_name: root.to_string(),
+                source_file: root_source.to_string(),
+                alias: req.alias.clone(),
+                array_depth: inf.array_depth,
+                payload_borrow_witness: false,
+            }
+        })
+        .collect()
+}
+
 /// Copy inference-resolved array depths onto explicit symbol requests (#306).
 ///
 /// An LLM-extracted anchor is a bare identifier by schema contract (`User[]` →
@@ -1081,6 +1237,7 @@ mod tests {
             source_file: "src/types.ts".to_string(),
             alias: Some("UserResponse".to_string()),
             array_depth: None,
+            payload_borrow_witness: false,
         };
         let json = serde_json::to_string(&request).unwrap();
         assert!(json.contains(r#""symbol_name":"User""#));
@@ -1133,6 +1290,7 @@ mod tests {
                 source_file: "src/types.ts".to_string(),
                 alias: None,
                 array_depth: None,
+                payload_borrow_witness: false,
             }],
         };
         let json = serde_json::to_string(&request).unwrap();
@@ -1169,6 +1327,7 @@ mod tests {
             source_file: "src/types.ts".to_string(),
             alias: Some(alias.to_string()),
             array_depth,
+            payload_borrow_witness: false,
         }
     }
 
@@ -1187,6 +1346,7 @@ mod tests {
             infer_kind: InferKind::FunctionReturn,
             primary_type_symbol: symbol.map(str::to_string),
             array_depth,
+            primary_type_symbol_source: None,
         }
     }
 
@@ -1245,6 +1405,232 @@ mod tests {
 
         assert_eq!(adjusted[0].array_depth, None);
         assert_eq!(adjusted[1].array_depth, None);
+    }
+
+    // ---- #413 two-anchor arbitration (pub/sub borrow demotion) ----
+
+    fn witnessed(mut req: SymbolRequest) -> SymbolRequest {
+        req.payload_borrow_witness = true;
+        req
+    }
+
+    fn inferred_with_anchor(
+        alias: &str,
+        symbol: Option<&str>,
+        type_string: &str,
+        symbol_source: Option<&str>,
+    ) -> InferredType {
+        let mut inf = inferred(alias, symbol, None);
+        inf.type_string = type_string.to_string();
+        inf.primary_type_symbol_source = symbol_source.map(str::to_string);
+        inf
+    }
+
+    /// Witnessed wrong symbol + named-root disagreement + bare named inferred
+    /// form → the explicit request is demoted: re-aimed at the inferred root
+    /// (symbol + declaration file), so the bundler defines the alias from the
+    /// tsc-witnessed payload type.
+    #[test]
+    fn arbitration_demotes_witnessed_wrong_symbol() {
+        let explicit = vec![witnessed(symbol_request(
+            "AuditRecord",
+            "Alias_Response",
+            None,
+        ))];
+        let inferred = vec![inferred_with_anchor(
+            "Alias_Response",
+            Some("OrderPlaced"),
+            "OrderPlaced",
+            Some("/repo/src/orders.ts"),
+        )];
+
+        let kept = demote_witnessed_borrowed_anchors(&explicit, &inferred);
+
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].symbol_name, "OrderPlaced", "re-aimed at the root");
+        assert_eq!(kept[0].source_file, "/repo/src/orders.ts");
+        assert_eq!(kept[0].alias.as_deref(), Some("Alias_Response"));
+        assert_eq!(kept[0].array_depth, None);
+        assert!(!kept[0].payload_borrow_witness, "witness consumed");
+    }
+
+    /// An array-form inference (`Root[]`) demotes with the inferred depth so
+    /// the bundler's array wrap restores the `[]` levels.
+    #[test]
+    fn arbitration_demotes_array_form_with_depth() {
+        let explicit = vec![witnessed(symbol_request(
+            "AuditRecord",
+            "Alias_Response",
+            None,
+        ))];
+        let mut inf = inferred_with_anchor(
+            "Alias_Response",
+            Some("OrderPlaced"),
+            "OrderPlaced[]",
+            Some("/repo/src/orders.ts"),
+        );
+        inf.array_depth = Some(1);
+        let inferred = vec![inf];
+
+        let kept = demote_witnessed_borrowed_anchors(&explicit, &inferred);
+
+        assert_eq!(kept[0].symbol_name, "OrderPlaced");
+        assert_eq!(kept[0].array_depth, Some(1));
+    }
+
+    /// The same disagreement WITHOUT the scanner's borrow witness keeps the
+    /// explicit request: a bare tsc-vs-LLM disagreement never demotes.
+    #[test]
+    fn arbitration_keeps_unwitnessed_disagreement() {
+        let explicit = vec![symbol_request("AuditRecord", "Alias_Response", None)];
+        let inferred = vec![inferred_with_anchor(
+            "Alias_Response",
+            Some("OrderPlaced"),
+            "OrderPlaced",
+            Some("/repo/src/orders.ts"),
+        )];
+
+        let kept = demote_witnessed_borrowed_anchors(&explicit, &inferred);
+
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].symbol_name, "AuditRecord");
+    }
+
+    /// Root agreement keeps the explicit request even with a witness (the
+    /// witness was evidently wrong or vacuous — tsc confirms the anchor).
+    #[test]
+    fn arbitration_keeps_agreement() {
+        let explicit = vec![witnessed(symbol_request(
+            "OrderPlaced",
+            "Alias_Response",
+            None,
+        ))];
+        let inferred = vec![inferred_with_anchor(
+            "Alias_Response",
+            Some("OrderPlaced"),
+            "OrderPlaced",
+            Some("/repo/src/orders.ts"),
+        )];
+
+        let kept = demote_witnessed_borrowed_anchors(&explicit, &inferred);
+
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].symbol_name, "OrderPlaced");
+        assert_eq!(kept[0].source_file, "src/types.ts", "request untouched");
+    }
+
+    /// Anonymous inferred type (no root symbol): the named-root-disagreement
+    /// rule cannot fire, so the explicit symbol is kept — witness or not.
+    /// There is deliberately no resolution for this case.
+    #[test]
+    fn arbitration_keeps_explicit_on_anonymous_inference() {
+        let explicit = vec![witnessed(symbol_request(
+            "OrderPlaced",
+            "Alias_Response",
+            None,
+        ))];
+        let inferred = vec![inferred_with_anchor(
+            "Alias_Response",
+            None,
+            "{ id: string; }",
+            None,
+        )];
+
+        let kept = demote_witnessed_borrowed_anchors(&explicit, &inferred);
+
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].symbol_name, "OrderPlaced");
+    }
+
+    /// A disagreeing inference whose type_string is not the bare named form
+    /// of its root (generic instantiation, expanded structural shape) never
+    /// demotes: bundling the bare root would change the type. Same for a
+    /// missing declaration source or a framework-machinery root.
+    #[test]
+    fn arbitration_keeps_explicit_when_reaim_would_change_the_type() {
+        let cases: Vec<InferredType> = vec![
+            // Generic instantiation: bundling bare `Envelope` loses the arg.
+            inferred_with_anchor(
+                "Alias_Response",
+                Some("Envelope"),
+                "Envelope<OrderPlaced>",
+                Some("/repo/src/types.ts"),
+            ),
+            // Structural expansion with a named root: not the bare form.
+            inferred_with_anchor(
+                "Alias_Response",
+                Some("OrderPlaced"),
+                "{ id: string; }",
+                Some("/repo/src/orders.ts"),
+            ),
+            // No declaration source: the bundler could not resolve the root.
+            inferred_with_anchor("Alias_Response", Some("OrderPlaced"), "OrderPlaced", None),
+            // Framework machinery root.
+            inferred_with_anchor(
+                "Alias_Response",
+                Some("FastifyReply"),
+                "FastifyReply",
+                Some("/repo/node_modules/fastify/types.d.ts"),
+            ),
+        ];
+        for inf in cases {
+            let explicit = vec![witnessed(symbol_request(
+                "AuditRecord",
+                "Alias_Response",
+                None,
+            ))];
+            let type_string = inf.type_string.clone();
+            let kept = demote_witnessed_borrowed_anchors(&explicit, &[inf]);
+
+            assert_eq!(kept.len(), 1);
+            assert_eq!(
+                kept[0].symbol_name, "AuditRecord",
+                "shape {type_string:?} must not demote"
+            );
+        }
+    }
+
+    /// An alias carried by more than one explicit request is fan-in
+    /// ambiguous: the inference cannot be attributed, so nothing is demoted.
+    #[test]
+    fn arbitration_keeps_fan_in_ambiguous_alias() {
+        let explicit = vec![
+            witnessed(symbol_request("AuditRecord", "Alias_Response", None)),
+            symbol_request("OtherThing", "Alias_Response", None),
+        ];
+        let inferred = vec![inferred_with_anchor(
+            "Alias_Response",
+            Some("OrderPlaced"),
+            "OrderPlaced",
+            Some("/repo/src/orders.ts"),
+        )];
+
+        let kept = demote_witnessed_borrowed_anchors(&explicit, &inferred);
+
+        assert_eq!(kept.len(), 2);
+        assert_eq!(kept[0].symbol_name, "AuditRecord");
+        assert_eq!(kept[1].symbol_name, "OtherThing");
+    }
+
+    /// No inference for the alias at all → keep (nothing to arbitrate with).
+    #[test]
+    fn arbitration_keeps_explicit_without_matching_inference() {
+        let explicit = vec![witnessed(symbol_request(
+            "AuditRecord",
+            "Alias_Response",
+            None,
+        ))];
+        let inferred = vec![inferred_with_anchor(
+            "Other_Response",
+            Some("OrderPlaced"),
+            "OrderPlaced",
+            Some("/repo/src/orders.ts"),
+        )];
+
+        let kept = demote_witnessed_borrowed_anchors(&explicit, &inferred);
+
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].symbol_name, "AuditRecord");
     }
 
     #[test]
@@ -1306,6 +1692,7 @@ mod tests {
             source_file: "src/types.ts".to_string(),
             alias: Some("Endpoint_abc_Response".to_string()),
             array_depth: None,
+            payload_borrow_witness: false,
         }];
 
         if had_explicit_dts {

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -443,13 +443,25 @@ export class TypeInferrer {
     }
 
     const isExplicit = target.param.getTypeNode() !== undefined;
-    const typeString = typeText(target.node.getType(), target.node);
+    const paramType = target.node.getType();
+    const typeString = typeText(paramType, target.node);
 
+    // Deterministic anchor for the pub/sub two-anchor arbitration
+    // (carrick#413): report the payload type's root symbol, its declaration
+    // file, and the peeled array depth. The type STRING deliberately keeps
+    // ts-morph's default named form (see the doc comment above) — the
+    // scanner re-aims the explicit bundle at the root symbol instead of
+    // pasting this string, so the alias's definition stays self-contained.
+    const anchor = this.unwrapArrayLevels(this.unwrapPromiseType(paramType));
     return this.createInferredType(
       request,
       typeString,
       isExplicit,
-      this.getNodeLocation(target.node)
+      this.getNodeLocation(target.node),
+      undefined,
+      this.primaryTypeSymbol(anchor.element),
+      anchor.depth,
+      this.primaryTypeSymbolSource(anchor.element)
     );
   }
 
@@ -809,12 +821,25 @@ export class TypeInferrer {
 
     typeString = this.unwrapPromise(typeString, type);
 
+    // Deterministic anchor for the pub/sub two-anchor arbitration
+    // (carrick#413). When an unwrap rule fired (envelope publishers), the
+    // anchor follows the extracted PAYLOAD type, so a correct explicit
+    // anchor naming the inner contract type reads as agreement, never as a
+    // disagreement to arbitrate.
+    const anchorSource =
+      unwrapResult.wasUnwrapped && unwrapResult.payloadType
+        ? unwrapResult.payloadType
+        : type;
+    const anchor = this.unwrapArrayLevels(this.unwrapPromiseType(anchorSource));
     return this.createInferredType(
       request,
       typeString,
       false,
       this.getNodeLocation(node),
-      unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined
+      unwrapResult.wasUnwrapped ? unwrapResult.typeString : undefined,
+      this.primaryTypeSymbol(anchor.element),
+      anchor.depth,
+      this.primaryTypeSymbolSource(anchor.element)
     );
   }
 
@@ -1817,6 +1842,23 @@ export class TypeInferrer {
   }
 
   /**
+   * Declaration file (absolute path) of the anchor symbol
+   * `primaryTypeSymbol` reports for this type, or `undefined` when the type
+   * has no user-facing anchor or no source declaration. The scanner's
+   * pub/sub two-anchor arbitration (carrick#413) uses this to re-aim a
+   * demoted explicit bundle request: the bundler resolves a `SymbolRequest`
+   * only against declarations IN its `source_file`, so the request must
+   * point at the file that actually declares the tsc-witnessed payload type.
+   */
+  private primaryTypeSymbolSource(type: Type): string | undefined {
+    if (this.primaryTypeSymbol(type) === undefined) {
+      return undefined;
+    }
+    const decl = (type.getSymbol() || type.getAliasSymbol())?.getDeclarations()?.[0];
+    return decl?.getSourceFile().getFilePath();
+  }
+
+  /**
    * Peel array levels off a resolved type: `TimelineEvent[]` → element
    * `TimelineEvent`, depth 1. An array type's own symbol is `Array` (builtin,
    * filtered), so without this a `T[]` payload has NO anchor and — worse — an
@@ -2638,7 +2680,8 @@ export class TypeInferrer {
     sourceLocation: SourceLocation,
     payloadTypeString?: string,
     primaryTypeSymbol?: string,
-    arrayDepth?: number
+    arrayDepth?: number,
+    primaryTypeSymbolSource?: string
   ): InferredType {
     const alias =
       request.alias ||
@@ -2658,6 +2701,9 @@ export class TypeInferrer {
         primaryTypeSymbol !== undefined && arrayDepth !== undefined && arrayDepth > 0
           ? arrayDepth
           : undefined,
+      // Same gate: a declaration source without an anchor symbol is useless.
+      primary_type_symbol_source:
+        primaryTypeSymbol !== undefined ? primaryTypeSymbolSource : undefined,
     };
   }
 

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -1849,13 +1849,31 @@ export class TypeInferrer {
    * demoted explicit bundle request: the bundler resolves a `SymbolRequest`
    * only against declarations IN its `source_file`, so the request must
    * point at the file that actually declares the tsc-witnessed payload type.
+   *
+   * Only declaration kinds the bundler's `validateSymbols` can resolve
+   * (interface, type alias, class, enum, function, variable) count. A
+   * symbol's declaration list can also contain re-export machinery — a
+   * barrel's `ExportSpecifier` (`export { Foo } from './foo'`) points at a
+   * file that does not DECLARE the type, and a request re-aimed there would
+   * fail validation, turning a resolvable explicit type into `unknown`.
+   * With no declaring node, no source is reported and the arbitration
+   * fails closed to the explicit anchor.
    */
   private primaryTypeSymbolSource(type: Type): string | undefined {
     if (this.primaryTypeSymbol(type) === undefined) {
       return undefined;
     }
-    const decl = (type.getSymbol() || type.getAliasSymbol())?.getDeclarations()?.[0];
-    return decl?.getSourceFile().getFilePath();
+    const decls = (type.getSymbol() || type.getAliasSymbol())?.getDeclarations() ?? [];
+    const declaring = decls.find(
+      (d) =>
+        Node.isInterfaceDeclaration(d) ||
+        Node.isTypeAliasDeclaration(d) ||
+        Node.isClassDeclaration(d) ||
+        Node.isEnumDeclaration(d) ||
+        Node.isFunctionDeclaration(d) ||
+        Node.isVariableDeclaration(d)
+    );
+    return declaring?.getSourceFile().getFilePath();
   }
 
   /**

--- a/src/sidecar/src/types.ts
+++ b/src/sidecar/src/types.ts
@@ -570,6 +570,17 @@ export interface InferredType {
    * compatible, #306). Omitted when 0 or when there is no anchor symbol.
    */
   array_depth?: number;
+  /**
+   * Declaration file of `primary_type_symbol` (absolute path), when the
+   * anchor symbol has a resolvable source declaration. Lets the scanner's
+   * pub/sub two-anchor arbitration (carrick#413) re-aim a demoted explicit
+   * `SymbolRequest` at the tsc-witnessed payload type: the bundler requires
+   * the symbol to be DECLARED in the request's `source_file`, and the
+   * inference is the only party that knows where that is. Reported only by
+   * the pub/sub infer kinds (`function_param`, `expression`); other kinds
+   * omit it.
+   */
+  primary_type_symbol_source?: string;
 }
 
 /**

--- a/src/sidecar/test/fixtures/sample-repo/src/pubsub-barrel-types.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/pubsub-barrel-types.ts
@@ -1,0 +1,6 @@
+// Declaring module for the barrel re-export case (carrick#413): the payload
+// interface LIVES here; pubsub-barrel.ts only re-exports it.
+export interface ReExportedPayload {
+  shipmentId: string;
+  carrier: string;
+}

--- a/src/sidecar/test/fixtures/sample-repo/src/pubsub-barrel.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/pubsub-barrel.ts
@@ -1,0 +1,4 @@
+// Barrel: re-exports the payload type without declaring it. A symbol's
+// declaration list can surface this ExportSpecifier — the anchor source must
+// NOT point here (the bundler resolves only real declarations).
+export { ReExportedPayload } from "./pubsub-barrel-types.js";

--- a/src/sidecar/test/fixtures/sample-repo/src/pubsub-handlers.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/pubsub-handlers.ts
@@ -73,3 +73,24 @@ export function publishSecond(): void {
   const payloadValue = { kind: "second", s: "x" };
   void send("second.topic", payloadValue);
 }
+
+// ---------------------------------------------------------------------------
+// Named-annotation payloads for the two-anchor arbitration (carrick#413):
+// the subscriber param and the publisher argument both carry a NAMED payload
+// type, so the deterministic anchor (primary_type_symbol + its declaration
+// source file) must be reported alongside the named type string.
+// ---------------------------------------------------------------------------
+
+export interface OrderPlacedPayload {
+  orderId: string;
+  totalCents: number;
+}
+
+export function onOrderPlaced(evt: OrderPlacedPayload): void {
+  void evt;
+}
+
+export function publishOrder(): void {
+  const order: OrderPlacedPayload = { orderId: "o1", totalCents: 100 };
+  void send("orders.placed", order);
+}

--- a/src/sidecar/test/fixtures/sample-repo/src/pubsub-handlers.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/pubsub-handlers.ts
@@ -94,3 +94,11 @@ export function publishOrder(): void {
   const order: OrderPlacedPayload = { orderId: "o1", totalCents: 100 };
   void send("orders.placed", order);
 }
+
+// Payload type imported through the barrel: the anchor source must be the
+// DECLARING file (pubsub-barrel-types.ts), never the barrel.
+import type { ReExportedPayload } from "./pubsub-barrel.js";
+
+export function onShipment(evt: ReExportedPayload): void {
+  void evt;
+}

--- a/src/sidecar/test/infer-pubsub-anchor-source.test.ts
+++ b/src/sidecar/test/infer-pubsub-anchor-source.test.ts
@@ -1,0 +1,139 @@
+/**
+ * carrick#413 (two-anchor arbitration): the pub/sub infer kinds
+ * (`function_param` for subscribers, `expression` for publishers) must report
+ * the deterministic anchor of the resolved payload — `primary_type_symbol`
+ * plus its declaration file (`primary_type_symbol_source`) — so the scanner
+ * can compare the tsc-resolved root against an LLM-emitted explicit symbol
+ * and, on a witnessed borrow, re-aim the explicit bundle request at the real
+ * payload type. The type STRING keeps ts-morph's default named form; the
+ * anchor is what makes the demotion self-contained.
+ *
+ * Anonymous payloads (destructured wrapper generics) stay anchor-less: no
+ * root symbol means the arbitration never fires for them.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const FIXTURE = path.join(FIXTURES_PATH, 'src/pubsub-handlers.ts');
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    is_explicit: boolean;
+    infer_kind: string;
+    primary_type_symbol?: string;
+    primary_type_symbol_source?: string;
+    array_depth?: number;
+  }>;
+  errors?: string[];
+}
+
+describe('pub/sub infer kinds report the payload anchor and its declaration source (carrick#413)', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'pas-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('function_param with a named annotation reports the root symbol and its source', async () => {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'pas-1',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: 89,
+          infer_kind: 'function_param',
+          param_name: 'evt',
+          alias: 'PubsubSubAnchor',
+        },
+      ],
+    });
+
+    assert.ok(
+      response.inferred_types && response.inferred_types.length > 0,
+      `expected inferred_types, got ${JSON.stringify(response)}`
+    );
+    const inferred = response.inferred_types[0];
+    assert.strictEqual(inferred.type_string, 'OrderPlacedPayload');
+    assert.strictEqual(inferred.is_explicit, true);
+    assert.strictEqual(inferred.primary_type_symbol, 'OrderPlacedPayload');
+    assert.ok(
+      inferred.primary_type_symbol_source?.endsWith('pubsub-handlers.ts'),
+      `anchor source must be the declaration file, got ${JSON.stringify(
+        inferred.primary_type_symbol_source
+      )}`
+    );
+  });
+
+  it('expression of a named publisher argument reports the root symbol and its source', async () => {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'pas-2',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: 95,
+          expression_text: 'order',
+          expression_line: 95,
+          infer_kind: 'expression',
+          alias: 'PubsubPubAnchor',
+        },
+      ],
+    });
+
+    assert.ok(
+      response.inferred_types && response.inferred_types.length > 0,
+      `expected inferred_types, got ${JSON.stringify(response)}`
+    );
+    const inferred = response.inferred_types[0];
+    assert.strictEqual(inferred.type_string, 'OrderPlacedPayload');
+    assert.strictEqual(inferred.primary_type_symbol, 'OrderPlacedPayload');
+    assert.ok(
+      inferred.primary_type_symbol_source?.endsWith('pubsub-handlers.ts'),
+      `anchor source must be the declaration file, got ${JSON.stringify(
+        inferred.primary_type_symbol_source
+      )}`
+    );
+  });
+
+  it('an anonymous destructured payload stays anchor-less', async () => {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'pas-3',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: 26,
+          infer_kind: 'function_param',
+          param_name: '{ time, item }',
+          alias: 'PubsubAnonAnchor',
+        },
+      ],
+    });
+
+    assert.ok(
+      response.inferred_types && response.inferred_types.length > 0,
+      `expected inferred_types, got ${JSON.stringify(response)}`
+    );
+    const inferred = response.inferred_types[0];
+    assert.strictEqual(inferred.primary_type_symbol, undefined);
+    assert.strictEqual(inferred.primary_type_symbol_source, undefined);
+  });
+});

--- a/src/sidecar/test/infer-pubsub-anchor-source.test.ts
+++ b/src/sidecar/test/infer-pubsub-anchor-source.test.ts
@@ -113,6 +113,35 @@ describe('pub/sub infer kinds report the payload anchor and its declaration sour
     );
   });
 
+  it('a barrel-re-exported payload reports the DECLARING file, never the barrel', async () => {
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'pas-4',
+      requests: [
+        {
+          file_path: FIXTURE,
+          line_number: 102,
+          infer_kind: 'function_param',
+          param_name: 'evt',
+          alias: 'PubsubBarrelAnchor',
+        },
+      ],
+    });
+
+    assert.ok(
+      response.inferred_types && response.inferred_types.length > 0,
+      `expected inferred_types, got ${JSON.stringify(response)}`
+    );
+    const inferred = response.inferred_types[0];
+    assert.strictEqual(inferred.primary_type_symbol, 'ReExportedPayload');
+    assert.ok(
+      inferred.primary_type_symbol_source?.endsWith('pubsub-barrel-types.ts'),
+      `anchor source must be the declaring file, got ${JSON.stringify(
+        inferred.primary_type_symbol_source
+      )}`
+    );
+  });
+
   it('an anonymous destructured payload stays anchor-less', async () => {
     const response = await client.send<InferResponseShape>({
       action: 'infer',

--- a/tests/sidecar_integration_test.rs
+++ b/tests/sidecar_integration_test.rs
@@ -781,6 +781,7 @@ export async function getOrderCount(): Promise<number> {
         source_file: repo.join("src/types.ts").to_string_lossy().to_string(),
         alias: Some(alias.to_string()),
         array_depth: None,
+        payload_borrow_witness: false,
     }];
     // The LLM's compact single-line locator for the multi-line call.
     let infer = vec![InferRequestItem {
@@ -981,6 +982,7 @@ notificationRouter.get('/status', async () => {
         source_file: repo.join("src/types.ts").to_string_lossy().to_string(),
         alias: Some(alias.to_string()),
         array_depth: None,
+        payload_borrow_witness: false,
     }];
     // Span locator only — the live data_call carried no expression text.
     let infer = vec![InferRequestItem {
@@ -1155,6 +1157,7 @@ notificationRouter.get('/status', async () => {
         source_file: repo.join("src/types.ts").to_string_lossy().to_string(),
         alias: Some(alias.to_string()),
         array_depth: None,
+        payload_borrow_witness: false,
     }];
     let infer = vec![InferRequestItem {
         file_path: repo.join("src/api.ts").to_string_lossy().to_string(),
@@ -1274,6 +1277,198 @@ fn test_full_carrick_analysis_with_sidecar() {
         stdout.contains("🪢 CARRICK") || stdout.contains("CARRICK"),
         "Should have CARRICK output. Got: {}",
         stdout
+    );
+}
+
+/// carrick#413 two-anchor arbitration, end to end through the real sidecar:
+/// a pub/sub explicit anchor carrying the scanner's borrow witness whose
+/// alias the location-based inference resolves to a DIFFERENT named root is
+/// demoted — the bundle request is re-aimed at the tsc-witnessed payload
+/// type, so the alias's dts definition (the thing compat verdicts are
+/// computed from) is the real payload shape, not the borrowed one. The same
+/// disagreement WITHOUT the witness keeps the explicit symbol untouched.
+#[test]
+fn test_pubsub_witnessed_borrow_demotes_to_inferred_payload_type() {
+    use carrick::services::type_sidecar::{
+        InferKind, InferRequestItem, SymbolRequest, TypeSidecar,
+    };
+    use std::time::Duration;
+
+    if !is_node_available() {
+        eprintln!("Skipping test: Node.js not available");
+        return;
+    }
+    let sidecar_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/sidecar/dist/src/index.js");
+    if !sidecar_path.exists() {
+        eprintln!("Skipping test: Sidecar not built (run: cd src/sidecar && npm run build)");
+        return;
+    }
+
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let repo = temp_dir.path().join("subscriber-svc");
+    fs::create_dir_all(repo.join("src")).expect("Failed to create src");
+    fs::write(
+        repo.join("package.json"),
+        r#"{ "name": "subscriber-svc", "version": "1.0.0" }"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo.join("src/types.ts"),
+        r#"export interface OrderPlaced {
+  orderId: string;
+  totalCents: number;
+}
+
+export interface AuditRecord {
+  auditId: string;
+  note: string;
+}
+"#,
+    )
+    .unwrap();
+    // The borrow shape: the handler's payload is annotated `OrderPlaced`,
+    // while `AuditRecord` (the borrowed symbol) annotates a different
+    // binding in the same file.
+    fs::write(
+        repo.join("src/subscriber.ts"),
+        r#"import { OrderPlaced, AuditRecord } from "./types";
+
+export function onOrderPlaced(evt: OrderPlaced): void {
+  const record: AuditRecord = { auditId: "a1", note: "seen" };
+  void record;
+  void evt;
+}
+"#,
+    )
+    .unwrap();
+
+    let sidecar = TypeSidecar::spawn(&sidecar_path).expect("Failed to spawn sidecar");
+    sidecar.start_init(&repo, None);
+    sidecar
+        .wait_ready(Duration::from_secs(60))
+        .expect("Sidecar failed to initialize");
+
+    let types_file = repo.join("src/types.ts").to_string_lossy().to_string();
+    let subscriber_file = repo.join("src/subscriber.ts").to_string_lossy().to_string();
+
+    let demoted_alias = "Pubsub_Demoted_Response";
+    let kept_alias = "Pubsub_Kept_Response";
+    let explicit = vec![
+        // The borrowed anchor WITH the scanner's AST witness: must demote.
+        SymbolRequest {
+            symbol_name: "AuditRecord".to_string(),
+            source_file: types_file.clone(),
+            alias: Some(demoted_alias.to_string()),
+            array_depth: None,
+            payload_borrow_witness: true,
+        },
+        // The same borrowed anchor WITHOUT a witness: must stay explicit.
+        SymbolRequest {
+            symbol_name: "AuditRecord".to_string(),
+            source_file: types_file.clone(),
+            alias: Some(kept_alias.to_string()),
+            array_depth: None,
+            payload_borrow_witness: false,
+        },
+    ];
+    let infer_item = |alias: &str| InferRequestItem {
+        file_path: subscriber_file.clone(),
+        line_number: 4,
+        span_start: None,
+        span_end: None,
+        expression_text: None,
+        expression_line: None,
+        infer_kind: InferKind::FunctionParam,
+        alias: Some(alias.to_string()),
+        param_name: Some("evt".to_string()),
+    };
+    let infer = vec![infer_item(demoted_alias), infer_item(kept_alias)];
+
+    let result = sidecar
+        .resolve_all_types(&explicit, &infer, None)
+        .expect("resolve_all_types failed");
+
+    // The inference reported the deterministic anchor + declaration source
+    // (the fields the arbitration runs on).
+    let inf = result
+        .inferred_types
+        .iter()
+        .find(|i| i.alias == demoted_alias)
+        .expect("expected an inference for the demoted alias");
+    assert_eq!(inf.primary_type_symbol.as_deref(), Some("OrderPlaced"));
+    assert!(
+        inf.primary_type_symbol_source
+            .as_deref()
+            .is_some_and(|s| s.ends_with("types.ts")),
+        "anchor source must be the declaration file, got {:?}",
+        inf.primary_type_symbol_source
+    );
+
+    // Witnessed borrow: the alias is bundled from the tsc-witnessed payload
+    // type (OrderPlaced), not the borrowed AuditRecord.
+    let demoted_entry = result
+        .explicit_manifest
+        .iter()
+        .find(|e| e.alias == demoted_alias)
+        .expect("demoted alias must still be bundled (re-aimed, not dropped)");
+    assert_eq!(
+        demoted_entry.original_name, "OrderPlaced",
+        "witnessed borrow must be re-aimed at the inferred root"
+    );
+
+    // Unwitnessed disagreement: explicit stays authoritative.
+    let kept_entry = result
+        .explicit_manifest
+        .iter()
+        .find(|e| e.alias == kept_alias)
+        .expect("kept alias must be bundled");
+    assert_eq!(
+        kept_entry.original_name, "AuditRecord",
+        "without a witness the explicit symbol must win"
+    );
+
+    // And the dts — the artifact compat verdicts are computed from — carries
+    // the payload shape for the demoted alias and the explicit shape for the
+    // kept one.
+    let dts = result.dts_content.expect("expected bundled dts content");
+    let demoted_def = dts
+        .split("export")
+        .find(|chunk| chunk.contains(demoted_alias))
+        .expect("demoted alias definition in dts");
+    assert!(
+        demoted_def.contains("orderId"),
+        "demoted alias must carry the payload shape:\n{}",
+        dts
+    );
+    assert!(
+        !demoted_def.contains("auditId"),
+        "demoted alias must not carry the borrowed shape:\n{}",
+        dts
+    );
+    let kept_def = dts
+        .split("export")
+        .find(|chunk| chunk.contains(kept_alias))
+        .expect("kept alias definition in dts");
+    assert!(
+        kept_def.contains("auditId"),
+        "kept alias must stay the explicit shape:\n{}",
+        dts
     );
 }
 


### PR DESCRIPTION
## The borrow class

A pub/sub op with a present-but-wrong `primary_type_symbol` took the explicit bundle path unconditionally: the isolation guard in `collect_pubsub_infer_requests` suppressed the payload-locator inference for any op carrying a symbol, so a borrowed symbol became the alias's dts definition — the artifact compat verdicts are computed from — with no rescue path. Measured 13/20 on the honest live-captured `c1-payments-audit-sdk-decoy` harness fixture, where the borrow was the only failing axis and the payload locator was intact in every borrow run. Live c2/c3 analyzer dumps show every symbol-carrying pub/sub op (18/18) co-emits a usable payload locator, so the deterministic second anchor exists exactly where the first anchor can be wrong.

Closes #413. Part of the #403/#359 borrow-class lineage. Pub/sub stage only; the HTTP path is deliberately untouched (it needs its own decoy-fixture A/B first).

## The mechanism

1. `collect_pubsub_infer_requests` no longer isolates named anchors: an op with a `primary_type_symbol` also emits its infer request when it carries a usable payload locator (text present, envelope-copy guard still applies).
2. The sidecar's pub/sub infer kinds (`function_param`, `expression`) now report the deterministic anchor of the resolved payload: `primary_type_symbol` (root symbol, lib globals filtered), `array_depth`, and a new `primary_type_symbol_source` (the root's declaration file). The type STRING keeps ts-morph's default named form; no other infer kind changes.
3. `collect_pubsub_type_requests` computes a deterministic AST borrow witness per request (`payload_borrow_witness`), the pub/sub analogue of `suppress_borrowed_request_types`' binding-type check: the payload binding is annotated with a type that never MENTIONS the emitted symbol at any depth, while the symbol annotates a different binding in the same file. Mention-based on purpose: `envelope: Envelope<OrderPlaced>` credits the inner contract type to the payload binding, so the corpus-2 envelope publisher (explicit symbol = inner type, locator = wrapper binding) can never be witnessed as a borrow. Unannotated payloads, destructured locators, and unparseable files all fail closed to no witness.
4. `resolve_all_types` arbitrates BEFORE the bundle runs (a post-hoc flag flip in `enrich_manifest_with_type_resolution` could never undo a wrong explicit definition): a witnessed request whose alias inference resolved a DIFFERENT named root is demoted — re-aimed at the inferred root (symbol, declaration file, array depth), so the bundler defines the alias from the tsc-witnessed payload type. Re-aiming rather than pasting the inferred `type_string` keeps the alias definition self-contained: the inferred string keeps named types as names, which would dangle as a standalone `export type`.

## Decisions pinned

- **No witness, no demotion.** A bare tsc-vs-LLM disagreement keeps the explicit symbol, so a mis-anchored inference can never displace a correct anchor on its own.
- **Anonymous inferred types are not arbitrated.** When inference returns a structural type with no root symbol (object literals, encoded payloads, wrapper-generic projections), the named-root-disagreement rule cannot fire and the explicit symbol is kept, witness or not. There is deliberately no resolution for that case: a structural shape carries no identity to disagree with, and inventing one (shape equality) would demote on formatting noise.
- **Re-aiming only when it is loss-free.** A disagreeing inference whose `type_string` is not the bare named form of its own root (generic instantiation like `Envelope<Order>`, expanded structural shape), has no declaration source, or roots on framework machinery keeps the explicit symbol.
- **Fan-in ambiguity keeps everything.** An alias carried by more than one explicit request cannot attribute the inference to either.
- The witness flag is scanner-internal (`#[serde(skip)]`), so the sidecar wire format for bundle requests is unchanged; only pub/sub collectors ever set it, making the arbitration structurally inert for HTTP/socket/GraphQL requests.
- Alias contracts between the collectors and `append_pubsub_manifest_entries` are byte-identical and untouched; every existing alias test is green unchanged.

## Verification (deterministic)

- New unit tests: witness verdicts across eight AST shapes (borrow, agreement, wrapper mention, unannotated, no borrow source, non-bare locator, envelope copy, no locator), fail-closed on unparseable files, qualified-symbol leaf compare; arbitration verdicts (demote, array-form demote with depth, unwitnessed keep, agreement keep, anonymous keep, loss-free guards, fan-in keep, no-inference keep).
- New sidecar tests: `function_param`/`expression` report root + declaration source; anonymous destructured payloads stay anchor-less.
- New end-to-end integration test through the real sidecar: witnessed borrow re-aims the alias to the payload shape; the unwitnessed twin keeps the explicit shape.
- Full `cargo test` green (all CI suites, including the pub/sub wrapper capture test and the cassette hard gate), sidecar suite 120 tests green, ts_check 90 tests green, fmt + clippy clean.
- Demotion events log at `info` with alias, explicit symbol, inferred root, and root source, so gate-run dumps show any arbitration that fires.

## Gate plan

Per the standing A/B protocol: 2 live runs each on corpora 1/2/3 from this branch after review, scored per-edge against the #402-gate baseline table (plus the #411 gate columns on #403). No merge without no-regression per edge; results will be posted on #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
