### PR TITLE
wp2: v2 check core, tsc as the judge (stacked on #415, do not merge)

### DIFF
--- a/src/sidecar/package-lock.json
+++ b/src/sidecar/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "pnpm": "9.15.9",
         "typescript": "^5.8.0"
       },
       "engines": {
@@ -240,6 +241,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pnpm": {
+      "version": "9.15.9",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz",
+      "integrity": "sha512-aARhQYk8ZvrQHAeSMRKOmvuJ74fiaR1p5NQO7iKJiClf1GghgbrlW1hBjDolO95lpQXsfF+UA+zlzDzTfc8lMQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pnpm": "bin/pnpm.cjs",
+        "pnpx": "bin/pnpx.cjs"
+      },
+      "engines": {
+        "node": ">=18.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
       }
     },
     "node_modules/queue-microtask": {

--- a/src/sidecar/package.json
+++ b/src/sidecar/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "pnpm": "9.15.9",
     "typescript": "^5.8.0"
   },
   "engines": {

--- a/src/sidecar/src/capture/api.ts
+++ b/src/sidecar/src/capture/api.ts
@@ -154,3 +154,126 @@ export interface CaptureStubOptions {
   outDir: string;
   tsconfigPath?: string;
 }
+
+// ===========================================================================
+// Check phase ("tsc as the judge") — WP2
+//
+// The check phase assembles two or more capture stub packages into a scratch
+// synthetic monorepo (pnpm, node-linker=isolated), installs their pinned deps,
+// generates one probe file per matched pair, runs the vendored `tsc` CLI over
+// the probes, and classifies the diagnostics into four buckets. It imports
+// only node builtins + `typescript` + itself — same seam as capture.
+// ===========================================================================
+
+/** Wire protocol of a matched pair (drives the direction table). */
+export type ProbeProtocol = 'http' | 'graphql' | 'socket' | 'pubsub';
+
+/**
+ * Type kind of a matched pair. `request`/`response` disambiguate HTTP body
+ * direction (the confirmed inversion the direction table fixes); socket/pubsub
+ * pairs are `both`.
+ */
+export type ProbeTypeKind = 'request' | 'response' | 'both';
+
+/** One capture stub package to assemble into the check workspace. */
+export interface CheckStubInput {
+  /** Service name (used for scrub labels + pair endpoints). */
+  service_name: string;
+  /** Absolute path to the capture stub dir (package.json + types/ tree). */
+  stub_dir: string;
+}
+
+/** One side of a matched pair: a service + the surface alias to probe. */
+export interface CheckPairEndpoint {
+  service_name: string;
+  alias: string;
+}
+
+/**
+ * One matched pair to verify. The direction table maps (protocol, type_kind)
+ * to which endpoint is the `sent` value and which is the `expected` binding,
+ * so callers pass semantic producer/consumer roles and never a raw direction.
+ * (WP3 in Rust feeds protocol + type_kind; the table stays here, one place.)
+ */
+export interface CheckPairSpec {
+  /** Stable caller key echoed back on the verdict; the pair_id is derived from it. */
+  pair_key: string;
+  protocol: ProbeProtocol;
+  type_kind: ProbeTypeKind;
+  producer: CheckPairEndpoint;
+  consumer: CheckPairEndpoint;
+}
+
+/**
+ * Four-bucket classifier output (pinned decision 7):
+ *  - compatible: no diagnostics; the value-level assignment holds.
+ *  - incompatible: an assignment-class diagnostic (TS2322/2741/...) — real
+ *    compiler text is the report.
+ *  - unverifiable: a side decayed to unknown/never, a surface export is
+ *    missing/renamed, or a stub tree carries its own diagnostics (poison).
+ *  - gate_caught_baked_any: a side resolved to `any` (the IsAny probe gate
+ *    fired) — the backstop that stops a baked-any reading as compatible.
+ */
+export type VerdictBucket =
+  | 'compatible'
+  | 'incompatible'
+  | 'unverifiable'
+  | 'gate_caught_baked_any';
+
+export interface CheckVerdict {
+  /** Deterministic FNV-1a hash of the pair (never a temp path). */
+  pair_id: string;
+  /** Caller key, echoed for the WP3 verdict join. */
+  pair_key: string;
+  bucket: VerdictBucket;
+  /**
+   * For gate/import buckets: which side and which gate fired, e.g.
+   * `producer:any`, `consumer:unknown`, `import:producer`. Absent for
+   * compatible.
+   */
+  gate?: string;
+  /** User-facing message: scrubbed real TS text, or a synthesized reason.
+   * Never contains absolute paths or scan internals. Absent for compatible. */
+  diagnostic?: string;
+  /** TS diagnostic codes attributed to this pair's probe, sorted. */
+  codes: number[];
+}
+
+/** A service whose pairs are degraded wholesale (install failure or poison). */
+export interface DegradedService {
+  service_name: string;
+  reason: string;
+}
+
+export interface CheckResult {
+  success: boolean;
+  /** Scratch workspace directory (kept unless caller cleans it). */
+  workspace_dir: string;
+  /** `pnpm` when isolation held; `unavailable` when the vendored pnpm is
+   * missing (soundness over availability — pinned design, Check step 2). */
+  isolation: 'pnpm' | 'unavailable';
+  install_ok: boolean;
+  /** Scrubbed install-failure summary when install_ok is false. */
+  install_error?: string;
+  ts_version: string;
+  /** Verdicts, sorted by pair_id for byte-stable output. */
+  verdicts: CheckVerdict[];
+  degraded_services: DegradedService[];
+  errors: string[];
+}
+
+export interface CheckOptions {
+  stubs: CheckStubInput[];
+  pairs: CheckPairSpec[];
+  /** Parent dir for the scratch workspace (default: os.tmpdir()). */
+  workspaceRoot?: string;
+  /** Absolute path to the vendored pnpm binary. Defaults to the sidecar's
+   * own node_modules/.bin/pnpm resolved from this bundle's location. */
+  pnpmPath?: string;
+  /** Delete the scratch workspace before returning (default true). Tests that
+   * inspect the assembled tree pass false. */
+  cleanup?: boolean;
+}
+
+/** Progress phases emitted over the async install protocol. */
+export type CheckProgressPhase = 'assembling' | 'installing' | 'checking';

--- a/src/sidecar/src/capture/check-classify.ts
+++ b/src/sidecar/src/capture/check-classify.ts
@@ -1,0 +1,192 @@
+/**
+ * Diagnostic parsing + four-bucket classification for the v2 check phase.
+ *
+ * The judge is the vendored `tsc` CLI with `--pretty false`, run from the
+ * workspace root so file locations print workspace-relative (no temp path in
+ * the location prefix). This module turns that text into per-pair verdicts,
+ * classifying by diagnostic code + file + line (never by line position alone):
+ *
+ *   poison (stub-file diagnostic)         -> unverifiable   [highest precedence]
+ *   surface import error (probe lines 1-2)-> unverifiable
+ *   IsAny gate fired (TS2344)             -> gate_caught_baked_any
+ *   IsUnknown/IsNever gate fired (TS2344) -> unverifiable
+ *   assignment-class error                -> incompatible
+ *   no diagnostics                        -> compatible     [lowest precedence]
+ *
+ * Gate precedence over the assignment line is load-bearing: an `unknown` side
+ * produces BOTH a gate TS2344 and an assignment TS2322, and reading the latter
+ * would mislabel an unverifiable pair as incompatible.
+ *
+ * Seam: node builtins + this bundle only.
+ */
+
+import type { CheckVerdict } from './api.js';
+import type { GateName, ProbePlan, Side } from './check-probe.js';
+import { scrubDiagnostic, type ScrubContext } from './check-scrub.js';
+
+export interface RawDiagnostic {
+  /** Workspace-relative, forward-slash file path (empty for global errors). */
+  file: string;
+  line: number;
+  col: number;
+  code: number;
+  /** Primary text plus any indented elaboration lines, joined with '\n'. */
+  message: string;
+}
+
+const PRIMARY_RE =
+  /^(?<file>(?:[a-zA-Z]:)?[^(]*?)\((?<line>\d+),(?<col>\d+)\): error TS(?<code>\d+): (?<msg>.*)$/;
+
+/** Parse `tsc --pretty false` output into structured diagnostics. */
+export function parseTscOutput(stdout: string): RawDiagnostic[] {
+  const diags: RawDiagnostic[] = [];
+  let current: RawDiagnostic | null = null;
+  for (const rawLine of stdout.split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    const m = line.match(PRIMARY_RE);
+    if (m && m.groups) {
+      current = {
+        file: m.groups.file.split('\\').join('/'),
+        line: Number(m.groups.line),
+        col: Number(m.groups.col),
+        code: Number(m.groups.code),
+        message: m.groups.msg,
+      };
+      diags.push(current);
+      continue;
+    }
+    // Indented continuation lines belong to the preceding primary diagnostic.
+    if (current && /^\s+\S/.test(line)) {
+      current.message += '\n' + line;
+      continue;
+    }
+    // Blank line or summary ("Found N errors.") ends the current run.
+    current = null;
+  }
+  return diags;
+}
+
+/** Assignment-class codes: a real structural mismatch on the value assignment. */
+const ASSIGNMENT_CODES = new Set([2322, 2559, 2739, 2740, 2741, 2769, 2345]);
+
+function sideForGate(name: GateName, plan: ProbePlan): { side: Side; kind: string } {
+  const [which, kind] = name.split(':');
+  const side = which === 'sent' ? plan.direction.sent : plan.direction.expected;
+  return { side, kind };
+}
+
+function endpointAliasFor(side: Side, plan: ProbePlan): string {
+  return side === plan.direction.sent
+    ? plan.sentEndpoint.alias
+    : plan.expectedEndpoint.alias;
+}
+
+export interface ClassifyInput {
+  plan: ProbePlan;
+  /** Diagnostics attributed to this pair's probe file. */
+  probeDiags: RawDiagnostic[];
+  /** Returns a reason string if the service's stub tree is poisoned. */
+  poisonReason: (serviceName: string) => string | undefined;
+  scrubCtx: ScrubContext;
+}
+
+/** Classify one pair into exactly one bucket, honouring the precedence order. */
+export function classifyPair(input: ClassifyInput): CheckVerdict {
+  const { plan, probeDiags, poisonReason, scrubCtx } = input;
+  const codes = [...new Set(probeDiags.map((d) => d.code))].sort((a, b) => a - b);
+  const base = { pair_id: plan.pairId, pair_key: plan.spec.pair_key, codes };
+
+  // 1. Poison: any diagnostic in either side's stub tree makes the pair
+  //    unverifiable, never "no probe error -> compatible".
+  for (const side of ['producer', 'consumer'] as const) {
+    const service = plan.spec[side].service_name;
+    const reason = poisonReason(service);
+    if (reason) {
+      return {
+        ...base,
+        bucket: 'unverifiable',
+        gate: `poison:${side}`,
+        diagnostic: `types for service '${service}' contain declaration conflicts; compatibility cannot be verified.`,
+      };
+    }
+  }
+
+  // 2. Surface import error (missing/renamed export): probe import lines.
+  const importDiag = probeDiags.find((d) => plan.importLines.includes(d.line));
+  if (importDiag) {
+    const side: Side = plan.importLines[0] === importDiag.line ? plan.direction.sent : plan.direction.expected;
+    const alias = endpointAliasFor(side, plan);
+    return {
+      ...base,
+      bucket: 'unverifiable',
+      gate: `import:${side}`,
+      diagnostic: `surface export '${alias}' for the ${side} is missing or renamed; compatibility cannot be verified.`,
+    };
+  }
+
+  // 3/4. Probe gates (TS2344). IsAny outranks IsUnknown/IsNever.
+  const gateDiags = probeDiags.filter(
+    (d) => d.code === 2344 && plan.gateLines.has(d.line)
+  );
+  const anyGate = gateDiags
+    .map((d) => plan.gateLines.get(d.line)!)
+    .find((name) => name.endsWith(':any'));
+  if (anyGate) {
+    const { side } = sideForGate(anyGate, plan);
+    return {
+      ...base,
+      bucket: 'gate_caught_baked_any',
+      gate: `${side}:any`,
+      diagnostic: `the ${side} type resolved to 'any' at check time; compatibility cannot be verified (a type inferred through a missing library bakes to any).`,
+    };
+  }
+  const decayGate = gateDiags
+    .map((d) => plan.gateLines.get(d.line)!)
+    .find((name) => name.endsWith(':unknown') || name.endsWith(':never'));
+  if (decayGate) {
+    const { side, kind } = sideForGate(decayGate, plan);
+    return {
+      ...base,
+      bucket: 'unverifiable',
+      gate: `${side}:${kind}`,
+      diagnostic: `the ${side} type resolved to '${kind}' at check time; compatibility cannot be verified.`,
+    };
+  }
+
+  // 5. Assignment-class error on the value assignment line -> incompatible.
+  const assignDiag = probeDiags.find(
+    (d) => d.line === plan.assignmentLine && ASSIGNMENT_CODES.has(d.code)
+  );
+  if (assignDiag) {
+    return {
+      ...base,
+      bucket: 'incompatible',
+      diagnostic: scrubDiagnostic(
+        assignDiag.message,
+        scrubCtx,
+        plan.sentEndpoint.alias,
+        plan.expectedEndpoint.alias
+      ),
+    };
+  }
+
+  // Any other diagnostic on the assignment line that is not a known assignment
+  // code still means the pair could not be cleanly verified.
+  const otherAssign = probeDiags.find((d) => d.line === plan.assignmentLine);
+  if (otherAssign) {
+    return {
+      ...base,
+      bucket: 'unverifiable',
+      gate: 'assignment:other',
+      diagnostic: scrubDiagnostic(
+        otherAssign.message,
+        scrubCtx,
+        plan.sentEndpoint.alias,
+        plan.expectedEndpoint.alias
+      ),
+    };
+  }
+
+  // 6. No diagnostics -> compatible.
+  return { ...base, bucket: 'compatible' };
+}

--- a/src/sidecar/src/capture/check-probe.ts
+++ b/src/sidecar/src/capture/check-probe.ts
@@ -1,0 +1,168 @@
+/**
+ * Probe generation for the v2 check phase ("tsc as the judge").
+ *
+ * One probe file per matched pair. The probe is a value-level assignment in
+ * the data-flow direction, guarded by six top/bottom-type gates on BOTH sides
+ * (IsAny/IsUnknown/IsNever). Value-level (not `[X] extends [Y]`) because the
+ * conditional-type relation diverges around `any`, and because the compiler's
+ * elaborated assignment error is the user-facing mismatch report.
+ *
+ * Seam: node builtins + `typescript` + this bundle only. No imports needed here.
+ */
+
+import type {
+  CheckPairEndpoint,
+  CheckPairSpec,
+  ProbeProtocol,
+  ProbeTypeKind,
+} from './api.js';
+
+/** Which pair endpoint supplies the `sent` value / the `expected` binding. */
+export type Side = 'producer' | 'consumer';
+
+export interface Direction {
+  sent: Side;
+  expected: Side;
+}
+
+/**
+ * The direction table, keyed on (protocol, type_kind) — one place. Structurally
+ * fixes the confirmed HTTP request-body inversion (data flows consumer ->
+ * producer for request bodies, so the check is consumer <= producer).
+ *
+ *  | protocol       | type_kind | sent     | expected |
+ *  | http, graphql  | response  | producer | consumer |
+ *  | http           | request   | consumer | producer |
+ *  | socket, pubsub | both      | consumer | producer |
+ */
+export function directionFor(
+  protocol: ProbeProtocol,
+  typeKind: ProbeTypeKind
+): Direction {
+  if (protocol === 'socket' || protocol === 'pubsub') {
+    return { sent: 'consumer', expected: 'producer' };
+  }
+  if (protocol === 'http' && typeKind === 'request') {
+    return { sent: 'consumer', expected: 'producer' };
+  }
+  // http/graphql response, and any other (http, graphql) shape.
+  return { sent: 'producer', expected: 'consumer' };
+}
+
+/** Deterministic FNV-1a (32-bit) over the pair's stable key. Never a path. */
+export function fnv1a(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    // hash *= 16777619, kept in 32-bit unsigned range.
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+/** The pair ID is derived from the pair's semantic identity, not the workspace
+ * path, so it is byte-stable across runs. */
+export function pairId(spec: CheckPairSpec): string {
+  const key = [
+    spec.protocol,
+    spec.type_kind,
+    spec.producer.service_name,
+    spec.producer.alias,
+    spec.consumer.service_name,
+    spec.consumer.alias,
+    spec.pair_key,
+  ].join('|');
+  return fnv1a(key);
+}
+
+/** Names each gate line so a TS2344 can be attributed to a specific side+kind. */
+export type GateName =
+  | 'sent:any'
+  | 'sent:unknown'
+  | 'sent:never'
+  | 'expected:any'
+  | 'expected:unknown'
+  | 'expected:never';
+
+export interface ProbePlan {
+  pairId: string;
+  spec: CheckPairSpec;
+  /** Probe file basename, e.g. pair_1a2b3c4d.ts */
+  fileName: string;
+  /** Which endpoint is sent vs expected (resolved via the direction table). */
+  direction: Direction;
+  sentEndpoint: CheckPairEndpoint;
+  expectedEndpoint: CheckPairEndpoint;
+  /** Generated probe source. */
+  source: string;
+  /** Lines the surface imports sit on (1-based). Errors here => unverifiable. */
+  importLines: number[];
+  /** 1-based line -> gate name. TS2344 here => baked-any / unverifiable. */
+  gateLines: Map<number, GateName>;
+  /** 1-based line of the value-level assignment. Errors here => incompatible. */
+  assignmentLine: number;
+}
+
+/**
+ * Build one probe, recording the exact line of every gate and the assignment so
+ * the classifier never depends on hard-coded offsets. `packageOf` maps a
+ * service name to its workspace package specifier (e.g. `@carrick/orders`).
+ */
+export function buildProbe(
+  spec: CheckPairSpec,
+  packageOf: (serviceName: string) => string
+): ProbePlan {
+  const id = pairId(spec);
+  const direction = directionFor(spec.protocol, spec.type_kind);
+  const sentEndpoint = direction.sent === 'producer' ? spec.producer : spec.consumer;
+  const expectedEndpoint =
+    direction.expected === 'producer' ? spec.producer : spec.consumer;
+
+  const sentPkg = packageOf(sentEndpoint.service_name);
+  const expectedPkg = packageOf(expectedEndpoint.service_name);
+
+  const lines: string[] = [];
+  const importLines: number[] = [];
+  const gateLines = new Map<number, GateName>();
+
+  const push = (text: string): number => {
+    lines.push(text);
+    return lines.length; // 1-based line number just written
+  };
+
+  importLines.push(
+    push(`import type { ${sentEndpoint.alias} as Sent } from '${sentPkg}';`)
+  );
+  importLines.push(
+    push(`import type { ${expectedEndpoint.alias} as Expected } from '${expectedPkg}';`)
+  );
+  push(`type IsAny<T> = 0 extends 1 & T ? true : false;`);
+  push(`type IsUnknown<T> = unknown extends T ? (0 extends 1 & T ? false : true) : false;`);
+  push(`type IsNever<T> = [T] extends [never] ? true : false;`);
+  push(`type Not<T extends boolean> = T extends true ? false : true;`);
+  push(`type Assert<T extends true> = T;`);
+  gateLines.set(push(`type _G_sent_any = Assert<Not<IsAny<Sent>>>;`), 'sent:any');
+  gateLines.set(push(`type _G_sent_unknown = Assert<Not<IsUnknown<Sent>>>;`), 'sent:unknown');
+  gateLines.set(push(`type _G_sent_never = Assert<Not<IsNever<Sent>>>;`), 'sent:never');
+  gateLines.set(push(`type _G_expected_any = Assert<Not<IsAny<Expected>>>;`), 'expected:any');
+  gateLines.set(
+    push(`type _G_expected_unknown = Assert<Not<IsUnknown<Expected>>>;`),
+    'expected:unknown'
+  );
+  gateLines.set(push(`type _G_expected_never = Assert<Not<IsNever<Expected>>>;`), 'expected:never');
+  push(`declare const sent: Sent;`);
+  const assignmentLine = push(`const expected: Expected = sent;`);
+
+  return {
+    pairId: id,
+    spec,
+    fileName: `pair_${id}.ts`,
+    direction,
+    sentEndpoint,
+    expectedEndpoint,
+    source: lines.join('\n') + '\n',
+    importLines,
+    gateLines,
+    assignmentLine,
+  };
+}

--- a/src/sidecar/src/capture/check-scrub.ts
+++ b/src/sidecar/src/capture/check-scrub.ts
@@ -1,0 +1,93 @@
+/**
+ * Diagnostic scrub for the v2 check phase.
+ *
+ * Raw tsc diagnostics leak two run-varying / internal things into the most
+ * interesting error class (cross-stub conflicts): stub-absolute
+ * `import("/tmp/xxxx/packages/orders/types/surface")` paths inside elaboration
+ * text, and the probe's `Sent`/`Expected` import aliases in the headline. This
+ * pass maps every workspace-absolute path to a stable `@carrick/<service>` (or
+ * `pkg@version`) label and rewrites the aliases to the real surface names, so
+ * the message is user-facing AND byte-stable across runs with different temp
+ * dirs. Real TS text (e.g. TS2741 "... missing in type 'StockLevel'") is
+ * preserved intact.
+ *
+ * Seam: node builtins only; no imports needed.
+ */
+
+export interface ScrubContext {
+  /** Absolute path of the scratch workspace root (fully removed from output). */
+  workspaceRoot: string;
+  /** Workspace package dir (== sanitized service) -> the @carrick/<dir> label. */
+  packageLabelOf: (packageDir: string) => string | undefined;
+}
+
+const IMPORT_PATH_RE = /import\("([^"]+)"\)/g;
+const PNPM_SEGMENT_RE = /\/\.pnpm\/([^/]+)\/node_modules\//;
+const NODE_MODULES_TAIL_RE = /\/node_modules\/((?:@[^/]+\/)?[^/]+)(?:\/|$)/;
+const PACKAGES_SEGMENT_RE = /\/packages\/([^/]+)\//;
+
+/** Map one absolute import specifier to a stable, path-free label. */
+function labelForImportPath(absPath: string, ctx: ScrubContext): string {
+  const normalized = absPath.split('\\').join('/');
+
+  // pnpm isolated store: .../.pnpm/<name>@<ver>/node_modules/<name>/...
+  const pnpm = normalized.match(PNPM_SEGMENT_RE);
+  if (pnpm) return pnpm[1];
+
+  // A stub tree file: .../packages/<dir>/types/surface -> @carrick/<service>
+  const pkg = normalized.match(PACKAGES_SEGMENT_RE);
+  if (pkg) {
+    const label = ctx.packageLabelOf(pkg[1]);
+    if (label) return label;
+  }
+
+  // Any other node_modules path (defensive; isolated linker should not hit).
+  const nm = normalized.match(NODE_MODULES_TAIL_RE);
+  if (nm) return nm[1];
+
+  // Fall back to just stripping the workspace root prefix.
+  if (normalized.startsWith(ctx.workspaceRoot.split('\\').join('/'))) {
+    return normalized.slice(ctx.workspaceRoot.length).replace(/^\/+/, '');
+  }
+  return normalized;
+}
+
+/** Replace stub-absolute import paths and any lingering workspace root. */
+export function scrubPaths(text: string, ctx: ScrubContext): string {
+  let out = text.replace(IMPORT_PATH_RE, (_m, p1: string) => {
+    return `import("${labelForImportPath(p1, ctx)}")`;
+  });
+  // Defensive: no raw temp path may survive anywhere in the message.
+  if (ctx.workspaceRoot) {
+    out = out.split(ctx.workspaceRoot).join('');
+    out = out.split(ctx.workspaceRoot.split('/').join('\\')).join('');
+  }
+  return out;
+}
+
+/**
+ * Rewrite the probe's `Sent`/`Expected` import aliases (which the compiler
+ * prints in the headline) to the real surface alias names. Only quoted forms
+ * are touched, so real type names in nested elaboration lines are preserved.
+ */
+export function rewriteAliases(
+  text: string,
+  sentAlias: string,
+  expectedAlias: string
+): string {
+  return text
+    .split(`'Sent'`)
+    .join(`'${sentAlias}'`)
+    .split(`'Expected'`)
+    .join(`'${expectedAlias}'`);
+}
+
+/** Full scrub applied to an incompatible pair's diagnostic message. */
+export function scrubDiagnostic(
+  text: string,
+  ctx: ScrubContext,
+  sentAlias: string,
+  expectedAlias: string
+): string {
+  return rewriteAliases(scrubPaths(text, ctx), sentAlias, expectedAlias);
+}

--- a/src/sidecar/src/capture/check-workspace.ts
+++ b/src/sidecar/src/capture/check-workspace.ts
@@ -1,0 +1,276 @@
+/**
+ * Scratch synthetic-monorepo assembly for the v2 check phase.
+ *
+ * Copies each capture stub package into a temp pnpm workspace
+ * (node-linker=isolated, so every stub keeps its OWN node_modules and two
+ * versions of one dependency genuinely coexist), adds a `carrick-probes`
+ * package that depends on every stub via `workspace:*`, writes the checker
+ * tsconfig, and computes semver-dedupe overrides so patch/minor drift on a
+ * private-member class does not manufacture a nominal false-incompatible
+ * (design Check step 6) while genuinely conflicting majors stay physically
+ * duplicated (and thus verdict incompatible, correctly).
+ *
+ * Seam: node builtins + this bundle only.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { CheckStubInput } from './api.js';
+import type { ProbePlan } from './check-probe.js';
+
+const PROBES_PACKAGE = 'carrick-probes';
+
+export interface AssembledStub {
+  serviceName: string;
+  /** Workspace package dir under packages/ (== the @carrick/<dir> suffix). */
+  packageDir: string;
+  /** Full package specifier, e.g. @carrick/orders-engine. */
+  packageName: string;
+}
+
+export interface AssembledWorkspace {
+  workspaceDir: string;
+  probesDir: string; // absolute
+  /** Relative (forward-slash) probes dir, e.g. packages/carrick-probes. */
+  probesRel: string;
+  stubs: AssembledStub[];
+  /** service name -> package specifier (for probe imports). */
+  packageOf: (serviceName: string) => string;
+  /** package dir -> package specifier (for scrub labels). */
+  packageLabelOf: (packageDir: string) => string | undefined;
+  /** package dir -> service name (for poison attribution). */
+  serviceOfPackageDir: (packageDir: string) => string | undefined;
+}
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  raw: string;
+}
+
+function parseVersion(v: string): ParsedVersion {
+  const core = v.replace(/^[^\d]*/, '').split('-')[0].split('+')[0];
+  const [maj = '0', min = '0', pat = '0'] = core.split('.');
+  return {
+    major: Number(maj) || 0,
+    minor: Number(min) || 0,
+    patch: Number(pat) || 0,
+    raw: v,
+  };
+}
+
+/** Semver compat key: same key => dedupe candidates. 0.x is minor-scoped. */
+function compatKey(v: ParsedVersion): string {
+  return v.major > 0 ? `${v.major}` : `0.${v.minor}`;
+}
+
+function versionGreater(a: ParsedVersion, b: ParsedVersion): boolean {
+  if (a.major !== b.major) return a.major > b.major;
+  if (a.minor !== b.minor) return a.minor > b.minor;
+  return a.patch > b.patch;
+}
+
+/**
+ * Build pnpm exact-selector overrides that collapse semver-compatible drift to
+ * the max version in each compat group, leaving conflicting majors untouched.
+ * Returns a deterministically key-sorted map, e.g. { "bson@6.8.0": "6.10.1" }.
+ */
+export function computeDedupeOverrides(
+  stubs: { dependencies: Record<string, string> }[]
+): Record<string, string> {
+  const byName = new Map<string, Set<string>>();
+  for (const stub of stubs) {
+    for (const [name, version] of Object.entries(stub.dependencies ?? {})) {
+      if (!byName.has(name)) byName.set(name, new Set());
+      byName.get(name)!.add(version);
+    }
+  }
+
+  const overrides: Record<string, string> = {};
+  for (const [name, versions] of byName) {
+    if (versions.size < 2) continue;
+    const groups = new Map<string, ParsedVersion[]>();
+    for (const raw of versions) {
+      const parsed = parseVersion(raw);
+      const key = compatKey(parsed);
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)!.push(parsed);
+    }
+    for (const members of groups.values()) {
+      if (members.length < 2) continue;
+      let max = members[0];
+      for (const m of members) if (versionGreater(m, max)) max = m;
+      for (const m of members) {
+        if (m.raw !== max.raw) overrides[`${name}@${m.raw}`] = max.raw;
+      }
+    }
+  }
+
+  return Object.fromEntries(
+    Object.keys(overrides)
+      .sort()
+      .map((k) => [k, overrides[k]])
+  );
+}
+
+function readStubPackageName(stubDir: string): string {
+  const pkgPath = path.join(stubDir, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+    name?: string;
+    dependencies?: Record<string, string>;
+  };
+  if (!pkg.name) throw new Error(`stub package.json missing 'name': ${pkgPath}`);
+  return pkg.name;
+}
+
+function readStubDependencies(stubDir: string): Record<string, string> {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(stubDir, 'package.json'), 'utf8')
+  ) as { dependencies?: Record<string, string> };
+  return pkg.dependencies ?? {};
+}
+
+/** Package dir under packages/ == the sanitized suffix of @carrick/<suffix>. */
+function packageDirOf(packageName: string): string {
+  const slash = packageName.lastIndexOf('/');
+  return slash >= 0 ? packageName.slice(slash + 1) : packageName;
+}
+
+export interface AssembleOptions {
+  stubs: CheckStubInput[];
+  workspaceRoot?: string;
+}
+
+/** Create the scratch workspace and copy in the stub packages. */
+export function assembleWorkspace(opts: AssembleOptions): AssembledWorkspace {
+  const root = opts.workspaceRoot ?? os.tmpdir();
+  fs.mkdirSync(root, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(root, 'carrick-check-v2-'));
+  const packagesDir = path.join(workspaceDir, 'packages');
+  fs.mkdirSync(packagesDir, { recursive: true });
+
+  fs.writeFileSync(path.join(workspaceDir, '.npmrc'), NPMRC);
+  fs.writeFileSync(
+    path.join(workspaceDir, 'pnpm-workspace.yaml'),
+    'packages:\n  - "packages/*"\n'
+  );
+
+  const assembled: AssembledStub[] = [];
+  const dependencySets: { dependencies: Record<string, string> }[] = [];
+  const svcToPkg = new Map<string, string>();
+  const dirToPkg = new Map<string, string>();
+  const dirToSvc = new Map<string, string>();
+
+  for (const stub of opts.stubs) {
+    const packageName = readStubPackageName(stub.stub_dir);
+    const packageDir = packageDirOf(packageName);
+    const dest = path.join(packagesDir, packageDir);
+    fs.cpSync(stub.stub_dir, dest, {
+      recursive: true,
+      filter: (src) => !src.split(path.sep).includes('node_modules'),
+    });
+    assembled.push({ serviceName: stub.service_name, packageDir, packageName });
+    dependencySets.push({ dependencies: readStubDependencies(stub.stub_dir) });
+    svcToPkg.set(stub.service_name, packageName);
+    dirToPkg.set(packageDir, packageName);
+    dirToSvc.set(packageDir, stub.service_name);
+  }
+
+  // Root manifest carries the semver-dedupe overrides.
+  const overrides = computeDedupeOverrides(dependencySets);
+  fs.writeFileSync(
+    path.join(workspaceDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'carrick-check-workspace',
+        version: '0.0.0',
+        private: true,
+        ...(Object.keys(overrides).length > 0 ? { pnpm: { overrides } } : {}),
+      },
+      null,
+      2
+    ) + '\n'
+  );
+
+  const probesDir = path.join(packagesDir, PROBES_PACKAGE);
+  fs.mkdirSync(path.join(probesDir, 'probes'), { recursive: true });
+  const probeDeps: Record<string, string> = {};
+  for (const stub of assembled) probeDeps[stub.packageName] = 'workspace:*';
+  fs.writeFileSync(
+    path.join(probesDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: PROBES_PACKAGE,
+        version: '0.0.0',
+        private: true,
+        dependencies: probeDeps,
+      },
+      null,
+      2
+    ) + '\n'
+  );
+  fs.writeFileSync(path.join(probesDir, 'tsconfig.json'), CHECKER_TSCONFIG);
+
+  return {
+    workspaceDir,
+    probesDir,
+    probesRel: `packages/${PROBES_PACKAGE}`,
+    stubs: assembled,
+    packageOf: (s) => {
+      const pkg = svcToPkg.get(s);
+      if (!pkg) throw new Error(`no stub for service '${s}'`);
+      return pkg;
+    },
+    packageLabelOf: (dir) => dirToPkg.get(dir),
+    serviceOfPackageDir: (dir) => dirToSvc.get(dir),
+  };
+}
+
+/** Write the generated probe files into the assembled probes package. */
+export function writeProbes(ws: AssembledWorkspace, plans: ProbePlan[]): void {
+  for (const plan of plans) {
+    fs.writeFileSync(path.join(ws.probesDir, 'probes', plan.fileName), plan.source);
+  }
+}
+
+const NPMRC = [
+  // Every stub gets its own node_modules: two versions of one dep coexist and
+  // tsc resolves each stub's ref to its own copy (the isolation guarantee).
+  'node-linker=isolated',
+  // Stubs pin arbitrary library majors; peer conflicts must degrade to
+  // unverifiable via the probe gates, never abort the whole install.
+  'strict-peer-dependencies=false',
+  // Determinism: install exactly the pinned closure, no implicit peer pull-in.
+  'auto-install-peers=false',
+  '',
+].join('\n');
+
+// skipLibCheck:false is load-bearing (surfaces cross-stub declare-global
+// TS2717 collisions so the poison rule can convert them to honest
+// unverifiables). noUnusedLocals/Parameters:false keep TS6133/6196 off the
+// gate/assignment lines. moduleResolution bundler accepts both node16
+// `.js`-suffixed and extensionless specifiers in one program.
+const CHECKER_TSCONFIG =
+  JSON.stringify(
+    {
+      compilerOptions: {
+        strict: true,
+        exactOptionalPropertyTypes: false,
+        skipLibCheck: false,
+        noUnusedLocals: false,
+        noUnusedParameters: false,
+        moduleResolution: 'bundler',
+        module: 'esnext',
+        target: 'es2022',
+        lib: ['es2022', 'dom', 'dom.iterable'],
+        types: [],
+        noEmit: true,
+        forceConsistentCasingInFileNames: true,
+      },
+      include: ['probes/**/*.ts'],
+    },
+    null,
+    2
+  ) + '\n';

