### PR TITLE
fix(scanner): resolve `./types.js` imports to the `.ts` sibling (#148)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -3612,26 +3612,60 @@ impl FileOrchestrator {
             || path.ends_with(".jsx")
     }
 
+    /// TypeScript's NodeNext/ESM module resolution rewrites a relative
+    /// import's output-JS extension back to the input-TS extension: an
+    /// `import ... from './types.js'` written for a `types.ts` source
+    /// resolves to `types.ts` (then `.tsx`/`.d.ts`), and only falls back to a
+    /// real emitted `types.js` when no TS sibling exists. Return that ordered
+    /// candidate list for a JS-family specifier so the TS source wins, mirroring
+    /// tsc (carrick#148). `None` for specifiers without a rewritable JS
+    /// extension — those keep their existing probe behaviour.
+    fn ts_sibling_candidates(base: &str) -> Option<Vec<String>> {
+        let (stem, ts_exts): (&str, &[&str]) = if let Some(stem) = base.strip_suffix(".js") {
+            (stem, &[".ts", ".tsx", ".d.ts"])
+        } else if let Some(stem) = base.strip_suffix(".jsx") {
+            (stem, &[".tsx", ".ts", ".d.ts"])
+        } else if let Some(stem) = base.strip_suffix(".mjs") {
+            (stem, &[".mts", ".d.mts"])
+        } else if let Some(stem) = base.strip_suffix(".cjs") {
+            (stem, &[".cts", ".d.cts"])
+        } else {
+            return None;
+        };
+        let mut candidates: Vec<String> =
+            ts_exts.iter().map(|ext| format!("{stem}{ext}")).collect();
+        // The literal emitted JS is the last resort — only when no TS source
+        // sits beside it (a genuine `.js`-only module).
+        candidates.push(base.to_string());
+        Some(candidates)
+    }
+
     /// Probe a path on disk and return a canonicalized absolute string if
     /// it (or one of the standard `.ts/.tsx/.js/.jsx`/`index.*` candidates)
     /// exists. Returns `None` when nothing matches; callers decide on a
-    /// fallback. If the input already has a TS-family extension we only
-    /// probe that exact path — extension-swapping isn't TS resolver
+    /// fallback. A JS-family specifier resolves to its TS sibling first
+    /// (tsc's ESM `.js`→`.ts` rewrite, carrick#148). A TS-family specifier
+    /// is probed exactly — extension-swapping a `.ts` isn't TS resolver
     /// behaviour and would mask import bugs.
     fn canonicalize_or_probe(base: &str) -> Option<String> {
         use std::path::Path;
 
+        let probe = |candidate: &str| -> Option<String> {
+            Path::new(candidate).exists().then(|| {
+                Path::new(candidate)
+                    .canonicalize()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|_| candidate.to_string())
+            })
+        };
+
+        // ESM/NodeNext: `./types.js` resolves to the `types.ts` source first.
+        if let Some(candidates) = Self::ts_sibling_candidates(base) {
+            return candidates.iter().find_map(|c| probe(c));
+        }
+
         if Self::has_ts_extension(base) {
-            return if Path::new(base).exists() {
-                Some(
-                    Path::new(base)
-                        .canonicalize()
-                        .map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_else(|_| base.to_string()),
-                )
-            } else {
-                None
-            };
+            return probe(base);
         }
 
         let candidates = [
@@ -3645,17 +3679,7 @@ impl FileOrchestrator {
             format!("{}/index.jsx", base),
         ];
 
-        for candidate in &candidates {
-            if Path::new(candidate).exists() {
-                return Some(
-                    Path::new(candidate)
-                        .canonicalize()
-                        .map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_else(|_| candidate.clone()),
-                );
-            }
-        }
-        None
+        candidates.iter().find_map(|c| probe(c))
     }
 
     /// Walk up from `start_dir` looking for `tsconfig.json`. Return its
@@ -4613,6 +4637,66 @@ mod tests {
         assert_eq!(
             std::path::Path::new(&resolved).canonicalize().unwrap(),
             expected,
+        );
+    }
+
+    /// carrick#148: NodeNext/ESM writes a relative import as `./types.js`
+    /// even when the source is `types.ts`. tsc resolves the `.js` specifier
+    /// to the `.ts` sibling; our resolver must too, or the `.js` path is
+    /// carried into the sidecar bundle where it `fs.existsSync`-fails and
+    /// logs "Source file not found" (losing the type).
+    #[test]
+    fn test_resolve_import_path_js_specifier_resolves_to_ts_sibling() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(
+            repo.path().join("src/types.ts"),
+            "export interface SearchByIntentResponse { hits: number }",
+        )
+        .unwrap();
+        let server = repo.path().join("src/index.ts");
+        std::fs::write(&server, "// stub").unwrap();
+
+        let resolved =
+            FileOrchestrator::resolve_import_path(server.to_string_lossy().as_ref(), "./types.js");
+
+        let resolved_path = std::path::Path::new(&resolved);
+        assert!(
+            resolved_path.is_file(),
+            "`.js` specifier should resolve to the on-disk `.ts` sibling, got `{resolved}`",
+        );
+        let expected = repo.path().join("src/types.ts").canonicalize().unwrap();
+        assert_eq!(
+            resolved_path.canonicalize().unwrap(),
+            expected,
+            "`./types.js` must resolve to `types.ts`, not a non-existent `types.js`",
+        );
+    }
+
+    /// The `.ts` sibling must win even when a real emitted `types.js` also
+    /// sits next to it — tsc prefers the TypeScript source over the JS output.
+    #[test]
+    fn test_resolve_import_path_ts_wins_over_js_sibling() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(
+            repo.path().join("src/types.ts"),
+            "export interface SearchByIntentResponse { hits: number }",
+        )
+        .unwrap();
+        // Decoy emitted output next to the source.
+        std::fs::write(repo.path().join("src/types.js"), "module.exports = {};").unwrap();
+        let server = repo.path().join("src/index.ts");
+        std::fs::write(&server, "// stub").unwrap();
+
+        let resolved =
+            FileOrchestrator::resolve_import_path(server.to_string_lossy().as_ref(), "./types.js");
+
+        let expected = repo.path().join("src/types.ts").canonicalize().unwrap();
+        assert_eq!(
+            std::path::Path::new(&resolved).canonicalize().unwrap(),
+            expected,
+            "`.ts` sibling must win over an emitted `.js` decoy",
         );
     }
 

