### PR TITLE
test(sidecar): WP6 capture-fidelity corpus harness + checked-in baseline

### DIFF
--- a/src/sidecar/test/capture-v2-fidelity.test.ts
+++ b/src/sidecar/test/capture-v2-fidelity.test.ts
@@ -1,0 +1,118 @@
+/**
+ * WP6: capture-fidelity corpus regression net.
+ *
+ * Runs the deterministic, LLM-free capture-fidelity harness over the fixed
+ * corpus (fidelity-corpus.ts) and pins its surface-fidelity metric against a
+ * checked-in baseline. This is the diff target future WP2/WP3 changes are read
+ * against: a shift in any tier / self-check / anchor-origin count, or a
+ * per-alias tier change, fails here with the computed metric printed and a
+ * regen instruction.
+ *
+ * Deliberately NOT the corpus live eval: capture/check is deterministic given
+ * anchors, so this whole suite runs locally at zero paid GCP/LLM spend. The
+ * paid xrepo eval stays the separate regression net.
+ *
+ * To intentionally move the baseline after a capture-core change:
+ *   UPDATE_FIDELITY_BASELINE=1 npm test
+ * which rewrites test/fidelity-baseline.json from the current capture output.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SidecarClient } from './helpers.js';
+import { runCaptureFidelity, serializeBaseline, type FidelityRun } from './fidelity-harness.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// dist/test -> src/sidecar/test: the baseline is checked in beside the sources,
+// read with fs at runtime (never `import`ed — resolveJsonModule would inline a
+// compile-time copy and defeat the diff-against-checked-in-file purpose).
+const BASELINE_PATH = path.join(__dirname, '..', '..', 'test', 'fidelity-baseline.json');
+const UPDATE = process.env.UPDATE_FIDELITY_BASELINE === '1';
+
+describe('capture fidelity corpus (WP6)', () => {
+  const client = new SidecarClient();
+  let outDir: string;
+  let run: FidelityRun;
+  let computed: string;
+
+  before(async () => {
+    outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-fidelity-'));
+    await client.start();
+    run = await runCaptureFidelity(client, outDir);
+    computed = serializeBaseline(run.baseline);
+  });
+
+  after(async () => {
+    await client.stop();
+    fs.rmSync(outDir, { recursive: true, force: true });
+  });
+
+  it('matches the checked-in fidelity baseline', () => {
+    if (UPDATE) {
+      fs.writeFileSync(BASELINE_PATH, computed);
+      return;
+    }
+    assert.ok(
+      fs.existsSync(BASELINE_PATH),
+      `baseline missing at ${BASELINE_PATH}; regenerate with UPDATE_FIDELITY_BASELINE=1`,
+    );
+    const expected = fs.readFileSync(BASELINE_PATH, 'utf8');
+    assert.strictEqual(
+      computed,
+      expected,
+      'capture fidelity drifted from the checked-in baseline.\n' +
+        'If this change to the capture core is intended, regenerate with:\n' +
+        '  UPDATE_FIDELITY_BASELINE=1 npm test\n' +
+        '--- computed ---\n' +
+        computed,
+    );
+  });
+
+  it('is byte-stable across two runs', async () => {
+    const second = await runCaptureFidelity(client, outDir);
+    assert.strictEqual(serializeBaseline(second.baseline), computed);
+  });
+
+  it('the corpus exercises every fidelity tier, outcome, and anchor origin', () => {
+    // A degenerate corpus (e.g. all-emitted) would make the baseline blind to
+    // regressions in the harder tiers; assert the aggregate spans the matrix.
+    const agg = run.baseline.aggregate;
+    for (const tier of ['emitted', 'node_builder', 'structural_fallback'] as const) {
+      assert.ok(agg.by_serialization[tier] > 0, `no aliases at tier ${tier}`);
+    }
+    for (const outcome of ['ok', 'allowlisted_external', 'decayed_internal'] as const) {
+      assert.ok(agg.by_self_check[outcome] > 0, `no aliases with self-check ${outcome}`);
+    }
+    for (const origin of ['llm-symbol', 'deterministic-infer', 'anchor-backfill'] as const) {
+      assert.ok(agg.by_anchor_origin[origin] > 0, `no aliases from origin ${origin}`);
+    }
+  });
+
+  it('aggregate is the exact sum of per-fixture counts', () => {
+    const { fixtures, aggregate } = run.baseline;
+    const sum = (pick: (f: (typeof fixtures)[number]) => number) =>
+      fixtures.reduce((n, f) => n + pick(f), 0);
+    assert.strictEqual(aggregate.total_aliases, sum((f) => f.total_aliases));
+    assert.strictEqual(
+      aggregate.by_serialization.emitted,
+      sum((f) => f.by_serialization.emitted),
+    );
+    assert.strictEqual(
+      aggregate.by_anchor_origin['llm-symbol'],
+      sum((f) => f.by_anchor_origin['llm-symbol']),
+    );
+  });
+
+  it('demotion reasons carry a diagnosable category (not baselined)', () => {
+    // Free-text reasons are excluded from the byte-stable baseline; their
+    // category is still pinned here so a silent reason regression is caught.
+    const bare = run.raw.get('capture-v2-bare')!;
+    const byAlias = new Map(bare.aliases.map((a) => [a.alias, a]));
+    assert.match(byAlias.get('Endpoint_overloaded_Handler')!.capture_failure_reason ?? '', /overload/);
+    assert.match(byAlias.get('Endpoint_generic_Handler')!.capture_failure_reason ?? '', /generic/);
+  });
+});

--- a/src/sidecar/test/capture-v2-fidelity.test.ts
+++ b/src/sidecar/test/capture-v2-fidelity.test.ts
@@ -35,7 +35,9 @@ const UPDATE = process.env.UPDATE_FIDELITY_BASELINE === '1';
 
 describe('capture fidelity corpus (WP6)', () => {
   const client = new SidecarClient();
-  let outDir: string;
+  // Nullable: if before() throws before this is assigned, after() must not
+  // rmSync an undefined path and mask the original failure.
+  let outDir: string | undefined;
   let run: FidelityRun;
   let computed: string;
 
@@ -48,7 +50,7 @@ describe('capture fidelity corpus (WP6)', () => {
 
   after(async () => {
     await client.stop();
-    fs.rmSync(outDir, { recursive: true, force: true });
+    if (outDir) fs.rmSync(outDir, { recursive: true, force: true });
   });
 
   it('matches the checked-in fidelity baseline', () => {
@@ -73,6 +75,7 @@ describe('capture fidelity corpus (WP6)', () => {
   });
 
   it('is byte-stable across two runs', async () => {
+    assert.ok(outDir, 'outDir must be set by before()');
     const second = await runCaptureFidelity(client, outDir);
     assert.strictEqual(serializeBaseline(second.baseline), computed);
   });

--- a/src/sidecar/test/fidelity-baseline.json
+++ b/src/sidecar/test/fidelity-baseline.json
@@ -1,0 +1,204 @@
+{
+  "fixtures": [
+    {
+      "id": "capture-v2-bare",
+      "bare_checkout": true,
+      "total_aliases": 10,
+      "by_serialization": {
+        "emitted": 6,
+        "node_builder": 2,
+        "structural_fallback": 2
+      },
+      "by_self_check": {
+        "ok": 6,
+        "allowlisted_external": 2,
+        "decayed_internal": 2
+      },
+      "by_anchor_origin": {
+        "llm-symbol": 7,
+        "deterministic-infer": 2,
+        "anchor-backfill": 1
+      },
+      "usable_rate": 0.8,
+      "aliases": [
+        {
+          "alias": "Endpoint_generic_Handler",
+          "serialization": "structural_fallback",
+          "self_check": "decayed_internal",
+          "anchor_origin": "llm-symbol",
+          "top_type_at_self_check": true
+        },
+        {
+          "alias": "Endpoint_getorder_Handler",
+          "serialization": "emitted",
+          "self_check": "ok",
+          "anchor_origin": "llm-symbol",
+          "top_type_at_self_check": false
+        },
+        {
+          "alias": "Endpoint_order_Request",
+          "serialization": "emitted",
+          "self_check": "ok",
+          "anchor_origin": "llm-symbol",
+          "top_type_at_self_check": false
+        },
+        {
+          "alias": "Endpoint_order_Response",
+          "serialization": "emitted",
+          "self_check": "ok",
+          "anchor_origin": "llm-symbol",
+          "top_type_at_self_check": false
+        },
+        {
+          "alias": "Endpoint_overloaded_Handler",
+          "serialization": "structural_fallback",
+          "self_check": "decayed_internal",
+          "anchor_origin": "llm-symbol",
+          "top_type_at_self_check": true
+        },
+        {
+          "alias": "Graphql_orderquery_Result",
+          "serialization": "emitted",
+          "self_check": "ok",
+          "anchor_origin": "llm-symbol",
+          "top_type_at_self_check": false
+        },
+        {
+          "alias": "Pub_derivedconfig_Payload",
+          "serialization": "emitted",
+          "self_check": "allowlisted_external",
+          "anchor_origin": "anchor-backfill",
+          "top_type_at_self_check": true
+        },
+        {
+          "alias": "Pub_ordershipped_Payload",
+          "serialization": "node_builder",
+          "self_check": "ok",
+          "anchor_origin": "deterministic-infer",
+          "top_type_at_self_check": false
+        },
+        {
+          "alias": "Pub_shipmentsync_Payload",
+          "serialization": "node_builder",
+          "self_check": "ok",
+          "anchor_origin": "deterministic-infer",
+          "top_type_at_self_check": false
+        },
+        {
+          "alias": "Pub_shipmentthing_Payload",
+          "serialization": "emitted",
+          "self_check": "allowlisted_external",
+          "anchor_origin": "llm-symbol",
+          "top_type_at_self_check": true
+        }
+      ]
+    },
+    {
+      "id": "capture-v2-installed",
+      "bare_checkout": false,
+      "total_aliases": 3,
+      "by_serialization": {
+        "emitted": 2,
+        "node_builder": 1,
+        "structural_fallback": 0
+      },
+      "by_self_check": {
+        "ok": 3,
+        "allowlisted_external": 0,
+        "decayed_internal": 0
+      },
+      "by_anchor_origin": {
+        "llm-symbol": 2,
+        "deterministic-infer": 1,
+        "anchor-backfill": 0
+      },
+      "usable_rate": 1,
+      "aliases": [
+        {
+          "alias": "Endpoint_listwidgets_Handler",
+          "serialization": "emitted",
+          "self_check": "ok",
+          "anchor_origin": "llm-symbol",
+          "top_type_at_self_check": false
+        },
+        {
+          "alias": "Endpoint_widget_Response",
+          "serialization": "emitted",
+          "self_check": "ok",
+          "anchor_origin": "llm-symbol",
+          "top_type_at_self_check": false
+        },
+        {
+          "alias": "Pub_widgetupdated_Payload",
+          "serialization": "node_builder",
+          "self_check": "ok",
+          "anchor_origin": "deterministic-infer",
+          "top_type_at_self_check": false
+        }
+      ]
+    },
+    {
+      "id": "xrepo-corpus-3-inventory-svc",
+      "bare_checkout": true,
+      "total_aliases": 3,
+      "by_serialization": {
+        "emitted": 3,
+        "node_builder": 0,
+        "structural_fallback": 0
+      },
+      "by_self_check": {
+        "ok": 3,
+        "allowlisted_external": 0,
+        "decayed_internal": 0
+      },
+      "by_anchor_origin": {
+        "llm-symbol": 2,
+        "deterministic-infer": 1,
+        "anchor-backfill": 0
+      },
+      "usable_rate": 1,
+      "aliases": [
+        {
+          "alias": "Endpoint_stock_Response",
+          "serialization": "emitted",
+          "self_check": "ok",
+          "anchor_origin": "llm-symbol",
+          "top_type_at_self_check": false
+        },
+        {
+          "alias": "Sub_priceupdated_Payload",
+          "serialization": "emitted",
+          "self_check": "ok",
+          "anchor_origin": "deterministic-infer",
+          "top_type_at_self_check": false
+        },
+        {
+          "alias": "Sub_stockadjust_Payload",
+          "serialization": "emitted",
+          "self_check": "ok",
+          "anchor_origin": "llm-symbol",
+          "top_type_at_self_check": false
+        }
+      ]
+    }
+  ],
+  "aggregate": {
+    "total_aliases": 16,
+    "by_serialization": {
+      "emitted": 11,
+      "node_builder": 3,
+      "structural_fallback": 2
+    },
+    "by_self_check": {
+      "ok": 12,
+      "allowlisted_external": 2,
+      "decayed_internal": 2
+    },
+    "by_anchor_origin": {
+      "llm-symbol": 11,
+      "deterministic-infer": 4,
+      "anchor-backfill": 1
+    },
+    "usable_rate": 0.875
+  }
+}

--- a/src/sidecar/test/fidelity-corpus.ts
+++ b/src/sidecar/test/fidelity-corpus.ts
@@ -1,0 +1,224 @@
+/**
+ * WP6 capture-fidelity corpus: the fixed set of (fixture, service, anchors)
+ * the fidelity harness captures over. Deterministic and LLM-free — the anchors
+ * are hand-authored here, not produced by the analyzer, so the whole harness
+ * runs locally at zero paid spend (design plan WP6: "capture/check is
+ * deterministic given anchors; unit-test locally free").
+ *
+ * Coverage rationale (why these three fixtures):
+ *  - capture-v2-bare is the only fixture that exercises the FULL fidelity
+ *    matrix: node_builder and structural_fallback tiers, the
+ *    allowlisted_external and decayed_internal self-check outcomes, and the
+ *    anchor-backfill origin. Its anchors mirror capture-v2-forms.test.ts
+ *    (bare block), less the span-locator duplicate — expression_text locators
+ *    keep the corpus spec free of fixture-source byte offsets.
+ *  - capture-v2-installed adds the resolved-through-node_modules path: the
+ *    same anchor shapes classify against a committed dependency instead of a
+ *    bare checkout.
+ *  - xrepo-corpus-3/inventory-svc is a real bare corpus service (all
+ *    emitted / ok / llm-symbol), so the baseline is anchored on production
+ *    fixture shapes and not only the synthetic ones.
+ * Broadening to the other xrepo-corpus-3 services needs hand-authored,
+ * ground-truthed anchors per service and is tracked as a follow-up, not a
+ * WP6 blocker.
+ *
+ * The anchor definitions here are cross-referenced by capture-v2.test.ts and
+ * capture-v2-forms.test.ts, which assert the same shapes at the per-alias
+ * level; this module is the roll-up source, those files are the unit pins.
+ */
+
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { CaptureAnchorRequest } from '../src/capture/api.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// dist/test -> src/sidecar/test (fixtures live under source, never compiled).
+const SIDECAR_FIXTURES = path.join(__dirname, '..', '..', 'test', 'fixtures');
+// dist/test -> repo root is four levels up (dist/test -> dist -> sidecar ->
+// src -> root), matching capture-v2.test.ts.
+const REPO_FIXTURES = path.join(
+  __dirname, '..', '..', '..', '..', 'tests', 'fixtures'
+);
+
+export interface FidelityFixture {
+  /** Stable key for the baseline and for cross-run ordering. */
+  id: string;
+  repoRoot: string;
+  serviceName: string;
+  /** Documented precondition: true when the fixture has no node_modules. */
+  bareExpected: boolean;
+  anchors: CaptureAnchorRequest[];
+}
+
+/**
+ * The full-matrix synthetic bare fixture. Anchor set mirrors the bare block of
+ * capture-v2-forms.test.ts (span-locator infer omitted; the text-locator infer
+ * covers the same node_builder tier).
+ */
+const CAPTURE_V2_BARE: FidelityFixture = {
+  id: 'capture-v2-bare',
+  repoRoot: path.join(SIDECAR_FIXTURES, 'capture-v2-bare'),
+  serviceName: 'Capture Bare Svc',
+  bareExpected: true,
+  anchors: [
+    {
+      kind: 'symbol',
+      alias: 'Endpoint_order_Response',
+      symbol_name: 'OrderResponse',
+      source_file: 'src/http/routes.ts',
+      anchor_origin: 'llm-symbol',
+    },
+    {
+      kind: 'symbol',
+      alias: 'Endpoint_order_Request',
+      symbol_name: 'CreateOrderRequest',
+      source_file: 'src/http/routes.ts',
+      anchor_origin: 'llm-symbol',
+    },
+    {
+      kind: 'symbol',
+      alias: 'Graphql_orderquery_Result',
+      symbol_name: 'OrderQueryResult',
+      source_file: 'src/graphql/ops.ts',
+      anchor_origin: 'llm-symbol',
+    },
+    {
+      kind: 'handler_return',
+      alias: 'Endpoint_getorder_Handler',
+      symbol_name: 'getOrder',
+      source_file: 'src/http/routes.ts',
+      anchor_origin: 'llm-symbol',
+    },
+    {
+      kind: 'handler_return',
+      alias: 'Endpoint_overloaded_Handler',
+      symbol_name: 'overloadedHandler',
+      source_file: 'src/http/routes.ts',
+      anchor_origin: 'llm-symbol',
+    },
+    {
+      kind: 'handler_return',
+      alias: 'Endpoint_generic_Handler',
+      symbol_name: 'genericHandler',
+      source_file: 'src/http/routes.ts',
+      anchor_origin: 'llm-symbol',
+    },
+    {
+      kind: 'symbol',
+      alias: 'Pub_shipmentthing_Payload',
+      symbol_name: 'ShipmentThing',
+      source_file: 'src/events/pub.ts',
+      anchor_origin: 'llm-symbol',
+    },
+    {
+      kind: 'symbol',
+      alias: 'Pub_derivedconfig_Payload',
+      symbol_name: 'DerivedConfigType',
+      source_file: 'src/events/pub.ts',
+      anchor_origin: 'anchor-backfill',
+    },
+    {
+      kind: 'infer',
+      alias: 'Pub_ordershipped_Payload',
+      source_file: 'src/events/pub.ts',
+      anchor_origin: 'deterministic-infer',
+      expression_text: "{ orderId: '1', eta: 'soon' }",
+    },
+    {
+      kind: 'infer',
+      alias: 'Pub_shipmentsync_Payload',
+      source_file: 'src/events/pub.ts',
+      anchor_origin: 'deterministic-infer',
+      expression_text: 'fetchShipment()',
+    },
+  ],
+};
+
+/** Installed counterpart: externals resolve through committed node_modules. */
+const CAPTURE_V2_INSTALLED: FidelityFixture = {
+  id: 'capture-v2-installed',
+  repoRoot: path.join(SIDECAR_FIXTURES, 'capture-v2-installed'),
+  serviceName: 'capture-installed-svc',
+  bareExpected: false,
+  anchors: [
+    {
+      kind: 'symbol',
+      alias: 'Endpoint_widget_Response',
+      symbol_name: 'WidgetResponse',
+      source_file: 'src/service.ts',
+      anchor_origin: 'llm-symbol',
+    },
+    {
+      kind: 'handler_return',
+      alias: 'Endpoint_listwidgets_Handler',
+      symbol_name: 'listWidgets',
+      source_file: 'src/service.ts',
+      anchor_origin: 'llm-symbol',
+    },
+    {
+      kind: 'infer',
+      alias: 'Pub_widgetupdated_Payload',
+      source_file: 'src/service.ts',
+      anchor_origin: 'deterministic-infer',
+      expression_text: "{ widget: w, at: 'now' }",
+    },
+  ],
+};
+
+/** Real bare corpus service: all emitted / ok / llm-symbol. */
+const INVENTORY_SVC: FidelityFixture = {
+  id: 'xrepo-corpus-3-inventory-svc',
+  repoRoot: path.join(REPO_FIXTURES, 'xrepo-corpus-3', 'inventory-svc'),
+  serviceName: 'inventory-svc',
+  bareExpected: true,
+  anchors: [
+    {
+      kind: 'symbol',
+      alias: 'Endpoint_stock_Response',
+      symbol_name: 'StockLevel',
+      source_file: 'src/types/stock.ts',
+      anchor_origin: 'llm-symbol',
+    },
+    {
+      kind: 'symbol',
+      alias: 'Sub_stockadjust_Payload',
+      symbol_name: 'StockAdjustCommand',
+      source_file: 'src/types/stock.ts',
+      anchor_origin: 'llm-symbol',
+    },
+    {
+      kind: 'symbol',
+      alias: 'Sub_priceupdated_Payload',
+      symbol_name: 'PriceUpdatedEvent',
+      source_file: 'src/types/stock.ts',
+      anchor_origin: 'deterministic-infer',
+    },
+  ],
+};
+
+/**
+ * Ordered by id (code-unit, locale-independent so the baseline is byte-stable
+ * across machines); the harness and baseline preserve this order.
+ */
+export const FIDELITY_CORPUS: FidelityFixture[] = [
+  CAPTURE_V2_BARE,
+  CAPTURE_V2_INSTALLED,
+  INVENTORY_SVC,
+].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+/**
+ * Verdict-fidelity scaffold (WP2). Once WP2's four-bucket check classifier
+ * (compatible / incompatible / unverifiable / gate-caught, pinned decision 7)
+ * lands its stdio contract, author VerdictCase entries here and extend the
+ * harness with a check-side pass over paired producer/consumer stubs. Left a
+ * stub deliberately: WP6 does not guess WP2's wire shape (a live WP2 agent
+ * owns it), and a wrong guess is worse than an empty scaffold.
+ */
+export interface VerdictCase {
+  id: string;
+  producer: FidelityFixture;
+  consumer: FidelityFixture;
+  expected_verdict: 'compatible' | 'incompatible' | 'unverifiable' | 'gate_caught';
+}
+
+export const VERDICT_CASES: VerdictCase[] = [];