--- a/src/sidecar/src/capture/check.ts
+++ b/src/sidecar/src/capture/check.ts
@@ -1,0 +1,337 @@
+/**
+ * v2 check core: "tsc as the judge"
+ * (docs/reference/type-compat-synthetic-monorepo.md, Check phase).
+ *
+ * Consumes two or more capture stub packages, assembles a scratch synthetic
+ * monorepo, installs pinned deps with the vendored pnpm (isolated linker),
+ * generates one probe per matched pair, runs the vendored `tsc` CLI, and
+ * classifies diagnostics into the four buckets. Deterministic given the stubs
+ * and pairs: verdicts are byte-stable across runs (the scrub pass removes the
+ * per-run temp path, and the pair IDs / ordering derive from the pair specs).
+ *
+ * Seam: this file imports only node builtins, `typescript` (for the version
+ * string), and the rest of this bundle. The sidecar reaches it only through
+ * ./index.js. The judge is the `tsc` CLI (no compiler API), which keeps the
+ * check phase TS7-ready by construction.
+ */
+
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import type {
+  CheckOptions,
+  CheckProgressPhase,
+  CheckResult,
+  CheckVerdict,
+  DegradedService,
+} from './api.js';
+import { buildProbe, type ProbePlan } from './check-probe.js';
+import {
+  classifyPair,
+  parseTscOutput,
+  type RawDiagnostic,
+} from './check-classify.js';
+import { scrubPaths, type ScrubContext } from './check-scrub.js';
+import {
+  assembleWorkspace,
+  writeProbes,
+  type AssembledWorkspace,
+} from './check-workspace.js';
+
+export type CheckProgress = (phase: CheckProgressPhase, message: string) => void;
+
+interface SpawnResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runProcess(
+  command: string,
+  args: string[],
+  cwd: string
+): Promise<SpawnResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d: Buffer) => (stdout += d.toString()));
+    child.stderr.on('data', (d: Buffer) => (stderr += d.toString()));
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+/** Resolve the sidecar root (where the vendored pnpm/tsc live) from this bundle. */
+function sidecarRoot(): string {
+  // dist/src/capture/check.js -> up three -> sidecar root.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, '..', '..', '..');
+}
+
+function binPath(name: string): string {
+  return path.join(sidecarRoot(), 'node_modules', '.bin', name);
+}
+
+function unverifiableAll(
+  plans: ProbePlan[],
+  gate: string,
+  diagnostic: string
+): CheckVerdict[] {
+  return plans.map((plan) => ({
+    pair_id: plan.pairId,
+    pair_key: plan.spec.pair_key,
+    bucket: 'unverifiable' as const,
+    gate,
+    diagnostic,
+    codes: [],
+  }));
+}
+
+function sortVerdicts(verdicts: CheckVerdict[]): CheckVerdict[] {
+  return [...verdicts].sort((a, b) =>
+    a.pair_id < b.pair_id ? -1 : a.pair_id > b.pair_id ? 1 : 0
+  );
+}
+
+/** Run the deterministic check phase. Async: install + tsc run off the event
+ * loop so the sidecar stays responsive and can emit keepalive frames. */
+export async function runCheck(
+  opts: CheckOptions,
+  onProgress?: CheckProgress
+): Promise<CheckResult> {
+  const progress: CheckProgress = onProgress ?? (() => {});
+  const cleanup = opts.cleanup !== false;
+  const pnpmPath = opts.pnpmPath ?? binPath('pnpm');
+  const tscPath = binPath('tsc');
+  const tsVersion = ts.version;
+
+  // Isolation is non-negotiable: without the vendored pnpm we would fall back
+  // to a flat npm install that manufactures nominal false-incompatibles. Fail
+  // explicitly instead (design Check step 2).
+  if (!fs.existsSync(pnpmPath)) {
+    const planned = planPairs(opts, (s) => `@carrick/${s}`);
+    return {
+      success: false,
+      workspace_dir: '',
+      isolation: 'unavailable',
+      install_ok: false,
+      install_error: 'vendored pnpm not found; type isolation is unavailable',
+      ts_version: tsVersion,
+      verdicts: sortVerdicts(
+        unverifiableAll(
+          planned,
+          'isolation:unavailable',
+          'type isolation unavailable (pnpm missing); compatibility cannot be verified.'
+        )
+      ),
+      degraded_services: opts.stubs.map((s) => ({
+        service_name: s.service_name,
+        reason: 'isolation unavailable',
+      })),
+      errors: ['vendored pnpm not found'],
+    };
+  }
+
+  progress('assembling', 'assembling synthetic workspace');
+  const ws = assembleWorkspace({
+    stubs: opts.stubs,
+    workspaceRoot: opts.workspaceRoot,
+  });
+
+  const scrubCtx: ScrubContext = {
+    workspaceRoot: ws.workspaceDir,
+    packageLabelOf: ws.packageLabelOf,
+  };
+
+  // Generate probes. A pair naming a service with no stub is unverifiable.
+  const plans: ProbePlan[] = [];
+  const unresolved: CheckVerdict[] = [];
+  for (const spec of opts.pairs) {
+    try {
+      plans.push(buildProbe(spec, ws.packageOf));
+    } catch {
+      unresolved.push({
+        pair_id: '',
+        pair_key: spec.pair_key,
+        bucket: 'unverifiable',
+        gate: 'missing:stub',
+        diagnostic: 'a stub for one side of this pair was not provided; compatibility cannot be verified.',
+        codes: [],
+      });
+    }
+  }
+  // Backfill deterministic pair IDs for unresolved pairs from the spec.
+  for (const v of unresolved) {
+    const spec = opts.pairs.find((p) => p.pair_key === v.pair_key)!;
+    v.pair_id = fnvOfSpec(spec);
+  }
+  writeProbes(ws, plans);
+
+  const errors: string[] = [];
+  const degraded: DegradedService[] = [];
+
+  // ---- Install (async, off the event loop) --------------------------------
+  progress('installing', 'installing pinned dependencies');
+  const install = await runProcess(pnpmPath, ['install'], ws.workspaceDir);
+  const installOk = install.code === 0;
+  let installError: string | undefined;
+  if (!installOk) {
+    installError = scrubPaths(
+      (install.stderr || install.stdout).trim().slice(0, 2000),
+      scrubCtx
+    );
+    for (const s of opts.stubs) {
+      degraded.push({ service_name: s.service_name, reason: 'workspace install failed' });
+    }
+    const verdicts = sortVerdicts([
+      ...unverifiableAll(
+        plans,
+        'install:failed',
+        'workspace dependency install failed; compatibility cannot be verified.'
+      ),
+      ...unresolved,
+    ]);
+    if (cleanup) safeRm(ws.workspaceDir);
+    return {
+      success: false,
+      workspace_dir: cleanup ? '' : ws.workspaceDir,
+      isolation: 'pnpm',
+      install_ok: false,
+      install_error: installError,
+      ts_version: tsVersion,
+      verdicts,
+      degraded_services: degraded,
+      errors,
+    };
+  }
+
+  // ---- Judge (async, off the event loop) ----------------------------------
+  progress('checking', 'type-checking probes');
+  const tsc = await runProcess(
+    tscPath,
+    ['--noEmit', '--pretty', 'false', '-p', path.join(ws.probesRel, 'tsconfig.json')],
+    ws.workspaceDir
+  );
+  const diagnostics = parseTscOutput(tsc.stdout + '\n' + tsc.stderr);
+
+  const { probeDiagsByPair, poison, globalErrors } = attributeDiagnostics(
+    diagnostics,
+    ws,
+    plans
+  );
+  for (const e of globalErrors) errors.push(scrubPaths(e, scrubCtx));
+  for (const [service, reason] of poison) {
+    degraded.push({ service_name: service, reason });
+  }
+
+  const verdicts = sortVerdicts([
+    ...plans.map((plan) =>
+      classifyPair({
+        plan,
+        probeDiags: probeDiagsByPair.get(plan.pairId) ?? [],
+        poisonReason: (svc) => poison.get(svc),
+        scrubCtx,
+      })
+    ),
+    ...unresolved,
+  ]);
+
+  const workspaceDirOut = cleanup ? '' : ws.workspaceDir;
+  if (cleanup) safeRm(ws.workspaceDir);
+
+  return {
+    success: true,
+    workspace_dir: workspaceDirOut,
+    isolation: 'pnpm',
+    install_ok: true,
+    ts_version: tsVersion,
+    verdicts,
+    degraded_services: dedupeDegraded(degraded),
+    errors,
+  };
+}
+
+/** Group diagnostics: per-probe (for classification), plus stub-tree poison. */
+function attributeDiagnostics(
+  diagnostics: RawDiagnostic[],
+  ws: AssembledWorkspace,
+  plans: ProbePlan[]
+): {
+  probeDiagsByPair: Map<string, RawDiagnostic[]>;
+  poison: Map<string, string>;
+  globalErrors: string[];
+} {
+  const probeFileToPair = new Map<string, string>();
+  for (const plan of plans) {
+    probeFileToPair.set(`${ws.probesRel}/probes/${plan.fileName}`, plan.pairId);
+  }
+  const stubDirs = new Set(ws.stubs.map((s) => s.packageDir));
+
+  const probeDiagsByPair = new Map<string, RawDiagnostic[]>();
+  const poison = new Map<string, string>();
+  const globalErrors: string[] = [];
+
+  for (const d of diagnostics) {
+    if (!d.file) {
+      globalErrors.push(`TS${d.code}: ${d.message}`);
+      continue;
+    }
+    const pairId = probeFileToPair.get(d.file);
+    if (pairId) {
+      if (!probeDiagsByPair.has(pairId)) probeDiagsByPair.set(pairId, []);
+      probeDiagsByPair.get(pairId)!.push(d);
+      continue;
+    }
+    // Stub-tree diagnostics poison that stub (its OWN sources, not deps).
+    const pkgMatch = d.file.match(/^packages\/([^/]+)\//);
+    if (pkgMatch && !d.file.includes('/node_modules/') && stubDirs.has(pkgMatch[1])) {
+      const service = ws.serviceOfPackageDir(pkgMatch[1]);
+      if (service && !poison.has(service)) {
+        poison.set(service, 'stub type tree carries its own diagnostics');
+      }
+    }
+    // Anything else (node_modules, TS lib) is environmental: ignored for
+    // verdicts so it cannot inject nondeterministic noise.
+  }
+
+  return { probeDiagsByPair, poison, globalErrors };
+}
+
+function dedupeDegraded(list: DegradedService[]): DegradedService[] {
+  const seen = new Map<string, DegradedService>();
+  for (const d of list) if (!seen.has(d.service_name)) seen.set(d.service_name, d);
+  return [...seen.values()].sort((a, b) =>
+    a.service_name < b.service_name ? -1 : a.service_name > b.service_name ? 1 : 0
+  );
+}
+
+/** Plan pairs without a workspace (for the isolation-unavailable early exit). */
+function planPairs(
+  opts: CheckOptions,
+  packageOf: (serviceName: string) => string
+): ProbePlan[] {
+  const plans: ProbePlan[] = [];
+  for (const spec of opts.pairs) {
+    try {
+      plans.push(buildProbe(spec, packageOf));
+    } catch {
+      /* skipped in the early-exit path */
+    }
+  }
+  return plans;
+}
+
+function fnvOfSpec(spec: CheckOptions['pairs'][number]): string {
+  return buildProbe(spec, (s) => `@carrick/${s}`).pairId;
+}
+
+function safeRm(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+}

--- a/src/sidecar/src/capture/index.ts
+++ b/src/sidecar/src/capture/index.ts
@@ -49,6 +49,10 @@ import { selfCheckStub } from './self-check.js';
 import { collectSpecifiers, isRelative, packageNameOf } from './specifiers.js';
 
 export type { CaptureStubOptions, CaptureStubResult } from './api.js';
+// v2 check core ("tsc as the judge"). Same bundle, same seam: the sidecar
+// reaches it only through this door (index.js).
+export { runCheck } from './check.js';
+export type { CheckProgress } from './check.js';
 
 const SURFACE_ENTRY_BASENAME = '__carrick_surface__';
 

--- a/src/sidecar/src/index.ts
+++ b/src/sidecar/src/index.ts
@@ -19,7 +19,7 @@ import { TypeBundler, SurfaceEmitter } from './bundler.js';
 import { TypeInferrer } from './type-inferrer.js';
 import { MonorepoBuilder } from './monorepo-builder.js';
 import { DefinitionResolver } from './definition-resolver.js';
-import { captureStub } from './capture/index.js';
+import { captureStub, runCheck } from './capture/index.js';
 import type {
   SidecarRequest,
   SidecarResponse,
@@ -27,6 +27,7 @@ import type {
   BundleResponse,
   EmitSurfaceResponse,
   CaptureV2Response,
+  CheckV2Response,
   InferResponse,
   BuildWorkspaceResponse,
   CheckCompatibilityResponse,
@@ -247,6 +248,56 @@ function handleCaptureV2(request: SidecarRequest & { action: 'capture_v2' }): Ca
       status: 'error',
       errors: [error],
     };
+  }
+}
+
+/**
+ * Handle the 'check_v2' action - v2 "tsc as judge" compatibility check.
+ *
+ * Async by necessity: the vendored pnpm install can exceed the Rust client's
+ * read deadline, and running it off the event loop (spawn, not execSync) keeps
+ * the sidecar responsive. Emits `status: 'progress'` keepalive frames during
+ * install/check and one terminal `success`/`error` frame. Writes its own
+ * frames, so processLine hands off and does not write a response for it.
+ */
+async function handleCheckV2Async(
+  request: SidecarRequest & { action: 'check_v2' }
+): Promise<void> {
+  let phase = 'assembling';
+  const keepalive = setInterval(() => {
+    writeProgress(request.request_id, phase, `check ${phase}`);
+  }, 1500);
+  keepalive.unref();
+  try {
+    log(`check_v2: ${request.stubs.length} stub(s), ${request.pairs.length} pair(s)`);
+    const result = await runCheck(
+      {
+        stubs: request.stubs,
+        pairs: request.pairs,
+        workspaceRoot: request.workspace_root,
+        cleanup: request.keep_workspace !== true,
+      },
+      (p) => {
+        phase = p;
+      }
+    );
+    clearInterval(keepalive);
+    const response: CheckV2Response = {
+      request_id: request.request_id,
+      status: result.success ? 'success' : 'error',
+      result,
+      errors: result.errors.length > 0 ? result.errors : undefined,
+    };
+    writeResponse(response);
+  } catch (err) {
+    clearInterval(keepalive);
+    const error = err instanceof Error ? err.message : String(err);
+    logError(`check_v2 failed: ${error}`);
+    writeResponse({
+      request_id: request.request_id,
+      status: 'error',
+      errors: [error],
+    });
   }
 }
 