--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -3605,11 +3605,20 @@ impl FileOrchestrator {
     }
 
     /// Returns true if `path` ends in a TypeScript-family source extension.
+    /// True when the path already carries a JS/TS module extension, so it must
+    /// be probed as-is and never get a `.ts` appended. Covers the NodeNext
+    /// families (`.mts`/`.cts`/`.mjs`/`.cjs`) too — `.d.mts`/`.d.cts` match via
+    /// their `.mts`/`.cts` suffix — so a literal `foo.mts` import resolves
+    /// exactly instead of probing a nonsensical `foo.mts.ts`.
     fn has_ts_extension(path: &str) -> bool {
         path.ends_with(".ts")
             || path.ends_with(".tsx")
+            || path.ends_with(".mts")
+            || path.ends_with(".cts")
             || path.ends_with(".js")
             || path.ends_with(".jsx")
+            || path.ends_with(".mjs")
+            || path.ends_with(".cjs")
     }
 
     /// TypeScript's NodeNext/ESM module resolution rewrites a relative
@@ -4697,6 +4706,32 @@ mod tests {
             std::path::Path::new(&resolved).canonicalize().unwrap(),
             expected,
             "`.ts` sibling must win over an emitted `.js` decoy",
+        );
+    }
+
+    /// A literal NodeNext TS-family extension (`.mts`/`.cts`) must be probed
+    /// exactly, not treated as extensionless and probed as `foo.mts.ts`
+    /// (Copilot review on #148).
+    #[test]
+    fn test_resolve_import_path_mts_specifier_resolves_exactly() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(
+            repo.path().join("src/types.mts"),
+            "export interface SearchByIntentResponse { hits: number }",
+        )
+        .unwrap();
+        let server = repo.path().join("src/index.ts");
+        std::fs::write(&server, "// stub").unwrap();
+
+        let resolved =
+            FileOrchestrator::resolve_import_path(server.to_string_lossy().as_ref(), "./types.mts");
+
+        let expected = repo.path().join("src/types.mts").canonicalize().unwrap();
+        assert_eq!(
+            std::path::Path::new(&resolved).canonicalize().unwrap(),
+            expected,
+            "`./types.mts` must resolve to `types.mts`, not a nonsensical `types.mts.ts`",
         );
     }
 


### PR DESCRIPTION
## Root cause

On the carrick-cloud scan the sidecar logged:

```
Symbol failed to resolve symbol=SearchByIntentResponse source_file=.../mcp-server/src/./types.js reason=Source file not found: .../mcp-server/src/./types.js
```

The source is `types.ts`, but the import is written NodeNext/ESM-style as `import { SearchByIntentResponse } from './types.js'` — a `.js` specifier is the correct ESM form even for a `.ts` source. The `.js` path was manufactured in the **scanner engine**, not the sidecar (the issue's `project-loader.ts` guess was a hypothesis; the sidecar only receives the already-wrong path and `fs.existsSync`-fails on it).

`FileOrchestrator::resolve_import_path` → `canonicalize_or_probe` treated any `.js`/`.jsx`-suffixed specifier as a fixed path via `has_ts_extension` and probed **only** the literal `.js`. When the emitted `.js` is absent (the module is `types.ts`), it returned `None`, and the caller's fallback returned the raw joined `./types.js`. That path flowed into the sidecar bundle, failed to exist, and produced the warning — losing the type and adding log noise.

## The fix (resolution-order, structural)

Mirror tsc's ESM/NodeNext `.js`→`.ts` rewrite at the extension-preference level in `canonicalize_or_probe`:

- A `.js`/`.jsx`/`.mjs`/`.cjs` relative specifier now probes its TypeScript sibling **first** (`.js`→`.ts`/`.tsx`/`.d.ts`, `.mjs`→`.mts`/`.d.mts`, `.cjs`→`.cts`/`.d.cts`), and only falls back to a real emitted `.js` when no TS source sits beside it — so a sibling `.ts` wins over a decoy `.js`.
- A `.ts`-family specifier is still probed exactly (extension-swapping a `.ts` isn't tsc behaviour and would mask real import bugs).
- Extensionless specifiers keep their existing `.ts`-first candidate list.

No special-case for `types` or any symbol/module name — it is purely the resolver's extension-preference order.

## Pre-fix failure evidence

Both new tests fail on `origin/main`:

- `test_resolve_import_path_js_specifier_resolves_to_ts_sibling`: `./types.js` (only `types.ts` on disk) resolved to `.../src/./types.js` — reproducing the exact scan log.
- `test_resolve_import_path_ts_wins_over_js_sibling`: with both siblings present, `./types.js` resolved to `types.js` instead of `types.ts`.

After the fix both resolve to `types.ts`.

## Tests

- New Rust tests added next to the existing `resolve_import_path` suite in `src/agents/file_orchestrator.rs`.
- Full Rust suite green via the pre-commit hook (659 lib + 674 unit + all integration suites, 0 failures); `cargo fmt`/`clippy` clean.
- Sidecar vitest unchanged and green (274 pass / 0 fail).

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)