### PR TITLE
fix(sidecar): keep partially emitted declaration tree when one file's emit is skipped

### DIFF
--- a/src/sidecar/src/capture/index.ts
+++ b/src/sidecar/src/capture/index.ts
@@ -194,6 +194,7 @@ export function captureStub(opts: CaptureStubOptions): CaptureStubResult {
   // hand-written declarations in the import closure) are never re-emitted by
   // tsc; they must ship verbatim or the tree's references to them dangle.
   const declarationSources = new Map<string, string>();
+  let emitPartial = false;
   try {
     fs.writeFileSync(entryPath, entryLines.join('\n') + '\n');
     const emitOptions: ts.CompilerOptions = {
@@ -217,9 +218,15 @@ export function captureStub(opts: CaptureStubOptions): CaptureStubResult {
       undefined,
       /* emitOnlyDtsFiles */ true
     );
-    if (emitResult.emitSkipped) {
+    // emitSkipped is PER-PROGRAM even when only one file's declaration emit
+    // failed (e.g. TS4023 from a hand-rolled ambient stub shadowing a real
+    // package): every other file's .d.ts was still written to the callback.
+    // Fail wholesale only when nothing at all emitted; otherwise keep the
+    // emitted subset and demote exactly the aliases it cannot support.
+    if (emitResult.emitSkipped && emitted.size === 0) {
       return fail(stubDir, packageName, ['declaration emit was skipped']);
     }
+    emitPartial = emitResult.emitSkipped;
     for (const d of emitResult.diagnostics) {
       errors.push(ts.flattenDiagnosticMessageText(d.messageText, '\n'));
     }
@@ -235,6 +242,24 @@ export function captureStub(opts: CaptureStubOptions): CaptureStubResult {
   } finally {
     if (fs.existsSync(entryPath)) fs.unlinkSync(entryPath);
     fs.rmSync(staging, { recursive: true, force: true });
+  }
+
+  // ---- Partial-emit recovery ----
+  // The corpus-2 notifications-svc shape: one file's declaration emit was
+  // skipped but the rest of the tree emitted fine. Keep the tree; demote any
+  // alias whose surface reference would dangle (its module produced no .d.ts)
+  // and rewrite its surface line to `unknown` so the kept tree carries no
+  // dangling specifiers that would smear the healthy aliases at self-check or
+  // poison the whole service at check time. Fail-closed: a demoted alias is
+  // `unknown` at the surface, so the check phase's IsUnknown probe gate (or
+  // the poison rule, for unemitted modules still referenced by kept files)
+  // decays it to unverifiable — it can never read compatible.
+  if (emitPartial) {
+    errors.push(
+      `declaration emit was partial: kept ${emitted.size} emitted file(s); ` +
+        'aliases referencing unemitted modules are demoted to structural_fallback'
+    );
+    resolved = demoteDanglingAliases({ resolved, emitted, declarationSources, staging });
   }
 
   // ---- Relocate the emitted tree into the stub package ----
@@ -382,6 +407,90 @@ export function captureStub(opts: CaptureStubOptions): CaptureStubResult {
     ts_version: ts.version,
     errors,
   };
+}
+
+/**
+ * Partial-emit demotion: with the set of modules that DID reach the tree
+ * (emitted .d.ts plus verbatim declaration sources), demote every anchor
+ * whose alias text references a relative module absent from that set, and
+ * rewrite the demoted aliases' lines in the emitted surface to `unknown`.
+ * Anchors already demoted stay as they are; anchors whose text is
+ * self-contained (node-builder structural prints, literal object text) are
+ * untouched even when their source file failed to emit — their surface line
+ * references nothing that can dangle.
+ */
+function demoteDanglingAliases(args: {
+  resolved: ResolvedAnchor[];
+  /** Staging-absolute emitted file -> text. Surface text is patched in place. */
+  emitted: Map<string, string>;
+  /** entryDir-relative verbatim .d.ts sources that will ship with the tree. */
+  declarationSources: Map<string, string>;
+  staging: string;
+}): ResolvedAnchor[] {
+  // Extensionless, entryDir-relative POSIX module ids present in the tree.
+  const treeModules = new Set<string>();
+  let surfaceKey: string | undefined;
+  for (const fileName of args.emitted.keys()) {
+    const rel = path.relative(args.staging, fileName).split(path.sep).join('/');
+    if (rel === `${SURFACE_ENTRY_BASENAME}.d.ts`) surfaceKey = fileName;
+    if (rel.endsWith('.d.ts')) treeModules.add(rel.slice(0, -'.d.ts'.length));
+  }
+  for (const rel of args.declarationSources.keys()) {
+    if (rel.endsWith('.d.ts')) treeModules.add(rel.slice(0, -'.d.ts'.length));
+  }
+  // The surface sits at the tree root, so its relative specifiers resolve
+  // against the root; anything escaping the root cannot be in the tree.
+  const moduleInTree = (spec: string): boolean => {
+    const id = path.posix.normalize(spec);
+    if (id.startsWith('..')) return false;
+    return treeModules.has(id) || treeModules.has(`${id}/index`);
+  };
+
+  const demoted = new Set<string>();
+  const next = args.resolved.map((anchor): ResolvedAnchor => {
+    if (anchor.failureReason !== undefined) return anchor;
+    const dangling = [...collectSpecifiers(anchor.aliasText)].find(
+      (spec) => isRelative(spec) && !moduleInTree(spec)
+    );
+    if (dangling === undefined) return anchor;
+    demoted.add(anchor.request.alias);
+    return {
+      request: anchor.request,
+      aliasText: 'unknown',
+      serialization: 'structural_fallback',
+      failureReason:
+        `declaration emit was skipped for module '${dangling}'; ` +
+        'alias demoted to keep the partially emitted tree usable',
+    };
+  });
+
+  if (surfaceKey !== undefined && demoted.size > 0) {
+    args.emitted.set(
+      surfaceKey,
+      rewriteSurfaceAliasesToUnknown(args.emitted.get(surfaceKey)!, demoted)
+    );
+  }
+  return next;
+}
+
+/** Replace `export type <name> = ...;` with `= unknown` for each demoted
+ * alias in the emitted surface text (span-accurate, statement-level). */
+function rewriteSurfaceAliasesToUnknown(text: string, demoted: Set<string>): string {
+  const sf = ts.createSourceFile('surface.d.ts', text, ts.ScriptTarget.Latest, true);
+  const spans: Array<{ start: number; end: number; name: string }> = [];
+  for (const stmt of sf.statements) {
+    if (ts.isTypeAliasDeclaration(stmt) && demoted.has(stmt.name.text)) {
+      spans.push({ start: stmt.getStart(sf), end: stmt.getEnd(), name: stmt.name.text });
+    }
+  }
+  let out = text;
+  for (const span of spans.reverse()) {
+    out =
+      out.slice(0, span.start) +
+      `export type ${span.name} = unknown;` +
+      out.slice(span.end);
+  }
+  return out;
 }
 
 /** Phase A: build the placeholder entry, then resolve every anchor. */

--- a/src/sidecar/src/capture/index.ts
+++ b/src/sidecar/src/capture/index.ts
@@ -441,7 +441,10 @@ function demoteDanglingAliases(args: {
   // The surface sits at the tree root, so its relative specifiers resolve
   // against the root; anything escaping the root cannot be in the tree.
   const moduleInTree = (spec: string): boolean => {
-    const id = path.posix.normalize(spec);
+    // nodenext-style source specifiers keep a runtime extension (./x.js) that
+    // tree module ids never carry; strip it so a healthy alias is not demoted
+    // for extension spelling alone.
+    const id = path.posix.normalize(spec).replace(/\.(js|mjs|cjs)$/, '');
     if (id.startsWith('..')) return false;
     return treeModules.has(id) || treeModules.has(`${id}/index`);
   };

--- a/src/sidecar/test/capture-v2-partial-emit.test.ts
+++ b/src/sidecar/test/capture-v2-partial-emit.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Partially skipped declaration emit — the corpus-2 notifications-svc
+ * collapse.
+ *
+ * `program.emit` sets `emitSkipped` per-PROGRAM even when only one file's
+ * declaration emit failed: an ambient `declare module "fastify"` stub with
+ * `export =` and no `FastifyInstance` export makes `export default app`
+ * unnameable (TS4023), that one file's .d.ts is skipped, and every other
+ * file's .d.ts is still written to the emit callback. The old wholesale
+ * `if (emitSkipped) fail` threw the entire emitted tree away, so the whole
+ * service's types went unresolved and its pub/sub edges collapsed to None.
+ *
+ * Pins:
+ *  1. capture keeps the emitted subset: success, healthy aliases fully
+ *     resolved, the tree contains their .d.ts files;
+ *  2. an alias whose module produced no .d.ts is demoted to
+ *     structural_fallback with a capture_failure_reason, and its surface
+ *     line is rewritten to `unknown` (no dangling specifier that would
+ *     smear healthy aliases at self-check or poison the service at check);
+ *  3. the total-failure path is retained: nothing emitted at all is still
+ *     the wholesale 'declaration emit was skipped' fail;
+ *  4. fail-closed at check: a demoted producer alias verdicts unverifiable
+ *     (IsUnknown probe gate), never compatible, while a healthy alias from
+ *     the SAME partially-emitted capture still probes compatible.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { captureStub, runCheck } from '../src/capture/index.js';
+import type { CaptureStubResult } from '../src/capture/api.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// dist/test -> dist -> sidecar -> src -> repo root.
+const CORPUS2_NOTIFICATIONS = path.join(
+  __dirname, '..', '..', '..', '..',
+  'tests', 'fixtures', 'xrepo-corpus-2', 'notifications-svc'
+);
+
+/** Ambient stub whose `export =` hides FastifyInstance: `export default app`
+ * in a file importing it hits TS4023 and that file's declaration emit is
+ * skipped. Mirrors tests/fixtures/xrepo-corpus-2/notifications-svc. */
+const FASTIFY_STUB = `declare module "fastify" {
+  interface FastifyInstance {
+    get(path: string, handler: () => void): this;
+  }
+  function fastify(): FastifyInstance;
+  export = fastify;
+}
+`;
+
+const TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    target: 'ES2020',
+    module: 'commonjs',
+    strict: true,
+    esModuleInterop: true,
+    skipLibCheck: true,
+    declaration: true,
+    rootDir: './',
+  },
+  include: ['**/*.ts'],
+});
+
+function writeRepo(root: string, files: Record<string, string>): string {
+  fs.mkdirSync(root, { recursive: true });
+  for (const [name, text] of Object.entries(files)) {
+    const p = path.join(root, name);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, text);
+  }
+  return root;
+}
+
+/** The corpus-2 shape: a TS4023-poisoned routes file + a clean events file. */
+function capturePartialRepo(root: string): CaptureStubResult {
+  const repoRoot = writeRepo(path.join(root, 'partial-repo'), {
+    'tsconfig.json': TSCONFIG,
+    'src/types/stubs.d.ts': FASTIFY_STUB,
+    'src/http/routes.ts':
+      'import fastify from "fastify";\n' +
+      'const app = fastify();\n' +
+      'export interface RouteReply { id: string; message: string; }\n' +
+      'export default app;\n',
+    'src/types/events.ts':
+      'export interface OrderPlacedEvent {\n' +
+      '  id: string;\n' +
+      '  total: { amountCents: number; currency: string };\n' +
+      '}\n',
+  });
+  return captureStub({
+    repoRoot,
+    serviceName: 'partial-emit-svc',
+    outDir: path.join(root, 'partial-stub'),
+    anchors: [
+      {
+        kind: 'symbol',
+        alias: 'P_Event',
+        symbol_name: 'OrderPlacedEvent',
+        source_file: 'src/types/events.ts',
+        anchor_origin: 'llm-symbol',
+      },
+      {
+        kind: 'symbol',
+        alias: 'P_RouteReply',
+        symbol_name: 'RouteReply',
+        source_file: 'src/http/routes.ts',
+        anchor_origin: 'llm-symbol',
+      },
+    ],
+  });
+}
+
+describe('capture v2: partially skipped declaration emit keeps the emitted subset', () => {
+  let root: string;
+  let result: CaptureStubResult;
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-partial-emit-'));
+    result = capturePartialRepo(root);
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('capture succeeds instead of failing wholesale', () => {
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    // The TS4023 diagnostic and the partial-emit note ride the errors channel
+    // so the scanner can see the degradation.
+    assert.ok(
+      result.errors.some((e) => /cannot be named/.test(e)),
+      JSON.stringify(result.errors)
+    );
+    assert.ok(
+      result.errors.some((e) => /declaration emit was partial/.test(e)),
+      JSON.stringify(result.errors)
+    );
+  });
+
+  it('the emitted tree contains the healthy events .d.ts and not the skipped module', () => {
+    assert.ok(
+      result.emitted_files.includes('types/src/types/events.d.ts'),
+      JSON.stringify(result.emitted_files)
+    );
+    assert.ok(
+      !result.emitted_files.includes('types/src/http/routes.d.ts'),
+      JSON.stringify(result.emitted_files)
+    );
+  });
+
+  it('the events alias is fully resolved and usable', () => {
+    const event = result.aliases.find((a) => a.alias === 'P_Event')!;
+    assert.strictEqual(event.serialization, 'emitted');
+    assert.strictEqual(event.self_check, 'ok', event.self_check_detail);
+    assert.strictEqual(event.capture_failure_reason, undefined);
+  });
+
+  it('the routes alias is demoted with a recorded capture_failure_reason', () => {
+    const reply = result.aliases.find((a) => a.alias === 'P_RouteReply')!;
+    assert.strictEqual(reply.serialization, 'structural_fallback');
+    assert.strictEqual(reply.self_check, 'decayed_internal');
+    assert.match(reply.capture_failure_reason ?? '', /declaration emit was skipped for module/);
+  });
+
+  it('the demoted surface line is `unknown`, never a dangling import', () => {
+    const surface = fs.readFileSync(
+      path.join(result.stub_dir, 'types', 'surface.d.ts'),
+      'utf8'
+    );
+    assert.match(surface, /export type P_RouteReply = unknown;/);
+    assert.ok(!surface.includes('src/http/routes'), surface);
+    // The healthy alias keeps its real emitted reference.
+    assert.match(surface, /export type P_Event = import\(.\.\/src\/types\/events.\)\.OrderPlacedEvent;/);
+  });
+});
+
+describe('capture v2: total emit failure still fails wholesale', () => {
+  let root: string;
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-total-skip-'));
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("zero emitted files returns the 'declaration emit was skipped' fail", () => {
+    // noEmitOnError + a syntax error blocks the WHOLE emit (syntactic
+    // diagnostics survive noCheck), so not even the surface entry emits —
+    // the true nothing-emitted shape the wholesale fail is reserved for.
+    const repoRoot = writeRepo(path.join(root, 'total-repo'), {
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2020',
+          module: 'commonjs',
+          strict: true,
+          declaration: true,
+          noEmitOnError: true,
+          rootDir: './',
+        },
+        include: ['**/*.ts'],
+      }),
+      'src/broken.ts': 'export interface Order { id: string\nconst oops = ;\n',
+    });
+    const result = captureStub({
+      repoRoot,
+      serviceName: 'total-skip-svc',
+      outDir: path.join(root, 'total-stub'),
+      anchors: [
+        {
+          kind: 'symbol',
+          alias: 'P_Order',
+          symbol_name: 'Order',
+          source_file: 'src/broken.ts',
+          anchor_origin: 'llm-symbol',
+        },
+      ],
+    });
+    assert.strictEqual(result.success, false);
+    assert.deepStrictEqual(result.errors, ['declaration emit was skipped']);
+    assert.deepStrictEqual(result.aliases, []);
+    assert.deepStrictEqual(result.emitted_files, []);
+  });
+});
+
+describe('check v2: a partial-emit-demoted alias is never compatible', () => {
+  let root: string;
+  let producer: CaptureStubResult;
+  let consumer: CaptureStubResult;
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-partial-check-'));
+    producer = capturePartialRepo(root);
+    assert.strictEqual(producer.success, true, JSON.stringify(producer.errors));
+    const consumerRepo = writeRepo(path.join(root, 'consumer-repo'), {});
+    consumer = captureStub({
+      repoRoot: consumerRepo,
+      serviceName: 'partial-consumer',
+      outDir: path.join(root, 'consumer-stub'),
+      anchors: [
+        {
+          kind: 'literal',
+          alias: 'C_Reply',
+          type_text: '{ id: string; message: string }',
+          anchor_origin: 'deterministic-infer',
+        },
+        {
+          kind: 'literal',
+          alias: 'C_Event',
+          type_text: '{ id: string; total: { amountCents: number; currency: string } }',
+          anchor_origin: 'deterministic-infer',
+        },
+      ],
+    });
+    assert.strictEqual(consumer.success, true, JSON.stringify(consumer.errors));
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('demoted producer -> unverifiable (unknown gate); healthy sibling still compatible', async () => {
+    const result = await runCheck({
+      stubs: [
+        { service_name: 'partial-emit-svc', stub_dir: producer.stub_dir },
+        { service_name: 'partial-consumer', stub_dir: consumer.stub_dir },
+      ],
+      pairs: [
+        {
+          pair_key: 'demoted-pair',
+          protocol: 'http',
+          type_kind: 'response',
+          producer: { service_name: 'partial-emit-svc', alias: 'P_RouteReply' },
+          consumer: { service_name: 'partial-consumer', alias: 'C_Reply' },
+        },
+        {
+          pair_key: 'healthy-pair',
+          protocol: 'pubsub',
+          type_kind: 'both',
+          producer: { service_name: 'partial-emit-svc', alias: 'P_Event' },
+          consumer: { service_name: 'partial-consumer', alias: 'C_Event' },
+        },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    const byKey = new Map(result.verdicts.map((v) => [v.pair_key, v]));
+
+    // FAIL-CLOSED INVARIANT: the demoted alias must never read compatible.
+    const demoted = byKey.get('demoted-pair')!;
+    assert.notStrictEqual(demoted.bucket, 'compatible', JSON.stringify(demoted));
+    assert.strictEqual(demoted.bucket, 'unverifiable', JSON.stringify(demoted));
+    assert.strictEqual(demoted.gate, 'producer:unknown');
+
+    // The recovery is real: the healthy alias from the SAME partial capture
+    // still verifies (this also proves the kept tree carries no poison).
+    const healthy = byKey.get('healthy-pair')!;
+    assert.strictEqual(healthy.bucket, 'compatible', JSON.stringify(healthy));
+  });
+});
+
+describe('capture v2: corpus-2 notifications-svc regression (repo fixture)', () => {
+  const available = fs.existsSync(CORPUS2_NOTIFICATIONS);
+  let outDir: string;
+
+  before(() => {
+    outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-notif-fixture-'));
+  });
+
+  after(() => {
+    fs.rmSync(outDir, { recursive: true, force: true });
+  });
+
+  it('pub/sub contract aliases survive the routes-file TS4023', { skip: !available }, () => {
+    const result = captureStub({
+      repoRoot: CORPUS2_NOTIFICATIONS,
+      serviceName: 'notifications-svc',
+      outDir: path.join(outDir, 'stub'),
+      anchors: [
+        {
+          kind: 'symbol',
+          alias: 'Pub_OrderPlacedEvent',
+          symbol_name: 'OrderPlacedEvent',
+          source_file: 'src/types/events.ts',
+          anchor_origin: 'llm-symbol',
+        },
+        {
+          kind: 'symbol',
+          alias: 'Pub_UserRegisteredEvent',
+          symbol_name: 'UserRegisteredEvent',
+          source_file: 'src/types/events.ts',
+          anchor_origin: 'llm-symbol',
+        },
+        {
+          kind: 'symbol',
+          alias: 'Http_Notification',
+          symbol_name: 'Notification',
+          source_file: 'src/http/routes.ts',
+          anchor_origin: 'llm-symbol',
+        },
+      ],
+    });
+    // Pre-fix: success false, errors ['declaration emit was skipped'], zero
+    // aliases — the whole service collapsed and its 4 pub/sub edges read None.
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    assert.ok(result.emitted_files.includes('types/src/types/events.d.ts'));
+    const byAlias = new Map(result.aliases.map((a) => [a.alias, a]));
+    for (const alias of ['Pub_OrderPlacedEvent', 'Pub_UserRegisteredEvent']) {
+      const rec = byAlias.get(alias)!;
+      assert.strictEqual(rec.serialization, 'emitted', alias);
+      assert.strictEqual(rec.self_check, 'ok', `${alias}: ${rec.self_check_detail}`);
+    }
+    const routes = byAlias.get('Http_Notification')!;
+    assert.strictEqual(routes.serialization, 'structural_fallback');
+    assert.match(routes.capture_failure_reason ?? '', /declaration emit was skipped for module/);
+  });
+});


### PR DESCRIPTION
Stacked on #422, do not merge before it.

## Root cause

`program.emit` sets `emitSkipped` per-PROGRAM even when only a single file's declaration emit failed. In corpus-2 `notifications-svc`, the hand-rolled ambient stub (`declare module "fastify"` with `export =` and no `FastifyInstance` export) makes `export default app` unnameable, so TS4023 skips the routes file's `.d.ts` while `events.d.ts` and the surface emit fine. The wholesale `if (emitSkipped) fail` in `src/sidecar/src/capture/index.ts` (introduced in f3dc85d) discarded the entire emitted tree, the whole service's types went unresolved, and its 4 pub/sub producer edges collapsed to None (corpus-2 85% instead of 100%). TS4023-on-export from hand-rolled ambient stubs is a common real-world shape, so this is not a fixture quirk.

## Fix shape

1. Fail wholesale only when `emitSkipped && emitted.size === 0`. Empirically that is a genuinely-nothing-emitted program (e.g. repo `noEmitOnError` plus a syntax error, which survives `noCheck`); a per-file TS4023 always leaves the surface and the healthy files in the emit callback.
2. Otherwise keep the emitted subset. Any alias whose surface reference would dangle (a relative specifier in its alias text with no `.d.ts` in the kept tree, neither emitted nor a verbatim declaration source) is demoted to the existing `structural_fallback` tier with a `capture_failure_reason`, reusing the existing `ResolvedAnchor.failureReason` -> `demotedRecord` path — no new fields.
3. The demoted alias's line in the emitted surface is rewritten to `unknown` (span-accurate, AST-based). This is load-bearing: the surface file is in every alias's self-check closure, so a dangling specifier there would smear every healthy alias to `decayed_internal`, and at check time would poison the whole service.
4. The TS4023 diagnostic plus an explicit `declaration emit was partial: kept N emitted file(s)` note ride the existing `errors` channel, so the scanner sees the degradation on a successful capture.

## Fail-closed argument

A demoted alias resolves to `unknown` at the surface, so at check time the IsUnknown probe gate verdicts the pair `unverifiable` (`producer:unknown`), never `compatible`. If a kept tree file still references the unemitted module, the existing dangling-specifier self-check (`decayed_internal`) and the check-side poison rule own that path — also never `compatible`. None of the gates from the review-fix commits (deep-any pre-gate, member-level detection, seam test) are touched; the check side is unchanged.

## Test evidence

New suite `src/sidecar/test/capture-v2-partial-emit.test.ts` (8 tests):

- Corpus-2 shape regression: capture succeeds, `events.d.ts` is in the tree, the events alias is `emitted`/`ok`, the routes alias is `structural_fallback` + `capture_failure_reason`, and the surface line is `unknown` with no dangling import.
- Total-failure retained: a zero-emit program (`noEmitOnError` + syntax error) still returns the wholesale `declaration emit was skipped` fail.
- Fail-closed end-to-end: `runCheck` over a pair whose producer alias was demoted verdicts `unverifiable` with gate `producer:unknown`; the healthy alias from the same partial capture still verdicts `compatible` (proving the kept tree carries no poison).
- Repo-fixture regression against `tests/fixtures/xrepo-corpus-2/notifications-svc` (skips gracefully if absent): pub/sub aliases `emitted`/`ok`, routes alias demoted.

Suite: 213 pass / 1 known skip / 0 fail (baseline on the base branch: 205 pass / 1 skip). Manual before/after on the real notifications-svc fixture: pre-fix `success: false, errors: ["declaration emit was skipped"]`, zero aliases; post-fix `success: true`, all three events-file aliases `emitted`/`ok` with `usable_rate` 0.75 and only the routes alias demoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)