--- a/src/sidecar/test/fidelity-harness.ts
+++ b/src/sidecar/test/fidelity-harness.ts
@@ -141,6 +141,17 @@ async function captureFixture(
     `capture_v2 failed for ${fixture.id}: ${JSON.stringify(response.errors)}`,
   );
   assert.ok(response.result, `no result for ${fixture.id}`);
+  // Guard the fixture's installed-vs-bare state before any fidelity count is
+  // derived: a fixture that silently gains or loses node_modules shifts the
+  // self-check outcomes (bare -> allowlisted_external vs installed -> ok) and
+  // would otherwise be laundered into a "legitimate" baseline update. The
+  // capture result records this as bare_checkout.
+  assert.strictEqual(
+    response.result.bare_checkout,
+    fixture.bareExpected,
+    `${fixture.id}: bare_checkout drifted (expected ${fixture.bareExpected}, ` +
+      `got ${response.result.bare_checkout}) — the fixture gained or lost node_modules`,
+  );
   return response.result;
 }
 

--- a/src/sidecar/test/fidelity-harness.ts
+++ b/src/sidecar/test/fidelity-harness.ts
@@ -1,0 +1,202 @@
+/**
+ * WP6 capture-fidelity harness.
+ *
+ * Drives the `capture_v2` stdio action over FIDELITY_CORPUS and rolls the
+ * per-alias fidelity fields WP1 already emits (serialization tier, self-check
+ * outcome, anchor origin) into a corpus-wide surface-fidelity metric, broken
+ * out BY TIER and BY ANCHOR-ORIGIN, per fixture and in aggregate.
+ *
+ * Seam (pinned decision 11a): the harness consumes only the stdio-action
+ * output and the public result JSON. It imports types from capture/api.js and
+ * nothing from capture/ internals; it never calls captureStub directly.
+ *
+ * Determinism: fixtures are ordered by id, aliases by name, and every Record
+ * is built with a fixed key order, so JSON.stringify is byte-stable run to run.
+ * The baseline snapshot deliberately excludes anything path-, version-, or
+ * toolchain-shaped (stub_dir, ts_version, pinned_dependencies, emitted_files,
+ * and the free-text self_check_detail / capture_failure_reason). Those vary per
+ * run or per TS bump; the harness returns the raw results alongside so tests
+ * can still assert failure-reason categories without baselining them.
+ */
+
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import type { SidecarClient } from './helpers.js';
+import { FIDELITY_CORPUS, type FidelityFixture } from './fidelity-corpus.js';
+import type {
+  AnchorOrigin,
+  CaptureStubResult,
+  SelfCheckOutcome,
+  SerializationTier,
+} from '../src/capture/api.js';
+
+/**
+ * Locale-independent code-unit comparator. `String.localeCompare` orders by the
+ * runtime's default locale, which differs across machines (CI Linux vs macOS
+ * ICU) and would make the baseline non-byte-stable; identifiers are ASCII so a
+ * code-unit sort is total and portable.
+ */
+export function byCodeUnit(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+const TIERS: SerializationTier[] = ['emitted', 'node_builder', 'structural_fallback'];
+const OUTCOMES: SelfCheckOutcome[] = ['ok', 'allowlisted_external', 'decayed_internal'];
+const ORIGINS: AnchorOrigin[] = ['llm-symbol', 'deterministic-infer', 'anchor-backfill'];
+
+/** Per-alias metric fields (structured only; no free-text, no paths). */
+export interface AliasFidelity {
+  alias: string;
+  serialization: SerializationTier;
+  self_check: SelfCheckOutcome;
+  anchor_origin: AnchorOrigin;
+  top_type_at_self_check: boolean;
+}
+
+export interface FidelityCounts {
+  total_aliases: number;
+  by_serialization: Record<SerializationTier, number>;
+  by_self_check: Record<SelfCheckOutcome, number>;
+  by_anchor_origin: Record<AnchorOrigin, number>;
+  usable_rate: number;
+}
+
+export interface FixtureFidelity extends FidelityCounts {
+  id: string;
+  bare_checkout: boolean;
+  aliases: AliasFidelity[];
+}
+
+export interface CorpusFidelity {
+  fixtures: FixtureFidelity[];
+  aggregate: FidelityCounts;
+}
+
+export interface FidelityRun {
+  /** The byte-stable, baselined metric. */
+  baseline: CorpusFidelity;
+  /** Full public result per fixture id, for non-baselined category assertions. */
+  raw: Map<string, CaptureStubResult>;
+}
+
+interface CaptureV2ResponseShape {
+  request_id: string;
+  status: string;
+  result?: CaptureStubResult;
+  errors?: string[];
+}
+
+function zeroed<T extends string>(keys: T[]): Record<T, number> {
+  const out = {} as Record<T, number>;
+  for (const k of keys) out[k] = 0;
+  return out;
+}
+
+function usableRate(bySelfCheck: Record<SelfCheckOutcome, number>, total: number): number {
+  if (total === 0) return 0;
+  const usable = bySelfCheck.ok + bySelfCheck.allowlisted_external;
+  return Math.round((usable / total) * 1000) / 1000;
+}
+
+function countsFromAliases(aliases: AliasFidelity[]): FidelityCounts {
+  const bySer = zeroed(TIERS);
+  const bySelf = zeroed(OUTCOMES);
+  const byOrigin = zeroed(ORIGINS);
+  for (const a of aliases) {
+    bySer[a.serialization]++;
+    bySelf[a.self_check]++;
+    byOrigin[a.anchor_origin]++;
+  }
+  return {
+    total_aliases: aliases.length,
+    by_serialization: bySer,
+    by_self_check: bySelf,
+    by_anchor_origin: byOrigin,
+    usable_rate: usableRate(bySelf, aliases.length),
+  };
+}
+
+async function captureFixture(
+  client: SidecarClient,
+  fixture: FidelityFixture,
+  outRoot: string,
+): Promise<CaptureStubResult> {
+  const response = (await client.send(
+    {
+      request_id: `fidelity-${fixture.id}`,
+      action: 'capture_v2',
+      repo_root: fixture.repoRoot,
+      service_name: fixture.serviceName,
+      // Stubs land in a caller-owned temp root, never inside the fixture tree.
+      out_dir: path.join(outRoot, fixture.id),
+      anchors: fixture.anchors,
+    },
+    // Compiler-heavy action: CI runners need far more than the 10s default.
+    120000,
+  )) as CaptureV2ResponseShape;
+
+  assert.strictEqual(
+    response.status,
+    'success',
+    `capture_v2 failed for ${fixture.id}: ${JSON.stringify(response.errors)}`,
+  );
+  assert.ok(response.result, `no result for ${fixture.id}`);
+  return response.result;
+}
+
+function fixtureFidelity(fixture: FidelityFixture, result: CaptureStubResult): FixtureFidelity {
+  const aliases: AliasFidelity[] = result.aliases
+    .map((a) => ({
+      alias: a.alias,
+      serialization: a.serialization,
+      self_check: a.self_check,
+      anchor_origin: a.anchor_origin,
+      top_type_at_self_check: a.top_type_at_self_check,
+    }))
+    .sort((a, b) => byCodeUnit(a.alias, b.alias));
+
+  const counts = countsFromAliases(aliases);
+  return {
+    id: fixture.id,
+    bare_checkout: result.bare_checkout,
+    total_aliases: counts.total_aliases,
+    by_serialization: counts.by_serialization,
+    by_self_check: counts.by_self_check,
+    by_anchor_origin: counts.by_anchor_origin,
+    usable_rate: counts.usable_rate,
+    aliases,
+  };
+}
+
+function aggregate(fixtures: FixtureFidelity[]): FidelityCounts {
+  const allAliases = fixtures.flatMap((f) => f.aliases);
+  return countsFromAliases(allAliases);
+}
+
+/**
+ * Run the whole fidelity corpus against an already-started client. The client
+ * is warm-standby: one process serves all fixtures in order. `outRoot` is a
+ * caller-owned (temp) directory the per-fixture stubs are written under.
+ */
+export async function runCaptureFidelity(
+  client: SidecarClient,
+  outRoot: string,
+): Promise<FidelityRun> {
+  const raw = new Map<string, CaptureStubResult>();
+  const fixtures: FixtureFidelity[] = [];
+  for (const fixture of FIDELITY_CORPUS) {
+    const result = await captureFixture(client, fixture, outRoot);
+    raw.set(fixture.id, result);
+    fixtures.push(fixtureFidelity(fixture, result));
+  }
+  fixtures.sort((a, b) => byCodeUnit(a.id, b.id));
+  return { baseline: { fixtures, aggregate: aggregate(fixtures) }, raw };
+}
+
+/**
+ * Canonical serialization for the checked-in baseline. Two-space JSON with a
+ * trailing newline; object key order is fixed by construction above.
+ */
+export function serializeBaseline(baseline: CorpusFidelity): string {
+  return JSON.stringify(baseline, null, 2) + '\n';
+}


### PR DESCRIPTION
Stacked on #415 (WP1 capture core). Base = `feat/v2-wp1-capture-core`, **not** main. Do not merge before #415.

## What this is
WP6 (EVALS) of the type-compat v2 migration: a deterministic, LLM-free regression net that captures the WP1 fidelity metric on a fixed corpus and pins it against a checked-in baseline, so future WP2/WP3 changes diff against it with zero paid spend. The paid xrepo corpus eval stays the separate regression net and is untouched here.

## Files
- `src/sidecar/test/fidelity-corpus.ts` — the fixed `(fixture, service, anchors)` corpus. Three fixtures by design:
  - `capture-v2-bare` is the only fixture that exercises the FULL matrix (node_builder + structural_fallback tiers, allowlisted_external + decayed_internal outcomes, anchor-backfill origin).
  - `capture-v2-installed` adds the resolved-through-`node_modules` path.
  - `xrepo-corpus-3/inventory-svc` anchors the baseline on a real bare corpus service.
  Anchors are hand-authored (cross-referenced by the existing WP1 unit tests), so the harness runs locally at zero GCP/LLM cost. Broadening to the other corpus-3 services needs ground-truthed anchors per service and is a follow-up, not a blocker.
- `src/sidecar/test/fidelity-harness.ts` — drives the `capture_v2` stdio action (the only seam Rust consumes; consumes public result JSON only, no `capture/` reach-ins per pinned decision 11a) and rolls the per-alias fidelity fields WP1 emits into a surface-fidelity metric broken out **by tier** and **by anchor-origin**, per fixture and in aggregate.
- `src/sidecar/test/fidelity-baseline.json` — the checked-in snapshot. Excludes path/version/toolchain-shaped fields (`stub_dir`, `ts_version`, `pinned_dependencies`, `emitted_files`, free-text reasons); sorts are locale-independent so it is byte-stable across machines. Regenerate intentionally with `UPDATE_FIDELITY_BASELINE=1 npm test`.
- `src/sidecar/test/capture-v2-fidelity.test.ts` — asserts current fidelity == baseline, byte-stability across two runs, full-matrix coverage, aggregate == sum of per-fixture counts, and demotion-reason categories (asserted but not baselined).
- `VerdictCase` scaffold: a typed stub for the eventual WP2 check-verdict eval. Left empty deliberately, WP6 does not guess WP2's classifier contract.

## Baseline (aggregate over 16 aliases)
- by tier: emitted 11, node_builder 3, structural_fallback 2
- by self-check: ok 12, allowlisted_external 2, decayed_internal 2
- by anchor-origin: llm-symbol 11, deterministic-infer 4, anchor-backfill 1
- usable_rate: 0.875

## Verification
- Deterministic + byte-stable across two runs (asserted in-suite).
- Full sidecar `npm test`: 156 pass, 0 fail, 1 pre-existing skip.
- Full `cargo test` green (fmt + clippy clean; I touched no Rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)