@@ -494,6 +545,17 @@ function writeResponse(response: SidecarResponse): void {
 }
 
 /**
+ * Write a non-terminal progress/keepalive frame (async install protocol).
+ * Distinct `status: 'progress'` so clients skip it and wait for the terminal
+ * success/error frame.
+ */
+function writeProgress(requestId: string, phase: string, message: string): void {
+  process.stdout.write(
+    JSON.stringify({ request_id: requestId, status: 'progress', phase, message }) + '\n'
+  );
+}
+
+/**
  * Write an error response for an invalid request
  */
 function writeErrorResponse(requestId: string, error: string): void {
@@ -547,6 +609,13 @@ function processLine(line: string): void {
       (json as { request_id?: string })?.request_id || 'unknown',
       parseResult.error
     );
+    return;
+  }
+
+  // check_v2 runs async (spawned pnpm install + tsc) and writes its own
+  // progress + terminal frames; hand off and return.
+  if (parseResult.request.action === 'check_v2') {
+    void handleCheckV2Async(parseResult.request);
     return;
   }
 

--- a/src/sidecar/src/types.ts
+++ b/src/sidecar/src/types.ts
@@ -246,6 +246,33 @@ export interface CaptureV2Response extends BaseResponse {
 }
 
 /**
+ * Request to run the v2 "tsc as judge" check for a set of matched pairs.
+ * Assembles the given capture stubs into a scratch synthetic monorepo and
+ * returns one verdict per pair. The full contract lives in ./capture/api.ts --
+ * the seam between the sidecar and the v2 capture/check bundle.
+ */
+export interface CheckV2Request extends BaseRequest {
+  action: 'check_v2';
+  /** Capture stub packages to assemble (one per participating service). */
+  stubs: import('./capture/api.js').CheckStubInput[];
+  /** Matched pairs to verify. */
+  pairs: import('./capture/api.js').CheckPairSpec[];
+  /** Parent dir for the scratch workspace (default: OS temp dir). */
+  workspace_root?: string;
+  /** Keep the assembled workspace on disk (default false; tests set true). */
+  keep_workspace?: boolean;
+}
+
+/**
+ * Response for the check_v2 action. Emitted as the terminal frame; the async
+ * install protocol emits `status: 'progress'` keepalive frames before it.
+ */
+export interface CheckV2Response extends BaseResponse {
+  result?: import('./capture/api.js').CheckResult;
+  errors?: string[];
+}
+
+/**
  * Request to infer implicit types at specific locations
  */
 export interface InferRequest extends BaseRequest {
@@ -326,6 +353,7 @@ export type SidecarRequest =
   | BundleRequest
   | EmitSurfaceRequest
   | CaptureV2Request
+  | CheckV2Request
   | InferRequest
   | BuildWorkspaceRequest
   | CheckCompatibilityRequest
@@ -542,6 +570,7 @@ export type SidecarResponse =
   | BundleResponse
   | EmitSurfaceResponse
   | CaptureV2Response
+  | CheckV2Response
   | InferResponse
   | BuildWorkspaceResponse
   | CheckCompatibilityResponse

--- a/src/sidecar/src/validators.ts
+++ b/src/sidecar/src/validators.ts
@@ -261,6 +261,32 @@ export const CaptureV2RequestSchema = BaseRequestSchema.extend({
   tsconfig_path: z.string().optional(),
 });
 
+const CheckStubInputSchema = z.object({
+  service_name: z.string().min(1),
+  stub_dir: z.string().min(1),
+});
+
+const CheckPairEndpointSchema = z.object({
+  service_name: z.string().min(1),
+  alias: z.string().min(1),
+});
+
+const CheckPairSpecSchema = z.object({
+  pair_key: z.string().min(1),
+  protocol: z.enum(['http', 'graphql', 'socket', 'pubsub']),
+  type_kind: z.enum(['request', 'response', 'both']),
+  producer: CheckPairEndpointSchema,
+  consumer: CheckPairEndpointSchema,
+});
+
+export const CheckV2RequestSchema = BaseRequestSchema.extend({
+  action: z.literal('check_v2'),
+  stubs: z.array(CheckStubInputSchema).min(1, 'At least one stub is required'),
+  pairs: z.array(CheckPairSpecSchema).min(1, 'At least one pair is required'),
+  workspace_root: z.string().optional(),
+  keep_workspace: z.boolean().optional(),
+});
+
 export const InferRequestSchema = BaseRequestSchema.extend({
   action: z.literal('infer'),
   requests: z.array(InferRequestItemSchema).min(1, 'At least one infer request is required'),
@@ -305,6 +331,7 @@ export const SidecarRequestSchema = z.discriminatedUnion('action', [
   BundleRequestSchema,
   EmitSurfaceRequestSchema,
   CaptureV2RequestSchema,
+  CheckV2RequestSchema,
   InferRequestSchema,
   BuildWorkspaceRequestSchema,
   CheckCompatibilityRequestSchema,

--- a/src/sidecar/test/check-v2-corpus.test.ts
+++ b/src/sidecar/test/check-v2-corpus.test.ts
@@ -1,0 +1,234 @@
+/**
+ * v2 check core — corpus end-to-end over the JSON-over-stdio wire.
+ *
+ * Drives the sidecar exactly as the Rust client will (WP3): capture_v2 to build
+ * stub packages for real corpus services, then check_v2 to verify matched
+ * pairs, handling the async install protocol's `status: 'progress'` keepalive
+ * frames. Uses one corpus-2 pair and one corpus-3 pair (acceptance: two corpus
+ * fixtures), both deliberately-incompatible edges from the fixtures, and pins
+ * that the full verdict payload is byte-stable across two independent runs.
+ *
+ * All four fixtures are bare checkouts with no external-dep references in the
+ * captured closures, so the check install is local-only (network-free).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { CheckResult } from '../src/capture/api.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SIDECAR = path.join(__dirname, '..', 'src', 'index.js');
+// dist/test -> repo root is four levels up.
+const FIXTURES = path.join(__dirname, '..', '..', '..', '..', 'tests', 'fixtures');
+
+/** Minimal client that tolerates progress frames and matches by request_id. */
+class ProgressAwareClient {
+  private proc: ChildProcessWithoutNullStreams | null = null;
+  private buffer = '';
+  private waiters = new Map<string, (v: unknown) => void>();
+
+  async start(): Promise<void> {
+    this.proc = spawn('node', [SIDECAR], { stdio: ['pipe', 'pipe', 'pipe'] });
+    this.proc.stdout.on('data', (d: Buffer) => {
+      this.buffer += d.toString();
+      const lines = this.buffer.split('\n');
+      this.buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let msg: { request_id?: string; status?: string };
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (msg.status === 'progress') continue; // keepalive: keep waiting
+        const w = msg.request_id ? this.waiters.get(msg.request_id) : undefined;
+        if (w) {
+          this.waiters.delete(msg.request_id!);
+          w(msg);
+        }
+      }
+    });
+    await new Promise((r) => setTimeout(r, 150));
+  }
+
+  send<T>(request: Record<string, unknown>, timeoutMs = 120000): Promise<T> {
+    const id = request.request_id as string;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.waiters.delete(id);
+        reject(new Error(`timeout for ${id}`));
+      }, timeoutMs);
+      timer.unref();
+      this.waiters.set(id, (v) => {
+        clearTimeout(timer);
+        resolve(v as T);
+      });
+      this.proc!.stdin.write(JSON.stringify(request) + '\n');
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.proc) return;
+    try {
+      this.proc.stdin.write(JSON.stringify({ action: 'shutdown', request_id: 'sd' }) + '\n');
+    } catch {
+      /* ignore */
+    }
+    this.proc.kill();
+    this.proc = null;
+  }
+}
+
+interface CaptureResp {
+  status: string;
+  result?: { success: boolean; stub_dir: string };
+  errors?: string[];
+}
+interface CheckResp {
+  status: string;
+  result?: CheckResult;
+  errors?: string[];
+}
+
+describe('check_v2 corpus end-to-end (stdio, byte-stable)', () => {
+  const client = new ProgressAwareClient();
+  let workRoot: string;
+  let stubDirs: Record<string, string>;
+
+  const services: Record<string, { repo: string; symbol: string; file: string }> = {
+    'orders-engine': {
+      repo: path.join(FIXTURES, 'xrepo-corpus-2', 'orders-engine'),
+      symbol: 'OrderPlaced',
+      file: 'src/types/order.ts',
+    },
+    'billing-svc': {
+      repo: path.join(FIXTURES, 'xrepo-corpus-2', 'billing-svc'),
+      symbol: 'OrderPlaced',
+      file: 'src/types/billing.ts',
+    },
+    'orders-api': {
+      repo: path.join(FIXTURES, 'xrepo-corpus-3', 'orders-api'),
+      symbol: 'DispatchRequest',
+      file: 'src/types/orders.ts',
+    },
+    'fulfillment-worker': {
+      repo: path.join(FIXTURES, 'xrepo-corpus-3', 'fulfillment-worker'),
+      symbol: 'DispatchJob',
+      file: 'src/types/fulfillment.ts',
+    },
+  };
+
+  const pairs = [
+    {
+      pair_key: 'corpus2:order.placed',
+      protocol: 'http' as const,
+      type_kind: 'response' as const,
+      producer: { service_name: 'orders-engine', alias: 'Sig_orders_engine' },
+      consumer: { service_name: 'billing-svc', alias: 'Sig_billing_svc' },
+    },
+    {
+      pair_key: 'corpus3:dispatch',
+      protocol: 'http' as const,
+      type_kind: 'response' as const,
+      producer: { service_name: 'orders-api', alias: 'Sig_orders_api' },
+      consumer: { service_name: 'fulfillment-worker', alias: 'Sig_fulfillment_worker' },
+    },
+  ];
+
+  before(async () => {
+    workRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-check-v2-corpus-'));
+    await client.start();
+    stubDirs = {};
+    let n = 0;
+    for (const [service, def] of Object.entries(services)) {
+      assert.ok(fs.existsSync(def.repo), `fixture missing: ${def.repo}`);
+      const outDir = path.join(workRoot, 'stubs', service);
+      const resp = await client.send<CaptureResp>(
+        {
+          request_id: `cap-${n++}`,
+          action: 'capture_v2',
+          repo_root: def.repo,
+          service_name: service,
+          out_dir: outDir,
+          anchors: [
+            {
+              kind: 'symbol',
+              alias: `Sig_${service.replace(/-/g, '_')}`,
+              symbol_name: def.symbol,
+              source_file: def.file,
+              anchor_origin: 'llm-symbol',
+            },
+          ],
+        },
+        120000
+      );
+      assert.strictEqual(resp.status, 'success', `${service}: ${JSON.stringify(resp.errors)}`);
+      stubDirs[service] = resp.result!.stub_dir;
+    }
+  });
+
+  after(async () => {
+    await client.stop();
+    fs.rmSync(workRoot, { recursive: true, force: true });
+  });
+
+  function checkRequest(id: string) {
+    return {
+      request_id: id,
+      action: 'check_v2' as const,
+      stubs: Object.entries(services).map(([service]) => ({
+        service_name: service,
+        stub_dir: stubDirs[service],
+      })),
+      pairs,
+    };
+  }
+
+  it('produces a verdict per pair over the wire (async install protocol)', async () => {
+    const resp = await client.send<CheckResp>(checkRequest('chk-1'), 180000);
+    assert.strictEqual(resp.status, 'success', JSON.stringify(resp.errors));
+    const result = resp.result!;
+    assert.strictEqual(result.isolation, 'pnpm');
+    assert.strictEqual(result.install_ok, true);
+    assert.strictEqual(result.verdicts.length, pairs.length);
+    for (const v of result.verdicts) {
+      assert.ok(
+        ['compatible', 'incompatible', 'unverifiable', 'gate_caught_baked_any'].includes(v.bucket),
+        v.bucket
+      );
+    }
+  });
+
+  it('resolves the deliberate corpus incompatibilities', async () => {
+    const resp = await client.send<CheckResp>(checkRequest('chk-2'), 180000);
+    const byKey = new Map(resp.result!.verdicts.map((v) => [v.pair_key, v]));
+    // corpus-2: OrderPlaced.total Money(object) vs bare number.
+    assert.strictEqual(byKey.get('corpus2:order.placed')!.bucket, 'incompatible');
+    // corpus-3: DispatchRequest.dispatchAfter string vs DispatchJob Date.
+    assert.strictEqual(byKey.get('corpus3:dispatch')!.bucket, 'incompatible');
+  });
+
+  it('verdicts are byte-stable across two independent check runs', async () => {
+    const a = await client.send<CheckResp>(checkRequest('chk-a'), 180000);
+    const b = await client.send<CheckResp>(checkRequest('chk-b'), 180000);
+    assert.strictEqual(
+      JSON.stringify(a.result!.verdicts),
+      JSON.stringify(b.result!.verdicts)
+    );
+  });
+
+  it('no verdict diagnostic leaks an absolute path or scan internal', async () => {
+    const resp = await client.send<CheckResp>(checkRequest('chk-3'), 180000);
+    for (const v of resp.result!.verdicts) {
+      if (!v.diagnostic) continue;
+      assert.ok(!/\/(private\/)?tmp\//.test(v.diagnostic), v.diagnostic);
+      assert.ok(!v.diagnostic.includes(workRoot), v.diagnostic);
+    }
+  });
+});

--- a/src/sidecar/test/check-v2-units.test.ts
+++ b/src/sidecar/test/check-v2-units.test.ts
@@ -1,0 +1,251 @@
+/**
+ * v2 check core — pure-unit tests (no pnpm, no tsc).
+ *
+ * Pins the deterministic pieces the byte-stable end-to-end runner depends on:
+ * the (protocol, type_kind) direction table (incl. the confirmed HTTP
+ * request-body inversion), stable pair IDs, the four-bucket classifier
+ * precedence, the diagnostic scrub, and semver-dedupe override computation.
+ */
+
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import {
+  buildProbe,
+  directionFor,
+  fnv1a,
+  pairId,
+} from '../src/capture/check-probe.js';
+import { classifyPair, parseTscOutput } from '../src/capture/check-classify.js';
+import { scrubPaths, rewriteAliases } from '../src/capture/check-scrub.js';
+import { computeDedupeOverrides } from '../src/capture/check-workspace.js';
+import type { CheckPairSpec } from '../src/capture/api.js';
+import type { RawDiagnostic } from '../src/capture/check-classify.js';
+
+const PKG = (s: string) => `@carrick/${s}`;
+
+function spec(over: Partial<CheckPairSpec> = {}): CheckPairSpec {
+  return {
+    pair_key: 'k1',
+    protocol: 'http',
+    type_kind: 'response',
+    producer: { service_name: 'orders', alias: 'Endpoint_a_Response' },
+    consumer: { service_name: 'web', alias: 'Call_a_Response' },
+    ...over,
+  };
+}
+
+describe('direction table (protocol, type_kind)', () => {
+  it('http/graphql response: sent=producer, expected=consumer', () => {
+    assert.deepStrictEqual(directionFor('http', 'response'), {
+      sent: 'producer',
+      expected: 'consumer',
+    });
+    assert.deepStrictEqual(directionFor('graphql', 'response'), {
+      sent: 'producer',
+      expected: 'consumer',
+    });
+  });
+
+  it('http request INVERTS: sent=consumer, expected=producer (the confirmed bug fix)', () => {
+    assert.deepStrictEqual(directionFor('http', 'request'), {
+      sent: 'consumer',
+      expected: 'producer',
+    });
+  });
+
+  it('socket/pubsub: sent=consumer(publisher), expected=producer(subscriber)', () => {
+    assert.deepStrictEqual(directionFor('socket', 'both'), {
+      sent: 'consumer',
+      expected: 'producer',
+    });
+    assert.deepStrictEqual(directionFor('pubsub', 'both'), {
+      sent: 'consumer',
+      expected: 'producer',
+    });
+  });
+});
+
+describe('pair IDs', () => {
+  it('are deterministic and stable across calls', () => {
+    assert.strictEqual(pairId(spec()), pairId(spec()));
+  });
+  it('differ when the pair identity differs', () => {
+    assert.notStrictEqual(pairId(spec()), pairId(spec({ pair_key: 'k2' })));
+    assert.notStrictEqual(
+      pairId(spec()),
+      pairId(spec({ producer: { service_name: 'orders', alias: 'Other' } }))
+    );
+  });
+  it('fnv1a is a stable 8-hex hash', () => {
+    assert.match(fnv1a('abc'), /^[0-9a-f]{8}$/);
+    assert.strictEqual(fnv1a('abc'), fnv1a('abc'));
+  });
+});
+
+describe('four-bucket classifier precedence', () => {
+  const plan = buildProbe(spec(), PKG);
+  const scrubCtx = { workspaceRoot: '/tmp/ws', packageLabelOf: () => undefined };
+  const noPoison = () => undefined;
+
+  const diag = (line: number, code: number, message = 'x'): RawDiagnostic => ({
+    file: `packages/carrick-probes/probes/${plan.fileName}`,
+    line,
+    col: 1,
+    code,
+    message,
+  });
+
+  it('no diagnostics -> compatible', () => {
+    const v = classifyPair({ plan, probeDiags: [], poisonReason: noPoison, scrubCtx });
+    assert.strictEqual(v.bucket, 'compatible');
+    assert.strictEqual(v.diagnostic, undefined);
+  });
+
+  it('assignment-class error -> incompatible with real text', () => {
+    const v = classifyPair({
+      plan,
+      probeDiags: [
+        diag(plan.assignmentLine, 2741, "Property 'b' is missing in type 'X'."),
+      ],
+      poisonReason: noPoison,
+      scrubCtx,
+    });
+    assert.strictEqual(v.bucket, 'incompatible');
+    assert.match(v.diagnostic!, /Property 'b' is missing/);
+    assert.deepStrictEqual(v.codes, [2741]);
+  });
+
+  it('IsAny gate (TS2344) -> gate_caught_baked_any on the right side', () => {
+    const anyLine = [...plan.gateLines].find(([, n]) => n === 'sent:any')![0];
+    const v = classifyPair({
+      plan,
+      probeDiags: [diag(anyLine, 2344)],
+      poisonReason: noPoison,
+      scrubCtx,
+    });
+    assert.strictEqual(v.bucket, 'gate_caught_baked_any');
+    // http/response => sent is the producer.
+    assert.strictEqual(v.gate, 'producer:any');
+  });
+
+  it('IsUnknown gate -> unverifiable; gate wins over a co-occurring assignment error', () => {
+    const unkLine = [...plan.gateLines].find(([, n]) => n === 'sent:unknown')![0];
+    const v = classifyPair({
+      plan,
+      // unknown produces BOTH a gate TS2344 and an assignment TS2322.
+      probeDiags: [diag(unkLine, 2344), diag(plan.assignmentLine, 2322)],
+      poisonReason: noPoison,
+      scrubCtx,
+    });
+    assert.strictEqual(v.bucket, 'unverifiable');
+    assert.strictEqual(v.gate, 'producer:unknown');
+  });
+
+  it('surface import error -> unverifiable (missing/renamed export)', () => {
+    const v = classifyPair({
+      plan,
+      probeDiags: [diag(plan.importLines[0], 2305, "Module has no exported member.")],
+      poisonReason: noPoison,
+      scrubCtx,
+    });
+    assert.strictEqual(v.bucket, 'unverifiable');
+    assert.strictEqual(v.gate, 'import:producer');
+  });
+
+  it('stub poison outranks everything -> unverifiable', () => {
+    const v = classifyPair({
+      plan,
+      probeDiags: [diag(plan.assignmentLine, 2741)],
+      poisonReason: (svc) => (svc === 'orders' ? 'conflict' : undefined),
+      scrubCtx,
+    });
+    assert.strictEqual(v.bucket, 'unverifiable');
+    assert.strictEqual(v.gate, 'poison:producer');
+  });
+});
+
+describe('tsc output parsing', () => {
+  it('parses primary lines and folds indented elaboration', () => {
+    const out = [
+      "packages/carrick-probes/probes/pair_x.ts(15,7): error TS2322: Type 'A' is not assignable to type 'B'.",
+      '  Types of property "p" are incompatible.',
+      'Found 1 error.',
+    ].join('\n');
+    const diags = parseTscOutput(out);
+    assert.strictEqual(diags.length, 1);
+    assert.strictEqual(diags[0].code, 2322);
+    assert.strictEqual(diags[0].line, 15);
+    assert.match(diags[0].message, /Types of property/);
+  });
+});
+
+describe('diagnostic scrub', () => {
+  const ctx = {
+    workspaceRoot: '/tmp/carrick-check-v2-abc123',
+    packageLabelOf: (dir: string) =>
+      dir === 'orders' ? '@carrick/orders' : dir === 'web' ? '@carrick/web' : undefined,
+  };
+
+  it('maps stub-absolute import paths to @carrick/<service> labels', () => {
+    const raw =
+      'Type \'import("/tmp/carrick-check-v2-abc123/packages/orders/types/surface").Money\' ' +
+      'is not assignable to type \'import("/tmp/carrick-check-v2-abc123/packages/web/types/surface").Money\'.';
+    const out = scrubPaths(raw, ctx);
+    assert.match(out, /import\("@carrick\/orders"\)/);
+    assert.match(out, /import\("@carrick\/web"\)/);
+    assert.ok(!out.includes('/tmp/'), out);
+  });
+
+  it('maps pnpm store paths to pkg@version', () => {
+    const raw =
+      'import("/tmp/carrick-check-v2-abc123/node_modules/.pnpm/bson@6.10.1/node_modules/bson/bson").ObjectId';
+    const out = scrubPaths(raw, ctx);
+    assert.match(out, /import\("bson@6\.10\.1"\)/);
+    assert.ok(!out.includes('/tmp/'), out);
+  });
+
+  it('rewrites the Sent/Expected probe aliases to real names', () => {
+    const raw = "Type 'Sent' is not assignable to type 'Expected'.";
+    const out = rewriteAliases(raw, 'Endpoint_a_Response', 'Call_a_Response');
+    assert.strictEqual(
+      out,
+      "Type 'Endpoint_a_Response' is not assignable to type 'Call_a_Response'."
+    );
+  });
+});
+
+describe('semver dedupe overrides', () => {
+  it('collapses same-major drift to the max version', () => {
+    const overrides = computeDedupeOverrides([
+      { dependencies: { bson: '6.8.0' } },
+      { dependencies: { bson: '6.10.1' } },
+    ]);
+    assert.deepStrictEqual(overrides, { 'bson@6.8.0': '6.10.1' });
+  });
+
+  it('leaves conflicting majors physically separate (no override)', () => {
+    const overrides = computeDedupeOverrides([
+      { dependencies: { bson: '6.10.1' } },
+      { dependencies: { bson: '5.4.0' } },
+    ]);
+    assert.deepStrictEqual(overrides, {});
+  });
+
+  it('treats 0.x as minor-scoped compat groups', () => {
+    const overrides = computeDedupeOverrides([
+      { dependencies: { pkg: '0.2.1' } },
+      { dependencies: { pkg: '0.2.5' } },
+      { dependencies: { pkg: '0.3.0' } },
+    ]);
+    // 0.2.x dedupes to 0.2.5; 0.3.0 stays separate.
+    assert.deepStrictEqual(overrides, { 'pkg@0.2.1': '0.2.5' });
+  });
+
+  it('identical pins need no override', () => {
+    const overrides = computeDedupeOverrides([
+      { dependencies: { zod: '3.23.0' } },
+      { dependencies: { zod: '3.23.0' } },
+    ]);
+    assert.deepStrictEqual(overrides, {});
+  });
+});

--- a/src/sidecar/test/check-v2.test.ts
+++ b/src/sidecar/test/check-v2.test.ts
@@ -1,0 +1,162 @@
+/**
+ * v2 check core — end-to-end integration (real vendored pnpm + real tsc CLI).
+ *
+ * Hand-authored stub packages with no external dependencies (so the install is
+ * local-only and network-free) exercise the whole runCheck pipeline: workspace
+ * assembly, pnpm install, probe generation, the tsc judge, and the four-bucket
+ * classifier. Pins each of the four buckets and byte-stability across two runs
+ * (the acceptance criteria for WP2).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runCheck } from '../src/capture/index.js';
+import type { CheckPairSpec, CheckStubInput, CheckVerdict } from '../src/capture/api.js';
+
+let root: string;
+let stubs: CheckStubInput[];
+
+function writeStub(dir: string, serviceName: string, surface: string): void {
+  const stubDir = path.join(dir, serviceName);
+  fs.mkdirSync(path.join(stubDir, 'types'), { recursive: true });
+  fs.writeFileSync(
+    path.join(stubDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: `@carrick/${serviceName}`,
+        version: '0.0.0-carrick',
+        private: true,
+        types: './types/surface.d.ts',
+      },
+      null,
+      2
+    ) + '\n'
+  );
+  fs.writeFileSync(path.join(stubDir, 'types', 'surface.d.ts'), surface);
+}
+
+function mk(
+  pair_key: string,
+  producerAlias: string,
+  consumerAlias: string,
+  over: Partial<CheckPairSpec> = {}
+): CheckPairSpec {
+  return {
+    pair_key,
+    protocol: 'http',
+    type_kind: 'response',
+    producer: { service_name: 'orders', alias: producerAlias },
+    consumer: { service_name: 'web', alias: consumerAlias },
+    ...over,
+  };
+}
+
+const PAIRS: CheckPairSpec[] = [
+  mk('compatible', 'C_Sent', 'C_Exp'),
+  mk('incompatible', 'I_Sent', 'I_Exp'),
+  mk('unverifiable', 'U_Sent', 'U_Exp'),
+  mk('bakedany', 'A_Sent', 'A_Exp'),
+  // HTTP request-body: sent=consumer(subset), expected=producer(superset) =>
+  // the consumer body cannot satisfy the producer's required field => incompatible.
+  mk('reqdir', 'Req_Superset', 'Req_Subset', { type_kind: 'request' }),
+];
+
+function byKey(verdicts: CheckVerdict[]): Map<string, CheckVerdict> {
+  return new Map(verdicts.map((v) => [v.pair_key, v]));
+}
+
+describe('check_v2 core: four buckets + determinism (real pnpm + tsc)', () => {
+  let verdicts: Map<string, CheckVerdict>;
+
+  before(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-check-v2-stubs-'));
+    writeStub(
+      root,
+      'orders',
+      [
+        'export type C_Sent = { a: string; };',
+        'export type I_Sent = { a: string; };',
+        'export type U_Sent = unknown;',
+        'export type A_Sent = any;',
+        'export type Req_Superset = { a: string; b: number; };',
+      ].join('\n') + '\n'
+    );
+    writeStub(
+      root,
+      'web',
+      [
+        'export type C_Exp = { a: string; };',
+        'export type I_Exp = { a: string; b: number; };',
+        'export type U_Exp = { a: string; };',
+        'export type A_Exp = { a: string; };',
+        'export type Req_Subset = { a: string; };',
+      ].join('\n') + '\n'
+    );
+    stubs = [
+      { service_name: 'orders', stub_dir: path.join(root, 'orders') },
+      { service_name: 'web', stub_dir: path.join(root, 'web') },
+    ];
+    const result = await runCheck({ stubs, pairs: PAIRS });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    assert.strictEqual(result.isolation, 'pnpm');
+    assert.strictEqual(result.install_ok, true);
+    verdicts = byKey(result.verdicts);
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('bucket 1 — compatible: identical/assignable types', () => {
+    const v = verdicts.get('compatible')!;
+    assert.strictEqual(v.bucket, 'compatible');
+    assert.strictEqual(v.diagnostic, undefined);
+  });
+
+  it('bucket 2 — incompatible: real TS text is the report', () => {
+    const v = verdicts.get('incompatible')!;
+    assert.strictEqual(v.bucket, 'incompatible');
+    assert.match(v.diagnostic!, /Property 'b' is missing/);
+    assert.ok(v.codes.includes(2741));
+  });
+
+  it('bucket 3 — unverifiable: a side decayed to unknown (gate fired)', () => {
+    const v = verdicts.get('unverifiable')!;
+    assert.strictEqual(v.bucket, 'unverifiable');
+    assert.strictEqual(v.gate, 'producer:unknown');
+  });
+
+  it('bucket 4 — gate_caught_baked_any: a side is any (IsAny gate)', () => {
+    const v = verdicts.get('bakedany')!;
+    assert.strictEqual(v.bucket, 'gate_caught_baked_any');
+    assert.strictEqual(v.gate, 'producer:any');
+  });
+
+  it('HTTP request-body direction is inverted (consumer <= producer)', () => {
+    // With the buggy producer<=consumer direction this pair would read
+    // compatible; the direction table makes it correctly incompatible.
+    const v = verdicts.get('reqdir')!;
+    assert.strictEqual(v.bucket, 'incompatible');
+  });
+
+  it('diagnostics carry no absolute paths or scan internals', () => {
+    for (const v of verdicts.values()) {
+      if (!v.diagnostic) continue;
+      assert.ok(!/\/(private\/)?tmp\//.test(v.diagnostic), v.diagnostic);
+      assert.ok(!v.diagnostic.includes(os.tmpdir()), v.diagnostic);
+    }
+  });
+
+  it('verdicts are byte-stable across two independent runs', async () => {
+    const a = await runCheck({ stubs, pairs: PAIRS });
+    const b = await runCheck({ stubs, pairs: PAIRS });
+    assert.strictEqual(
+      JSON.stringify(a.verdicts),
+      JSON.stringify(b.verdicts),
+      'verdict payloads must be byte-identical'
+    );
+  });
+});


### PR DESCRIPTION
Stacked on #415 (`feat/v2-wp1-capture-core`). Do not merge before #415; do not merge into main until the WP3/WP4/WP8 release bundle.

## Scope

WP2 of the type-compat v2 migration: the deterministic check phase ("tsc as the judge"), consuming the WP1 capture stub packages and producing four-bucket verdicts. Additive behind a new `check_v2` stdio action; Rust does not call it yet (WP3). No Rust changes, no prompt or schema changes.

Everything lives inside the capture/check bundle (`src/sidecar/src/capture/`), same seam as WP1 (pinned decision 11a): the bundle imports only node builtins, `typescript`, and itself; the sidecar reaches it through the `capture/index.js` door only. The seam test covers the new files and stays green.

- `check-workspace.ts`: scratch pnpm workspace (node-linker isolated, per-stub node_modules), semver dedupe via pnpm overrides. Same-major drift collapses to the group max so byte-identical private-member classes stop producing nominal false-incompatibles (the banked TS2322 finding); conflicting majors stay physically duplicated and verdict incompatible, correctly.
- `check-probe.ts`: one probe per matched pair. Six top/bottom gates (IsAny/IsUnknown/IsNever, both sides) around a value-level assignment. The (protocol, type_kind) direction table lives here, one place, and structurally fixes the confirmed HTTP request-body direction inversion. Pair IDs are FNV-1a over pair identity, never a path.
- `check-classify.ts`: parses `tsc --pretty false` output and classifies by diagnostic code + file + recorded probe line into compatible / incompatible / unverifiable / gate_caught_baked_any. Stub poisoning: any diagnostic in a stub's own tree degrades every pair touching that stub (covers the TS2717 declare-global collision class, which attributes to one stub only).
- `check-scrub.ts`: user-facing messages keep real compiler text (`TS2741 Property 'b' is missing in type ...`) but never an absolute path. Stub paths become `@carrick/<service>` labels, pnpm store paths become `pkg@version`, and the probe's `Sent`/`Expected` aliases are rewritten to the real surface alias names.
- `check.ts`: async runner. pnpm install and the tsc CLI are spawned, not execSync, so the event loop stays free; `status: 'progress'` keepalive frames precede the terminal response (the async install protocol). Missing pnpm fails explicitly with `isolation: 'unavailable'` rather than falling back to a flat npm install.
- pnpm 9.15.9 vendored as a sidecar devDependency, installed by the existing `npm ci` step, invoked as `node_modules/.bin/pnpm`. No corepack.

The judge is the `tsc` CLI with no compiler API use, which keeps the check phase TS7-ready by construction (design doc, TS version policy).

## Install-cost measurement (required before WP3)

Measured on a dep-heavy two-stub set (12 dependency pins, 7 distinct packages including `@types/*`, 42 resolved packages with transitives, 49MB node_modules), Apple Silicon macOS, warm network:

| Path | Wall clock | Peak RSS |
|---|---|---|
| pnpm cold install (fresh store) | 2.5s | 411MB |
| tsc probe check | 0.4s | 304MB |
| Full `runCheck`, cold store | 2.9 to 3.2s | 423 to 426MB |
| Full `runCheck`, warm store | 2.1s | 398MB |

Verdict: not prohibitive. The WP5 content-addressed cache remains an optimisation, not a prerequisite, at corpus scale. Cost grows with the number of unique pinned packages, so a fleet-scale stub set will be slower but bounded by the same shape; CI runners get the cold path as the norm, as the design assumes.

## Acceptance evidence

- End-to-end check on two corpus fixtures over the stdio wire (capture_v2 then check_v2): xrepo-corpus-2 `orders-engine`/`billing-svc` OrderPlaced edge and xrepo-corpus-3 `orders-api`/`fulfillment-worker` dispatch edge. Both deliberate incompatibilities resolve as incompatible, and the full verdict payload is byte-identical across two independent check runs (pinned by test).
- Four classifier buckets each pinned by their own test (integration on real pnpm + tsc, plus pure-unit precedence coverage).
- Gate precedence pinned: an unknown-decayed side produces both a gate TS2344 and an assignment TS2322 in the same probe; the classifier reads the gate first, otherwise unverifiable pairs would mislabel as incompatible.
- Diagnostic scrub pinned: no absolute path or scan internal in any verdict diagnostic; real TS elaboration text preserved.
- Full `cargo test` green (34 test binaries, exit 0). Sidecar suite: 183 tests, 182 pass, 0 fail (1 pre-existing skip). fmt and clippy clean. Cassette hard gate green. Seam test green.
- Pre-commit hook (fmt + clippy + 642 lib tests + ts_check suite) ran green on every commit.

## Notes and limitations

- The corpus-3 services without lockfiles (`fulfillment-worker` here) exercised the no-lockfile path: capture emits no pins for closures without external references, so the check install is trivially clean. Closures that do reference externals on those services will need the separate corpus-3 lockfile PR (targets main) before their pins resolve.
- The HTTP request-body direction fix means WP3's verdict join must not re-invert; the direction table is the single source.
- `strict-peer-dependencies=false` and `auto-install-peers=false` are set in the workspace `.npmrc` for determinism; peer conflicts degrade through the probe gates rather than failing the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
