### PR TITLE
feat(evals): install_corpus_deps dispatch input for bare-checkout eval arms

### DIFF
--- a/.github/workflows/eval-oss.yml
+++ b/.github/workflows/eval-oss.yml
@@ -33,6 +33,10 @@ on:
         description: "N repeated cross-repo scans"
         required: false
         default: "1"
+      install_corpus_deps:
+        description: "install each corpus repo's deps before scanning (false = bare checkout, the Action's default posture)"
+        required: false
+        default: "true"
 
 permissions:
   id-token: write
@@ -120,6 +124,7 @@ jobs:
       # repos and must not execute arbitrary code on the runner (yarn-berry
       # skips builds via --mode=skip-build; classic yarn via --ignore-scripts).
       - name: Install corpus dependencies (yarn/pnpm/npm-aware, tolerant)
+        if: ${{ inputs.install_corpus_deps != 'false' }}
         run: |
           corepack enable || true
           # Log-file capture instead of a pipe: without pipefail a

--- a/.github/workflows/eval-oss.yml
+++ b/.github/workflows/eval-oss.yml
@@ -36,7 +36,8 @@ on:
       install_corpus_deps:
         description: "install each corpus repo's deps before scanning (false = bare checkout, the Action's default posture)"
         required: false
-        default: "true"
+        type: boolean
+        default: true
 
 permissions:
   id-token: write
@@ -124,7 +125,7 @@ jobs:
       # repos and must not execute arbitrary code on the runner (yarn-berry
       # skips builds via --mode=skip-build; classic yarn via --ignore-scripts).
       - name: Install corpus dependencies (yarn/pnpm/npm-aware, tolerant)
-        if: ${{ inputs.install_corpus_deps != 'false' }}
+        if: ${{ inputs.install_corpus_deps }}
         run: |
           corepack enable || true
           # Log-file capture instead of a pipe: without pipefail a

--- a/.github/workflows/eval-xrepo.yml
+++ b/.github/workflows/eval-xrepo.yml
@@ -32,7 +32,8 @@ on:
       install_corpus_deps:
         description: "npm-install each corpus repo before scanning (false = bare checkout, the Action's default posture)"
         required: false
-        default: "true"
+        type: boolean
+        default: true
 
 permissions:
   id-token: write
@@ -68,7 +69,7 @@ jobs:
         run: cd ts_check && npm ci
 
       - name: Install corpus dependencies
-        if: ${{ inputs.install_corpus_deps != 'false' }}
+        if: ${{ inputs.install_corpus_deps }}
         env:
           CORPUS_INPUT: ${{ inputs.corpus }}
         run: |

--- a/.github/workflows/eval-xrepo.yml
+++ b/.github/workflows/eval-xrepo.yml
@@ -29,6 +29,10 @@ on:
         description: "corpus fixture dir name under tests/fixtures/"
         required: false
         default: "xrepo-corpus-1"
+      install_corpus_deps:
+        description: "npm-install each corpus repo before scanning (false = bare checkout, the Action's default posture)"
+        required: false
+        default: "true"
 
 permissions:
   id-token: write
@@ -64,6 +68,7 @@ jobs:
         run: cd ts_check && npm ci
 
       - name: Install corpus dependencies
+        if: ${{ inputs.install_corpus_deps != 'false' }}
         env:
           CORPUS_INPUT: ${{ inputs.corpus }}
         run: |


### PR DESCRIPTION
Both eval workflows (eval-xrepo, eval-oss) unconditionally install corpus deps before scanning. That masks the bare-checkout behavior the production Action actually exhibits: the Action never installs the scanned repo's deps, so a fresh dedicated workflow scans a bare checkout.

This adds a `install_corpus_deps` dispatch input (default `true`, preserving every existing dispatch) that, when `false`, skips the corpus install step. It enables measuring v1-vs-v2 type-pipeline arms on the same bare inputs (the #349 measurement), with no harness or scanner changes.

Two-line-per-workflow change: one input declaration, one `if:` on the install step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)