### PR TITLE
fix: type-compat v2 adversarial-review fixes (false-compatible cluster + correctness + determinism)

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2845,10 +2845,14 @@ fn enrich_manifest_with_type_resolution(
         }
 
         if let Some((type_string, is_explicit)) = resolved_types.get(&entry.type_alias) {
-            // Check if the type is actually resolved (not "unknown")
-            let is_unknown_type = type_string.trim() == "unknown"
-                || type_string.trim() == "any"
-                || type_string.is_empty()
+            // Check if the type is actually resolved. The shared
+            // disqualifying-top-type notion (adversarial-review finding 2)
+            // rejects not just whole-string "any"/"unknown" but any/unknown
+            // at ANY position — `any[]`, `Promise<any>`, `Record<string,
+            // any>`, `{ metadata: any }` — matching the capture self-check's
+            // deep walk, so the two layers agree on what counts as resolved.
+            let is_unknown_type = type_string.trim().is_empty()
+                || type_compat_v2::contains_disqualifying_top_type(type_string)
                 || dts_trivially_unknown(&entry.type_alias);
 
             if is_unknown_type {

--- a/src/engine/type_compat_v2.rs
+++ b/src/engine/type_compat_v2.rs
@@ -51,11 +51,90 @@ fn repo_relative(file_path: &str, repo_root: &str) -> String {
     stripped.strip_prefix("./").unwrap_or(stripped).to_string()
 }
 
+/// One shared notion of a "disqualifying top type" in printed TypeScript
+/// type text (adversarial-review finding 2, aligned with the capture
+/// self-check's deep walk): `any` or `unknown` appearing as a TYPE token at
+/// ANY position — the whole text, an element (`any[]`), a type argument
+/// (`Promise<any>`, `Record<string, any>`), a member
+/// (`{ metadata: any }`), or an index signature (`{ [k: string]: any }`).
+/// Such text must never anchor a literal capture or count as a resolved
+/// shape: `any` is bidirectionally assignable, so an arbitrary counterparty
+/// shape would read compatible, and `unknown` is the scrubbers' failed-
+/// inference placeholder.
+///
+/// String-literal types are stripped first (`{ kind: "any" }` is fine) and
+/// property-NAME positions are excluded (`{ any: string }`, `{ any?: T }`).
+/// The error direction is deliberate: a false positive only demotes toward
+/// unverifiable; a false negative is a false-compatible.
+pub(crate) fn contains_disqualifying_top_type(text: &str) -> bool {
+    let scrubbed = strip_string_literal_contents(text);
+    let bytes = scrubbed.as_bytes();
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b == b'$';
+    for keyword in ["any", "unknown"] {
+        let mut search_from = 0;
+        while let Some(pos) = scrubbed[search_from..].find(keyword) {
+            let begin = search_from + pos;
+            let end = begin + keyword.len();
+            search_from = begin + 1;
+            // Identifier boundaries (`company`, `unknownField`, `Anything`).
+            if begin > 0 && is_ident(bytes[begin - 1]) {
+                continue;
+            }
+            if end < bytes.len() && is_ident(bytes[end]) {
+                continue;
+            }
+            // Property-name position: printers emit `name: T` / `name?: T`
+            // with the colon immediately after the name.
+            let rest = &bytes[end..];
+            let rest = if rest.first() == Some(&b'?') {
+                &rest[1..]
+            } else {
+                rest
+            };
+            if rest.first() == Some(&b':') {
+                continue;
+            }
+            return true;
+        }
+    }
+    false
+}
+
+/// Replace the CONTENTS of string-literal types with nothing, keeping the
+/// quotes, so `{ kind: "any" }` cannot false-positive the token scan.
+fn strip_string_literal_contents(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars();
+    while let Some(c) = chars.next() {
+        out.push(c);
+        if c == '\'' || c == '"' || c == '`' {
+            let quote = c;
+            let mut escaped = false;
+            for inner in chars.by_ref() {
+                if escaped {
+                    escaped = false;
+                    continue;
+                }
+                if inner == '\\' {
+                    escaped = true;
+                } else if inner == quote {
+                    out.push(quote);
+                    break;
+                }
+            }
+        }
+    }
+    out
+}
+
 /// A v1 inferred type text is usable as a literal anchor when it carries an
-/// actual shape (not the unknown/any placeholders the scrubbers leave).
+/// actual shape: not the unknown/any placeholders the scrubbers leave, and
+/// not container-decayed text (`any[]`, `Promise<any>`, `Record<string,
+/// any>`, `{ metadata: any }`) — a rejected text falls back to the
+/// locator-based infer anchor, whose result the capture self-check owns.
 fn usable_inferred_text(text: &str) -> Option<&str> {
     let trimmed = text.trim().trim_end_matches(';').trim();
-    if trimmed.is_empty() || trimmed == "unknown" || trimmed == "any" {
+    if trimmed.is_empty() || contains_disqualifying_top_type(trimmed) {
         None
     } else {
         Some(trimmed)
@@ -869,6 +948,123 @@ mod tests {
                 assert_eq!(type_text, "{ ok: boolean }");
             }
             other => panic!("expected literal anchor, got {:?}", other),
+        }
+    }
+
+    // ---- contains_disqualifying_top_type ----------------------------------
+
+    /// The shared notion: any/unknown as a TYPE token at any position
+    /// disqualifies (adversarial-review finding 2); property names, string
+    /// literals, and ordinary identifiers containing the words do not.
+    #[test]
+    fn disqualifying_top_type_token_scan() {
+        for text in [
+            "any",
+            "unknown",
+            "any[]",
+            "Array<any>",
+            "Promise<any>",
+            "Record<string, any>",
+            "{ [k: string]: any }",
+            "{ orderId: string; metadata: any }",
+            "{ a: { b: unknown } }",
+            "{ items: any[] }",
+            "Promise<{ data: unknown }>",
+            "(string | any)[]",
+        ] {
+            assert!(
+                contains_disqualifying_top_type(text),
+                "must disqualify: {text}"
+            );
+        }
+        for text in [
+            "{ ok: boolean }",
+            "string[]",
+            "Promise<{ a: string }>",
+            "{ kind: \"any\" }",
+            "{ kind: 'unknown' }",
+            "{ any: string }",
+            "{ any?: string }",
+            "{ unknown: number }",
+            "{ company: string }",
+            "Anything",
+            "{ unknownField: number; anyhow: string }",
+        ] {
+            assert!(
+                !contains_disqualifying_top_type(text),
+                "must NOT disqualify: {text}"
+            );
+        }
+    }
+
+    /// Container-decayed v1 inference text (`Promise<any>`, `any[]`, member
+    /// any) must NOT ride a literal anchor: pre-fix it became a literal
+    /// surface alias that probed clean and read compatible. Rejected text
+    /// falls back to the locator-based infer anchor.
+    #[test]
+    fn derive_anchors_rejects_container_decayed_inferred_text() {
+        let infer_item = |alias: &str| crate::services::type_sidecar::InferRequestItem {
+            file_path: "src/bus.ts".to_string(),
+            line_number: 4,
+            span_start: None,
+            span_end: None,
+            expression_text: Some("payload".to_string()),
+            expression_line: Some(4),
+            infer_kind: InferKind::Expression,
+            alias: Some(alias.to_string()),
+            param_name: None,
+        };
+        let inferred_type = |alias: &str, text: &str| crate::services::type_sidecar::InferredType {
+            alias: alias.to_string(),
+            type_string: text.to_string(),
+            is_explicit: false,
+            source_location: crate::services::type_sidecar::SourceLocation {
+                file_path: "src/bus.ts".to_string(),
+                start_line: 4,
+                end_line: 4,
+                start_column: None,
+                end_column: None,
+            },
+            infer_kind: InferKind::Expression,
+            primary_type_symbol: None,
+            array_depth: None,
+        };
+
+        let infer = vec![
+            infer_item("Pub_PromiseAny"),
+            infer_item("Pub_ArrayAny"),
+            infer_item("Pub_MemberAny"),
+            infer_item("Pub_Clean"),
+        ];
+        let inferred = vec![
+            inferred_type("Pub_PromiseAny", "Promise<any>"),
+            inferred_type("Pub_ArrayAny", "any[]"),
+            inferred_type("Pub_MemberAny", "{ orderId: string; metadata: any }"),
+            inferred_type("Pub_Clean", "{ ok: boolean }"),
+        ];
+
+        let anchors = derive_capture_anchors(&[], &infer, &[], &inferred, ".");
+        assert_eq!(anchors.len(), 4);
+        for (anchor, alias) in
+            anchors
+                .iter()
+                .zip(["Pub_PromiseAny", "Pub_ArrayAny", "Pub_MemberAny"])
+        {
+            match anchor {
+                CaptureAnchor::Infer { alias: a, .. } => assert_eq!(a, alias),
+                other => {
+                    panic!("{alias}: decayed text must fall back to an infer anchor, got {other:?}")
+                }
+            }
+        }
+        match &anchors[3] {
+            CaptureAnchor::Literal {
+                alias, type_text, ..
+            } => {
+                assert_eq!(alias, "Pub_Clean");
+                assert_eq!(type_text, "{ ok: boolean }");
+            }
+            other => panic!("clean text must stay a literal anchor, got {other:?}"),
         }
     }
 

--- a/src/services/type_sidecar.rs
+++ b/src/services/type_sidecar.rs
@@ -295,6 +295,14 @@ pub struct CaptureAliasRecord {
     #[serde(default)]
     pub capture_failure_reason: Option<String>,
     pub top_type_at_self_check: bool,
+    /// Set when the self-check found a disqualifying `any`/`unknown` at
+    /// DEPTH (member / element / index signature / type argument) with no
+    /// failing-external explanation; the check phase pre-gates these pairs.
+    #[serde(default)]
+    pub deep_top_type_kind: Option<String>,
+    /// Member path of the deep find, e.g. `metadata` or `items<0>.meta`.
+    #[serde(default)]
+    pub deep_top_type_path: Option<String>,
 }
 
 /// Aggregate fidelity metric for one service's capture.

--- a/src/sidecar/src/capture/api.ts
+++ b/src/sidecar/src/capture/api.ts
@@ -137,6 +137,16 @@ export interface CaptureAliasRecord {
    * With self_check === 'allowlisted_external' this is expected on a bare
    * checkout and is NOT a decay; the probe gates own the final verdict. */
   top_type_at_self_check: boolean;
+  /**
+   * Set when the self-check found a disqualifying `any`/`unknown` at DEPTH
+   * (member / element / index signature / type argument) with no failing
+   * pinned-external explanation. The check phase pre-gates exactly these
+   * aliases: its whole-type probe gates cannot see member-level decay, and
+   * `any` at any depth lets an arbitrary counterparty shape read compatible.
+   */
+  deep_top_type_kind?: 'any' | 'unknown';
+  /** Member path of the deep find, e.g. `metadata` or `items<0>.meta`. */
+  deep_top_type_path?: string;
 }
 
 /** Aggregate fidelity metric, emitted per capture (one service). */

--- a/src/sidecar/src/capture/api.ts
+++ b/src/sidecar/src/capture/api.ts
@@ -298,6 +298,10 @@ export interface CheckOptions {
   /** Absolute path to the vendored pnpm binary. Defaults to the sidecar's
    * own node_modules/.bin/pnpm resolved from this bundle's location. */
   pnpmPath?: string;
+  /** Absolute path to the tsc CLI. Defaults to the sidecar's own
+   * node_modules/.bin/tsc. Tests inject a stand-in to pin the
+   * abnormal-termination path. */
+  tscPath?: string;
   /** Delete the scratch workspace before returning (default true). Tests that
    * inspect the assembled tree pass false. */
   cleanup?: boolean;

--- a/src/sidecar/src/capture/check-workspace.ts
+++ b/src/sidecar/src/capture/check-workspace.ts
@@ -252,6 +252,14 @@ const NPMRC = [
   'strict-peer-dependencies=false',
   // Determinism: install exactly the pinned closure, no implicit peer pull-in.
   'auto-install-peers=false',
+  // Determinism: the scratch workspace has no committed lockfile, so the
+  // transitive closure would otherwise be a pure function of live registry
+  // state. prefer-offline resolves from the local store/metadata cache
+  // whenever possible (byte-stable across runs on a host), and the explicit
+  // resolution-mode pins pnpm's resolver behavior across pnpm versions.
+  // Direct deps are exact-pinned by the stubs; only transitives resolve.
+  'prefer-offline=true',
+  'resolution-mode=highest',
   '',
 ].join('\n');
 

--- a/src/sidecar/src/capture/check-workspace.ts
+++ b/src/sidecar/src/capture/check-workspace.ts
@@ -61,9 +61,17 @@ function parseVersion(v: string): ParsedVersion {
   };
 }
 
-/** Semver compat key: same key => dedupe candidates. 0.x is minor-scoped. */
+/**
+ * Semver compat key: same key => dedupe candidates. 0.x is minor-scoped, and
+ * 0.0.x is patch-scoped: semver treats every 0.0.x release as its own
+ * breaking boundary, so 0.0.3 and 0.0.5 must never collapse onto one
+ * physical copy (that would manufacture a false-compatible for by-reference
+ * library types).
+ */
 function compatKey(v: ParsedVersion): string {
-  return v.major > 0 ? `${v.major}` : `0.${v.minor}`;
+  if (v.major > 0) return `${v.major}`;
+  if (v.minor > 0) return `0.${v.minor}`;
+  return `0.0.${v.patch}`;
 }
 
 function versionGreater(a: ParsedVersion, b: ParsedVersion): boolean {

--- a/src/sidecar/src/capture/check.ts
+++ b/src/sidecar/src/capture/check.ts
@@ -105,7 +105,7 @@ export async function runCheck(
   const progress: CheckProgress = onProgress ?? (() => {});
   const cleanup = opts.cleanup !== false;
   const pnpmPath = opts.pnpmPath ?? binPath('pnpm');
-  const tscPath = binPath('tsc');
+  const tscPath = opts.tscPath ?? binPath('tsc');
   const tsVersion = ts.version;
 
   // Isolation is non-negotiable: without the vendored pnpm we would fall back
@@ -216,6 +216,49 @@ export async function runCheck(
     ws.workspaceDir
   );
   const diagnostics = parseTscOutput(tsc.stdout + '\n' + tsc.stderr);
+
+  // Abnormal tsc termination: OOM/SIGKILL (exit code null), an internal
+  // crash, or a fileless config error (e.g. TS18003, printed without a
+  // (line,col) prefix) all yield ZERO parseable diagnostics — and an empty
+  // diagnostic set must never fall through to "compatible". A non-zero exit
+  // WITH parsed diagnostics is the legitimate incompatible path (tsc exits 1
+  // on ordinary type errors) and stays untouched. Mirrors the install step's
+  // `code === 0` guard.
+  if (tsc.code !== 0 && diagnostics.length === 0) {
+    const excerpt = scrubPaths(
+      (tsc.stderr || tsc.stdout).trim().slice(0, 2000),
+      scrubCtx
+    );
+    errors.push(
+      `tsc terminated abnormally (exit code ${tsc.code ?? 'null'}) ` +
+        `with no parseable diagnostics${excerpt ? `: ${excerpt}` : ''}`
+    );
+    for (const s of opts.stubs) {
+      degraded.push({
+        service_name: s.service_name,
+        reason: 'type checker terminated abnormally',
+      });
+    }
+    const verdicts = sortVerdicts([
+      ...unverifiableAll(
+        plans,
+        'tsc:abnormal-termination',
+        'the type checker terminated abnormally; compatibility cannot be verified.'
+      ),
+      ...unresolved,
+    ]);
+    if (cleanup) safeRm(ws.workspaceDir);
+    return {
+      success: false,
+      workspace_dir: cleanup ? '' : ws.workspaceDir,
+      isolation: 'pnpm',
+      install_ok: true,
+      ts_version: tsVersion,
+      verdicts,
+      degraded_services: dedupeDegraded(degraded),
+      errors,
+    };
+  }
 
   const { probeDiagsByPair, poison, globalErrors } = attributeDiagnostics(
     diagnostics,

--- a/src/sidecar/src/capture/check.ts
+++ b/src/sidecar/src/capture/check.ts
@@ -21,9 +21,11 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 import type {
+  CaptureAliasRecord,
   CheckOptions,
   CheckProgressPhase,
   CheckResult,
+  CheckStubInput,
   CheckVerdict,
   DegradedService,
 } from './api.js';
@@ -168,7 +170,36 @@ export async function runCheck(
     const spec = opts.pairs.find((p) => p.pair_key === v.pair_key)!;
     v.pair_id = fnvOfSpec(spec);
   }
-  writeProbes(ws, plans);
+
+  // Capture-time deep-decay pre-gate (adversarial-review finding 1): a
+  // member-level `any`/`unknown` recorded by the capture self-check with no
+  // failing-external explanation. The probe gates below are WHOLE-type only
+  // — `{ orderId: string; metadata: any }` sails through IsAny and the
+  // assignment compiles clean — so such pairs must never reach a probe.
+  // `any` routes to gate_caught_baked_any, `unknown` to unverifiable; both
+  // read as None downstream, never compatible.
+  const aliasRecords = readStubAliasRecords(opts.stubs);
+  const preGated: CheckVerdict[] = [];
+  const probing: ProbePlan[] = [];
+  for (const plan of plans) {
+    const hit = deepDecayOf(plan, aliasRecords);
+    if (!hit) {
+      probing.push(plan);
+      continue;
+    }
+    preGated.push({
+      pair_id: plan.pairId,
+      pair_key: plan.spec.pair_key,
+      bucket: hit.kind === 'any' ? 'gate_caught_baked_any' : 'unverifiable',
+      gate: `capture:${hit.side}:${hit.kind}`,
+      diagnostic:
+        `the ${hit.side} type carries '${hit.kind}' at '${hit.path}' from ` +
+        `capture; compatibility cannot be verified (a partially-unresolved ` +
+        `type would let an arbitrary shape read compatible).`,
+      codes: [],
+    });
+  }
+  writeProbes(ws, probing);
 
   const errors: string[] = [];
   const degraded: DegradedService[] = [];
@@ -188,10 +219,12 @@ export async function runCheck(
     }
     const verdicts = sortVerdicts([
       ...unverifiableAll(
-        plans,
+        probing,
         'install:failed',
         'workspace dependency install failed; compatibility cannot be verified.'
       ),
+      // Capture-decay verdicts stand regardless of the install outcome.
+      ...preGated,
       ...unresolved,
     ]);
     if (cleanup) safeRm(ws.workspaceDir);
@@ -241,10 +274,11 @@ export async function runCheck(
     }
     const verdicts = sortVerdicts([
       ...unverifiableAll(
-        plans,
+        probing,
         'tsc:abnormal-termination',
         'the type checker terminated abnormally; compatibility cannot be verified.'
       ),
+      ...preGated,
       ...unresolved,
     ]);
     if (cleanup) safeRm(ws.workspaceDir);
@@ -263,7 +297,7 @@ export async function runCheck(
   const { probeDiagsByPair, poison, globalErrors } = attributeDiagnostics(
     diagnostics,
     ws,
-    plans
+    probing
   );
   for (const e of globalErrors) errors.push(scrubPaths(e, scrubCtx));
   for (const [service, reason] of poison) {
@@ -271,7 +305,7 @@ export async function runCheck(
   }
 
   const verdicts = sortVerdicts([
-    ...plans.map((plan) =>
+    ...probing.map((plan) =>
       classifyPair({
         plan,
         probeDiags: probeDiagsByPair.get(plan.pairId) ?? [],
@@ -279,6 +313,7 @@ export async function runCheck(
         scrubCtx,
       })
     ),
+    ...preGated,
     ...unresolved,
   ]);
 
@@ -295,6 +330,57 @@ export async function runCheck(
     degraded_services: dedupeDegraded(degraded),
     errors,
   };
+}
+
+/**
+ * Per-service alias records from each stub's carrick-manifest.json. Absent
+ * or unparseable manifests (e.g. hand-authored stubs in tests) contribute
+ * nothing — only positively-recorded deep decay pre-gates a pair.
+ */
+function readStubAliasRecords(
+  stubs: CheckStubInput[]
+): Map<string, Map<string, CaptureAliasRecord>> {
+  const byService = new Map<string, Map<string, CaptureAliasRecord>>();
+  for (const stub of stubs) {
+    try {
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(stub.stub_dir, 'carrick-manifest.json'), 'utf8')
+      ) as { aliases?: CaptureAliasRecord[] };
+      const byAlias = new Map<string, CaptureAliasRecord>();
+      for (const record of manifest.aliases ?? []) {
+        if (record?.alias) byAlias.set(record.alias, record);
+      }
+      byService.set(stub.service_name, byAlias);
+    } catch {
+      // No manifest: nothing to pre-gate for this stub.
+    }
+  }
+  return byService;
+}
+
+interface DeepDecayHit {
+  side: 'producer' | 'consumer';
+  kind: 'any' | 'unknown';
+  path: string;
+}
+
+/** First side (producer, then consumer) whose capture recorded a deep decay. */
+function deepDecayOf(
+  plan: ProbePlan,
+  aliasRecords: Map<string, Map<string, CaptureAliasRecord>>
+): DeepDecayHit | undefined {
+  for (const side of ['producer', 'consumer'] as const) {
+    const endpoint = plan.spec[side];
+    const record = aliasRecords.get(endpoint.service_name)?.get(endpoint.alias);
+    if (record?.deep_top_type_kind) {
+      return {
+        side,
+        kind: record.deep_top_type_kind,
+        path: record.deep_top_type_path ?? '<unknown>',
+      };
+    }
+  }
+  return undefined;
 }
 
 /** Group diagnostics: per-probe (for classification), plus stub-tree poison. */

--- a/src/sidecar/src/capture/lockfile.ts
+++ b/src/sidecar/src/capture/lockfile.ts
@@ -2,6 +2,13 @@
  * Exact-version dependency pins from the producer repo's lockfile (pinned
  * decision 2: stub packages pin FROM THE LOCKFILE; npm and pnpm lockfiles in
  * scope, yarn-berry is a tracked follow-up).
+ *
+ * Pin selection prefers the DIRECT (top-level) dependency version: a package
+ * present at multiple versions must pin to the version the emitted tree
+ * resolves against — the hoisted/direct install — never to whichever nested
+ * copy happens to appear first in the lockfile (npm sorts
+ * `node_modules/a/node_modules/b` before `node_modules/b`, so first-match
+ * picks a nested version the tree never sees).
  */
 
 import * as fs from 'node:fs';
@@ -10,14 +17,25 @@ import * as path from 'node:path';
 /** package-lock.json (v2/v3 `packages` map, v1 `dependencies` fallback). */
 function npmLockfileVersions(lockPath: string): Map<string, string> {
   const versions = new Map<string, string>();
+  const nested = new Map<string, string>();
   try {
     const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
     if (lock.packages && typeof lock.packages === 'object') {
       for (const [key, entry] of Object.entries<{ version?: string }>(lock.packages)) {
         const idx = key.lastIndexOf('node_modules/');
-        if (idx === -1) continue;
+        if (idx === -1 || !entry?.version) continue;
         const name = key.slice(idx + 'node_modules/'.length);
-        if (entry?.version && !versions.has(name)) versions.set(name, entry.version);
+        // Direct dependency: the top-level install path, exactly
+        // `node_modules/<name>` (idx === 0 means no nesting prefix).
+        if (idx === 0) {
+          if (!versions.has(name)) versions.set(name, entry.version);
+        } else if (!nested.has(name)) {
+          nested.set(name, entry.version);
+        }
+      }
+      // Nested copies only pin packages with no top-level install at all.
+      for (const [name, version] of nested) {
+        if (!versions.has(name)) versions.set(name, version);
       }
     } else if (lock.dependencies && typeof lock.dependencies === 'object') {
       for (const [name, entry] of Object.entries<{ version?: string }>(lock.dependencies)) {
@@ -30,33 +48,89 @@ function npmLockfileVersions(lockPath: string): Map<string, string> {
   return versions;
 }
 
+/** Strip a pnpm peer suffix / quoting from a resolved version value. */
+function cleanPnpmVersion(raw: string): string {
+  return raw.trim().replace(/^['"]|['"]$/g, '').split('(')[0].trim();
+}
+
 /**
- * pnpm-lock.yaml `packages:` section. Keys look like `/zod@3.23.0:` (v6),
- * `zod@3.23.0:` (v9), `/@scope/pkg@1.2.3(peer@x)…:`. A targeted line parse
- * avoids a YAML dependency; peer-suffix parentheses are stripped.
+ * pnpm-lock.yaml. Two tiers, both via a targeted line parse (no YAML dep):
+ *
+ *  1. `importers:` — every importer's dependencies/devDependencies/
+ *     optionalDependencies with their RESOLVED `version:` values. These are
+ *     the direct (top-level) installs and win.
+ *  2. `packages:` — the flat closure. Keys look like `/zod@3.23.0:` (v6),
+ *     `zod@3.23.0:` (v9), `/@scope/pkg@1.2.3(peer@x)…:`. Fallback for
+ *     packages that are not a direct dependency of any importer; the
+ *     packages map is name-sorted, so first-match here would otherwise pin
+ *     the LOWEST version of a multi-version package.
  */
 function pnpmLockfileVersions(lockPath: string): Map<string, string> {
-  const versions = new Map<string, string>();
+  const direct = new Map<string, string>();
+  const fallback = new Map<string, string>();
   try {
     const text = fs.readFileSync(lockPath, 'utf8');
     const lines = text.split('\n');
+
     let inPackages = false;
+    let inImporters = false;
+    let inDepsSection = false;
+    let currentDep: string | undefined;
+
     for (const line of lines) {
-      if (/^packages:\s*$/.test(line)) {
-        inPackages = true;
+      if (/^\S/.test(line)) {
+        // New top-level key.
+        inPackages = /^packages:\s*$/.test(line);
+        inImporters = /^importers:\s*$/.test(line);
+        inDepsSection = false;
+        currentDep = undefined;
         continue;
       }
-      if (inPackages && /^\S/.test(line)) inPackages = false; // next top-level key
-      if (!inPackages) continue;
-      // Two-space-indented keys only (package entries), e.g.
-      //   /zod@3.23.0: | 'zod@3.23.0': | /@scope/pkg@1.2.3(peer@1.0.0):
-      const m = /^ {2}['"]?\/?((?:@[^/@'"]+\/)?[^/@'"]+)@([^('":]+)/.exec(line);
-      if (!m) continue;
-      const [, name, version] = m;
-      if (!versions.has(name)) versions.set(name, version.trim());
+
+      if (inImporters) {
+        // `  <importer>:` (2-space) resets; `    dependencies:` (4-space)
+        // opens a deps section; `      <name>:` (6-space) names a dep;
+        // `        version: <v>` (8-space) resolves it.
+        if (/^ {2}\S/.test(line)) {
+          inDepsSection = false;
+          currentDep = undefined;
+        } else if (/^ {4}\S/.test(line)) {
+          inDepsSection = /^ {4}(dependencies|devDependencies|optionalDependencies):\s*$/.test(
+            line
+          );
+          currentDep = undefined;
+        } else if (inDepsSection && /^ {6}\S/.test(line)) {
+          const m = /^ {6}['"]?([^'":]+)['"]?:\s*(\S.*)?$/.exec(line);
+          currentDep = m?.[1];
+          // Old inline form: `      zod: 3.23.8`.
+          if (m?.[1] && m[2] && !direct.has(m[1])) {
+            const v = cleanPnpmVersion(m[2]);
+            if (/^\d/.test(v)) direct.set(m[1], v);
+          }
+        } else if (inDepsSection && currentDep && /^ {8}version:/.test(line)) {
+          const v = cleanPnpmVersion(line.slice(line.indexOf(':') + 1));
+          if (v && !direct.has(currentDep) && /^\d/.test(v)) direct.set(currentDep, v);
+          currentDep = undefined;
+        }
+        continue;
+      }
+
+      if (inPackages) {
+        // Two-space-indented keys only (package entries), e.g.
+        //   /zod@3.23.0: | 'zod@3.23.0': | /@scope/pkg@1.2.3(peer@1.0.0):
+        const m = /^ {2}['"]?\/?((?:@[^/@'"]+\/)?[^/@'"]+)@([^('":]+)/.exec(line);
+        if (!m) continue;
+        const [, name, version] = m;
+        if (!fallback.has(name)) fallback.set(name, version.trim());
+      }
     }
   } catch {
     // Unparseable lockfile: every external ends up in unpinned_externals.
+  }
+
+  const versions = new Map<string, string>(direct);
+  for (const [name, version] of fallback) {
+    if (!versions.has(name)) versions.set(name, version);
   }
   return versions;
 }

--- a/src/sidecar/src/capture/self-check.ts
+++ b/src/sidecar/src/capture/self-check.ts
@@ -170,6 +170,100 @@ function demotedRecord(anchor: ResolvedAnchor): CaptureAliasRecord {
   };
 }
 
+/** A disqualifying `any`/`unknown` found below the root of a captured type. */
+interface DeepTopType {
+  kind: 'any' | 'unknown';
+  /** Human-readable member path, e.g. `metadata`, `items<0>.meta`, `[index]`. */
+  path: string;
+}
+
+/**
+ * Depth-bounded structural walk for a disqualifying top type at ANY depth:
+ * a member, array element, index signature, or type argument that resolved
+ * to `any` (bidirectionally assignable — an arbitrary counterparty shape
+ * reads compatible) or `unknown` (a failed-inference bake; carries no shape
+ * information). The check phase's probe gates are WHOLE-type only, so this
+ * walk owns the depths they cannot see.
+ *
+ * Bounded (depth + node budget) and cycle-safe. Types with call/construct
+ * signatures are skipped: callable members are not wire payloads, and lib
+ * callable surfaces legitimately carry `any` parameters. A type the walk
+ * cannot cheaply finish is NOT flagged — over-demoting a legitimately
+ * fully-resolved type is the failure mode this guard must not have.
+ */
+function findDisqualifyingTopType(
+  root: ts.Type,
+  checker: ts.TypeChecker,
+  location: ts.Node
+): DeepTopType | undefined {
+  const MAX_DEPTH = 8;
+  const MAX_VISITED = 256;
+  const seen = new Set<ts.Type>();
+  let visited = 0;
+
+  const flagOf = (t: ts.Type): 'any' | 'unknown' | undefined =>
+    t.flags & ts.TypeFlags.Any
+      ? 'any'
+      : t.flags & ts.TypeFlags.Unknown
+        ? 'unknown'
+        : undefined;
+
+  const walk = (t: ts.Type, path: string, depth: number): DeepTopType | undefined => {
+    if (depth > MAX_DEPTH || visited > MAX_VISITED || seen.has(t)) return undefined;
+    seen.add(t);
+    visited++;
+
+    // Root-level top types are the caller's whole-type check (and the check
+    // phase's probe gates catch them); this walk owns depth > 0.
+    if (depth > 0) {
+      const kind = flagOf(t);
+      if (kind) return { kind, path };
+    }
+
+    if (t.flags & (ts.TypeFlags.Union | ts.TypeFlags.Intersection)) {
+      for (const part of (t as ts.UnionOrIntersectionType).types) {
+        const found = walk(part, path, depth + 1);
+        if (found) return found;
+      }
+      return undefined;
+    }
+
+    if (!(t.flags & ts.TypeFlags.Object)) return undefined;
+
+    if (t.getCallSignatures().length > 0 || t.getConstructSignatures().length > 0) {
+      return undefined;
+    }
+
+    // Type arguments: arrays, tuples, Promise<T>, Map<K, V>, ...
+    if ((t as ts.ObjectType).objectFlags & ts.ObjectFlags.Reference) {
+      const args = checker.getTypeArguments(t as ts.TypeReference);
+      for (let i = 0; i < args.length; i++) {
+        const found = walk(args[i], `${path}<${i}>`, depth + 1);
+        if (found) return found;
+      }
+    }
+
+    // Index signatures: { [k: string]: T }, Record<string, T>.
+    for (const info of checker.getIndexInfosOfType(t)) {
+      const found = walk(info.type, `${path}[index]`, depth + 1);
+      if (found) return found;
+    }
+
+    for (const prop of t.getProperties()) {
+      const propType = checker.getTypeOfSymbolAtLocation(prop, location);
+      const found = walk(
+        propType,
+        path === '' ? prop.getName() : `${path}.${prop.getName()}`,
+        depth + 1
+      );
+      if (found) return found;
+    }
+    return undefined;
+  };
+
+  return walk(root, '', 0);
+}
+
 function checkedRecord(
   anchor: ResolvedAnchor,
   ctx: {
@@ -183,6 +277,7 @@ function checkedRecord(
 ): CaptureAliasRecord {
   const alias = anchor.request.alias;
   let topType = true;
+  let deep: DeepTopType | undefined;
   const seeds: string[] = [];
 
   if (ctx.surfaceSource) {
@@ -191,6 +286,9 @@ function checkedRecord(
       const type = ctx.checker.getTypeAtLocation(stmt.name);
       topType =
         (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Never)) !== 0;
+      if (!topType) {
+        deep = findDisqualifyingTopType(type, ctx.checker, stmt.name);
+      }
       // Seed the closure with the alias's own import-type targets.
       const visit = (node: ts.Node) => {
         if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
@@ -229,23 +327,58 @@ function checkedRecord(
     if (!internalFailure) internalFailure = [...failures.internal][0];
   }
 
+  // Classification consults the closure failures REGARDLESS of the root
+  // type: a dangling internal specifier means part of this alias's closure
+  // is missing and the emitted tree is silently wrong even when the root
+  // resolves to a concrete shape (adversarial-review finding 1).
   let outcome: SelfCheckOutcome = 'ok';
   let detail: string | undefined;
-  if (topType) {
-    if (ctx.args.bareCheckout && blamedExternal && !internalFailure) {
-      const pkg = packageNameOf(blamedExternal);
-      outcome = 'allowlisted_external';
+  const allowlisted = (): void => {
+    const pkg = packageNameOf(blamedExternal!);
+    outcome = 'allowlisted_external';
+    detail =
+      `unresolved external '${blamedExternal}' is pinned ` +
+      `(${pkg}@${ctx.args.pinned[pkg]}); kept at tier ${anchor.serialization} ` +
+      'on bare checkout; probe gates are the backstop';
+  };
+  // `unexplainedDeep`: a member-level any/unknown with NO failing-external
+  // explanation (literal text or the author's own source carried it). The
+  // check phase must pre-gate exactly these — an external-blamed decay can
+  // heal when the check workspace installs the pins, and the probe gates /
+  // poison rule backstop those paths.
+  let unexplainedDeep: DeepTopType | undefined;
+  if (internalFailure) {
+    outcome = 'decayed_internal';
+    detail = `dangling internal specifier '${internalFailure}'`;
+  } else if (topType || deep) {
+    if (blamedExternal) {
+      if (ctx.args.bareCheckout) {
+        allowlisted();
+      } else {
+        outcome = 'decayed_internal';
+        detail = `unresolved pinned external '${blamedExternal}' on an installed checkout`;
+      }
+    } else if (topType) {
+      outcome = 'decayed_internal';
+      detail = 'alias resolved to a top type with no allowlisted external failure';
+    } else {
+      unexplainedDeep = deep;
+      outcome = 'decayed_internal';
       detail =
-        `unresolved external '${blamedExternal}' is pinned ` +
-        `(${pkg}@${ctx.args.pinned[pkg]}); kept at tier ${anchor.serialization} ` +
-        'on bare checkout; probe gates are the backstop';
+        `type carries '${deep!.kind}' at '${deep!.path}' with no allowlisted ` +
+        'external failure; an arbitrary counterparty shape would read compatible';
+    }
+  } else if (blamedExternal) {
+    // The alias's own type is fully concrete, but its closure has failing
+    // pinned-external specifiers — previously invisible behind the topType
+    // gate. On a bare checkout that is the expected amendment-1 shape; on an
+    // installed checkout it means the tree references something the repo's
+    // own node_modules could not resolve.
+    if (ctx.args.bareCheckout) {
+      allowlisted();
     } else {
       outcome = 'decayed_internal';
-      detail = internalFailure
-        ? `dangling internal specifier '${internalFailure}'`
-        : blamedExternal
-          ? `unresolved pinned external '${blamedExternal}' on an installed checkout`
-          : 'alias resolved to a top type with no allowlisted external failure';
+      detail = `unresolved pinned external '${blamedExternal}' on an installed checkout`;
     }
   }
 
@@ -259,6 +392,12 @@ function checkedRecord(
     self_check: outcome,
     self_check_detail: detail,
     top_type_at_self_check: topType,
+    ...(unexplainedDeep
+      ? {
+          deep_top_type_kind: unexplainedDeep.kind,
+          deep_top_type_path: unexplainedDeep.path,
+        }
+      : {}),
   };
 }
 

--- a/src/sidecar/test/capture-v2-deep-any.test.ts
+++ b/src/sidecar/test/capture-v2-deep-any.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Deep (member-level) any/unknown detection — adversarial-review finding 1,
+ * the CRITICAL false-compatible.
+ *
+ * The self-check's top-type gate was WHOLE-type only (`flags & Any|Unknown|
+ * Never` on the alias root), and the check phase's probe gates are whole-type
+ * too. A captured type carrying `any` at a member/element/type-arg position —
+ * `{ orderId: string; metadata: any }`, `any[]`, `Promise<any>`,
+ * `Record<string, any>` — recorded self_check 'ok', probed clean, and the
+ * pair read COMPATIBLE against a counterparty that constrains that position
+ * to a concrete shape. `any` is bidirectionally assignable: an arbitrary
+ * shape reads compatible, which is the dangerous direction.
+ *
+ * Pins:
+ *  1. capture: member/container any|unknown records decayed_internal with a
+ *     deep_top_type_kind/path and a reason;
+ *  2. capture: fully-resolved types (including function-typed members and
+ *     unions) are NOT over-demoted;
+ *  3. check: a pair whose side carries a deep `any` verdicts
+ *     gate_caught_baked_any (None downstream), a deep `unknown` verdicts
+ *     unverifiable — never compatible.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { captureStub, runCheck } from '../src/capture/index.js';
+import type { CaptureAliasRecord, CaptureStubResult } from '../src/capture/api.js';
+
+function captureLiterals(
+  root: string,
+  serviceName: string,
+  literals: Record<string, string>
+): CaptureStubResult {
+  const repoRoot = path.join(root, `${serviceName}-repo`);
+  fs.mkdirSync(repoRoot, { recursive: true });
+  const result = captureStub({
+    repoRoot,
+    serviceName,
+    outDir: path.join(root, `${serviceName}-stub`),
+    anchors: Object.entries(literals).map(([alias, type_text]) => ({
+      kind: 'literal' as const,
+      alias,
+      type_text,
+      anchor_origin: 'deterministic-infer' as const,
+    })),
+  });
+  assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+  return result;
+}
+
+describe('capture self-check: deep any/unknown decays, concrete types do not', () => {
+  let root: string;
+  let byAlias: Map<string, CaptureAliasRecord>;
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-deep-any-'));
+    const result = captureLiterals(root, 'deep-any-svc', {
+      M_MemberAny: '{ orderId: string; metadata: any }',
+      M_MemberUnknown: '{ orderId: string; metadata: unknown }',
+      M_NestedAny: '{ outer: { inner: { leaked: any } } }',
+      C_ArrayAny: 'any[]',
+      C_PromiseAny: 'Promise<any>',
+      C_RecordAny: 'Record<string, any>',
+      C_IndexAny: '{ [k: string]: any }',
+      OK_Concrete: '{ orderId: string; metadata: { source: string } }',
+      OK_Union: '{ v: string | null; w?: number }',
+      OK_Array: '{ items: { sku: string }[] }',
+      OK_FuncMember: '{ id: string; cb: (x: any) => void }',
+    });
+    byAlias = new Map(result.aliases.map((a) => [a.alias, a]));
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('member-level any decays with a recorded reason and kind', () => {
+    const rec = byAlias.get('M_MemberAny')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'any');
+    assert.strictEqual(rec.deep_top_type_path, 'metadata');
+    assert.match(rec.self_check_detail ?? '', /carries 'any'/);
+    // The root is NOT a top type — that is exactly why the old gate missed it.
+    assert.strictEqual(rec.top_type_at_self_check, false);
+  });
+
+  it('member-level unknown decays with kind unknown', () => {
+    const rec = byAlias.get('M_MemberUnknown')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'unknown');
+  });
+
+  it('nested member any is found below the first level', () => {
+    const rec = byAlias.get('M_NestedAny')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'any');
+    assert.strictEqual(rec.deep_top_type_path, 'outer.inner.leaked');
+  });
+
+  it('container-decayed forms (any[], Promise<any>, Record<string, any>, index) decay', () => {
+    for (const alias of ['C_ArrayAny', 'C_PromiseAny', 'C_RecordAny', 'C_IndexAny']) {
+      const rec = byAlias.get(alias)!;
+      assert.strictEqual(rec.self_check, 'decayed_internal', `${alias}: ${rec.self_check_detail}`);
+      assert.strictEqual(rec.deep_top_type_kind, 'any', alias);
+    }
+  });
+
+  it('fully-resolved types are not over-demoted', () => {
+    for (const alias of ['OK_Concrete', 'OK_Union', 'OK_Array', 'OK_FuncMember']) {
+      const rec = byAlias.get(alias)!;
+      assert.strictEqual(rec.self_check, 'ok', `${alias}: ${rec.self_check_detail}`);
+      assert.strictEqual(rec.deep_top_type_kind, undefined, alias);
+    }
+  });
+});
+
+describe('capture self-check: deep any through a symbol anchor', () => {
+  let symRoot: string;
+
+  before(() => {
+    symRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-deep-any-sym-'));
+  });
+
+  after(() => {
+    fs.rmSync(symRoot, { recursive: true, force: true });
+  });
+
+  it('an author-level any member in captured source decays the alias', () => {
+    const repoRoot = path.join(symRoot, 'repo');
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(repoRoot, 'types.ts'),
+      'export interface Order { id: string; meta: any; }\n' +
+        'export interface Clean { id: string; total: number; }\n'
+    );
+    const result = captureStub({
+      repoRoot,
+      serviceName: 'deep-any-symbol-svc',
+      outDir: path.join(symRoot, 'stub'),
+      anchors: [
+        {
+          kind: 'symbol',
+          alias: 'P_Order',
+          symbol_name: 'Order',
+          source_file: 'types.ts',
+          anchor_origin: 'llm-symbol',
+        },
+        {
+          kind: 'symbol',
+          alias: 'P_Clean',
+          symbol_name: 'Clean',
+          source_file: 'types.ts',
+          anchor_origin: 'llm-symbol',
+        },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    const byAlias = new Map(result.aliases.map((a) => [a.alias, a]));
+    const order = byAlias.get('P_Order')!;
+    assert.strictEqual(order.self_check, 'decayed_internal', order.self_check_detail);
+    assert.strictEqual(order.deep_top_type_kind, 'any');
+    assert.strictEqual(order.deep_top_type_path, 'meta');
+    const clean = byAlias.get('P_Clean')!;
+    assert.strictEqual(clean.self_check, 'ok', clean.self_check_detail);
+  });
+});
+
+describe('check phase: capture-recorded deep decay is never read as compatible', () => {
+  let checkRoot: string;
+  let producerStub: string;
+  let consumerStub: string;
+
+  before(() => {
+    checkRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-deep-any-check-'));
+    const producer = captureLiterals(checkRoot, 'deep-producer', {
+      P_MemberAny: '{ orderId: string; metadata: any }',
+      P_MemberUnknown: '{ orderId: string; metadata: unknown }',
+      P_Clean: '{ orderId: string; metadata: { source: string } }',
+    });
+    const consumer = captureLiterals(checkRoot, 'deep-consumer', {
+      C_Concrete: '{ orderId: string; metadata: { source: string } }',
+      C_Concrete2: '{ orderId: string; metadata: { source: string } }',
+      C_Concrete3: '{ orderId: string; metadata: { source: string } }',
+    });
+    producerStub = producer.stub_dir;
+    consumerStub = consumer.stub_dir;
+  });
+
+  after(() => {
+    fs.rmSync(checkRoot, { recursive: true, force: true });
+  });
+
+  it('deep any -> gate_caught_baked_any; deep unknown -> unverifiable; clean pair still probes', async () => {
+    const result = await runCheck({
+      stubs: [
+        { service_name: 'deep-producer', stub_dir: producerStub },
+        { service_name: 'deep-consumer', stub_dir: consumerStub },
+      ],
+      pairs: [
+        {
+          pair_key: 'any-pair',
+          protocol: 'http',
+          type_kind: 'response',
+          producer: { service_name: 'deep-producer', alias: 'P_MemberAny' },
+          consumer: { service_name: 'deep-consumer', alias: 'C_Concrete' },
+        },
+        {
+          pair_key: 'unknown-pair',
+          protocol: 'http',
+          type_kind: 'response',
+          producer: { service_name: 'deep-producer', alias: 'P_MemberUnknown' },
+          consumer: { service_name: 'deep-consumer', alias: 'C_Concrete2' },
+        },
+        {
+          pair_key: 'clean-pair',
+          protocol: 'http',
+          type_kind: 'response',
+          producer: { service_name: 'deep-producer', alias: 'P_Clean' },
+          consumer: { service_name: 'deep-consumer', alias: 'C_Concrete3' },
+        },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    const byKey = new Map(result.verdicts.map((v) => [v.pair_key, v]));
+
+    // Pre-fix this read 'compatible': member-level any sails through the
+    // whole-type IsAny gate and the assignment compiles clean.
+    const anyVerdict = byKey.get('any-pair')!;
+    assert.strictEqual(anyVerdict.bucket, 'gate_caught_baked_any', JSON.stringify(anyVerdict));
+    assert.strictEqual(anyVerdict.gate, 'capture:producer:any');
+    assert.match(anyVerdict.diagnostic ?? '', /metadata/);
+
+    const unknownVerdict = byKey.get('unknown-pair')!;
+    assert.strictEqual(unknownVerdict.bucket, 'unverifiable', JSON.stringify(unknownVerdict));
+    assert.strictEqual(unknownVerdict.gate, 'capture:producer:unknown');
+
+    // A fully-resolved pair still goes through the real probe path.
+    const cleanVerdict = byKey.get('clean-pair')!;
+    assert.strictEqual(cleanVerdict.bucket, 'compatible', JSON.stringify(cleanVerdict));
+  });
+});

--- a/src/sidecar/test/capture-v2-seam.test.ts
+++ b/src/sidecar/test/capture-v2-seam.test.ts
@@ -51,12 +51,38 @@ describe('capture bundle seam (pinned decision 11a)', () => {
   it('capture/ imports only node builtins, typescript, and itself', () => {
     for (const file of tsFiles(CAPTURE)) {
       for (const spec of importsOf(file)) {
-        const ok =
-          spec.startsWith('node:') ||
-          spec === 'typescript' ||
-          spec.startsWith('./');
-        assert.ok(ok, `${path.basename(file)} imports '${spec}' across the seam`);
+        if (spec.startsWith('node:') || spec === 'typescript') continue;
+        // A relative specifier must RESOLVE inside capture/: a `./`-prefixed
+        // escape like `./../legacy.js` or `./sub/../../x.js` is a boundary
+        // violation the bare prefix check waved through (adversarial-review
+        // finding 7).
+        assert.ok(
+          spec.startsWith('./'),
+          `${path.basename(file)} imports '${spec}' across the seam`
+        );
+        const resolved = path.resolve(path.dirname(file), spec);
+        assert.ok(
+          resolved.startsWith(CAPTURE + path.sep),
+          `${path.basename(file)} imports '${spec}', which resolves outside capture/ (${resolved})`
+        );
       }
+    }
+  });
+
+  it('capture/ never uses require() or createRequire (invisible to the import scan)', () => {
+    for (const file of tsFiles(CAPTURE)) {
+      const text = fs
+        .readFileSync(file, 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*\/\/.*$/gm, '');
+      assert.ok(
+        !/\brequire\s*\(/.test(text),
+        `${path.basename(file)} calls require() — a seam crossing the import scan cannot see`
+      );
+      assert.ok(
+        !/\bcreateRequire\b/.test(text),
+        `${path.basename(file)} uses createRequire — a seam crossing the import scan cannot see`
+      );
     }
   });
 

--- a/src/sidecar/test/capture-v2-units.test.ts
+++ b/src/sidecar/test/capture-v2-units.test.ts
@@ -22,7 +22,7 @@ function tempDir(): string {
 }
 
 describe('lockfileVersions', () => {
-  it('parses npm lockfile v3 packages map, first entry wins', () => {
+  it('parses npm lockfile v3 packages map, direct entry wins', () => {
     const dir = tempDir();
     fs.writeFileSync(
       path.join(dir, 'package-lock.json'),
@@ -39,6 +39,77 @@ describe('lockfileVersions', () => {
     const versions = lockfileVersions(dir);
     assert.strictEqual(versions.get('zod'), '3.23.0');
     assert.strictEqual(versions.get('@scope/pkg'), '2.0.1');
+  });
+
+  it('npm: prefers the direct dependency when a nested copy sorts first', () => {
+    // npm sorts `node_modules/a/node_modules/b` BEFORE `node_modules/b`, so
+    // first-match-wins pinned the nested version the emitted tree never
+    // resolves against (adversarial-review finding 4).
+    const dir = tempDir();
+    fs.writeFileSync(
+      path.join(dir, 'package-lock.json'),
+      JSON.stringify({
+        lockfileVersion: 3,
+        packages: {
+          '': {},
+          'node_modules/aaa': { version: '1.0.0' },
+          'node_modules/aaa/node_modules/zod': { version: '2.9.9' },
+          'node_modules/zod': { version: '3.23.0' },
+          // Nested-only package: the nested copy is the only install.
+          'node_modules/aaa/node_modules/nested-only': { version: '5.5.5' },
+        },
+      })
+    );
+    const versions = lockfileVersions(dir);
+    assert.strictEqual(versions.get('zod'), '3.23.0');
+    assert.strictEqual(versions.get('nested-only'), '5.5.5');
+  });
+
+  it('pnpm: prefers the importer-resolved (direct) version over the packages map', () => {
+    // The pnpm packages map is name-sorted, so a multi-version package's
+    // first entry is its LOWEST version; the importers section carries the
+    // resolved direct-dependency version (adversarial-review finding 4).
+    const dir = tempDir();
+    fs.writeFileSync(
+      path.join(dir, 'pnpm-lock.yaml'),
+      [
+        'lockfileVersion: 9.0',
+        '',
+        'importers:',
+        '  .:',
+        '    dependencies:',
+        '      zod:',
+        "        specifier: ^3.24.0",
+        "        version: 3.24.1",
+        '  packages/member:',
+        '    dependencies:',
+        '      redis:',
+        "        specifier: ^4.6.0",
+        "        version: 4.6.7(peer@1.0.0)",
+        '',
+        'packages:',
+        '',
+        // Lower version of a transitive copy sorts first.
+        "  zod@3.22.0:",
+        "    resolution: {integrity: sha512-a}",
+        '',
+        "  zod@3.24.1:",
+        "    resolution: {integrity: sha512-b}",
+        '',
+        "  redis@4.6.7:",
+        "    resolution: {integrity: sha512-c}",
+        '',
+        "  transitive-only@1.2.3:",
+        "    resolution: {integrity: sha512-d}",
+        '',
+      ].join('\n')
+    );
+    const versions = lockfileVersions(dir);
+    assert.strictEqual(versions.get('zod'), '3.24.1');
+    // Peer suffix stripped from the importer-resolved version.
+    assert.strictEqual(versions.get('redis'), '4.6.7');
+    // Non-direct packages still pin from the packages map.
+    assert.strictEqual(versions.get('transitive-only'), '1.2.3');
   });
 
   it('parses npm lockfile v1 dependencies fallback', () => {

--- a/src/sidecar/test/check-v2-abnormal-tsc.test.ts
+++ b/src/sidecar/test/check-v2-abnormal-tsc.test.ts
@@ -1,0 +1,145 @@
+/**
+ * v2 check core — abnormal tsc termination (adversarial-review finding 3).
+ *
+ * runCheck used to ignore the tsc exit code entirely: an OOM/SIGKILL
+ * (code null), an internal crash, or a fileless config error (TS18003
+ * prints WITHOUT a `(line,col)` prefix, so parseTscOutput yields zero
+ * diagnostics) all fell through classifyPair's empty-diagnostics branch and
+ * every pair read COMPATIBLE with success:true — the dangerous direction.
+ *
+ * These tests inject a stand-in tsc via CheckOptions.tscPath (the same
+ * injection seam as pnpmPath) to pin:
+ *  1. non-zero exit + zero parseable diagnostics -> every pair unverifiable,
+ *     success:false, degraded services recorded;
+ *  2. signal death (exit code null) -> same;
+ *  3. non-zero exit WITH parseable probe diagnostics stays the legitimate
+ *     incompatible path (tsc exits 1 on ordinary type errors — the guard
+ *     must NOT be "fail on non-zero").
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runCheck } from '../src/capture/index.js';
+import { buildProbe } from '../src/capture/check-probe.js';
+import type { CheckPairSpec, CheckStubInput } from '../src/capture/api.js';
+
+let root: string;
+let stubs: CheckStubInput[];
+
+function writeStub(dir: string, serviceName: string, surface: string): void {
+  const stubDir = path.join(dir, serviceName);
+  fs.mkdirSync(path.join(stubDir, 'types'), { recursive: true });
+  fs.writeFileSync(
+    path.join(stubDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: `@carrick/${serviceName}`,
+        version: '0.0.0-carrick',
+        private: true,
+        types: './types/surface.d.ts',
+      },
+      null,
+      2
+    ) + '\n'
+  );
+  fs.writeFileSync(path.join(stubDir, 'types', 'surface.d.ts'), surface);
+}
+
+function fakeTsc(name: string, script: string): string {
+  const file = path.join(root, name);
+  fs.writeFileSync(file, `#!/bin/sh\n${script}\n`);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+const PAIRS: CheckPairSpec[] = [
+  {
+    pair_key: 'pair-a',
+    protocol: 'http',
+    type_kind: 'response',
+    producer: { service_name: 'orders', alias: 'P_Res' },
+    consumer: { service_name: 'web', alias: 'C_Res' },
+  },
+  {
+    pair_key: 'pair-b',
+    protocol: 'http',
+    type_kind: 'request',
+    producer: { service_name: 'orders', alias: 'P_Req' },
+    consumer: { service_name: 'web', alias: 'C_Req' },
+  },
+];
+
+describe('check_v2: abnormal tsc termination is never read as compatible', () => {
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-check-v2-tsc-'));
+    writeStub(
+      root,
+      'orders',
+      'export type P_Res = { a: string; };\nexport type P_Req = { a: string; };\n'
+    );
+    writeStub(
+      root,
+      'web',
+      'export type C_Res = { a: string; };\nexport type C_Req = { a: string; };\n'
+    );
+    stubs = [
+      { service_name: 'orders', stub_dir: path.join(root, 'orders') },
+      { service_name: 'web', stub_dir: path.join(root, 'web') },
+    ];
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('crash exit with no parseable diagnostics -> all pairs unverifiable', async () => {
+    const tscPath = fakeTsc(
+      'tsc-crash',
+      "echo 'error TS18003: No inputs were found in config file.' >&2; exit 1"
+    );
+    const result = await runCheck({ stubs, pairs: PAIRS, tscPath });
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.install_ok, true);
+    assert.strictEqual(result.verdicts.length, PAIRS.length);
+    for (const v of result.verdicts) {
+      assert.strictEqual(v.bucket, 'unverifiable', JSON.stringify(v));
+      assert.strictEqual(v.gate, 'tsc:abnormal-termination');
+      assert.match(v.diagnostic ?? '', /terminated abnormally/);
+    }
+    assert.strictEqual(result.degraded_services.length, 2);
+    assert.match(result.errors.join('\n'), /exit code 1/);
+    assert.match(result.errors.join('\n'), /TS18003/);
+  });
+
+  it('signal death (exit code null, e.g. OOM SIGKILL) -> all pairs unverifiable', async () => {
+    const tscPath = fakeTsc('tsc-sigkill', 'kill -KILL $$');
+    const result = await runCheck({ stubs, pairs: PAIRS, tscPath });
+    assert.strictEqual(result.success, false);
+    for (const v of result.verdicts) {
+      assert.strictEqual(v.bucket, 'unverifiable', JSON.stringify(v));
+      assert.strictEqual(v.gate, 'tsc:abnormal-termination');
+    }
+    assert.match(result.errors.join('\n'), /exit code null/);
+  });
+
+  it('non-zero exit WITH parseable probe diagnostics stays the incompatible path', async () => {
+    // Fake tsc emits a real assignment-class diagnostic for pair-a's probe
+    // and exits 1 exactly like the real tsc does on ordinary type errors.
+    // The abnormal-termination guard must not swallow it.
+    const plan = buildProbe(PAIRS[0], (s) => `@carrick/${s}`);
+    const probeFile = `packages/carrick-probes/probes/${plan.fileName}`;
+    const tscPath = fakeTsc(
+      'tsc-type-error',
+      `echo "${probeFile}(${plan.assignmentLine},7): error TS2322: Type 'A' is not assignable to type 'B'."; exit 1`
+    );
+    const result = await runCheck({ stubs, pairs: PAIRS, tscPath });
+    assert.strictEqual(result.success, true);
+    const verdictA = result.verdicts.find((v) => v.pair_key === 'pair-a')!;
+    assert.strictEqual(verdictA.bucket, 'incompatible', JSON.stringify(verdictA));
+    const verdictB = result.verdicts.find((v) => v.pair_key === 'pair-b')!;
+    assert.strictEqual(verdictB.bucket, 'compatible', JSON.stringify(verdictB));
+  });
+});

--- a/src/sidecar/test/check-v2-units.test.ts
+++ b/src/sidecar/test/check-v2-units.test.ts
@@ -9,6 +9,9 @@
 
 import { describe, it } from 'node:test';
 import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   buildProbe,
   directionFor,
@@ -17,7 +20,7 @@ import {
 } from '../src/capture/check-probe.js';
 import { classifyPair, parseTscOutput } from '../src/capture/check-classify.js';
 import { scrubPaths, rewriteAliases } from '../src/capture/check-scrub.js';
-import { computeDedupeOverrides } from '../src/capture/check-workspace.js';
+import { assembleWorkspace, computeDedupeOverrides } from '../src/capture/check-workspace.js';
 import type { CheckPairSpec } from '../src/capture/api.js';
 import type { RawDiagnostic } from '../src/capture/check-classify.js';
 
@@ -247,6 +250,27 @@ describe('semver dedupe overrides', () => {
       { dependencies: { zod: '3.23.0' } },
     ]);
     assert.deepStrictEqual(overrides, {});
+  });
+
+  it('assembled workspace installs deterministically (offline-first, pinned resolver)', () => {
+    // The scratch workspace has no committed lockfile; without these settings
+    // the transitive closure is a function of live registry state and the
+    // byte-stability guarantee does not hold (adversarial-review finding 6).
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-npmrc-test-'));
+    const stubDir = path.join(root, 'stub');
+    fs.mkdirSync(stubDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(stubDir, 'package.json'),
+      JSON.stringify({ name: '@carrick/svc', version: '0.0.0-carrick', private: true })
+    );
+    const ws = assembleWorkspace({
+      stubs: [{ service_name: 'svc', stub_dir: stubDir }],
+      workspaceRoot: root,
+    });
+    const npmrc = fs.readFileSync(path.join(ws.workspaceDir, '.npmrc'), 'utf8');
+    assert.ok(npmrc.includes('prefer-offline=true'), npmrc);
+    assert.ok(npmrc.includes('resolution-mode=highest'), npmrc);
+    fs.rmSync(root, { recursive: true, force: true });
   });
 
   it('0.0.x pins are each their own breaking boundary (no override)', () => {

--- a/src/sidecar/test/check-v2-units.test.ts
+++ b/src/sidecar/test/check-v2-units.test.ts
@@ -248,4 +248,14 @@ describe('semver dedupe overrides', () => {
     ]);
     assert.deepStrictEqual(overrides, {});
   });
+
+  it('0.0.x pins are each their own breaking boundary (no override)', () => {
+    // Semver: every 0.0.x patch is breaking. Collapsing 0.0.3 onto 0.0.5
+    // would force one physical copy and manufacture a false-compatible.
+    const overrides = computeDedupeOverrides([
+      { dependencies: { pkg: '0.0.3' } },
+      { dependencies: { pkg: '0.0.5' } },
+    ]);
+    assert.deepStrictEqual(overrides, {});
+  });
 });


### PR DESCRIPTION
Fixes every confirmed finding from the two adversarial reviews of the type-compat v2 stack (WP1/WP2 review `wf_3acb9743-56b` + the WP3 review), applied at the top of the stack so nothing cascade-rebases. These are correctness-critical: WP3 wired v2 into the production scan path, so the false-compatible paths below were live-impacting. Each fix lands with a regression test that fails on the pre-fix code (verified individually by reverting the fix and re-running).

## Finding-by-finding map

### 1a. CRITICAL — member-level `any`/`unknown` invisible to every gate (false-compatible)
`self-check.ts` gated on whole-type flags (`Any|Unknown|Never` on the alias root) and the check probes gate whole-type too, so `{ orderId: string; metadata: any }`, `any[]`, `Promise<any>`, `Record<string, any>` recorded `self_check:'ok'`, probed clean, and read **compatible** against a counterparty that constrains that position to a concrete shape — `any` is bidirectionally assignable.

**Fix (capture, `self-check.ts`):** `findDisqualifyingTopType` — a depth-bounded, cycle-safe walk over members, union/intersection constituents, type arguments, and index signatures. A deep `any`/`unknown` with no failing-external explanation records `deep_top_type_kind`/`deep_top_type_path` on the alias record, outcome `decayed_internal`, with the member path in the reason. Call/construct-signature types are skipped (callable members are not wire payloads; lib callables legitimately carry `any` params) and an over-budget walk flags nothing — over-demoting a legitimately resolved type is the failure mode the guard must not have.

**Fix (check, `check.ts`):** pairs whose side carries a recorded deep decay never reach a probe: `any` verdicts `gate_caught_baked_any`, `unknown` verdicts `unverifiable` (both `None` downstream, never compatible), gate `capture:<side>:<kind>`. External-blamed decays still probe — the check-time pin install can heal them, and the probe gates / poison rule backstop those paths. Stubs without a `carrick-manifest.json` (hand-authored test stubs) pre-gate nothing.

**Regression tests:** `test/capture-v2-deep-any.test.ts` — member/nested/container/index forms decay with recorded kind+path; concrete shapes, unions, arrays, and function-typed members are NOT over-demoted; symbol-anchored source with an `any` member decays; end-to-end `runCheck` verdicts `gate_caught_baked_any` / `unverifiable` where the pre-fix code read `compatible`.

### 1b. CRITICAL (same cluster) — closure failures only consulted behind the top-type gate
`internalFailure`/`blamedExternal` were computed for every alias but only consulted when the root was a bare top type, so an alias with a concrete root but a dangling internal specifier in its closure shipped a silently wrong `.d.ts`.

**Fix:** classification consults them regardless of the root type. A dangling internal specifier decays the alias unconditionally (the check-phase poison rule backstops it at verdict time: the broken stub tree carries its own TS2307 under `skipLibCheck:false`). A failing pinned external on a bare checkout keeps the amendment-1 allowlist; on an installed checkout it decays. Covered by the reworked classification block; allowlist semantics pinned unchanged (`capture-v2-forms.test.ts` passes unmodified).

### 2. HIGH — `usable_inferred_text` admitted container-decayed v1 text (false-compatible)
`src/engine/type_compat_v2.rs` rejected only the exact whole strings `"any"`/`"unknown"`, so `Promise<any>` / `any[]` / `Record<string, any>` / `{ [k: string]: any }` became a literal anchor and read compatible. The related whole-string gate `is_unknown_type` (`src/engine/mod.rs:~2849`) had the same hole.

**Fix:** one shared notion — `contains_disqualifying_top_type()` scans printed type text for `any`/`unknown` as a TYPE token at any position, stripping string-literal contents (`{ kind: "any" }` stays fine) and excluding property-name positions (`{ any: string }` stays fine). Both `usable_inferred_text` and `is_unknown_type` now use it, so the Rust layer agrees with the capture-side deep walk (fix 1) on what counts as resolved. Rejected inference text falls back to the locator-based infer anchor, whose result the capture self-check owns. Error direction is deliberate: a false positive demotes toward unverifiable, a false negative is a false-compatible.

**Regression tests:** `disqualifying_top_type_token_scan` (positive/negative token matrix incl. string-literal and property-name exclusions) and `derive_anchors_rejects_container_decayed_inferred_text` (fails pre-fix: decayed text rode a literal anchor).

### 3. HIGH — tsc exit code ignored; abnormal termination read as all-compatible
OOM/SIGKILL (`code null`), internal crashes, and fileless config errors (TS18003 prints without a `(line,col)` prefix) produced zero parsed diagnostics, and `classifyPair`'s fall-through returned `compatible` for every pair with `success:true`.

**Fix (`check.ts`):** non-zero (or null) exit combined with zero parseable diagnostics returns `success:false` with every probed pair `unverifiable` (gate `tsc:abnormal-termination`) and the scrubbed tsc output in `errors`. Non-zero exit WITH diagnostics is untouched — that is the legitimate incompatible path (tsc exits 1 on ordinary type errors), mirroring the install step's `code === 0` guard. `CheckOptions` gains a `tscPath` injection seam (parallel to the existing `pnpmPath`) for the tests.

**Regression tests:** `test/check-v2-abnormal-tsc.test.ts` — crash exit (TS18003-style, no parseable output) and signal death (`kill -KILL $$`, exit code null) verdict unverifiable (both read compatible pre-fix); a stand-in that exits 1 while printing a real probe diagnostic still classifies incompatible, and an untouched pair in the same run stays compatible.

### 4. HIGH — lockfile pin selection was first-match-wins (wrong deps → wrong verdict)
npm sorts `node_modules/a/node_modules/b` BEFORE `node_modules/b`, and pnpm's packages map is name-sorted (a multi-version package's first entry is its LOWEST version), so a package could pin to a version the emitted tree never resolves against.

**Fix (`lockfile.ts`):** npm — top-level `node_modules/<name>` entries win; nested copies only pin packages with no top-level install. pnpm — the `importers:` section's resolved direct-dependency versions win (peer suffixes stripped); the flat packages map remains the fallback for transitive-only pins.

**Regression tests:** in `capture-v2-units.test.ts` — nested-copy-sorts-first (npm) and importer-vs-packages-map (pnpm) both fail pre-fix; nested-only and transitive-only fallback pinning also pinned.

### 5. MEDIUM — `compatKey` collapsed all `0.0.*` into one dedupe bucket
Every 0.0.x release is its own semver breaking boundary; forcing `foo@0.0.3` and `foo@0.0.5` onto one physical copy manufactures a false-compatible for by-reference library types.

**Fix (`check-workspace.ts`):** `major==0 && minor==0` keys on the patch. 0.x with minor > 0 stays minor-scoped.
**Regression test:** `0.0.x pins are each their own breaking boundary` in `check-v2-units.test.ts` (fails pre-fix: produced an override).

### 6. MEDIUM — plain `pnpm install` made the closure a function of registry state
**Fix (`check-workspace.ts`):** the workspace `.npmrc` adds `prefer-offline=true` (resolve from the local store/metadata cache whenever possible — byte-stable across runs on a host) and `resolution-mode=highest` (pin resolver behavior explicitly across pnpm versions). Direct deps were already exact-pinned by the stubs; this closes the transitive tier. Honesty note: without a persisted lockfile artifact, a cold cache plus newly published transitive versions can still shift the closure; full cross-host determinism would need a lockfile cache keyed on the dep set — follow-up-sized, not done here.
**Regression test:** workspace-assembly assertion on the emitted `.npmrc` (fails pre-fix).

### 7. LOW — seam test accepted `./`-escapes and could not see require()
**Fix (`capture-v2-seam.test.ts`):** relative specifiers must now RESOLVE inside `capture/` (catches `./../legacy.js`), and a second check fails on any `require(` / `createRequire` usage in the bundle sources. Verified to catch an injected violation (assertion failures on a deliberately broken file, green after revert). The fix is itself the test (hygiene finding).

## Expected verdict shifts (deliberate, not regressions)
Fixes 1/2 legitimately shift some verdicts from `compatible` to `unverifiable`/`gate_caught_baked_any` (`None` on the edge) wherever a capture type carries an unresolved `any`/`unknown` at member/container depth. That is the intended correctness improvement — the pre-fix `compatible` was a false positive the counterparty could not rely on. The release-candidate `eval-xrepo` smoke should read those as expected shifts, not regressions.

## Verification
- Full `cargo test` on the final tree: all 22 test binaries green (lib 654 + 669, all integration suites 0 failed), **including the cassette hard gate against the EXISTING golden** — no re-record was needed; the corpus fixtures carry no member-level any/unknown, so no recorded output changed.
- Sidecar suite: 206 tests, 205 pass, 0 fail, 1 pre-existing skip (`should follow call results through destructuring`).
- `cargo fmt --check` clean; `cargo clippy --all-targets` clean.
- Every regression test verified to FAIL with its fix reverted.
- No prompt/schema text touched; no eval ground truth touched; no framework-name heuristics; capture/ seam intact (node builtins + typescript + itself only — now enforced more strictly by finding 7's test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
