### PR TITLE
fix(sidecar): recover inline literal response types under an unresolvable generic (#433)

### DIFF
--- a/src/sidecar/src/capture/anchors.ts
+++ b/src/sidecar/src/capture/anchors.ts
@@ -161,6 +161,22 @@ export function resolveAnchor(
   if ((request.unwrap ?? 'awaited') === 'awaited') {
     type = checker.getAwaitedType(type) ?? type;
   }
+  // #433: the checker gave us nothing (whole top type) — try the syntactic
+  // recovery for an inline literal type argument of an unresolvable generic
+  // annotation. The literal is dependency-free source syntax; only the outer
+  // generic needed the missing package.
+  if (isTopType(type)) {
+    const literalNode = recoverInlineLiteralTypeArgument(
+      checker,
+      sourceFile,
+      request,
+      located
+    );
+    if (literalNode) {
+      const recovered = checker.getTypeAtLocation(literalNode);
+      if (!isTopType(recovered)) type = recovered;
+    }
+  }
   if (!args.placeholder) {
     return demote('internal: no placeholder destination for infer anchor');
   }
@@ -173,6 +189,222 @@ export function resolveAnchor(
     aliasText: printed.text,
     serialization: 'node_builder',
   };
+}
+
+function isTopType(type: ts.Type): boolean {
+  return (
+    (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Never)) !== 0
+  );
+}
+
+/**
+ * The checker's intrinsic ERROR type: resolution of the reference FAILED
+ * (missing package on a bare checkout, unresolvable symbol). Distinct from a
+ * legitimate `any`, whose intrinsic name is `any` — an author-written or
+ * alias-resolved `any` must never trigger the syntactic recovery.
+ * `intrinsicName` is internal but stable since TS 1.x (same standing as the
+ * internals node-builder.ts already mirrors).
+ */
+function isErrorType(type: ts.Type): boolean {
+  if (!(type.flags & ts.TypeFlags.Any)) return false;
+  const name = (type as unknown as { intrinsicName?: string }).intrinsicName;
+  return name === 'error' || name === 'unresolved';
+}
+
+/**
+ * #433 syntactic recovery: an infer anchor whose checker type decayed to a
+ * whole top type may sit under a DECLARED annotation of the form
+ * `SomeGeneric<{ ...literal... }>` where only the outer generic failed to
+ * resolve (error-typed; its package is absent on a bare checkout) while the
+ * literal type argument is dependency-free source syntax referencing only
+ * locally-resolvable symbols. Trigger is purely structural — no framework
+ * names anywhere:
+ *
+ *  1. Data-flow path: the payload node (the located node, or the anchor's
+ *     expression_text relocated) is an argument of a call — or IS a send
+ *     call — whose callee chain roots at an identifier whose declaration
+ *     carries the annotation (`res.json(payload)` -> `res`).
+ *  2. Registration path: the located node is a call registering inline
+ *     callbacks; the callbacks' parameter annotations are scanned.
+ *
+ * Either path recovers ONLY when exactly one literal type argument is in
+ * scope — ambiguity refuses recovery and the alias keeps decaying honestly.
+ * The recovered literal node's own type is printed through the normal
+ * node-builder path, so the alias still faces the real self-check.
+ */
+function recoverInlineLiteralTypeArgument(
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  request: InferAnchorRequest,
+  located: ts.Node
+): ts.TypeLiteralNode | undefined {
+  const candidates: ts.Node[] = [located];
+  if (request.expression_text) {
+    const byText = nodeByExpressionText(
+      sourceFile,
+      request.expression_text,
+      request.line_number
+    );
+    if (byText && byText !== located) candidates.push(byText);
+  }
+
+  // Data-flow first: the payload's own call names the annotated receiver.
+  for (const node of candidates) {
+    const call = governingCall(node);
+    if (!call) continue;
+    const root = calleeRootIdentifier(call.expression);
+    if (!root) continue;
+    const annotation = declaredAnnotationOf(checker, root);
+    if (!annotation || !isErroredGenericReference(checker, annotation)) continue;
+    // The payload carrier is identified; its annotation's verdict is FINAL —
+    // never fall through to the registration scan, which could pick a
+    // different parameter's literal for this payload.
+    const literals = literalTypeArguments(annotation);
+    if (literals.length !== 1) return undefined;
+    return literalResolvesLocally(checker, literals[0]) ? literals[0] : undefined;
+  }
+
+  // Registration shape: the located call passes inline callbacks whose
+  // parameters carry the annotations. Ambiguity is counted BEFORE any
+  // resolvability filtering: two literal-carrying annotations refuse even
+  // when one of them would be rejected later — filtering first could crown
+  // the wrong parameter's literal.
+  for (const node of candidates) {
+    if (!ts.isCallExpression(node)) continue;
+    const literals: ts.TypeLiteralNode[] = [];
+    for (const arg of node.arguments) {
+      if (!isFunctionArgument(arg)) continue;
+      for (const param of arg.parameters) {
+        if (param.type && isErroredGenericReference(checker, param.type)) {
+          literals.push(...literalTypeArguments(param.type));
+        }
+      }
+    }
+    if (literals.length !== 1) continue;
+    return literalResolvesLocally(checker, literals[0]) ? literals[0] : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * The call whose ARGUMENT list carries `node` (payload in argument position),
+ * or `node` itself when it is a call (the send call). Calls that register
+ * callbacks are excluded: their receiver is the framework app/router value,
+ * not a payload carrier — those go through the registration path instead.
+ */
+function governingCall(node: ts.Node): ts.CallExpression | undefined {
+  if (ts.isCallExpression(node)) {
+    return node.arguments.some(isFunctionArgument) ? undefined : node;
+  }
+  const parent = node.parent;
+  if (
+    parent !== undefined &&
+    ts.isCallExpression(parent) &&
+    node !== parent.expression &&
+    (parent.arguments as readonly ts.Node[]).includes(node)
+  ) {
+    return parent.arguments.some(isFunctionArgument) ? undefined : parent;
+  }
+  return undefined;
+}
+
+function isFunctionArgument(
+  arg: ts.Expression
+): arg is ts.ArrowFunction | ts.FunctionExpression {
+  return ts.isArrowFunction(arg) || ts.isFunctionExpression(arg);
+}
+
+/** Root identifier of a callee chain: `res.status(500).json` -> `res`. */
+function calleeRootIdentifier(expr: ts.Expression): ts.Identifier | undefined {
+  let current: ts.Expression = expr;
+  while (
+    ts.isPropertyAccessExpression(current) ||
+    ts.isElementAccessExpression(current) ||
+    ts.isCallExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isParenthesizedExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return ts.isIdentifier(current) ? current : undefined;
+}
+
+/** The explicit type annotation on the identifier's declaration, if any. */
+function declaredAnnotationOf(
+  checker: ts.TypeChecker,
+  identifier: ts.Identifier
+): ts.TypeNode | undefined {
+  const symbol = checker.getSymbolAtLocation(identifier);
+  const decl = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
+  if (!decl) return undefined;
+  if (
+    ts.isParameter(decl) ||
+    ts.isVariableDeclaration(decl) ||
+    ts.isPropertySignature(decl) ||
+    ts.isPropertyDeclaration(decl)
+  ) {
+    return decl.type;
+  }
+  return undefined;
+}
+
+/**
+ * A generic type reference whose OUTER resolution failed: the annotation is
+ * `Name<...args>` and its own type is the checker's error type. A resolvable
+ * generic (however it resolves) never triggers recovery; its checker answer
+ * is the truth.
+ */
+function isErroredGenericReference(
+  checker: ts.TypeChecker,
+  annotation: ts.TypeNode
+): annotation is ts.TypeReferenceNode {
+  return (
+    ts.isTypeReferenceNode(annotation) &&
+    (annotation.typeArguments?.length ?? 0) > 0 &&
+    isErrorType(checker.getTypeFromTypeNode(annotation))
+  );
+}
+
+/** Type-literal type arguments of a generic reference (parens unwrapped). */
+function literalTypeArguments(annotation: ts.TypeReferenceNode): ts.TypeLiteralNode[] {
+  const literals: ts.TypeLiteralNode[] = [];
+  for (const arg of annotation.typeArguments ?? []) {
+    let node: ts.TypeNode = arg;
+    while (ts.isParenthesizedTypeNode(node)) node = node.type;
+    if (ts.isTypeLiteralNode(node)) literals.push(node);
+  }
+  return literals;
+}
+
+/**
+ * Every type reference inside the literal must itself RESOLVE. A literal
+ * leaning on a third-party type (`{ thing: LibThing }` with the lib absent)
+ * is not the tractable class — recovering it would bake `any` at a member;
+ * it keeps decaying honestly instead. Author-written `any`/`unknown`
+ * keywords are allowed through: they are the source's truth, and the
+ * self-check's deep walk still owns that verdict.
+ */
+function literalResolvesLocally(
+  checker: ts.TypeChecker,
+  literal: ts.TypeLiteralNode
+): boolean {
+  let resolves = true;
+  const visit = (node: ts.Node): void => {
+    if (!resolves) return;
+    if (
+      (ts.isTypeReferenceNode(node) ||
+        ts.isImportTypeNode(node) ||
+        ts.isTypeQueryNode(node) ||
+        ts.isExpressionWithTypeArguments(node)) &&
+      isErrorType(checker.getTypeFromTypeNode(node))
+    ) {
+      resolves = false;
+      return;
+    }
+    node.forEachChild(visit);
+  };
+  visit(literal);
+  return resolves;
 }
 
 function locatorFailureReason(request: InferAnchorRequest): string {

--- a/src/sidecar/test/capture-v2-inline-literal.test.ts
+++ b/src/sidecar/test/capture-v2-inline-literal.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Issue #433: producer response types declared as INLINE type literals decay
+ * to `any` under bare-checkout capture.
+ *
+ * On a bare checkout the framework generic wrapping the literal
+ * (`Response<{ ... }>`) is error-typed — its package is absent — so the
+ * deterministic-infer path's checker lookup at the anchor site resolves to a
+ * top type and the surface emits `export type ... = any;` (self_check
+ * decayed_internal). But the literal type ARGUMENT is dependency-free source
+ * syntax: only the outer generic needed the missing package.
+ *
+ * The fix recovers syntactically, with a purely structural trigger (no
+ * framework names anywhere):
+ *  - the located node's inferred type is a whole top type, AND
+ *  - the governing declared annotation — found via the payload's own call
+ *    (argument position or the send call's receiver chain), or via the
+ *    located registration call's callback parameters — is a TypeReference
+ *    whose resolution FAILED (error type) and which carries exactly one
+ *    unambiguous type-literal type argument.
+ * The literal node's own type (members resolve against local imports) is then
+ * printed through the normal SymbolTracker-backed node-builder path, so local
+ * named references ride the surface as import("...") types and the emitted
+ * tree carries their declaration closure — the alias genuinely passes the
+ * real self-check.
+ *
+ * Ambiguity refuses recovery: when more than one literal argument is in
+ * scope and no payload locator disambiguates, the alias keeps decaying
+ * honestly.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { captureStub } from '../src/capture/index.js';
+import type { CaptureAliasRecord, CaptureStubResult } from '../src/capture/api.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BARE = path.join(__dirname, '..', '..', 'test', 'fixtures', 'capture-v2-bare');
+const ROUTES = path.join(BARE, 'src', 'http', 'inline-response.ts');
+const ROUTES_SOURCE = fs.readFileSync(ROUTES, 'utf8');
+
+/** Byte span of the unique occurrence of `text` in the routes fixture. */
+function spanOf(text: string): { span_start: number; span_end: number } {
+  const start = ROUTES_SOURCE.indexOf(text);
+  assert.ok(start >= 0, `fixture drift: '${text}' not found`);
+  assert.strictEqual(
+    ROUTES_SOURCE.indexOf(text, start + 1),
+    -1,
+    `fixture drift: '${text}' is not unique`
+  );
+  return { span_start: start, span_end: start + text.length };
+}
+
+/** Byte span of the registration call starting at `head` (balanced parens). */
+function registrationSpanOf(head: string): { span_start: number; span_end: number } {
+  const start = ROUTES_SOURCE.indexOf(head);
+  assert.ok(start >= 0, `fixture drift: '${head}' not found`);
+  const open = ROUTES_SOURCE.indexOf('(', start);
+  let depth = 0;
+  for (let i = open; i < ROUTES_SOURCE.length; i++) {
+    if (ROUTES_SOURCE[i] === '(') depth++;
+    else if (ROUTES_SOURCE[i] === ')') {
+      depth--;
+      if (depth === 0) return { span_start: start, span_end: i + 1 };
+    }
+  }
+  assert.fail(`fixture drift: unbalanced parens after '${head}'`);
+}
+
+describe('capture v2: inline literal response types under an unresolvable generic (#433)', () => {
+  let result: CaptureStubResult;
+  let surface: string;
+  let outRoot: string;
+  let byAlias: Map<string, CaptureAliasRecord>;
+
+  before(() => {
+    assert.ok(
+      !fs.existsSync(path.join(BARE, 'node_modules')),
+      'precondition: capture-v2-bare must have no node_modules'
+    );
+    outRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-capture-433-'));
+    result = captureStub({
+      repoRoot: BARE,
+      serviceName: 'inline-literal-svc',
+      outDir: path.join(outRoot, 'stub'),
+      anchors: [
+        // Send-call shape (the express-demo evidence): the locator text is the
+        // `res.json(...)` call, whole-typed `any` via the error-typed receiver.
+        {
+          kind: 'infer',
+          alias: 'Endpoint_itemdetail_Response',
+          source_file: 'src/http/inline-response.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: "res.json({ item, message: 'found' })",
+        },
+        // Argument-position shape: the payload identifier itself baked `any`
+        // through the missing library.
+        {
+          kind: 'infer',
+          alias: 'Endpoint_itemlist_Response',
+          source_file: 'src/http/inline-response.ts',
+          anchor_origin: 'deterministic-infer',
+          ...(() => {
+            const call = spanOf('res.json(items)');
+            return {
+              span_start: call.span_start + 'res.json('.length,
+              span_end: call.span_end - 1,
+            };
+          })(),
+        },
+        // Registration-call shape (span locator, no expression text): exactly
+        // one callback parameter annotation carries an inline literal.
+        {
+          kind: 'infer',
+          alias: 'Endpoint_health_Response',
+          source_file: 'src/http/inline-response.ts',
+          anchor_origin: 'deterministic-infer',
+          ...registrationSpanOf("app.get('/health'"),
+        },
+        // Ambiguous registration: two literal-carrying annotations, no payload
+        // locator — recovery must refuse; the alias decays honestly.
+        {
+          kind: 'infer',
+          alias: 'Endpoint_ambig_Response',
+          source_file: 'src/http/inline-response.ts',
+          anchor_origin: 'deterministic-infer',
+          ...registrationSpanOf("app.get('/ambig/:id'"),
+        },
+        // Literal referencing a third-party type: not the tractable class —
+        // recovery refuses instead of baking `any` at a member.
+        {
+          kind: 'infer',
+          alias: 'Endpoint_external_Response',
+          source_file: 'src/http/inline-response.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: "res.json({ thing: makeThing('t'), ok: true })",
+        },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    surface = fs.readFileSync(path.join(result.stub_dir, 'types', 'surface.d.ts'), 'utf8');
+    byAlias = new Map(result.aliases.map((a) => [a.alias, a]));
+  });
+
+  after(() => {
+    fs.rmSync(outRoot, { recursive: true, force: true });
+  });
+
+  it('recovers the send-call shape: literal with a local named type, self-check ok', () => {
+    const rec = byAlias.get('Endpoint_itemdetail_Response')!;
+    assert.strictEqual(rec.serialization, 'node_builder', rec.capture_failure_reason);
+    assert.strictEqual(rec.self_check, 'ok', rec.self_check_detail);
+    assert.strictEqual(rec.top_type_at_self_check, false);
+    // The d.ts carries the literal's real shape: the local named type rides an
+    // import("...") reference, primitives stay verbatim.
+    assert.match(
+      surface,
+      /Endpoint_itemdetail_Response = \{\s*item: import\("[^"]*"\)\.Item;\s*message: string;\s*\}/,
+      `surface should carry the recovered literal:\n${surface}`
+    );
+  });
+
+  it('recovers the argument-position shape: any-typed payload identifier', () => {
+    const rec = byAlias.get('Endpoint_itemlist_Response')!;
+    assert.strictEqual(rec.serialization, 'node_builder', rec.capture_failure_reason);
+    assert.strictEqual(rec.self_check, 'ok', rec.self_check_detail);
+    assert.match(
+      surface,
+      /Endpoint_itemlist_Response = \{\s*items: import\("[^"]*"\)\.Item\[\];\s*total: number;\s*\}/,
+      `surface should carry the recovered literal:\n${surface}`
+    );
+  });
+
+  it('recovers the registration-call shape when exactly one literal is in scope', () => {
+    const rec = byAlias.get('Endpoint_health_Response')!;
+    assert.strictEqual(rec.serialization, 'node_builder', rec.capture_failure_reason);
+    assert.strictEqual(rec.self_check, 'ok', rec.self_check_detail);
+    assert.match(
+      surface,
+      /Endpoint_health_Response = \{\s*service: string;\s*ok: boolean;\s*\}/,
+      `surface should carry the recovered literal:\n${surface}`
+    );
+  });
+
+  it('refuses ambiguous recovery: two candidate literals decay honestly', () => {
+    const rec = byAlias.get('Endpoint_ambig_Response')!;
+    // The anchor located and printed — refusal happened at the recovery
+    // layer, not through a locator-failure demotion.
+    assert.strictEqual(rec.serialization, 'node_builder');
+    assert.strictEqual(rec.capture_failure_reason, undefined);
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.top_type_at_self_check, true);
+    assert.match(surface, /Endpoint_ambig_Response = any;/);
+  });
+
+  it('refuses a literal referencing a third-party type: keeps decaying honestly', () => {
+    const rec = byAlias.get('Endpoint_external_Response')!;
+    assert.strictEqual(rec.serialization, 'node_builder');
+    assert.strictEqual(rec.capture_failure_reason, undefined);
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.top_type_at_self_check, true);
+    assert.match(surface, /Endpoint_external_Response = any;/);
+  });
+
+  it('ships the local declaration closure so the recovered aliases resolve', () => {
+    assert.ok(
+      result.emitted_files.includes('types/app/models/item.d.ts'),
+      JSON.stringify(result.emitted_files)
+    );
+    assert.strictEqual(result.fidelity.by_self_check.ok, 3);
+    assert.strictEqual(result.fidelity.by_self_check.decayed_internal, 2);
+  });
+});

--- a/src/sidecar/test/capture-v2-inline-literal.test.ts
+++ b/src/sidecar/test/capture-v2-inline-literal.test.ts
@@ -59,6 +59,7 @@ function registrationSpanOf(head: string): { span_start: number; span_end: numbe
   const start = ROUTES_SOURCE.indexOf(head);
   assert.ok(start >= 0, `fixture drift: '${head}' not found`);
   const open = ROUTES_SOURCE.indexOf('(', start);
+  assert.ok(open >= 0, `fixture drift: no '(' after '${head}'`);
   let depth = 0;
   for (let i = open; i < ROUTES_SOURCE.length; i++) {
     if (ROUTES_SOURCE[i] === '(') depth++;
@@ -146,7 +147,7 @@ describe('capture v2: inline literal response types under an unresolvable generi
   });
 
   after(() => {
-    fs.rmSync(outRoot, { recursive: true, force: true });
+    if (outRoot) fs.rmSync(outRoot, { recursive: true, force: true });
   });
 
   it('recovers the send-call shape: literal with a local named type, self-check ok', () => {

--- a/src/sidecar/test/fixtures/capture-v2-bare/src/http/inline-response.ts
+++ b/src/sidecar/test/fixtures/capture-v2-bare/src/http/inline-response.ts
@@ -1,0 +1,62 @@
+// Issue #433 shape: producer response types declared as INLINE type literals
+// inside a framework generic that cannot resolve on a bare checkout. fakelib
+// is pinned in the lockfile but absent (no node_modules), so FakeRequest /
+// FakeResponse are error-typed — but the literal type ARGUMENTS are
+// dependency-free source syntax referencing only local types.
+import type { FakeRequest, FakeResponse, FakeThing } from 'fakelib';
+import { makeThing } from 'fakelib';
+import type { Item } from '@app/models/item';
+
+// Mirrors `express.Router()` on a bare checkout: the app value is error-typed
+// through the missing library, so registration and send calls all type `any`.
+const app = makeThing('app');
+
+// Send-call shape: the anchor's expression text is the `res.json(...)` call,
+// whole-typed `any` on bare (error-typed receiver). The declared response
+// literal references a local named type plus primitive fields.
+app.get('/items/:id', async (
+  req: FakeRequest<{ id: string }>,
+  res: FakeResponse<{ item: Item; message: string }>,
+) => {
+  const item = await makeThing(req);
+  res.json({ item, message: 'found' });
+});
+
+// Argument-position shape: the payload is an identifier whose inferred type
+// baked whole-`any` through the missing library.
+app.get('/items', async (
+  _req: FakeRequest,
+  res: FakeResponse<{ items: Item[]; total: number }>,
+) => {
+  const items = await makeThing('items');
+  res.json(items);
+});
+
+// Registration-call shape (span locator, no expression text): only ONE
+// callback parameter annotation carries an inline literal argument.
+app.get('/health', async (
+  _req: FakeRequest,
+  res: FakeResponse<{ service: string; ok: boolean }>,
+) => {
+  res.json({ service: 'bare-svc', ok: true });
+});
+
+// Ambiguous registration: BOTH parameter annotations carry inline literal
+// arguments and there is no payload locator to disambiguate — recovery must
+// refuse and the alias decays honestly.
+app.get('/ambig/:id', async (
+  req: FakeRequest<{ id: string }>,
+  res: FakeResponse<{ n: number }>,
+) => {
+  res.json({ n: Number(req) });
+});
+
+// Literal leaning on a THIRD-PARTY type: not the tractable class — the
+// recovery refuses (it would bake `any` at `thing`) and the alias keeps
+// decaying honestly.
+app.get('/external', async (
+  _req: FakeRequest,
+  res: FakeResponse<{ thing: FakeThing; ok: boolean }>,
+) => {
+  res.json({ thing: makeThing('t'), ok: true });
+});


### PR DESCRIPTION
## Problem

On a bare checkout, producer responses declared with an inline type literal (`res: Response<{ orderDetails: OrderWithUser; message: string }>`) decay to `any`: the framework generic is error-typed because its package is absent, so the deterministic-infer anchor's checker lookup at the anchor site resolves to a top type, the node builder prints `any`, and the surface ships `export type Endpoint_..._Response = any;` with `self_check: decayed_internal`. Named response types (`Response<User>`) anchor as symbols and survive fine, which is why carrick-demo-user-service scored usable_rate 1.0 while carrick-demo-notification-service scored 0.4 on the same corpus. The literal itself is dependency-free source syntax; only the outer generic needed the missing package.

## The structural trigger

No framework names anywhere. Recovery runs only when the infer anchor's checker type is a WHOLE top type (any/unknown/never), and then looks for a declared annotation of the form `SomeGeneric<{ ...literal... }>` where the outer reference is genuinely error-typed (the checker's intrinsic error type, not a legitimate `any`):

1. **Data-flow path**: the payload node (the located node, or the anchor's `expression_text` relocated) is an argument of a call, or is the send call itself; the callee chain's root identifier (`res.status(500).json` -> `res`) names a declaration whose annotation is the errored generic. Once that payload carrier is identified its verdict is final; the code never falls through to pick a different parameter's literal.
2. **Registration path**: the located node is a call passing inline callbacks (the span/line locator's route-registration shape); the callbacks' parameter annotations are scanned.

Either path recovers only when **exactly one** type-literal type argument is in scope, counted before any filtering. The recovered literal node's own type is then printed through the existing SymbolTracker-backed node-builder path, so local named references ride the surface as `import("...")` types, their declaration closure is emitted into the stub tree, and the alias faces the real, unweakened self-check. Verified end-to-end on the bare fixture: the surface carries `{ item: import("./app/models/item").Item; message: string; }`, the tree ships `app/models/item.d.ts`, and the alias self-checks `ok` with `top_type_at_self_check: false`.

## Covered

- Send-call locator shape (the express-demo evidence): `expression_text` is the `res.json({...})` call, whole-typed `any` through the error-typed receiver.
- Argument-position shape: the payload identifier itself baked whole-`any` through a missing library, while the receiver's annotation declares the literal contract.
- Registration-call shape (span/line locator, no expression text): exactly one callback parameter annotation carries an inline literal.

## Still decays, deliberately

- **Ambiguity**: two literal-carrying annotations in scope with no payload locator to disambiguate (e.g. `Request<{ id: string }>` alongside `Response<{ n: number }>` on a registration-located anchor). Picking one would risk publishing the params literal as the response contract; the alias keeps decaying honestly.
- **Literals referencing third-party types** (`Response<{ thing: LibThing }>`): recovering would bake `any` at a member; recovery refuses and the alias stays whole-`any` decayed, per the fail-closed rule.
- **Partially-decayed payload values** (object literal inferred as `{ x: any; y: string }` through a missing lib): the trigger is whole-top only. Inference produced real information there, and overriding it with the annotation could mask genuine drift between the declared and sent shapes; the self-check's deep walk keeps owning that verdict.
- **Named-handler registrations** (`app.get('/x', handlerRef)`) located at the registration call: the recovery does not follow the identifier to the handler declaration's parameters.

## Verification

- New suite `src/sidecar/test/capture-v2-inline-literal.test.ts` (6 tests) against a new bare-fixture route file; the three recovery cases fail on main with exactly the #433 decay (`alias resolved to a top type with no allowlisted external failure`) and pass with the fix; the two refusal cases pin honest decay at the recovery layer (`serialization: node_builder`, no `capture_failure_reason`).
- Full sidecar suite: 245 tests, 244 pass, 0 fail, 1 pre-existing skip (baseline on main: 239 tests).
- No manifest or wire-schema changes (no new fields; `serialization` stays `node_builder` for recovered aliases), so the Rust side is untouched; `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and the full `cargo test` gate run clean via the pre-commit hook.

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)
