### PR TITLE
fix(sidecar): contain stub poison + fix value-only and builder-chain anchors (#438, #439)

### DIFF
--- a/src/sidecar/src/capture/anchors.ts
+++ b/src/sidecar/src/capture/anchors.ts
@@ -7,7 +7,11 @@
 
 import ts from 'typescript';
 import * as path from 'node:path';
-import type { CaptureAnchorRequest, InferAnchorRequest } from './api.js';
+import type {
+  CaptureAnchorRequest,
+  InferAnchorRequest,
+  SymbolAnchorRequest,
+} from './api.js';
 import { printTypeForDestination } from './node-builder.js';
 
 export interface ResolvedAnchor {
@@ -17,6 +21,13 @@ export interface ResolvedAnchor {
   serialization: 'emitted' | 'node_builder' | 'structural_fallback';
   /** Present exactly for demotions (the alias line is `unknown`). */
   failureReason?: string;
+  /**
+   * Provenance for a non-demoting re-aim (#438/#439): recorded into the
+   * alias's `self_check_detail` when the alias self-checks clean, so a symbol
+   * anchor redirected from a value const to its `typeof` type sibling, or a
+   * builder-chain anchor moved off its config descriptor, stays traceable.
+   */
+  reaimNote?: string;
 }
 
 /** Repo-root-relative source file -> extensionless specifier from entryDir. */
@@ -111,6 +122,36 @@ export function resolveAnchor(
     // The anchor is the ELEMENT symbol; array_depth restores the use-site's
     // `[]` levels (#248/#306) so an array-vs-scalar mismatch stays visible.
     const arraySuffix = '[]'.repeat(Math.max(0, request.array_depth ?? 0));
+
+    // #438/#439: an LLM symbol anchor may name a schema VALUE const
+    // (`export const ZFooSchema = z.object({...})`) whose sibling
+    // `export type TFoo = z.infer<typeof ZFooSchema>` was the intended anchor.
+    // A value has no type-space meaning, so `import('./m').ZFooSchema` in TYPE
+    // position raises TS2694 in the stub tree and (before #438 part 2) poisons
+    // every producer pair. Guard structurally on symbol meaning, never on the
+    // name: resolve re-exports, then test for any type-space flag.
+    const resolvedExport = resolveSymbolAliases(checker, exported);
+    if (!symbolHasTypeMeaning(resolvedExport)) {
+      // #439 part 2: re-aim at a sibling type alias defined via a `typeof`
+      // type-query of this const (covers `z.infer<typeof C>` and equivalents;
+      // matched structurally, no library names). Guard A is the fallback.
+      const reaimed = reaimValueSymbolToTypeSibling(checker, sourceFile, {
+        request,
+        valueSymbol: resolvedExport,
+        spec,
+        arraySuffix,
+      });
+      if (reaimed) return reaimed;
+      // #438 part 1: value-only export with no type sibling. Demote so the
+      // existing demotion/backfill path engages (honest `unknown`) instead of
+      // emitting a surface line that references a value in type position.
+      return demote(
+        `'${request.symbol_name}' is a value export with no type-space meaning, ` +
+          `and no sibling type alias derives from it (e.g. \`typeof ${request.symbol_name}\`); ` +
+          'demoted so the surface line stays valid'
+      );
+    }
+
     return {
       request,
       aliasText: `import('${spec}').${request.symbol_name}${arraySuffix}`,
@@ -153,9 +194,24 @@ export function resolveAnchor(
   }
 
   // kind === 'infer'
-  const located = locateNode(sourceFile, request);
+  let located = locateNode(sourceFile, request);
   if (!located) {
     return demote(locatorFailureReason(request));
+  }
+  // #439 part 1: a producer anchor whose locator landed inside a fluent
+  // builder chain's config-descriptor argument (an all-literal metadata
+  // object) must never capture that descriptor as the request type. Re-aim at
+  // the chain's payload/schema argument, or demote when it cannot be picked
+  // unambiguously — never leave the descriptor captured (the artifact behind
+  // v1's false-incompatible verdicts; kept coupled with #438's containment).
+  let reaimNote: string | undefined;
+  const builderReaim = reaimBuilderChainPayload(located);
+  if (builderReaim.kind === 'demote') {
+    return demote(builderReaim.reason);
+  }
+  if (builderReaim.kind === 'reaim') {
+    located = builderReaim.node;
+    reaimNote = builderReaim.note;
   }
   let type = checker.getTypeAtLocation(located);
   if ((request.unwrap ?? 'awaited') === 'awaited') {
@@ -188,6 +244,7 @@ export function resolveAnchor(
     request,
     aliasText: printed.text,
     serialization: 'node_builder',
+    ...(reaimNote ? { reaimNote } : {}),
   };
 }
 
@@ -507,4 +564,286 @@ function firstExpressionOnLine(
   };
   visit(sourceFile);
   return best;
+}
+
+// ===========================================================================
+// #438/#439 symbol-anchor guards: value-only demotion + const->type re-aim.
+// ===========================================================================
+
+/** Follow re-export aliases to the symbol they ultimately denote. */
+function resolveSymbolAliases(checker: ts.TypeChecker, symbol: ts.Symbol): ts.Symbol {
+  let current = symbol;
+  // Bounded: alias chains are short; the guard is against a pathological cycle.
+  for (let i = 0; i < 16 && (current.flags & ts.SymbolFlags.Alias) !== 0; i++) {
+    let next: ts.Symbol | undefined;
+    try {
+      next = checker.getAliasedSymbol(current);
+    } catch {
+      break;
+    }
+    if (!next || next === current) break;
+    current = next;
+  }
+  return current;
+}
+
+/**
+ * True when the symbol can stand in TYPE position (class, interface, enum,
+ * type alias, type parameter, ...). A pure value export (const / let / var /
+ * function) has no type-space meaning, so referencing it as a type is TS2694.
+ * Structural — never a name check. `ts.SymbolFlags.Type` is the compiler's own
+ * composite of the type-space meanings.
+ */
+function symbolHasTypeMeaning(symbol: ts.Symbol): boolean {
+  return (symbol.flags & ts.SymbolFlags.Type) !== 0;
+}
+
+/**
+ * #439 part 2: when a symbol anchor names a value-only export, look in the
+ * SAME module for a single exported type alias whose type node contains a
+ * `typeof <const>` type-query (covers `z.infer<typeof C>`, `Infer<typeof C>`,
+ * and any equivalent — matched structurally, no library names). Exactly one
+ * match re-aims; zero or several fall back to the value-only demotion (never
+ * guess which of an input/output pair is the request).
+ */
+function reaimValueSymbolToTypeSibling(
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  ctx: {
+    request: SymbolAnchorRequest;
+    valueSymbol: ts.Symbol;
+    spec: string;
+    arraySuffix: string;
+  }
+): ResolvedAnchor | undefined {
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (!moduleSymbol) return undefined;
+  const matches: string[] = [];
+  for (const exported of checker.getExportsOfModule(moduleSymbol)) {
+    const resolved = resolveSymbolAliases(checker, exported);
+    if ((resolved.flags & ts.SymbolFlags.TypeAlias) === 0) continue;
+    const decl = resolved.declarations?.find(ts.isTypeAliasDeclaration);
+    if (!decl) continue;
+    if (
+      typeNodeQueriesSymbol(checker, decl.type, ctx.request.symbol_name, ctx.valueSymbol)
+    ) {
+      matches.push(exported.getName());
+    }
+  }
+  if (matches.length !== 1) return undefined;
+  return {
+    request: ctx.request,
+    aliasText: `import('${ctx.spec}').${matches[0]}${ctx.arraySuffix}`,
+    serialization: 'emitted',
+    reaimNote:
+      `symbol anchor '${ctx.request.symbol_name}' is a value; re-aimed at sibling ` +
+      `type alias '${matches[0]}' (derived via \`typeof ${ctx.request.symbol_name}\`)`,
+  };
+}
+
+/**
+ * Does `node` contain a `typeof X` type-query whose X denotes `valueSymbol`?
+ * Symbol identity is primary (resolves through re-exports and works on a bare
+ * checkout: the value symbol resolves without the schema library present); a
+ * textual identifier match on `symbolName` is the fallback.
+ */
+function typeNodeQueriesSymbol(
+  checker: ts.TypeChecker,
+  node: ts.TypeNode,
+  symbolName: string,
+  valueSymbol: ts.Symbol
+): boolean {
+  let found = false;
+  const visit = (n: ts.Node): void => {
+    if (found) return;
+    if (ts.isTypeQueryNode(n)) {
+      const entity = n.exprName;
+      const idNode = ts.isQualifiedName(entity) ? entity.right : entity;
+      const queried =
+        checker.getSymbolAtLocation(entity) ?? checker.getSymbolAtLocation(idNode);
+      if (queried && resolveSymbolAliases(checker, queried) === valueSymbol) {
+        found = true;
+        return;
+      }
+      if (ts.isIdentifier(idNode) && idNode.text === symbolName) {
+        found = true;
+        return;
+      }
+    }
+    n.forEachChild(visit);
+  };
+  visit(node);
+  return found;
+}
+
+// ===========================================================================
+// #439 part 1: builder-chain payload selection.
+//
+// A producer request anchor whose line-based locator lands inside a fluent
+// builder chain's config-descriptor argument (`.meta({ openapi: {...} })`)
+// would otherwise capture that literal metadata object as the request type.
+// We re-aim at the chain argument that carries a schema, or demote when the
+// payload cannot be picked unambiguously.
+//
+// STRUCTURAL, NOT NAME-BASED: no method name (`meta` / `input` / `mutation`)
+// is consulted anywhere. The signal that the located node is a config
+// descriptor is purely that it is a non-empty, all-literal-typed object
+// literal argument of a chain of >=2 fluent calls; the payload is the lone
+// non-literal, non-inline-function chain argument.
+//
+// LIMITATION (documented per the house rule that pragmatic is acceptable but
+// silent brittleness is not): a chain carrying two schema arguments — e.g.
+// both an input and an output schema — cannot be disambiguated structurally
+// without method-name knowledge, so it demotes to an honest `unknown` rather
+// than risk capturing the wrong side. This is coupling-safe: within this
+// trigger the locator already sat on the descriptor, so demoting can never be
+// worse than the (concrete, wrong) descriptor it replaces.
+// ===========================================================================
+
+type BuilderReaim =
+  | { kind: 'none' }
+  | { kind: 'reaim'; node: ts.Expression; note: string }
+  | { kind: 'demote'; reason: string };
+
+function reaimBuilderChainPayload(located: ts.Node): BuilderReaim {
+  const descriptorCall = enclosingChainDescriptorCall(located);
+  if (!descriptorCall) return { kind: 'none' };
+  const chain = fluentChainCalls(descriptorCall);
+  if (chain.length < 2) return { kind: 'none' };
+
+  const candidates = payloadCandidates(chain);
+  if (candidates.length === 1) {
+    return {
+      kind: 'reaim',
+      node: candidates[0],
+      note:
+        'producer anchor landed on a builder-chain config descriptor; ' +
+        're-aimed at the chain schema argument',
+    };
+  }
+  // Zero (a descriptor with no schema argument) or several (ambiguous
+  // input/output schemas): never keep the descriptor captured.
+  return {
+    kind: 'demote',
+    reason:
+      candidates.length === 0
+        ? 'producer anchor landed on a builder-chain config descriptor with no ' +
+          'identifiable schema argument; demoted to keep the request type honest'
+        : `producer anchor landed on a builder-chain config descriptor; ` +
+          `${candidates.length} schema arguments are present and cannot be ` +
+          'disambiguated structurally; demoted to keep the request type honest',
+  };
+}
+
+/**
+ * Walk up from the located node to the enclosing object literal that is (a) a
+ * direct argument of a call and (b) all-literal metadata (the descriptor
+ * signature). Returns that call, or undefined when the located node is not
+ * inside such a descriptor.
+ */
+function enclosingChainDescriptorCall(
+  located: ts.Node
+): ts.CallExpression | undefined {
+  let node: ts.Node | undefined = located;
+  while (node) {
+    if (
+      ts.isObjectLiteralExpression(node) &&
+      node.parent &&
+      ts.isCallExpression(node.parent) &&
+      (node.parent.arguments as readonly ts.Node[]).includes(node) &&
+      isAllLiteralMetadata(node)
+    ) {
+      return node.parent;
+    }
+    node = node.parent;
+  }
+  return undefined;
+}
+
+/**
+ * The full set of calls in the fluent chain containing `anyCall`
+ * (`x.a(...).b(...).c(...)` -> the three calls). Climbs to the outermost call,
+ * then descends the callee chain.
+ */
+function fluentChainCalls(anyCall: ts.CallExpression): ts.CallExpression[] {
+  let outer = anyCall;
+  for (;;) {
+    const access = outer.parent;
+    if (
+      access &&
+      (ts.isPropertyAccessExpression(access) || ts.isElementAccessExpression(access)) &&
+      access.expression === outer &&
+      access.parent &&
+      ts.isCallExpression(access.parent) &&
+      access.parent.expression === access
+    ) {
+      outer = access.parent;
+      continue;
+    }
+    break;
+  }
+  const calls: ts.CallExpression[] = [];
+  let current: ts.Expression = outer;
+  while (ts.isCallExpression(current)) {
+    calls.push(current);
+    const callee = current.expression;
+    if (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) {
+      current = callee.expression;
+    } else {
+      break;
+    }
+  }
+  return calls;
+}
+
+/**
+ * Chain arguments that carry type-space payload meaning: a named or
+ * constructed schema (identifier / member access / call). Primitive literals,
+ * inline object/array literals, and inline functions (handlers) are excluded —
+ * the classification is SYNTACTIC so it holds on a bare checkout where every
+ * schema resolves to `any`.
+ */
+function payloadCandidates(chain: ts.CallExpression[]): ts.Expression[] {
+  const out: ts.Expression[] = [];
+  for (const call of chain) {
+    for (const arg of call.arguments) {
+      if (
+        ts.isIdentifier(arg) ||
+        ts.isPropertyAccessExpression(arg) ||
+        ts.isElementAccessExpression(arg) ||
+        ts.isCallExpression(arg)
+      ) {
+        out.push(arg);
+      }
+    }
+  }
+  return out;
+}
+
+/** A non-empty object literal whose every property is a literal-typed value. */
+function isAllLiteralMetadata(obj: ts.ObjectLiteralExpression): boolean {
+  if (obj.properties.length === 0) return false;
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) return false;
+    if (!isLiteralValueExpression(prop.initializer)) return false;
+  }
+  return true;
+}
+
+function isLiteralValueExpression(expr: ts.Expression): boolean {
+  switch (expr.kind) {
+    case ts.SyntaxKind.StringLiteral:
+    case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
+    case ts.SyntaxKind.NumericLiteral:
+    case ts.SyntaxKind.TrueKeyword:
+    case ts.SyntaxKind.FalseKeyword:
+    case ts.SyntaxKind.NullKeyword:
+      return true;
+  }
+  if (ts.isPrefixUnaryExpression(expr)) return isLiteralValueExpression(expr.operand);
+  if (ts.isArrayLiteralExpression(expr)) {
+    return expr.elements.every(isLiteralValueExpression);
+  }
+  if (ts.isObjectLiteralExpression(expr)) return isAllLiteralMetadata(expr);
+  return false;
 }

--- a/src/sidecar/src/capture/anchors.ts
+++ b/src/sidecar/src/capture/anchors.ts
@@ -205,7 +205,7 @@ export function resolveAnchor(
   // unambiguously — never leave the descriptor captured (the artifact behind
   // v1's false-incompatible verdicts; kept coupled with #438's containment).
   let reaimNote: string | undefined;
-  const builderReaim = reaimBuilderChainPayload(located);
+  const builderReaim = reaimBuilderChainPayload(checker, located);
   if (builderReaim.kind === 'demote') {
     return demote(builderReaim.reason);
   }
@@ -625,7 +625,7 @@ function reaimValueSymbolToTypeSibling(
     const decl = resolved.declarations?.find(ts.isTypeAliasDeclaration);
     if (!decl) continue;
     if (
-      typeNodeQueriesSymbol(checker, decl.type, ctx.request.symbol_name, ctx.valueSymbol)
+      typeAliasRhsInfersConst(checker, decl.type, ctx.request.symbol_name, ctx.valueSymbol)
     ) {
       matches.push(exported.getName());
     }
@@ -642,38 +642,60 @@ function reaimValueSymbolToTypeSibling(
 }
 
 /**
- * Does `node` contain a `typeof X` type-query whose X denotes `valueSymbol`?
- * Symbol identity is primary (resolves through re-exports and works on a bare
- * checkout: the value symbol resolves without the schema library present); a
- * textual identifier match on `symbolName` is the fallback.
+ * True iff the type alias RHS IS the inferred type derived from a
+ * `typeof <const>` query — the ordinary `export type T = z.infer<typeof C>`
+ * shape — and NOT a wrapper that merely embeds it. Structurally: the whole
+ * type node is a generic type reference (`Infer<typeof C>` /
+ * `SomeGeneric<typeof C>`) whose DIRECT type arguments include a `typeof C`
+ * query.
+ *
+ * An object / union / intersection / array that embeds the query as a member
+ * or element (`{ data: Infer<typeof C>; meta: string }`) is a WRAPPER: re-aiming
+ * at it would capture the wrapper shape, not the payload, and (since the
+ * wrapper self-checks concretely) manufacture a false incompatible. Those fall
+ * back to the value-only demotion — a guaranteed abstain, never a wrong
+ * concrete verdict. A bare `typeof C` alias is also rejected: it denotes the
+ * schema wrapper value's type, not the inferred payload. Still no library-name
+ * checks: matched purely on shape.
  */
-function typeNodeQueriesSymbol(
+function typeAliasRhsInfersConst(
   checker: ts.TypeChecker,
   node: ts.TypeNode,
   symbolName: string,
   valueSymbol: ts.Symbol
 ): boolean {
-  let found = false;
-  const visit = (n: ts.Node): void => {
-    if (found) return;
-    if (ts.isTypeQueryNode(n)) {
-      const entity = n.exprName;
-      const idNode = ts.isQualifiedName(entity) ? entity.right : entity;
-      const queried =
-        checker.getSymbolAtLocation(entity) ?? checker.getSymbolAtLocation(idNode);
-      if (queried && resolveSymbolAliases(checker, queried) === valueSymbol) {
-        found = true;
-        return;
-      }
-      if (ts.isIdentifier(idNode) && idNode.text === symbolName) {
-        found = true;
-        return;
-      }
+  if (!ts.isTypeReferenceNode(node)) return false;
+  for (const arg of node.typeArguments ?? []) {
+    let inner: ts.TypeNode = arg;
+    while (ts.isParenthesizedTypeNode(inner)) inner = inner.type;
+    if (
+      ts.isTypeQueryNode(inner) &&
+      typeQueryMatchesSymbol(checker, inner, symbolName, valueSymbol)
+    ) {
+      return true;
     }
-    n.forEachChild(visit);
-  };
-  visit(node);
-  return found;
+  }
+  return false;
+}
+
+/**
+ * Does a `typeof X` query denote `valueSymbol`? Symbol identity is primary
+ * (resolves through re-exports and works on a bare checkout: the value symbol
+ * resolves without the schema library present); a textual identifier match on
+ * `symbolName` is the fallback.
+ */
+function typeQueryMatchesSymbol(
+  checker: ts.TypeChecker,
+  query: ts.TypeQueryNode,
+  symbolName: string,
+  valueSymbol: ts.Symbol
+): boolean {
+  const entity = query.exprName;
+  const idNode = ts.isQualifiedName(entity) ? entity.right : entity;
+  const queried =
+    checker.getSymbolAtLocation(entity) ?? checker.getSymbolAtLocation(idNode);
+  if (queried && resolveSymbolAliases(checker, queried) === valueSymbol) return true;
+  return ts.isIdentifier(idNode) && idNode.text === symbolName;
 }
 
 // ===========================================================================
@@ -688,16 +710,26 @@ function typeNodeQueriesSymbol(
 // STRUCTURAL, NOT NAME-BASED: no method name (`meta` / `input` / `mutation`)
 // is consulted anywhere. The signal that the located node is a config
 // descriptor is purely that it is a non-empty, all-literal-typed object
-// literal argument of a chain of >=2 fluent calls; the payload is the lone
-// non-literal, non-inline-function chain argument.
+// literal argument of a chain of >=2 fluent calls; a payload candidate is a
+// chain argument whose RESOLVED type has object/payload meaning (a schema
+// resolves to an object; a string/number tag does not).
+//
+// SAFETY of the two outcomes:
+//   - the DEMOTE branches (no object candidate, or several) are no-worse-than
+//     the descriptor: within this trigger the locator already sat on the
+//     descriptor, so an honest `unknown` can never be worse than the concrete,
+//     wrong descriptor it replaces — a guaranteed abstain.
+//   - the single-candidate RE-AIM branch is a HEURISTIC, not a guaranteed-safe
+//     substitution: it swaps the concrete descriptor for a concrete payload
+//     type, so it is deliberately guarded (object-typed candidate only, and
+//     exactly one) to keep the genuine single-schema case working while a
+//     non-object, ambiguous, or absent candidate abstains instead of guessing.
 //
 // LIMITATION (documented per the house rule that pragmatic is acceptable but
-// silent brittleness is not): a chain carrying two schema arguments — e.g.
-// both an input and an output schema — cannot be disambiguated structurally
-// without method-name knowledge, so it demotes to an honest `unknown` rather
-// than risk capturing the wrong side. This is coupling-safe: within this
-// trigger the locator already sat on the descriptor, so demoting can never be
-// worse than the (concrete, wrong) descriptor it replaces.
+// silent brittleness is not): a chain carrying two object-typed arguments —
+// e.g. both an input and an output schema — cannot be disambiguated as request
+// vs response without method-name knowledge, so it demotes rather than risk
+// the wrong side.
 // ===========================================================================
 
 type BuilderReaim =
@@ -705,13 +737,16 @@ type BuilderReaim =
   | { kind: 'reaim'; node: ts.Expression; note: string }
   | { kind: 'demote'; reason: string };
 
-function reaimBuilderChainPayload(located: ts.Node): BuilderReaim {
+function reaimBuilderChainPayload(
+  checker: ts.TypeChecker,
+  located: ts.Node
+): BuilderReaim {
   const descriptorCall = enclosingChainDescriptorCall(located);
   if (!descriptorCall) return { kind: 'none' };
   const chain = fluentChainCalls(descriptorCall);
   if (chain.length < 2) return { kind: 'none' };
 
-  const candidates = payloadCandidates(chain);
+  const candidates = payloadCandidates(checker, chain);
   if (candidates.length === 1) {
     return {
       kind: 'reaim',
@@ -797,27 +832,79 @@ function fluentChainCalls(anyCall: ts.CallExpression): ts.CallExpression[] {
 }
 
 /**
- * Chain arguments that carry type-space payload meaning: a named or
- * constructed schema (identifier / member access / call). Primitive literals,
- * inline object/array literals, and inline functions (handlers) are excluded —
- * the classification is SYNTACTIC so it holds on a bare checkout where every
- * schema resolves to `any`.
+ * Chain arguments that carry type-space PAYLOAD meaning: a named or constructed
+ * schema (identifier / member access / call) whose RESOLVED type is an object
+ * shape. Two filters, both load-bearing:
+ *  - syntactic: inline object/array literals and inline functions (handlers)
+ *    are never candidates;
+ *  - semantic: a candidate whose resolved type is a primitive or literal
+ *    (`.tag(routeName)` with `routeName: string`), a bare callable (a named
+ *    handler), or a top type is REJECTED — capturing a string-literal type as a
+ *    request payload manufactures a false incompatible. Only an object-typed
+ *    argument is a real schema.
+ * With this filter the single-candidate re-aim fires only on a genuine schema,
+ * and a non-object, ambiguous (>1), or absent candidate abstains via demote.
  */
-function payloadCandidates(chain: ts.CallExpression[]): ts.Expression[] {
+function payloadCandidates(
+  checker: ts.TypeChecker,
+  chain: ts.CallExpression[]
+): ts.Expression[] {
   const out: ts.Expression[] = [];
   for (const call of chain) {
     for (const arg of call.arguments) {
       if (
-        ts.isIdentifier(arg) ||
-        ts.isPropertyAccessExpression(arg) ||
-        ts.isElementAccessExpression(arg) ||
-        ts.isCallExpression(arg)
+        (ts.isIdentifier(arg) ||
+          ts.isPropertyAccessExpression(arg) ||
+          ts.isElementAccessExpression(arg) ||
+          ts.isCallExpression(arg)) &&
+        typeIsObjectPayload(checker.getTypeAtLocation(arg))
       ) {
         out.push(arg);
       }
     }
   }
   return out;
+}
+
+/**
+ * A type with object/payload meaning: a real object shape (or a union /
+ * intersection of them), never a primitive, string/number/boolean/bigint/enum
+ * literal, null/undefined/void, a top type (`any`/`unknown`/`never` — cannot be
+ * confirmed a payload), or a bare callable value (a handler function). This is
+ * the gate that keeps the builder-chain re-aim from capturing a non-schema.
+ */
+function typeIsObjectPayload(type: ts.Type): boolean {
+  const nonObject =
+    ts.TypeFlags.Any |
+    ts.TypeFlags.Unknown |
+    ts.TypeFlags.Never |
+    ts.TypeFlags.Null |
+    ts.TypeFlags.Undefined |
+    ts.TypeFlags.Void |
+    ts.TypeFlags.StringLike |
+    ts.TypeFlags.NumberLike |
+    ts.TypeFlags.BooleanLike |
+    ts.TypeFlags.BigIntLike |
+    ts.TypeFlags.ESSymbolLike |
+    ts.TypeFlags.EnumLike;
+  if (type.flags & nonObject) return false;
+  if (type.flags & (ts.TypeFlags.Union | ts.TypeFlags.Intersection)) {
+    // Every constituent must be an object shape: `string | { a }` is not a
+    // clean payload, while a union of objects stays eligible.
+    return (type as ts.UnionOrIntersectionType).types.every(typeIsObjectPayload);
+  }
+  if (type.flags & ts.TypeFlags.Object) {
+    // A bare callable (a named handler passed as a value) is not a payload; a
+    // schema object carries no top-level call/construct signature.
+    if (
+      type.getCallSignatures().length > 0 ||
+      type.getConstructSignatures().length > 0
+    ) {
+      return false;
+    }
+    return true;
+  }
+  return false;
 }
 
 /** A non-empty object literal whose every property is a literal-typed value. */

--- a/src/sidecar/src/capture/api.ts
+++ b/src/sidecar/src/capture/api.ts
@@ -277,7 +277,14 @@ export interface CheckVerdict {
   codes: number[];
 }
 
-/** A service whose pairs are degraded wholesale (install failure or poison). */
+/**
+ * A service degraded SERVICE-WIDE: install failure, or a stub-tree diagnostic
+ * that could not be attributed to any alias's import closure (#438). Poison
+ * contained to specific aliases does NOT appear here — those pairs carry their
+ * own `poison:*` verdicts while the service's clean pairs verify normally. So
+ * absence from this list is not a "fully verified" signal; read per-pair
+ * verdicts for that.
+ */
 export interface DegradedService {
   service_name: string;
   reason: string;

--- a/src/sidecar/src/capture/check-classify.ts
+++ b/src/sidecar/src/capture/check-classify.ts
@@ -111,7 +111,7 @@ export function classifyPair(input: ClassifyInput): CheckVerdict {
         ...base,
         bucket: 'unverifiable',
         gate: `poison:${side}`,
-        diagnostic: `types for service '${endpoint.service_name}' contain declaration conflicts; compatibility cannot be verified.`,
+        diagnostic: `the type stub for service '${endpoint.service_name}' does not typecheck (its own declarations carry diagnostics); compatibility cannot be verified.`,
       };
     }
   }

--- a/src/sidecar/src/capture/check-classify.ts
+++ b/src/sidecar/src/capture/check-classify.ts
@@ -85,8 +85,12 @@ export interface ClassifyInput {
   plan: ProbePlan;
   /** Diagnostics attributed to this pair's probe file. */
   probeDiags: RawDiagnostic[];
-  /** Returns a reason string if the service's stub tree is poisoned. */
-  poisonReason: (serviceName: string) => string | undefined;
+  /**
+   * Returns a reason string when THIS alias of the service is poisoned (#438
+   * part 2: poison is contained to the aliases whose closure includes the
+   * poisoned file, not the whole service).
+   */
+  poisonReason: (serviceName: string, alias: string) => string | undefined;
   scrubCtx: ScrubContext;
 }
 
@@ -96,17 +100,18 @@ export function classifyPair(input: ClassifyInput): CheckVerdict {
   const codes = [...new Set(probeDiags.map((d) => d.code))].sort((a, b) => a - b);
   const base = { pair_id: plan.pairId, pair_key: plan.spec.pair_key, codes };
 
-  // 1. Poison: any diagnostic in either side's stub tree makes the pair
-  //    unverifiable, never "no probe error -> compatible".
+  // 1. Poison: a diagnostic in this pair's own alias closure (either side)
+  //    makes the pair unverifiable, never "no probe error -> compatible". A
+  //    sibling alias's poison in the same service no longer reaches here.
   for (const side of ['producer', 'consumer'] as const) {
-    const service = plan.spec[side].service_name;
-    const reason = poisonReason(service);
+    const endpoint = plan.spec[side];
+    const reason = poisonReason(endpoint.service_name, endpoint.alias);
     if (reason) {
       return {
         ...base,
         bucket: 'unverifiable',
         gate: `poison:${side}`,
-        diagnostic: `types for service '${service}' contain declaration conflicts; compatibility cannot be verified.`,
+        diagnostic: `types for service '${endpoint.service_name}' contain declaration conflicts; compatibility cannot be verified.`,
       };
     }
   }

--- a/src/sidecar/src/capture/check-poison.ts
+++ b/src/sidecar/src/capture/check-poison.ts
@@ -1,0 +1,179 @@
+/**
+ * #438 part 2: stub-tree poison containment.
+ *
+ * A diagnostic in a service's own stub tree (a broken surface line, a nested
+ * declaration file that fails to typecheck) used to poison the WHOLE service —
+ * every pair with that service as producer/consumer read `unverifiable`
+ * (gate=poison:*), masking every clean pair behind one bad alias. This module
+ * contains poison to the aliases actually reachable from the poisoned file:
+ *
+ *  - a diagnostic on the surface entry is attributed to the alias whose
+ *    `export type` statement SPAN covers the diagnostic's line (a multi-line
+ *    alias reports on an interior line);
+ *  - a diagnostic in a nested tree file is attributed to every alias whose
+ *    import closure (surface import-type seeds, then BFS over relative
+ *    imports — the same closure the capture self-check computes) includes that
+ *    file.
+ *
+ * A stub-tree diagnostic reachable from NO alias (e.g. a cross-stub
+ * `declare global` TS2717 collision in an augmentation file, which
+ * `skipLibCheck:false` exists to surface — see check-workspace.ts) has no
+ * closure to contain it and genuinely can affect any alias's comparison, so it
+ * falls back to service-wide poison. Soundness (never falsely compatible) wins
+ * over precision in that one case; every attributable diagnostic is contained.
+ *
+ * Seam: node builtins + `typescript` + this bundle only.
+ */
+
+import ts from 'typescript';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { AssembledWorkspace } from './check-workspace.js';
+import { collectSpecifiers, isRelative } from './specifiers.js';
+
+export interface StubPoisonIndex {
+  serviceName: string;
+  /** Workspace-relative surface key: `packages/<dir>/types/surface.d.ts`. */
+  surfaceFile: string;
+  /** Every alias declared in the surface. */
+  allAliases: Set<string>;
+  /** Alias whose `export type` statement span covers the given surface line. */
+  aliasAtSurfaceLine(line: number): string | undefined;
+  /** Aliases whose import closure includes the given workspace-relative file. */
+  aliasesForFile(fileKey: string): string[];
+}
+
+/** One index per assembled stub, keyed by service name. */
+export function buildPoisonIndexes(
+  ws: AssembledWorkspace
+): Map<string, StubPoisonIndex> {
+  const indexes = new Map<string, StubPoisonIndex>();
+  for (const stub of ws.stubs) {
+    const index = buildOne(ws, stub.serviceName, stub.packageDir);
+    if (index) indexes.set(stub.serviceName, index);
+  }
+  return indexes;
+}
+
+function buildOne(
+  ws: AssembledWorkspace,
+  serviceName: string,
+  packageDir: string
+): StubPoisonIndex | undefined {
+  const typesDirAbs = path.join(ws.workspaceDir, 'packages', packageDir, 'types');
+  const surfaceAbs = path.join(typesDirAbs, 'surface.d.ts');
+  if (!fs.existsSync(surfaceAbs)) return undefined;
+
+  const keyPrefix = `packages/${packageDir}/types`;
+  const surfaceFile = `${keyPrefix}/surface.d.ts`;
+
+  // Collect the whole `.d.ts` tree, keyed as `packages/<dir>/types/<rel>`.
+  const treeAbs: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.name.endsWith('.d.ts')) treeAbs.push(p);
+    }
+  };
+  walk(typesDirAbs);
+  const treeAbsSet = new Set(treeAbs.map((f) => path.resolve(f)));
+  const keyOf = (abs: string): string =>
+    `${keyPrefix}/${path.relative(typesDirAbs, abs).split(path.sep).join('/')}`;
+
+  const resolveRel = (fromAbs: string, spec: string): string | undefined => {
+    if (!isRelative(spec)) return undefined;
+    const base = path.resolve(path.dirname(fromAbs), spec);
+    const candidates = [
+      `${base}.d.ts`,
+      path.join(base, 'index.d.ts'),
+      base.endsWith('.js') ? `${base.slice(0, -3)}.d.ts` : undefined,
+      base, // already `.d.ts`
+    ].filter((c): c is string => c !== undefined);
+    for (const c of candidates) {
+      if (treeAbsSet.has(path.resolve(c))) return c;
+    }
+    return undefined;
+  };
+
+  // Per-file relative-import adjacency, over the fileKey namespace.
+  const adjacency = new Map<string, string[]>();
+  for (const abs of treeAbs) {
+    const text = fs.readFileSync(abs, 'utf8');
+    const neighbors: string[] = [];
+    for (const spec of collectSpecifiers(text)) {
+      const target = resolveRel(abs, spec);
+      if (target) neighbors.push(keyOf(target));
+    }
+    adjacency.set(keyOf(abs), neighbors);
+  }
+
+  // Surface alias statement spans + each alias's import-type seed files.
+  const surfaceText = fs.readFileSync(surfaceAbs, 'utf8');
+  const sf = ts.createSourceFile(
+    'surface.d.ts',
+    surfaceText,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const allAliases = new Set<string>();
+  const spans: Array<{ alias: string; startLine: number; endLine: number }> = [];
+  const seedsByAlias = new Map<string, string[]>();
+  for (const stmt of sf.statements) {
+    if (!ts.isTypeAliasDeclaration(stmt)) continue;
+    const alias = stmt.name.text;
+    allAliases.add(alias);
+    spans.push({
+      alias,
+      startLine: sf.getLineAndCharacterOfPosition(stmt.getStart(sf)).line + 1,
+      endLine: sf.getLineAndCharacterOfPosition(stmt.getEnd()).line + 1,
+    });
+    const seeds: string[] = [];
+    const visit = (n: ts.Node): void => {
+      if (
+        ts.isImportTypeNode(n) &&
+        ts.isLiteralTypeNode(n.argument) &&
+        ts.isStringLiteral(n.argument.literal) &&
+        isRelative(n.argument.literal.text)
+      ) {
+        const target = resolveRel(surfaceAbs, n.argument.literal.text);
+        if (target) seeds.push(keyOf(target));
+      }
+      n.forEachChild(visit);
+    };
+    visit(stmt);
+    seedsByAlias.set(alias, seeds);
+  }
+
+  // Invert per-alias closures into fileKey -> aliases.
+  const fileToAliases = new Map<string, Set<string>>();
+  for (const [alias, seeds] of seedsByAlias) {
+    const closure = new Set<string>();
+    const queue = [...seeds];
+    while (queue.length > 0) {
+      const file = queue.pop()!;
+      if (closure.has(file)) continue;
+      closure.add(file);
+      for (const next of adjacency.get(file) ?? []) queue.push(next);
+    }
+    for (const file of closure) {
+      if (!fileToAliases.has(file)) fileToAliases.set(file, new Set());
+      fileToAliases.get(file)!.add(alias);
+    }
+  }
+
+  return {
+    serviceName,
+    surfaceFile,
+    allAliases,
+    aliasAtSurfaceLine(line: number): string | undefined {
+      for (const span of spans) {
+        if (line >= span.startLine && line <= span.endLine) return span.alias;
+      }
+      return undefined;
+    },
+    aliasesForFile(fileKey: string): string[] {
+      return [...(fileToAliases.get(fileKey) ?? [])];
+    },
+  };
+}

--- a/src/sidecar/src/capture/check.ts
+++ b/src/sidecar/src/capture/check.ts
@@ -41,7 +41,7 @@ import {
   writeProbes,
   type AssembledWorkspace,
 } from './check-workspace.js';
-import { buildPoisonIndexes } from './check-poison.js';
+import { buildPoisonIndexes, type StubPoisonIndex } from './check-poison.js';
 
 export type CheckProgress = (phase: CheckProgressPhase, message: string) => void;
 
@@ -424,7 +424,11 @@ function attributeDiagnostics(
     probeFileToPair.set(`${ws.probesRel}/probes/${plan.fileName}`, plan.pairId);
   }
   const stubDirs = new Set(ws.stubs.map((s) => s.packageDir));
-  const indexes = buildPoisonIndexes(ws);
+  // Lazy: the clean path (no stub-tree diagnostic) must not walk and parse
+  // every stub `.d.ts` tree. Built on first stub-tree diagnostic, at most once.
+  let indexesMemo: Map<string, StubPoisonIndex> | undefined;
+  const getIndexes = (): Map<string, StubPoisonIndex> =>
+    (indexesMemo ??= buildPoisonIndexes(ws));
 
   const probeDiagsByPair = new Map<string, RawDiagnostic[]>();
   const poison = new Map<string, PoisonScope>();
@@ -456,7 +460,7 @@ function attributeDiagnostics(
       const service = ws.serviceOfPackageDir(pkgMatch[1]);
       if (!service) continue;
       const scope = scopeFor(service);
-      const index = indexes.get(service);
+      const index = getIndexes().get(service);
       if (index && d.file === index.surfaceFile) {
         // Surface diagnostic: attribute by the alias statement span it sits in.
         const alias = index.aliasAtSurfaceLine(d.line);

--- a/src/sidecar/src/capture/check.ts
+++ b/src/sidecar/src/capture/check.ts
@@ -41,6 +41,7 @@ import {
   writeProbes,
   type AssembledWorkspace,
 } from './check-workspace.js';
+import { buildPoisonIndexes } from './check-poison.js';
 
 export type CheckProgress = (phase: CheckProgressPhase, message: string) => void;
 
@@ -300,16 +301,23 @@ export async function runCheck(
     probing
   );
   for (const e of globalErrors) errors.push(scrubPaths(e, scrubCtx));
-  for (const [service, reason] of poison) {
-    degraded.push({ service_name: service, reason });
+  // Only SERVICE-WIDE poison (an unattributable stub diagnostic) degrades the
+  // whole service; contained alias-scoped poison rides its own verdicts.
+  for (const [service, scope] of poison) {
+    if (scope.all) degraded.push({ service_name: service, reason: scope.reason });
   }
+  const poisonReason = (service: string, alias: string): string | undefined => {
+    const scope = poison.get(service);
+    if (!scope) return undefined;
+    return scope.all || scope.aliases.has(alias) ? scope.reason : undefined;
+  };
 
   const verdicts = sortVerdicts([
     ...probing.map((plan) =>
       classifyPair({
         plan,
         probeDiags: probeDiagsByPair.get(plan.pairId) ?? [],
-        poisonReason: (svc) => poison.get(svc),
+        poisonReason,
         scrubCtx,
       })
     ),
@@ -383,14 +391,32 @@ function deepDecayOf(
   return undefined;
 }
 
-/** Group diagnostics: per-probe (for classification), plus stub-tree poison. */
+/**
+ * Alias-scoped poison for a service (#438 part 2). `all` is set only when a
+ * stub diagnostic could not be attributed to any alias's closure (soundness
+ * fallback); otherwise exactly the reachable aliases are poisoned.
+ */
+interface PoisonScope {
+  all: boolean;
+  aliases: Set<string>;
+  reason: string;
+}
+
+const POISON_REASON = 'stub type tree carries its own diagnostics';
+
+/**
+ * Group diagnostics: per-probe (for classification), plus stub-tree poison
+ * CONTAINED to the aliases reachable from the poisoned file (#438 part 2). An
+ * unattributable stub diagnostic (an augmentation-file collision in no alias's
+ * closure) falls back to service-wide poison; everything else is scoped.
+ */
 function attributeDiagnostics(
   diagnostics: RawDiagnostic[],
   ws: AssembledWorkspace,
   plans: ProbePlan[]
 ): {
   probeDiagsByPair: Map<string, RawDiagnostic[]>;
-  poison: Map<string, string>;
+  poison: Map<string, PoisonScope>;
   globalErrors: string[];
 } {
   const probeFileToPair = new Map<string, string>();
@@ -398,10 +424,20 @@ function attributeDiagnostics(
     probeFileToPair.set(`${ws.probesRel}/probes/${plan.fileName}`, plan.pairId);
   }
   const stubDirs = new Set(ws.stubs.map((s) => s.packageDir));
+  const indexes = buildPoisonIndexes(ws);
 
   const probeDiagsByPair = new Map<string, RawDiagnostic[]>();
-  const poison = new Map<string, string>();
+  const poison = new Map<string, PoisonScope>();
   const globalErrors: string[] = [];
+
+  const scopeFor = (service: string): PoisonScope => {
+    let scope = poison.get(service);
+    if (!scope) {
+      scope = { all: false, aliases: new Set(), reason: POISON_REASON };
+      poison.set(service, scope);
+    }
+    return scope;
+  };
 
   for (const d of diagnostics) {
     if (!d.file) {
@@ -418,8 +454,22 @@ function attributeDiagnostics(
     const pkgMatch = d.file.match(/^packages\/([^/]+)\//);
     if (pkgMatch && !d.file.includes('/node_modules/') && stubDirs.has(pkgMatch[1])) {
       const service = ws.serviceOfPackageDir(pkgMatch[1]);
-      if (service && !poison.has(service)) {
-        poison.set(service, 'stub type tree carries its own diagnostics');
+      if (!service) continue;
+      const scope = scopeFor(service);
+      const index = indexes.get(service);
+      if (index && d.file === index.surfaceFile) {
+        // Surface diagnostic: attribute by the alias statement span it sits in.
+        const alias = index.aliasAtSurfaceLine(d.line);
+        if (alias) scope.aliases.add(alias);
+        else scope.all = true;
+      } else if (index) {
+        // Nested-file diagnostic: attribute to every alias whose closure reads
+        // it; a file in no closure (augmentation collision) falls back wide.
+        const affected = index.aliasesForFile(d.file);
+        if (affected.length > 0) for (const a of affected) scope.aliases.add(a);
+        else scope.all = true;
+      } else {
+        scope.all = true;
       }
     }
     // Anything else (node_modules, TS lib) is environmental: ignored for

--- a/src/sidecar/src/capture/self-check.ts
+++ b/src/sidecar/src/capture/self-check.ts
@@ -390,7 +390,9 @@ function checkedRecord(
     anchor_origin: anchor.request.anchor_origin,
     serialization: anchor.serialization,
     self_check: outcome,
-    self_check_detail: detail,
+    // A #438/#439 re-aim note is provenance only; a real decay detail always
+    // wins, so it surfaces exactly when the re-aimed alias self-checks clean.
+    self_check_detail: detail ?? anchor.reaimNote,
     top_type_at_self_check: topType,
     ...(unexplainedDeep
       ? {

--- a/src/sidecar/test/capture-v2-builder-chain.test.ts
+++ b/src/sidecar/test/capture-v2-builder-chain.test.ts
@@ -31,10 +31,14 @@ interface Builder {
   meta(config: object): Builder;
   input(schema: unknown): Builder;
   output(schema: unknown): Builder;
+  tag(name: string): Builder;
   mutation(handler: () => unknown): Route;
 }
 interface Route { readonly __route: true; }
 declare const procedure: Builder;
+
+// A non-schema string constant passed to a chain method.
+declare const routeTag: string;
 
 // A plain-object schema whose inferred payload is an anonymous object type
 // (the shape a \`.input(schema)\` argument carries after inference).
@@ -70,6 +74,23 @@ declare function send(body: unknown): void;
 export function handler() {
   send({ status: "ok", code: 200 });
 }
+
+// Non-schema lone argument: the only non-descriptor argument is a string const,
+// not a schema. Capturing "documents" as a request payload is a false
+// incompatible, so this must abstain (demote).
+export const tagRoute = procedure
+  .meta({ openapi: { method: "POST", path: "/documents/tag" } })
+  .tag(routeTag)
+  .mutation(() => ({}));
+
+// A chain whose true payload is an all-literal object arg (never a candidate)
+// alongside a non-schema string identifier: must abstain, not mis-aim onto the
+// identifier.
+export const literalPayloadRoute = procedure
+  .meta({ openapi: { method: "POST", path: "/documents/create" } })
+  .input({ orderId: 1, label: "x" })
+  .tag(routeTag)
+  .mutation(() => ({}));
 `;
 
 function writeRepo(): void {
@@ -141,6 +162,26 @@ describe('capture v2: builder-chain payload selection over config descriptor', (
           expression_text: '{ status: "ok", code: 200 }',
           unwrap: 'none',
         },
+        // Lone non-schema argument (a string const) -> must abstain, never
+        // capture the string as a payload.
+        {
+          kind: 'infer',
+          alias: 'Tag_Request',
+          source_file: 'src/router.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: '{ openapi: { method: "POST", path: "/documents/tag" } }',
+          unwrap: 'none',
+        },
+        // Chain with a literal-object payload + a non-schema identifier -> must
+        // abstain, never re-aim onto the identifier.
+        {
+          kind: 'infer',
+          alias: 'LiteralPayload_Request',
+          source_file: 'src/router.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: '{ openapi: { method: "POST", path: "/documents/create" } }',
+          unwrap: 'none',
+        },
       ],
     });
     assert.strictEqual(result.success, true, JSON.stringify(result.errors));
@@ -199,5 +240,24 @@ describe('capture v2: builder-chain payload selection over config descriptor', (
     assert.match(surface, /Single_Request = [\s\S]*status/);
     assert.match(surface, /Single_Request = [\s\S]*code/);
     assert.ok(!/Single_Request = unknown;/.test(surface), surface);
+  });
+
+  it('abstains when the lone chain argument is a non-schema string const', () => {
+    // Pre-fix this captured `string` (the tag const) as the request payload.
+    const r = record('Tag_Request');
+    assert.strictEqual(r.serialization, 'structural_fallback');
+    assert.ok(r.capture_failure_reason, 'a non-schema lone arg must demote');
+    assert.match(surface, /Tag_Request = unknown;/);
+    // Never captures the string constant as a payload.
+    assert.ok(!/Tag_Request = string;/.test(surface), surface);
+  });
+
+  it('abstains when a literal-object payload sits beside a non-schema identifier', () => {
+    // Pre-fix this re-aimed onto the string identifier instead of abstaining.
+    const r = record('LiteralPayload_Request');
+    assert.strictEqual(r.serialization, 'structural_fallback');
+    assert.ok(r.capture_failure_reason, 'an ambiguous non-object candidate must demote');
+    assert.match(surface, /LiteralPayload_Request = unknown;/);
+    assert.ok(!/LiteralPayload_Request = string;/.test(surface), surface);
   });
 });

--- a/src/sidecar/test/capture-v2-builder-chain.test.ts
+++ b/src/sidecar/test/capture-v2-builder-chain.test.ts
@@ -1,0 +1,203 @@
+/**
+ * #439 part 1: builder-chain producer anchors must select the schema
+ * argument, not the config descriptor.
+ *
+ * A producer request anchor whose line-based locator lands inside a fluent
+ * builder chain's config-descriptor argument (`.meta({ openapi: {...} })`)
+ * would otherwise capture that all-literal metadata object as the request
+ * type. The fix re-aims at the chain's lone schema argument, or demotes when
+ * the payload cannot be picked unambiguously — never keeping the descriptor
+ * (the artifact behind v1's false-incompatible verdicts).
+ *
+ * Detection is STRUCTURAL (no method names): the descriptor is a non-empty,
+ * all-literal object literal argument of a chain of >=2 fluent calls; the
+ * payload is the lone non-literal, non-inline-function chain argument. All
+ * fixtures are synthetic and generically named.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { captureStub } from '../src/capture/index.js';
+import type { CaptureStubResult } from '../src/capture/api.js';
+
+let repoDir: string;
+let outRoot: string;
+
+const ROUTER_TS = `
+interface Builder {
+  meta(config: object): Builder;
+  input(schema: unknown): Builder;
+  output(schema: unknown): Builder;
+  mutation(handler: () => unknown): Route;
+}
+interface Route { readonly __route: true; }
+declare const procedure: Builder;
+
+// A plain-object schema whose inferred payload is an anonymous object type
+// (the shape a \`.input(schema)\` argument carries after inference).
+declare const updateSchema: { documentId: number; title: string };
+
+// A fluent builder whose config descriptor is all-literal metadata and whose
+// single schema argument carries the request payload. The anchor's locator
+// lands on the descriptor object literal.
+export const updateRoute = procedure
+  .meta({ openapi: { method: "POST", path: "/documents/update", summary: "x" } })
+  .input(updateSchema)
+  .mutation(() => ({ ok: true }));
+
+declare const inputSchema: { a: number };
+declare const outputSchema: { b: string };
+
+// Two schema arguments (input + output) cannot be disambiguated structurally.
+export const twoSchemaRoute = procedure
+  .meta({ tag: "documents" })
+  .input(inputSchema)
+  .output(outputSchema)
+  .mutation(() => ({}));
+
+// Control: a real body object literal returned from a function (not a fluent
+// chain argument) must be captured as-is, never demoted.
+export function makeResponse() {
+  return { id: 1, name: "widget" };
+}
+
+// Control: an all-literal object literal argument of a SINGLE call (not a
+// fluent chain) must be captured as-is (the express \`res.json({...})\` shape).
+declare function send(body: unknown): void;
+export function handler() {
+  send({ status: "ok", code: 200 });
+}
+`;
+
+function writeRepo(): void {
+  fs.mkdirSync(path.join(repoDir, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoDir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        rootDir: 'src',
+        module: 'esnext',
+        moduleResolution: 'bundler',
+        target: 'es2022',
+        skipLibCheck: true,
+      },
+      include: ['src'],
+    })
+  );
+  fs.writeFileSync(path.join(repoDir, 'src', 'router.ts'), ROUTER_TS);
+}
+
+describe('capture v2: builder-chain payload selection over config descriptor', () => {
+  let result: CaptureStubResult;
+  let surface: string;
+
+  before(() => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-chain-repo-'));
+    outRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-chain-stub-'));
+    writeRepo();
+    result = captureStub({
+      repoRoot: repoDir,
+      serviceName: 'chain-svc',
+      outDir: path.join(outRoot, 'stub'),
+      anchors: [
+        // Locator lands on the descriptor object literal of the fluent chain.
+        {
+          kind: 'infer',
+          alias: 'Payload_Request',
+          source_file: 'src/router.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text:
+            '{ openapi: { method: "POST", path: "/documents/update", summary: "x" } }',
+          unwrap: 'none',
+        },
+        // Two schema args -> ambiguous -> demote.
+        {
+          kind: 'infer',
+          alias: 'TwoSchema_Request',
+          source_file: 'src/router.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: '{ tag: "documents" }',
+          unwrap: 'none',
+        },
+        // Control: return-body object literal, captured as-is.
+        {
+          kind: 'infer',
+          alias: 'Body_Response',
+          source_file: 'src/router.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: '{ id: 1, name: "widget" }',
+          unwrap: 'none',
+        },
+        // Control: single-call object-literal argument, captured as-is.
+        {
+          kind: 'infer',
+          alias: 'Single_Request',
+          source_file: 'src/router.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: '{ status: "ok", code: 200 }',
+          unwrap: 'none',
+        },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    surface = fs.readFileSync(
+      path.join(result.stub_dir, 'types', 'surface.d.ts'),
+      'utf8'
+    );
+  });
+
+  after(() => {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    fs.rmSync(outRoot, { recursive: true, force: true });
+  });
+
+  function record(alias: string) {
+    const r = result.aliases.find((a) => a.alias === alias);
+    assert.ok(r, `no alias record for ${alias}`);
+    return r;
+  }
+
+  it('captures the schema payload, not the descriptor, for a fluent chain', () => {
+    const r = record('Payload_Request');
+    assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
+    // The payload shape wins.
+    assert.match(surface, /Payload_Request = [\s\S]*documentId/);
+    assert.match(surface, /Payload_Request = [\s\S]*title/);
+    // The config descriptor is gone.
+    assert.ok(
+      !/Payload_Request = [\s\S]*openapi/.test(surface),
+      `descriptor metadata must not be captured:\n${surface}`
+    );
+    assert.match(r.self_check_detail ?? '', /re-aimed at the chain schema argument/);
+  });
+
+  it('demotes a chain with two schema arguments (ambiguous request/response)', () => {
+    const r = record('TwoSchema_Request');
+    assert.strictEqual(r.serialization, 'structural_fallback');
+    assert.ok(r.capture_failure_reason, 'ambiguous chain must demote with a reason');
+    assert.match(r.capture_failure_reason!, /2 schema arguments/);
+    assert.match(surface, /TwoSchema_Request = unknown;/);
+    // Never the descriptor.
+    assert.ok(!/TwoSchema_Request = [\s\S]*tag/.test(surface), surface);
+  });
+
+  it('control: a return-body object literal is captured as-is (not a chain)', () => {
+    const r = record('Body_Response');
+    assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
+    assert.match(surface, /Body_Response = [\s\S]*id/);
+    assert.match(surface, /Body_Response = [\s\S]*name/);
+    assert.ok(!/Body_Response = unknown;/.test(surface), surface);
+  });
+
+  it('control: a single-call object argument is captured as-is (not fluent)', () => {
+    const r = record('Single_Request');
+    assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
+    assert.match(surface, /Single_Request = [\s\S]*status/);
+    assert.match(surface, /Single_Request = [\s\S]*code/);
+    assert.ok(!/Single_Request = unknown;/.test(surface), surface);
+  });
+});

--- a/src/sidecar/test/capture-v2-value-symbol-anchor.test.ts
+++ b/src/sidecar/test/capture-v2-value-symbol-anchor.test.ts
@@ -54,6 +54,13 @@ export class OrderModel {
 export const ZAmbiguousSchema = object({ x: 0 });
 export type TAmbiguousInput = Infer<typeof ZAmbiguousSchema>;
 export type TAmbiguousOutput = Infer<typeof ZAmbiguousSchema>;
+
+// Value-only const whose SOLE typeof-derived sibling is a WRAPPER that embeds
+// the inferred payload as a member (not \`= Infer<typeof C>\`). Re-aiming would
+// capture { data; meta } instead of { id; name } -> a false incompatible, so
+// this must fall back to the value-only DEMOTE (abstain).
+export const ZFoo = object({ id: 0, name: '' });
+export type FooEnvelope = { data: Infer<typeof ZFoo>; meta: string };
 `;
 
 function writeRepo(): void {
@@ -120,6 +127,13 @@ describe('capture v2: value-only symbol anchor guard + const->type re-aim', () =
           kind: 'symbol',
           alias: 'Amb_Schema',
           symbol_name: 'ZAmbiguousSchema',
+          source_file: 'src/schema.ts',
+          anchor_origin: 'llm-symbol',
+        },
+        {
+          kind: 'symbol',
+          alias: 'Wrapper_Foo',
+          symbol_name: 'ZFoo',
           source_file: 'src/schema.ts',
           anchor_origin: 'llm-symbol',
         },
@@ -210,5 +224,20 @@ describe('capture v2: value-only symbol anchor guard + const->type re-aim', () =
     assert.strictEqual(r.self_check, 'decayed_internal');
     assert.ok(r.capture_failure_reason, 'ambiguous re-aim must demote with a reason');
     assert.match(surface, /Amb_Schema = unknown;/);
+  });
+
+  it('B wrapper: a sibling that EMBEDS the inferred type (not `= Infer<...>`) demotes', () => {
+    // FooEnvelope = { data: Infer<typeof ZFoo>; meta: string } is a wrapper:
+    // re-aiming would capture the envelope shape and self-check concretely,
+    // manufacturing a false incompatible. The guard requires the RHS to BE the
+    // inferred type, so this abstains (demotes) instead.
+    const r = record('Wrapper_Foo');
+    assert.strictEqual(r.serialization, 'structural_fallback');
+    assert.strictEqual(r.self_check, 'decayed_internal');
+    assert.ok(r.capture_failure_reason, 'wrapper sibling must demote with a reason');
+    assert.match(surface, /Wrapper_Foo = unknown;/);
+    // Never captures the wrapper's members.
+    assert.ok(!/Wrapper_Foo = [\s\S]*FooEnvelope/.test(surface), surface);
+    assert.ok(!/Wrapper_Foo = [\s\S]*meta/.test(surface), surface);
   });
 });

--- a/src/sidecar/test/capture-v2-value-symbol-anchor.test.ts
+++ b/src/sidecar/test/capture-v2-value-symbol-anchor.test.ts
@@ -1,0 +1,214 @@
+/**
+ * #438 part 1 (value-symbol guard) + #439 part 2 (const->type re-aim).
+ *
+ * An LLM symbol anchor may name a schema VALUE const
+ * (`export const ZFooSchema = object({...})`) instead of its sibling
+ * `export type TFoo = Infer<typeof ZFooSchema>`. Emitting the const in TYPE
+ * position produces a broken surface line (a value used as a type) that
+ * poisons the whole producer service. This suite pins the fix:
+ *
+ *  A. a value-only export with no type sibling DEMOTES (honest `unknown`, no
+ *     broken surface line, reason recorded);
+ *  B. a value-only export WITH a single `typeof`-derived sibling type alias
+ *     RE-AIMS at that alias and captures the inferred object type;
+ *  - a real type / a class (value + type meaning) still emit unchanged;
+ *  - two sibling type aliases over one const are ambiguous -> demote (A).
+ *
+ * All fixtures are synthetic and generically named; the schema helper is a
+ * local stand-in for any `object(...)` + `Infer<typeof ...>` library.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { captureStub } from '../src/capture/index.js';
+import type { CaptureStubResult } from '../src/capture/api.js';
+
+let repoDir: string;
+let outRoot: string;
+
+const SCHEMA_TS = `
+interface Schema<T> { readonly _output: T; }
+declare function object<T>(shape: T): Schema<T>;
+type Infer<S> = S extends Schema<infer T> ? T : never;
+
+// Value-only const, NO sibling type alias -> part A demote.
+export const ZWidgetSchema = object({ id: 0, label: '' });
+
+// Value-only const WITH a single typeof-derived sibling -> part B re-aim.
+export const ZOrderSchema = object({ orderId: '', total: 0 });
+export type TOrder = Infer<typeof ZOrderSchema>;
+
+// A real exported type -> control, must still emit unchanged.
+export interface Widget { id: number; label: string; }
+
+// A class has BOTH value and type meaning -> control, must still emit.
+export class OrderModel {
+  orderId = '';
+  total = 0;
+}
+
+// Value-only const with TWO typeof-derived siblings -> ambiguous, demote (A).
+export const ZAmbiguousSchema = object({ x: 0 });
+export type TAmbiguousInput = Infer<typeof ZAmbiguousSchema>;
+export type TAmbiguousOutput = Infer<typeof ZAmbiguousSchema>;
+`;
+
+function writeRepo(): void {
+  fs.mkdirSync(path.join(repoDir, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoDir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        rootDir: 'src',
+        module: 'esnext',
+        moduleResolution: 'bundler',
+        target: 'es2022',
+        skipLibCheck: true,
+      },
+      include: ['src'],
+    })
+  );
+  fs.writeFileSync(path.join(repoDir, 'src', 'schema.ts'), SCHEMA_TS);
+}
+
+describe('capture v2: value-only symbol anchor guard + const->type re-aim', () => {
+  let result: CaptureStubResult;
+  let surface: string;
+
+  before(() => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-vsym-repo-'));
+    outRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-vsym-stub-'));
+    writeRepo();
+    result = captureStub({
+      repoRoot: repoDir,
+      serviceName: 'vsym-svc',
+      outDir: path.join(outRoot, 'stub'),
+      anchors: [
+        {
+          kind: 'symbol',
+          alias: 'A_Widget',
+          symbol_name: 'ZWidgetSchema',
+          source_file: 'src/schema.ts',
+          anchor_origin: 'llm-symbol',
+        },
+        {
+          kind: 'symbol',
+          alias: 'B_Order',
+          symbol_name: 'ZOrderSchema',
+          source_file: 'src/schema.ts',
+          anchor_origin: 'llm-symbol',
+        },
+        {
+          kind: 'symbol',
+          alias: 'Ctrl_Widget',
+          symbol_name: 'Widget',
+          source_file: 'src/schema.ts',
+          anchor_origin: 'llm-symbol',
+        },
+        {
+          kind: 'symbol',
+          alias: 'Ctrl_Class',
+          symbol_name: 'OrderModel',
+          source_file: 'src/schema.ts',
+          anchor_origin: 'llm-symbol',
+        },
+        {
+          kind: 'symbol',
+          alias: 'Amb_Schema',
+          symbol_name: 'ZAmbiguousSchema',
+          source_file: 'src/schema.ts',
+          anchor_origin: 'llm-symbol',
+        },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    surface = fs.readFileSync(
+      path.join(result.stub_dir, 'types', 'surface.d.ts'),
+      'utf8'
+    );
+  });
+
+  after(() => {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    fs.rmSync(outRoot, { recursive: true, force: true });
+  });
+
+  function record(alias: string) {
+    const r = result.aliases.find((a) => a.alias === alias);
+    assert.ok(r, `no alias record for ${alias}`);
+    return r;
+  }
+
+  it('A: a value-only const with no type sibling is demoted, not emitted broken', () => {
+    const r = record('A_Widget');
+    assert.strictEqual(r.serialization, 'structural_fallback');
+    assert.strictEqual(r.self_check, 'decayed_internal');
+    assert.ok(r.capture_failure_reason, 'demotion reason must be recorded');
+    assert.match(r.capture_failure_reason!, /value export with no type-space meaning/);
+    assert.strictEqual(r.top_type_at_self_check, true);
+    // The surface line is honest `unknown` — never a value in type position.
+    assert.match(surface, /A_Widget = unknown;/);
+    assert.ok(
+      !/A_Widget = .*ZWidgetSchema/.test(surface),
+      `A_Widget must not reference the value const:\n${surface}`
+    );
+  });
+
+  it('B: a value-only const re-aims at its typeof sibling and captures the payload', () => {
+    const r = record('B_Order');
+    assert.strictEqual(r.serialization, 'emitted', r.self_check_detail);
+    assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
+    // Concrete resolution (the inferred object, not a decayed top type).
+    assert.strictEqual(r.top_type_at_self_check, false);
+    // The surface redirects from the const to the sibling type alias.
+    assert.match(
+      surface,
+      /B_Order = .*TOrder/,
+      `B_Order must reference the sibling type alias:\n${surface}`
+    );
+    assert.ok(
+      !/B_Order = .*ZOrderSchema/.test(surface),
+      `B_Order must not reference the value const:\n${surface}`
+    );
+    assert.match(r.self_check_detail ?? '', /re-aimed at sibling type alias 'TOrder'/);
+  });
+
+  it('B captures the inferred object shape (orderId/total) in the tree', () => {
+    // The sibling alias resolves to the object the schema describes; the
+    // emitted tree carries that inferred shape (not the schema wrapper).
+    const treeText = result.emitted_files
+      .map((rel) => fs.readFileSync(path.join(result.stub_dir, rel), 'utf8'))
+      .join('\n');
+    assert.match(treeText, /orderId/);
+    assert.match(treeText, /total/);
+  });
+
+  it('control: a real exported type still emits unchanged', () => {
+    const r = record('Ctrl_Widget');
+    assert.strictEqual(r.serialization, 'emitted');
+    assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
+    assert.match(surface, /Ctrl_Widget = .*Widget;/);
+  });
+
+  it('control: a class (value + type meaning) still emits unchanged', () => {
+    const r = record('Ctrl_Class');
+    assert.strictEqual(r.serialization, 'emitted', r.self_check_detail);
+    assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
+    assert.ok(
+      !/Ctrl_Class = unknown;/.test(surface),
+      `a class anchor must not demote:\n${surface}`
+    );
+  });
+
+  it('B ambiguity: two typeof siblings over one const refuse re-aim and demote', () => {
+    const r = record('Amb_Schema');
+    assert.strictEqual(r.serialization, 'structural_fallback');
+    assert.strictEqual(r.self_check, 'decayed_internal');
+    assert.ok(r.capture_failure_reason, 'ambiguous re-aim must demote with a reason');
+    assert.match(surface, /Amb_Schema = unknown;/);
+  });
+});

--- a/src/sidecar/test/check-v2-poison-containment.test.ts
+++ b/src/sidecar/test/check-v2-poison-containment.test.ts
@@ -1,0 +1,192 @@
+/**
+ * #438 part 2: stub-tree poison is contained to the aliases whose closure
+ * includes the poisoned file — a bad alias no longer masks every clean pair
+ * in the same service. Service-wide degradation stays reserved for install
+ * (isolation) failure.
+ *
+ * Real vendored pnpm + real tsc, hand-authored dependency-free stubs (as in
+ * check-v2.test.ts). Fixtures are synthetic and generically named.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runCheck } from '../src/capture/index.js';
+import type { CheckPairSpec, CheckStubInput, CheckVerdict } from '../src/capture/api.js';
+
+let root: string;
+
+interface StubFile {
+  rel: string;
+  text: string;
+}
+
+function writeStub(dir: string, serviceName: string, files: StubFile[]): void {
+  const stubDir = path.join(dir, serviceName);
+  fs.mkdirSync(path.join(stubDir, 'types'), { recursive: true });
+  fs.writeFileSync(
+    path.join(stubDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: `@carrick/${serviceName}`,
+        version: '0.0.0-carrick',
+        private: true,
+        types: './types/surface.d.ts',
+      },
+      null,
+      2
+    ) + '\n'
+  );
+  for (const f of files) {
+    const abs = path.join(stubDir, 'types', f.rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, f.text);
+  }
+}
+
+function fakeBin(name: string, script: string): string {
+  const file = path.join(root, name);
+  fs.writeFileSync(file, `#!/bin/sh\n${script}\n`);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+function byKey(verdicts: CheckVerdict[]): Map<string, CheckVerdict> {
+  return new Map(verdicts.map((v) => [v.pair_key, v]));
+}
+
+function mk(
+  pair_key: string,
+  producerAlias: string,
+  consumerAlias: string
+): CheckPairSpec {
+  return {
+    pair_key,
+    protocol: 'http',
+    type_kind: 'response',
+    producer: { service_name: 'orders', alias: producerAlias },
+    consumer: { service_name: 'web', alias: consumerAlias },
+  };
+}
+
+const PAIRS: CheckPairSpec[] = [
+  // Poisoned by a broken SURFACE line on the producer side.
+  mk('surface-poison', 'Surface_Poisoned_Sent', 'Surface_Poisoned_Exp'),
+  // Poisoned by a broken NESTED file the producer alias imports.
+  mk('nested-poison', 'Nested_Poisoned_Sent', 'Nested_Poisoned_Exp'),
+  // Clean pair in the SAME producer service — must still verdict.
+  mk('clean', 'Clean_Sent', 'Clean_Exp'),
+];
+
+let stubs: CheckStubInput[];
+
+describe('check_v2: stub poison is contained to the affected aliases (#438 part 2)', () => {
+  let verdicts: Map<string, CheckVerdict>;
+  let degraded: string[];
+
+  before(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-poison-contain-'));
+    writeStub(root, 'orders', [
+      {
+        rel: 'surface.d.ts',
+        text: [
+          // A value/type that does not exist -> TS2304 on THIS surface line.
+          'export type Surface_Poisoned_Sent = NoSuchTypeAnywhere;',
+          // Imports a broken nested file -> its closure is poisoned.
+          "export type Nested_Poisoned_Sent = import('./schema').BadSchema;",
+          // Fully clean, closure-independent.
+          'export type Clean_Sent = { a: string; };',
+        ].join('\n') + '\n',
+      },
+      {
+        rel: 'schema.d.ts',
+        // TS2304 in a nested file reachable only from Nested_Poisoned_Sent.
+        text: 'export type BadSchema = AnotherMissingType;\n',
+      },
+    ]);
+    writeStub(root, 'web', [
+      {
+        rel: 'surface.d.ts',
+        text: [
+          'export type Surface_Poisoned_Exp = { a: string; };',
+          'export type Nested_Poisoned_Exp = { a: string; };',
+          'export type Clean_Exp = { a: string; };',
+        ].join('\n') + '\n',
+      },
+    ]);
+    stubs = [
+      { service_name: 'orders', stub_dir: path.join(root, 'orders') },
+      { service_name: 'web', stub_dir: path.join(root, 'web') },
+    ];
+    const result = await runCheck({ stubs, pairs: PAIRS });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    verdicts = byKey(result.verdicts);
+    degraded = result.degraded_services.map((d) => d.service_name);
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('the surface-line-poisoned pair is unverifiable (poison:producer)', () => {
+    const v = verdicts.get('surface-poison')!;
+    assert.strictEqual(v.bucket, 'unverifiable', JSON.stringify(v));
+    assert.strictEqual(v.gate, 'poison:producer');
+  });
+
+  it('the nested-file-poisoned pair is unverifiable (poison:producer)', () => {
+    const v = verdicts.get('nested-poison')!;
+    assert.strictEqual(v.bucket, 'unverifiable', JSON.stringify(v));
+    assert.strictEqual(v.gate, 'poison:producer');
+  });
+
+  it('the CLEAN pair in the same service still verdicts (containment)', () => {
+    // Pre-fix this read `unverifiable` (poison:producer) because one bad alias
+    // poisoned the whole service. Contained, it must reach a real verdict.
+    const v = verdicts.get('clean')!;
+    assert.strictEqual(v.bucket, 'compatible', JSON.stringify(v));
+  });
+
+  it('contained poison does not degrade the whole service', () => {
+    assert.ok(
+      !degraded.includes('orders'),
+      `alias-scoped poison must not mark the service degraded: ${degraded.join(', ')}`
+    );
+  });
+});
+
+describe('check_v2: install failure still degrades service-wide (#438 part 2)', () => {
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-poison-install-'));
+    writeStub(root, 'orders', [
+      { rel: 'surface.d.ts', text: 'export type P_Res = { a: string; };\n' },
+    ]);
+    writeStub(root, 'web', [
+      { rel: 'surface.d.ts', text: 'export type C_Res = { a: string; };\n' },
+    ]);
+    stubs = [
+      { service_name: 'orders', stub_dir: path.join(root, 'orders') },
+      { service_name: 'web', stub_dir: path.join(root, 'web') },
+    ];
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('a failing install marks every pair unverifiable and every service degraded', async () => {
+    const pnpmPath = fakeBin('pnpm-fail', 'echo "boom" >&2; exit 1');
+    const pairs: CheckPairSpec[] = [mk('only', 'P_Res', 'C_Res')];
+    const result = await runCheck({ stubs, pairs, pnpmPath });
+    assert.strictEqual(result.install_ok, false);
+    assert.strictEqual(result.success, false);
+    for (const v of result.verdicts) {
+      assert.strictEqual(v.bucket, 'unverifiable', JSON.stringify(v));
+      assert.strictEqual(v.gate, 'install:failed');
+    }
+    const degraded = result.degraded_services.map((d) => d.service_name).sort();
+    assert.deepStrictEqual(degraded, ['orders', 'web']);
+  });
+});

--- a/src/sidecar/test/check-v2-units.test.ts
+++ b/src/sidecar/test/check-v2-units.test.ts
@@ -186,15 +186,31 @@ describe('four-bucket classifier precedence', () => {
     assert.strictEqual(v.gate, 'import:producer');
   });
 
-  it('stub poison outranks everything -> unverifiable', () => {
+  it('stub poison for THIS alias outranks everything -> unverifiable', () => {
     const v = classifyPair({
       plan,
       probeDiags: [diag(plan.assignmentLine, 2741)],
-      poisonReason: (svc) => (svc === 'orders' ? 'conflict' : undefined),
+      // #438 part 2: poison is scoped to a (service, alias); the producer
+      // alias here is poisoned, so it wins over the assignment error.
+      poisonReason: (svc, alias) =>
+        svc === 'orders' && alias === 'Endpoint_a_Response' ? 'conflict' : undefined,
       scrubCtx,
     });
     assert.strictEqual(v.bucket, 'unverifiable');
     assert.strictEqual(v.gate, 'poison:producer');
+  });
+
+  it('poison of a SIBLING alias in the same service does not contain this pair', () => {
+    // Only a different alias of the producer service is poisoned; this pair's
+    // own aliases are clean, so it must still verdict (the #438 containment).
+    const v = classifyPair({
+      plan,
+      probeDiags: [],
+      poisonReason: (svc, alias) =>
+        svc === 'orders' && alias === 'Some_Other_Alias' ? 'conflict' : undefined,
+      scrubCtx,
+    });
+    assert.strictEqual(v.bucket, 'compatible');
   });
 });
 


### PR DESCRIPTION
Coupled fix for the two capture/check defects root-caused in #432. They ship as **one PR by necessity**: #438's poison containment un-masks producer pairs that were previously hidden behind stub poison, and if a pair's request anchor still landed on a config-descriptor argument (#439), it would become a **live false-incompatible** (the artifact behind v1's 16 wrong `Some(false)` verdicts on the diagnosed corpus) the moment containment stops hiding it. Containment must not land ahead of the anchor fixes.

## Mechanisms fixed

**1. Value-only symbol anchors (#438 part 1) — `anchors.ts` symbol branch.** An LLM symbol anchor can name a schema *value* const (`export const ZFooSchema = z.object({...})`) instead of its sibling type. A value has no type-space meaning, so emitting `import('./m').ZFooSchema` in type position raised TS2694 in the stub tree. The branch now checks `ts.SymbolFlags.Type` (re-exports resolved) and, for a value-only export, demotes to an honest `unknown` with a recorded reason — engaging the existing demotion/backfill path instead of a broken surface line.

**2. Const→type re-aim (#439 part 2) — `anchors.ts`.** Before demoting a value-only symbol, the same module is scanned for a single exported type alias whose type node contains a `typeof <const>` type-query (covers `z.infer` and equivalents). Exactly one match re-aims at the alias and captures the inferred payload; zero or several fall back to the value-only demotion.

**3. Builder-chain payload selection (#439 part 1) — `anchors.ts` infer branch.** An infer anchor whose locator lands inside a fluent builder chain's all-literal config descriptor (`.meta({ openapi: {...} })`) re-aims at the chain's schema argument.

**4. Poison containment (#438 part 2) — `check.ts`, `check-poison.ts`, `check-classify.ts`.** Stub-tree diagnostics are attributed to the aliases whose import closure includes the poisoned file: a surface diagnostic by the `export type` statement span it sits in; a nested-file diagnostic by BFS over the alias closure (the same closure the capture self-check computes). `classifyPair` now consults poison per `(service, alias)`, and genuine poison still wins (highest precedence) for the affected aliases.

## Structural, not name-based (the C decision)

Builder-chain detection consults **no method name** (`meta`/`input`/`mutation`). The descriptor signal is purely structural: a non-empty, all-literal-typed object-literal argument of a chain of **≥2 fluent calls**; the payload is the lone non-literal, non-inline-function chain argument. Candidate classification is syntactic (identifier / member-access / call), so it holds on a bare checkout where every schema resolves to `any`.

**Documented limitation:** a chain carrying **two** schema arguments (e.g. both an input and an output schema) cannot be disambiguated from request vs response without method-name knowledge, so it **demotes to `unknown` by design** rather than risk capturing the wrong side. The "payload captured, not descriptor" outcome is therefore the single-schema chain; the two-schema chain demoting is the intended, coupling-safe behaviour (within this trigger the locator already sat on the descriptor, so demoting can never be worse than the concrete-but-wrong descriptor it replaces). Both cases are pinned by tests.

Global `declare global` collisions in a file reachable from no alias's closure fall back to service-wide poison for soundness; install/isolation failure stays service-wide.

## Honest outcomes preserved

- A demoted zod-const with no derivable payload stays `unknown` (deep-any) — the backfill acceptance is fail-closed, so it never re-adopts a top type.
- A builder-chain schema argument that bakes to `any` on a bare checkout stays **unverifiable** via the probe/deep-any gates — never falsely compatible, never falsely incompatible.

## Tests

Synthetic, generically-named fixtures for each part (no corpus-derived identifiers or type texts). Each new core assertion was confirmed **failing on `origin/main`** for the intended reason:

- value-only symbol anchor: main emits the value const in type position (no demotion, broken line);
- const→type re-aim: main references the const, not the sibling alias;
- builder-chain: main captures the descriptor concretely;
- poison containment: main poisons the whole service, so the clean sibling pair reads `unverifiable`.

Sidecar suite 256 → 272 (+16), 271 pass / 1 pre-existing skip, zero regressions. Full Rust suite green, including `engine::type_compat_v2::tests`, `sidecar_integration_test`, `pubsub_wrapper_type_capture_test`, `llm_cassette_hard_gate_test`. New tests are `.test.ts` files auto-covered by the sidecar `npm test` glob; no CI change needed.

Closes #438
Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)