### PR TITLE
fix(sidecar): abstain on wrapped response-envelope machinery (#371)

### DIFF
--- a/src/sidecar/src/capture/anchors.ts
+++ b/src/sidecar/src/capture/anchors.ts
@@ -13,6 +13,7 @@ import type {
   SymbolAnchorRequest,
 } from './api.js';
 import { printTypeForDestination } from './node-builder.js';
+import { typeIsOrContainsMachinery } from './machinery.js';
 
 export interface ResolvedAnchor {
   request: CaptureAnchorRequest;
@@ -232,6 +233,23 @@ export function resolveAnchor(
       const recovered = checker.getTypeAtLocation(literalNode);
       if (!isTopType(recovered)) type = recovered;
     }
+  }
+  // carrick#371 fail-closed guard: a producer anchor whose resolved type IS or
+  // CONTAINS framework machinery (a raw `Response`/`Request`, a wrapper envelope
+  // `{ response: Response; error }`, a wrapper function `(req) => Promise<Response>`)
+  // must never be emitted as a comparable contract — that manufactures a false
+  // compat mismatch against the consumer's real payload. This is the capture
+  // fallback for the case the v1-inferrer machinery guard leaves behind: when v1
+  // abstains on the envelope, `derive_capture_anchors` re-routes the alias to
+  // this locator-based infer anchor, which then resolves the WRAPPER FUNCTION
+  // type. No source locator points at a distinct clean payload here (the payload
+  // lives inside the wrapper's response builder), so degrade to `unknown` —
+  // abstain, never a concrete verdict off the machinery.
+  if (typeIsOrContainsMachinery(checker, type, located)) {
+    return demote(
+      'resolved type is or contains framework machinery (Response/Request-shaped); ' +
+        'degraded to unknown rather than emit a wrapper envelope as a response contract'
+    );
   }
   if (!args.placeholder) {
     return demote('internal: no placeholder destination for infer anchor');

--- a/src/sidecar/src/capture/machinery.ts
+++ b/src/sidecar/src/capture/machinery.ts
@@ -25,8 +25,11 @@ import ts from 'typescript';
  * identical to `MACHINERY_MEMBER_INDICATORS` in `type-inferrer.ts`. These are
  * the names no JSON payload carries (`ok`, `redirected`, `bodyUsed`,
  * `writeHead`, ...), so the origin gate + threshold never fire on real data.
+ * Exported so a drift-guard test (`machinery-indicator-mirror.test.ts`) asserts
+ * it stays equal to the `type-inferrer.ts` copy — nothing else enforces the
+ * lockstep, and if the two drift one path silently stops abstaining.
  */
-const MACHINERY_MEMBER_INDICATORS = new Set<string>([
+export const MACHINERY_MEMBER_INDICATORS = new Set<string>([
   // fetch / DOM Response & Request body-consumer surface
   'ok',
   'redirected',
@@ -52,13 +55,31 @@ const MACHINERY_INDICATOR_THRESHOLD = 3;
 
 /**
  * True when `type`, resolved against `node`, IS or CONTAINS framework
- * machinery. "CONTAINS" covers three structural shapes, all one level deep:
- *  - a union/intersection member that is machinery (the envelope union);
- *  - a direct property whose type is machinery (`{ response: Response }`);
- *  - a call signature whose (awaited) return type is machinery (the wrapper
- *    function `(req) => Promise<Response>` the Infer fallback resolves to).
- * The depth cap keeps a legitimate payload that merely references a machinery
- * type far inside from over-abstaining.
+ * machinery.
+ *
+ * DETECTS, exactly:
+ *   1. the type itself is machinery (`isFrameworkMachinery`);
+ *   2. a union/intersection member is machinery (the envelope union);
+ *   3. a DIRECT property whose type is machinery (`{ response: Response }`),
+ *      ONE level of descent only;
+ *   4. a CALL SIGNATURE whose AWAITED return type is machinery — the wrapper
+ *      function `(req) => Promise<Response>` the Infer fallback resolves to.
+ *      (Only the call return is awaited; property types below are not.)
+ *
+ * DELIBERATELY NOT DETECTED — stated so this comment never overstates the
+ * guarantee (mirrors the same list in `type-inferrer.ts`). Each is a
+ * non-regression (pre-existing verdict unchanged, never a new wrong one), a
+ * tracked follow-up:
+ *   - machinery nested deeper than one property level;
+ *   - a PROPERTY typed `Promise<Response>` (property types are not awaited /
+ *     Promise-unwrapped before the check — only call-signature returns are);
+ *   - an array element type: `Response[]` is not descended to its element;
+ *   - `interface X extends Response` declared in USER source — the origin gate
+ *     is lib/`node_modules` only, so a user-declared subtype reads as a real
+ *     contract.
+ *
+ * The depth cap + origin gate keep a legitimate payload that merely references a
+ * machinery type far inside from over-abstaining.
  */
 export function typeIsOrContainsMachinery(
   checker: ts.TypeChecker,

--- a/src/sidecar/src/capture/machinery.ts
+++ b/src/sidecar/src/capture/machinery.ts
@@ -1,0 +1,165 @@
+/**
+ * Framework-machinery detection for the v2 capture path (carrick#371).
+ *
+ * A producer response anchor whose resolved type IS or CONTAINS HTTP transport
+ * machinery — a fetch/DOM `Response`/`Request`, a Node `http.ServerResponse`, a
+ * wrapper envelope `{ response: Response; error?: undefined } | { ...; error }`,
+ * or a wrapper function `(req: Request) => Promise<Response>` — must never be
+ * emitted as a comparable contract. Comparing it against the consumer's real
+ * payload manufactures a false compat mismatch (the bug this module fixes).
+ *
+ * This is the raw-`ts` seam mirror of `type-inferrer.ts`'s
+ * `typeIsOrContainsResponseMachinery` (ts-morph): the capture/ seam forbids
+ * importing a module from outside it, so the canonical indicator set and the
+ * detection shape are duplicated here in lockstep — the same pattern by which
+ * `BUILTIN_ANCHOR_SYMBOLS` mirrors `socket_io.rs`. Detection is STRUCTURAL and
+ * framework-agnostic: no framework NAME appears, only the shared HTTP-message
+ * member surface, gated by a lib / `node_modules` declaration origin so a user
+ * payload that merely shares a member name can never trip it.
+ */
+
+import ts from 'typescript';
+
+/**
+ * Strongly-discriminating member names of HTTP transport machinery. Kept
+ * identical to `MACHINERY_MEMBER_INDICATORS` in `type-inferrer.ts`. These are
+ * the names no JSON payload carries (`ok`, `redirected`, `bodyUsed`,
+ * `writeHead`, ...), so the origin gate + threshold never fire on real data.
+ */
+const MACHINERY_MEMBER_INDICATORS = new Set<string>([
+  // fetch / DOM Response & Request body-consumer surface
+  'ok',
+  'redirected',
+  'bodyUsed',
+  'arrayBuffer',
+  'blob',
+  'formData',
+  'clone',
+  'json',
+  'statusText',
+  // Node http ServerResponse / reply-object surface
+  'statusCode',
+  'statusMessage',
+  'setHeader',
+  'getHeader',
+  'removeHeader',
+  'writeHead',
+  'flushHeaders',
+]);
+
+/** Machinery needs at least this many indicator members to be recognized. */
+const MACHINERY_INDICATOR_THRESHOLD = 3;
+
+/**
+ * True when `type`, resolved against `node`, IS or CONTAINS framework
+ * machinery. "CONTAINS" covers three structural shapes, all one level deep:
+ *  - a union/intersection member that is machinery (the envelope union);
+ *  - a direct property whose type is machinery (`{ response: Response }`);
+ *  - a call signature whose (awaited) return type is machinery (the wrapper
+ *    function `(req) => Promise<Response>` the Infer fallback resolves to).
+ * The depth cap keeps a legitimate payload that merely references a machinery
+ * type far inside from over-abstaining.
+ */
+export function typeIsOrContainsMachinery(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  node: ts.Node
+): boolean {
+  return isOrContains(checker, type, node, 0);
+}
+
+function isOrContains(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  node: ts.Node,
+  depth: number
+): boolean {
+  if (isFrameworkMachinery(checker, type)) {
+    return true;
+  }
+
+  if (type.isUnion() || type.isIntersection()) {
+    return (type as ts.UnionOrIntersectionType).types.some((part) =>
+      isOrContains(checker, part, node, depth)
+    );
+  }
+
+  if (depth >= 1) {
+    return false;
+  }
+
+  // A wrapper function value: descend into its (awaited) return type.
+  for (const sig of checker.getSignaturesOfType(type, ts.SignatureKind.Call)) {
+    const returnType = sig.getReturnType();
+    const awaited = checker.getAwaitedType?.(returnType) ?? returnType;
+    if (isOrContains(checker, awaited, node, depth + 1)) {
+      return true;
+    }
+  }
+
+  // Direct properties: the `{ response: Response; error }` envelope shape.
+  for (const prop of checker.getPropertiesOfType(type)) {
+    const propType = checker.getTypeOfSymbolAtLocation(prop, node);
+    if (isOrContains(checker, propType, node, depth + 1)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * True when `type` itself is an HTTP-machinery type: it structurally carries at
+ * least `MACHINERY_INDICATOR_THRESHOLD` of the indicator members AND its symbol
+ * is declared in a lib (`lib.*.d.ts`) or `node_modules` origin.
+ */
+function isFrameworkMachinery(checker: ts.TypeChecker, type: ts.Type): boolean {
+  let hits = 0;
+  for (const prop of checker.getPropertiesOfType(type)) {
+    if (MACHINERY_MEMBER_INDICATORS.has(prop.getName())) {
+      hits += 1;
+      if (hits >= MACHINERY_INDICATOR_THRESHOLD) break;
+    }
+  }
+  if (hits < MACHINERY_INDICATOR_THRESHOLD) {
+    return false;
+  }
+  return symbolIsLibOrExternalOrigin(checker, type.getSymbol() ?? type.aliasSymbol);
+}
+
+/**
+ * True when the symbol is declared in a TS lib file (`lib.*.d.ts`) or under
+ * `node_modules`. Works on a bare checkout: the DOM `Response`/`Request`
+ * resolve from the bundled `lib.dom.d.ts` even with no installed dependencies.
+ */
+function symbolIsLibOrExternalOrigin(
+  checker: ts.TypeChecker,
+  symbol: ts.Symbol | undefined
+): boolean {
+  if (!symbol) {
+    return false;
+  }
+  const isExternalPath = (filePath: string): boolean => {
+    const normalized = filePath.replace(/\\/g, '/');
+    return (
+      normalized.includes('/node_modules/') ||
+      /\/lib\.[^/]*\.d\.ts$/.test(normalized)
+    );
+  };
+  for (const decl of symbol.getDeclarations() ?? []) {
+    if (isExternalPath(decl.getSourceFile().fileName)) {
+      return true;
+    }
+  }
+  if (symbol.flags & ts.SymbolFlags.Alias) {
+    try {
+      const aliased = checker.getAliasedSymbol(symbol);
+      if (aliased && aliased !== symbol) {
+        return symbolIsLibOrExternalOrigin(checker, aliased);
+      }
+    } catch {
+      // Ignore errors when resolving the aliased symbol.
+    }
+  }
+  return false;
+}

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -102,6 +102,47 @@ const BUILTIN_ANCHOR_SYMBOLS = new Set<string>([
 ]);
 
 /**
+ * Strongly-discriminating member names of HTTP transport machinery — the
+ * fetch/DOM `Response` & `Request`, a Node `http.ServerResponse`, a framework
+ * reply object. A type declared in a lib or `node_modules` origin that carries
+ * a subset of these is framework machinery, never a user contract: the
+ * PRODUCER-side structural mirror of the consumer `machineryIndicators`
+ * (ExtractionConfig), used to reject a wrapper envelope whose response field is
+ * a raw `Response` (carrick#371) instead of emitting it as a comparable type.
+ *
+ * Framework-agnostic by construction: no framework NAME appears here, only the
+ * shared HTTP-message surface. The names are deliberately the ones no
+ * JSON payload ever carries (`ok`, `redirected`, `bodyUsed`, `arrayBuffer`,
+ * `writeHead`, ...), so the origin gate + `MACHINERY_INDICATOR_THRESHOLD` never
+ * fire on real data. Kept in lockstep with the capture-seam mirror
+ * `capture/machinery.ts` (the seam forbids sharing a module across it, same as
+ * `BUILTIN_ANCHOR_SYMBOLS` mirrors `socket_io.rs`).
+ */
+const MACHINERY_MEMBER_INDICATORS = new Set<string>([
+  // fetch / DOM Response & Request body-consumer surface
+  'ok',
+  'redirected',
+  'bodyUsed',
+  'arrayBuffer',
+  'blob',
+  'formData',
+  'clone',
+  'json',
+  'statusText',
+  // Node http ServerResponse / reply-object surface
+  'statusCode',
+  'statusMessage',
+  'setHeader',
+  'getHeader',
+  'removeHeader',
+  'writeHead',
+  'flushHeaders',
+]);
+
+/** Machinery needs at least this many indicator members to be recognized. */
+const MACHINERY_INDICATOR_THRESHOLD = 3;
+
+/**
  * Print a `Type` to its string form WITHOUT the compiler's default truncation.
  *
  * `Type.getText()` truncates large/anonymous object types to ~160 chars and inserts
@@ -343,6 +384,21 @@ export class TypeInferrer {
     if (unwrapResult.wasUnwrapped) {
       typeString = unwrapResult.typeString;
     } else {
+      // No wrapper rule fired. Before treating the raw return as the contract,
+      // reject a wrapper envelope that IS or CONTAINS framework machinery
+      // (carrick#371): `withApiWrapper({ handler: () => ({ response: Response,
+      // error })})` resolves the handler's return to `{ response: Response; ... }`,
+      // which is transport machinery, not a payload. Emitting it manufactures a
+      // false compat mismatch against the consumer's real payload. No rule
+      // recovered a payload here, so abstain (honest `unknown`) — fail-closed.
+      if (this.typeIsOrContainsResponseMachinery(awaitedType)) {
+        this.log(
+          `Return type at ${request.file_path}:${request.line_number} is or contains ` +
+            'framework machinery (Response/Request-shaped); abstaining rather than ' +
+            'capturing the wrapper envelope as a response contract'
+        );
+        return null;
+      }
       // No wrapper rule fired: the (awaited) return resolved to its own type.
       // A named object return (`async (): Promise<Payment> => …`) renders as the
       // bare name `Payment`, which dangles in the source-less cross-repo bundle.
@@ -625,12 +681,24 @@ export class TypeInferrer {
     if (unwrapResult.wasUnwrapped) {
       typeString = unwrapResult.typeString;
     } else {
+      const resolved = this.unwrapPromiseType(payloadType);
+      // Same carrick#371 fail-closed guard as the function-return path: a
+      // payload that IS or CONTAINS framework machinery (a raw `Response`, a
+      // `{ response: Response; ... }` envelope) is not a contract. No rule
+      // recovered a payload, so abstain rather than emit the machinery.
+      if (this.typeIsOrContainsResponseMachinery(resolved)) {
+        this.log(
+          `Response payload at ${request.file_path}:${request.line_number} is or contains ` +
+            'framework machinery (Response/Request-shaped); abstaining rather than ' +
+            'capturing it as a response contract'
+        );
+        return null;
+      }
       // No wrapper rule fired: the payload resolved straight to its own type.
       // If that's a named object (`res.json(payment)` with `payment: Payment`),
       // `typeText` keeps the bare name `Payment`, which dangles in the
       // source-less cross-repo bundle → `any` → unverifiable. Expand the
       // resolved object structurally so the real members land in the bundle.
-      const resolved = this.unwrapPromiseType(payloadType);
       typeString = this.expandResolvedTypeStructural(resolved, typeString);
     }
 
@@ -1557,6 +1625,123 @@ export class TypeInferrer {
     }
 
     return null;
+  }
+
+  /**
+   * A producer response type that IS or CONTAINS framework transport machinery
+   * (a fetch/DOM `Response`, a Node `ServerResponse`, a reply object) — the
+   * artifact behind carrick#371, where a wrapped route handler's literal return
+   * envelope `{ response: Response; error?: undefined } | { ...; error: Error }`
+   * was captured as the response contract. Machinery is never a comparable
+   * contract, so a response path that resolves here abstains (honest `unknown`)
+   * rather than emit a concrete-but-false type.
+   *
+   * "CONTAINS" is one structural level: a union/intersection member, or a direct
+   * property's type, that is itself machinery — enough for the envelope shape,
+   * shallow enough not to over-abstain on a payload that merely references a
+   * machinery type deep inside. The origin gate in `typeIsFrameworkMachinery`
+   * keeps a user object whose fields happen to share a name from tripping.
+   */
+  private typeIsOrContainsResponseMachinery(type: Type): boolean {
+    return this.typeIsOrContainsMachinery(type, 0);
+  }
+
+  private typeIsOrContainsMachinery(type: Type, depth: number): boolean {
+    if (this.typeIsFrameworkMachinery(type)) {
+      return true;
+    }
+    // Union/intersection: any envelope member wrapping machinery taints it.
+    if (type.isUnion()) {
+      return type
+        .getUnionTypes()
+        .some((part) => this.typeIsOrContainsMachinery(part, depth));
+    }
+    if (type.isIntersection()) {
+      return type
+        .getIntersectionTypes()
+        .some((part) => this.typeIsOrContainsMachinery(part, depth));
+    }
+    // One level of property descent: `{ response: Response; error?: undefined }`.
+    if (depth < 1) {
+      for (const prop of type.getProperties()) {
+        const decl = prop.getDeclarations()[0];
+        if (!decl) continue;
+        const propType = prop.getTypeAtLocation(decl);
+        if (this.typeIsOrContainsMachinery(propType, depth + 1)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * True when `type` itself is an HTTP-machinery type: it structurally carries
+   * at least `MACHINERY_INDICATOR_THRESHOLD` of the strongly-discriminating
+   * `MACHINERY_MEMBER_INDICATORS`, AND its symbol is declared in a lib
+   * (`lib.dom.d.ts`, ...) or `node_modules` origin. Both gates are required —
+   * the indicator subset alone essentially never matches a JSON payload, and
+   * the origin gate makes certain a user's own local type sharing those member
+   * names is never mistaken for framework machinery (the advisor's guard).
+   */
+  private typeIsFrameworkMachinery(type: Type): boolean {
+    const indicatorHits = this.countMachineryIndicators(type);
+    if (indicatorHits < MACHINERY_INDICATOR_THRESHOLD) {
+      return false;
+    }
+    const symbol = type.getSymbol() ?? type.getAliasSymbol();
+    return this.symbolIsLibOrExternalOrigin(symbol);
+  }
+
+  /** How many `MACHINERY_MEMBER_INDICATORS` the type carries (own + apparent). */
+  private countMachineryIndicators(type: Type): number {
+    const names = new Set<string>();
+    for (const prop of type.getProperties()) {
+      names.add(prop.getName());
+    }
+    for (const prop of type.getApparentProperties()) {
+      names.add(prop.getName());
+    }
+    let hits = 0;
+    for (const name of names) {
+      if (MACHINERY_MEMBER_INDICATORS.has(name)) {
+        hits += 1;
+      }
+    }
+    return hits;
+  }
+
+  /**
+   * True when the symbol is declared in a TypeScript lib file (`lib.*.d.ts`) or
+   * under `node_modules` — i.e. framework/runtime machinery, not user source.
+   * Works on a bare checkout: the DOM `Response`/`Request` resolve from the
+   * bundled `lib.dom.d.ts` even with no installed dependencies.
+   */
+  private symbolIsLibOrExternalOrigin(symbol: TsSymbol | undefined): boolean {
+    if (!symbol) {
+      return false;
+    }
+    const isExternalPath = (filePath: string): boolean => {
+      const normalized = filePath.replace(/\\/g, '/');
+      return (
+        normalized.includes('/node_modules/') ||
+        /\/lib\.[^/]*\.d\.ts$/.test(normalized)
+      );
+    };
+    for (const decl of symbol.getDeclarations()) {
+      if (isExternalPath(decl.getSourceFile().getFilePath())) {
+        return true;
+      }
+    }
+    try {
+      const aliased = symbol.getAliasedSymbol?.();
+      if (aliased && aliased !== symbol) {
+        return this.symbolIsLibOrExternalOrigin(aliased);
+      }
+    } catch {
+      // Ignore errors when resolving the aliased symbol.
+    }
+    return false;
   }
 
   /**

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -116,9 +116,10 @@ const BUILTIN_ANCHOR_SYMBOLS = new Set<string>([
  * `writeHead`, ...), so the origin gate + `MACHINERY_INDICATOR_THRESHOLD` never
  * fire on real data. Kept in lockstep with the capture-seam mirror
  * `capture/machinery.ts` (the seam forbids sharing a module across it, same as
- * `BUILTIN_ANCHOR_SYMBOLS` mirrors `socket_io.rs`).
+ * `BUILTIN_ANCHOR_SYMBOLS` mirrors `socket_io.rs`). Exported so a drift-guard
+ * test (`machinery-indicator-mirror.test.ts`) asserts the two sets stay equal.
  */
-const MACHINERY_MEMBER_INDICATORS = new Set<string>([
+export const MACHINERY_MEMBER_INDICATORS = new Set<string>([
   // fetch / DOM Response & Request body-consumer surface
   'ok',
   'redirected',
@@ -1628,19 +1629,40 @@ export class TypeInferrer {
   }
 
   /**
-   * A producer response type that IS or CONTAINS framework transport machinery
-   * (a fetch/DOM `Response`, a Node `ServerResponse`, a reply object) — the
-   * artifact behind carrick#371, where a wrapped route handler's literal return
+   * True when a producer RESPONSE type IS or CONTAINS framework transport
+   * machinery (a fetch/DOM `Response`, a Node `ServerResponse`, a reply object)
+   * — the artifact behind carrick#371, where a wrapped handler's literal return
    * envelope `{ response: Response; error?: undefined } | { ...; error: Error }`
    * was captured as the response contract. Machinery is never a comparable
    * contract, so a response path that resolves here abstains (honest `unknown`)
    * rather than emit a concrete-but-false type.
    *
-   * "CONTAINS" is one structural level: a union/intersection member, or a direct
-   * property's type, that is itself machinery — enough for the envelope shape,
-   * shallow enough not to over-abstain on a payload that merely references a
-   * machinery type deep inside. The origin gate in `typeIsFrameworkMachinery`
-   * keeps a user object whose fields happen to share a name from tripping.
+   * DETECTS, exactly (see `typeIsOrContainsMachinery`):
+   *   1. the type itself is machinery (`typeIsFrameworkMachinery`);
+   *   2. a union/intersection member is machinery (the envelope union);
+   *   3. a DIRECT property's type is machinery, ONE level of descent only
+   *      (`{ response: Response; error }`).
+   *
+   * DELIBERATELY NOT DETECTED — listed so this comment never overstates the
+   * guarantee (an overstated safety comment is what bit sibling PR #442). Each is
+   * a non-regression: it leaves the pre-existing verdict unchanged and never
+   * manufactures a new wrong one, tracked as a follow-up:
+   *   - machinery nested deeper than one property level (a property whose type
+   *     is itself a nested object wrapping the machinery);
+   *   - a property typed `Promise<Response>` (the property type is NOT awaited /
+   *     Promise-unwrapped before the machinery check);
+   *   - an array element type: `Response[]` is not descended to its element;
+   *   - `interface X extends Response` declared in USER source — the origin gate
+   *     is lib/`node_modules` only, so a user-declared subtype reads as a real
+   *     contract, not machinery;
+   *   - a function / call-signature return type: the response paths that call
+   *     this resolve a handler's RETURN (an envelope/object), never a function
+   *     value, so no call-signature descent happens here. The capture-seam
+   *     mirror `capture/machinery.ts` DOES descend call signatures — that is
+   *     where the wrapper-FUNCTION type the Infer fallback resolves is caught.
+   *
+   * The origin gate in `typeIsFrameworkMachinery` keeps a user object whose
+   * fields merely share a member name from tripping.
    */
   private typeIsOrContainsResponseMachinery(type: Type): boolean {
     return this.typeIsOrContainsMachinery(type, 0);
@@ -1685,30 +1707,34 @@ export class TypeInferrer {
    * names is never mistaken for framework machinery (the advisor's guard).
    */
   private typeIsFrameworkMachinery(type: Type): boolean {
-    const indicatorHits = this.countMachineryIndicators(type);
-    if (indicatorHits < MACHINERY_INDICATOR_THRESHOLD) {
+    if (!this.hasMachineryIndicatorThreshold(type)) {
       return false;
     }
     const symbol = type.getSymbol() ?? type.getAliasSymbol();
     return this.symbolIsLibOrExternalOrigin(symbol);
   }
 
-  /** How many `MACHINERY_MEMBER_INDICATORS` the type carries (own + apparent). */
-  private countMachineryIndicators(type: Type): number {
-    const names = new Set<string>();
+  /**
+   * True once the type carries at least `MACHINERY_INDICATOR_THRESHOLD` DISTINCT
+   * `MACHINERY_MEMBER_INDICATORS` (own + apparent). Deduplicates by name (own and
+   * apparent property lists overlap) and early-returns the moment the threshold
+   * is reached — the callers only need the boolean, never the full count.
+   */
+  private hasMachineryIndicatorThreshold(type: Type): boolean {
+    const matched = new Set<string>();
+    const consider = (name: string): boolean => {
+      if (MACHINERY_MEMBER_INDICATORS.has(name)) {
+        matched.add(name);
+      }
+      return matched.size >= MACHINERY_INDICATOR_THRESHOLD;
+    };
     for (const prop of type.getProperties()) {
-      names.add(prop.getName());
+      if (consider(prop.getName())) return true;
     }
     for (const prop of type.getApparentProperties()) {
-      names.add(prop.getName());
+      if (consider(prop.getName())) return true;
     }
-    let hits = 0;
-    for (const name of names) {
-      if (MACHINERY_MEMBER_INDICATORS.has(name)) {
-        hits += 1;
-      }
-    }
-    return hits;
+    return false;
   }
 
   /**

--- a/src/sidecar/test/capture-v2-response-machinery.test.ts
+++ b/src/sidecar/test/capture-v2-response-machinery.test.ts
@@ -231,10 +231,16 @@ describe('carrick#371 capture degrades a wrapped response envelope to unknown', 
     return r!;
   }
 
-  /** RHS of `export type <alias> = <rhs>;` — scoped to that one statement. */
+  /**
+   * Full RHS of `export type <alias> = <rhs>;` — scoped to that one statement.
+   * The terminating `;` is the one followed (after any whitespace) by the next
+   * `export type` or end-of-file, NOT the first inner `;` — so a multi-member
+   * object RHS (`{ id: number; name: string }`) is captured whole, never
+   * truncated at `{ id: number`.
+   */
   function rhsOf(alias: string): string {
     const m = surface.match(
-      new RegExp(`export type ${alias} = ([\\s\\S]*?);(?:\\n|$)`)
+      new RegExp(`export type ${alias} = ([\\s\\S]*?);(?=\\s*(?:export type |$))`)
     );
     assert.ok(m, `no surface line for ${alias}:\n${surface}`);
     return m![1];
@@ -267,8 +273,11 @@ describe('carrick#371 capture degrades a wrapped response envelope to unknown', 
   it('control: a real payload literal is captured as-is (no over-abstain)', () => {
     const r = record('Payload_Response');
     assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
-    assert.match(surface, /Payload_Response = [\s\S]*id/);
-    assert.match(surface, /Payload_Response = [\s\S]*name/);
+    // rhsOf captures the WHOLE multi-member object (both members past the first
+    // inner `;`): the truncating helper this replaced saw only `{ id: number`.
+    const rhs = rhsOf('Payload_Response');
+    assert.match(rhs, /id/);
+    assert.match(rhs, /name/);
     assert.ok(!/Payload_Response = unknown;/.test(surface), surface);
   });
 });

--- a/src/sidecar/test/capture-v2-response-machinery.test.ts
+++ b/src/sidecar/test/capture-v2-response-machinery.test.ts
@@ -1,0 +1,382 @@
+/**
+ * carrick#371: a wrapped route-handler's literal return ENVELOPE must never be
+ * emitted as a producer response contract.
+ *
+ * A Next.js-style producer `export const GET = withApiWrapper({ handler: () =>
+ * ({ response: Response.json(data), error: undefined }) })` resolves its
+ * handler return to `{ response: Response; error?: undefined } | { ...; error:
+ * Error }` — framework transport machinery, not the JSON payload. Captured as
+ * the response type, it manufactures a FALSE compat mismatch against the
+ * consumer that anchors the real payload (`{ id; name }`). This is the
+ * producer-side mirror of the consumer `machineryIndicators` guard.
+ *
+ * The fix is two fail-closed guards, both exercised here:
+ *  1. The v1 inferrer (`buildFunctionReturnInferredType`) abstains when the
+ *     resolved return IS or CONTAINS machinery — so no Literal anchor ever
+ *     carries the envelope text (the primary production path).
+ *  2. The capture Infer fallback (`resolveAnchor`) degrades to `unknown` when
+ *     its resolved type IS or CONTAINS machinery — so the wrapper FUNCTION type
+ *     `(req) => Promise<Response>` that the fallback resolves to never surfaces.
+ *
+ * Acceptable outcomes: the unwrapped payload, or `unknown`. Forbidden: any
+ * concrete verdict off the machinery. Detection is structural + origin-gated;
+ * no framework name is hardcoded.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { captureStub, runCheck } from '../src/capture/index.js';
+import type {
+  CaptureStubResult,
+  CheckPairSpec,
+  CheckVerdict,
+} from '../src/capture/api.js';
+import { SidecarClient } from './helpers.js';
+
+const ROUTE_TS = `interface Payload { id: number; name: string; }
+declare function fetchPayload(): Promise<Payload>;
+declare function withApiWrapper(cfg: {
+  handler: () => Promise<
+    { response: Response; error?: undefined } | { response: Response; error: Error }
+  >;
+}): (req: Request) => Promise<Response>;
+
+export const GET = withApiWrapper({
+  handler: async () => {
+    const data = await fetchPayload();
+    return { response: Response.json(data), error: undefined };
+  },
+});
+
+export async function plainHandler(): Promise<Payload> {
+  return { id: 1, name: "widget" };
+}
+`;
+
+function lineOf(marker: string): number {
+  const idx = ROUTE_TS.split('\n').findIndex((l) => l.includes(marker));
+  assert.ok(idx >= 0, `fixture must contain: ${marker}`);
+  return idx + 1;
+}
+
+const GET_LINE = lineOf('export const GET');
+const PLAIN_LINE = lineOf('export async function plainHandler');
+
+function writeRepo(repoDir: string): void {
+  fs.mkdirSync(path.join(repoDir, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoDir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        rootDir: 'src',
+        module: 'esnext',
+        moduleResolution: 'bundler',
+        target: 'es2022',
+        lib: ['es2022', 'dom'],
+        skipLibCheck: true,
+      },
+      include: ['src'],
+    })
+  );
+  fs.writeFileSync(path.join(repoDir, 'src', 'route.ts'), ROUTE_TS);
+}
+
+// ===========================================================================
+// Guard 1: the v1 inferrer abstains on the machinery envelope (Literal source).
+// ===========================================================================
+
+interface InferShape {
+  status: string;
+  inferred_types?: Array<{ alias: string; type_string: string }>;
+  errors?: string[];
+}
+
+describe('carrick#371 v1 inference abstains on a wrapped response envelope', () => {
+  let repoDir: string;
+  let client: SidecarClient;
+
+  before(async () => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-371-v1-'));
+    writeRepo(repoDir);
+    client = new SidecarClient();
+    await client.start();
+    await client.send({ action: 'init', request_id: 'init', repo_root: repoDir });
+  });
+
+  after(async () => {
+    await client.stop();
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('does NOT emit the machinery envelope as an inferred response type', async () => {
+    // Pre-fix: this returned `{ response: Response; error: undefined; }`, which
+    // rode a Literal capture anchor into the producer surface.
+    const res = await client.send<InferShape>({
+      action: 'infer',
+      request_id: 'envelope',
+      requests: [
+        {
+          file_path: path.join(repoDir, 'src', 'route.ts'),
+          line_number: GET_LINE,
+          infer_kind: 'function_return',
+          alias: 'Endpoint_GET_Response',
+        },
+      ],
+    });
+    const inferred = (res.inferred_types ?? []).find(
+      (t) => t.alias === 'Endpoint_GET_Response'
+    );
+    // The alias resolves to nothing usable (abstained) — never the envelope.
+    if (inferred) {
+      assert.ok(
+        !/response\s*:/.test(inferred.type_string) &&
+          !/Response/.test(inferred.type_string),
+        `must not carry the machinery envelope, got: ${inferred.type_string}`
+      );
+    } else {
+      assert.ok(true, 'abstained (no inferred type for the envelope alias)');
+    }
+  });
+
+  it('control: a plain payload return is still inferred (no over-abstain)', async () => {
+    const res = await client.send<InferShape>({
+      action: 'infer',
+      request_id: 'plain',
+      requests: [
+        {
+          file_path: path.join(repoDir, 'src', 'route.ts'),
+          line_number: PLAIN_LINE,
+          infer_kind: 'function_return',
+          alias: 'Endpoint_PLAIN_Response',
+        },
+      ],
+    });
+    const inferred = (res.inferred_types ?? []).find(
+      (t) => t.alias === 'Endpoint_PLAIN_Response'
+    );
+    assert.ok(inferred, 'a plain payload handler must still resolve');
+    assert.match(inferred!.type_string, /id/);
+    assert.match(inferred!.type_string, /name/);
+  });
+});
+
+// ===========================================================================
+// Guard 2: the capture Infer fallback degrades the machinery type to unknown.
+// ===========================================================================
+
+describe('carrick#371 capture degrades a wrapped response envelope to unknown', () => {
+  let repoDir: string;
+  let outRoot: string;
+  let result: CaptureStubResult;
+  let surface: string;
+
+  before(() => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-371-cap-'));
+    outRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-371-stub-'));
+    writeRepo(repoDir);
+    result = captureStub({
+      repoRoot: repoDir,
+      serviceName: 'route-svc',
+      outDir: path.join(outRoot, 'stub'),
+      anchors: [
+        // The FILE_BASED_ROUTE fallback shape once v1 abstains: a line-located
+        // infer anchor. Its resolved type is the WRAPPER FUNCTION
+        // `(req: Request) => Promise<Response>` — machinery in return position.
+        {
+          kind: 'infer',
+          alias: 'Endpoint_GET_Response',
+          source_file: 'src/route.ts',
+          anchor_origin: 'deterministic-infer',
+          line_number: GET_LINE,
+        },
+        // The envelope object literal itself: machinery in a direct property.
+        {
+          kind: 'infer',
+          alias: 'Envelope_Response',
+          source_file: 'src/route.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: '{ response: Response.json(data), error: undefined }',
+          unwrap: 'none',
+        },
+        // Control: a real payload object literal — captured as-is, not degraded.
+        {
+          kind: 'infer',
+          alias: 'Payload_Response',
+          source_file: 'src/route.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: '{ id: 1, name: "widget" }',
+          unwrap: 'none',
+        },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    surface = fs.readFileSync(
+      path.join(result.stub_dir, 'types', 'surface.d.ts'),
+      'utf8'
+    );
+  });
+
+  after(() => {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    fs.rmSync(outRoot, { recursive: true, force: true });
+  });
+
+  function record(alias: string) {
+    const r = result.aliases.find((a) => a.alias === alias);
+    assert.ok(r, `no alias record for ${alias}`);
+    return r!;
+  }
+
+  /** RHS of `export type <alias> = <rhs>;` — scoped to that one statement. */
+  function rhsOf(alias: string): string {
+    const m = surface.match(
+      new RegExp(`export type ${alias} = ([\\s\\S]*?);(?:\\n|$)`)
+    );
+    assert.ok(m, `no surface line for ${alias}:\n${surface}`);
+    return m![1];
+  }
+
+  it('degrades the line-anchored wrapper function type to unknown', () => {
+    // Pre-fix this captured `(req: Request) => Promise<Response>`.
+    const r = record('Endpoint_GET_Response');
+    assert.strictEqual(r.serialization, 'structural_fallback');
+    assert.ok(r.capture_failure_reason, 'must record a demotion reason');
+    assert.match(r.capture_failure_reason!, /framework machinery/);
+    assert.strictEqual(rhsOf('Endpoint_GET_Response'), 'unknown');
+  });
+
+  it('degrades the envelope object literal (machinery in a property) to unknown', () => {
+    // Pre-fix this captured `{ response: Response; error: undefined; }`.
+    const r = record('Envelope_Response');
+    assert.strictEqual(r.serialization, 'structural_fallback');
+    assert.match(r.capture_failure_reason!, /framework machinery/);
+    assert.strictEqual(rhsOf('Envelope_Response'), 'unknown');
+  });
+
+  it('no machinery type text survives anywhere in the surface', () => {
+    // Type-position machinery (never the `_Response` alias-name suffix).
+    assert.ok(!/:\s*Response\b/.test(surface), surface);
+    assert.ok(!/Promise<Response>/.test(surface), surface);
+    assert.ok(!/req:\s*Request\b/.test(surface), surface);
+  });
+
+  it('control: a real payload literal is captured as-is (no over-abstain)', () => {
+    const r = record('Payload_Response');
+    assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
+    assert.match(surface, /Payload_Response = [\s\S]*id/);
+    assert.match(surface, /Payload_Response = [\s\S]*name/);
+    assert.ok(!/Payload_Response = unknown;/.test(surface), surface);
+  });
+});
+
+// ===========================================================================
+// End-to-end: the captured producer never yields a false compat mismatch.
+// ===========================================================================
+
+describe('carrick#371 check: wrapped response envelope yields no false mismatch', () => {
+  let repoDir: string;
+  let outRoot: string;
+  let workRoot: string;
+  let verdicts: Map<string, CheckVerdict>;
+
+  before(async () => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-371-e2e-'));
+    outRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-371-e2e-stub-'));
+    workRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-371-e2e-ws-'));
+    writeRepo(repoDir);
+
+    // Producer: capture the wrapped route via the real FILE_BASED_ROUTE
+    // fallback anchor (line-located infer). Post-fix -> `unknown`.
+    const producer = captureStub({
+      repoRoot: repoDir,
+      serviceName: 'producer',
+      outDir: path.join(outRoot, 'producer'),
+      anchors: [
+        {
+          kind: 'infer',
+          alias: 'Wrapped_Sent',
+          source_file: 'src/route.ts',
+          anchor_origin: 'deterministic-infer',
+          line_number: GET_LINE,
+        },
+      ],
+    });
+    assert.strictEqual(producer.success, true, JSON.stringify(producer.errors));
+
+    // Consumer: a hand-written stub anchoring the REAL payload the handler
+    // sends, plus the raw envelope to document the pre-fix false mismatch.
+    const consumerDir = path.join(outRoot, 'consumer');
+    fs.mkdirSync(path.join(consumerDir, 'types'), { recursive: true });
+    fs.writeFileSync(
+      path.join(consumerDir, 'package.json'),
+      JSON.stringify({
+        name: '@carrick/consumer',
+        version: '0.0.0-carrick',
+        private: true,
+        types: './types/surface.d.ts',
+      }) + '\n'
+    );
+    fs.writeFileSync(
+      path.join(consumerDir, 'types', 'surface.d.ts'),
+      [
+        'export type Wrapped_Exp = { id: number; name: string };',
+        'export type RawEnvelope_Sent = { response: Response; error?: undefined } | { response: Response; error: Error };',
+        'export type RawEnvelope_Exp = { id: number; name: string };',
+      ].join('\n') + '\n'
+    );
+
+    const pairs: CheckPairSpec[] = [
+      // The fix: producer captured from the fixture vs the real payload.
+      {
+        pair_key: 'wrapped',
+        protocol: 'http',
+        type_kind: 'response',
+        producer: { service_name: 'producer', alias: 'Wrapped_Sent' },
+        consumer: { service_name: 'consumer', alias: 'Wrapped_Exp' },
+      },
+      // Control documenting the bug: the raw machinery envelope vs the payload
+      // IS an incompatible — exactly the false verdict the fix prevents.
+      {
+        pair_key: 'raw-envelope',
+        protocol: 'http',
+        type_kind: 'response',
+        producer: { service_name: 'consumer', alias: 'RawEnvelope_Sent' },
+        consumer: { service_name: 'consumer', alias: 'RawEnvelope_Exp' },
+      },
+    ];
+
+    const res = await runCheck({
+      stubs: [
+        { service_name: 'producer', stub_dir: producer.stub_dir },
+        { service_name: 'consumer', stub_dir: consumerDir },
+      ],
+      pairs,
+      workspaceRoot: workRoot,
+    });
+    assert.strictEqual(res.success, true, JSON.stringify(res.errors));
+    assert.strictEqual(res.install_ok, true, res.install_error);
+    verdicts = new Map(res.verdicts.map((v) => [v.pair_key, v]));
+  });
+
+  after(() => {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    fs.rmSync(outRoot, { recursive: true, force: true });
+    fs.rmSync(workRoot, { recursive: true, force: true });
+  });
+
+  it('the wrapped producer never reports a mismatch (unverifiable, not incompatible)', () => {
+    // Pre-fix the producer surface was the machinery type and this was
+    // `incompatible` — the stable false verdict carrick#371 reports.
+    const v = verdicts.get('wrapped')!;
+    assert.notStrictEqual(v.bucket, 'incompatible', v.diagnostic);
+    assert.strictEqual(v.bucket, 'unverifiable', JSON.stringify(v));
+  });
+
+  it('control: the raw envelope vs the payload IS the incompatible the fix avoids', () => {
+    assert.strictEqual(verdicts.get('raw-envelope')!.bucket, 'incompatible');
+  });
+});

--- a/src/sidecar/test/machinery-indicator-mirror.test.ts
+++ b/src/sidecar/test/machinery-indicator-mirror.test.ts
@@ -1,0 +1,36 @@
+/**
+ * carrick#371 mirror-drift guard.
+ *
+ * The machinery-indicator set is intentionally DUPLICATED across the capture
+ * seam: `type-inferrer.ts` (ts-morph, the v1 abstain path) and
+ * `capture/machinery.ts` (raw `ts`, the capture demote path) each carry their
+ * own copy, because the seam forbids sharing a module across it — a capture/
+ * file may import only node builtins + `typescript` + its own bundle, and the
+ * rest of the sidecar may reach the bundle only via `api.js`/`index.js`
+ * (enforced by capture-v2-seam.test.ts). De-duplicating into a shared module
+ * would break that boundary, so the two copies are kept in lockstep by THIS
+ * test instead: if they drift, one detection path silently stops abstaining and
+ * the carrick#371 false verdict can reappear on whichever path lost a member.
+ */
+
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { MACHINERY_MEMBER_INDICATORS as INFERRER_SET } from '../src/type-inferrer.js';
+import { MACHINERY_MEMBER_INDICATORS as CAPTURE_SET } from '../src/capture/machinery.js';
+
+describe('carrick#371 machinery-indicator mirror stays in lockstep', () => {
+  it('the two duplicated indicator sets are byte-for-byte equal', () => {
+    const inferrer = [...INFERRER_SET].sort();
+    const capture = [...CAPTURE_SET].sort();
+    assert.deepStrictEqual(
+      capture,
+      inferrer,
+      'type-inferrer.ts and capture/machinery.ts MACHINERY_MEMBER_INDICATORS ' +
+        'have drifted; update both copies together (see the doc comments)'
+    );
+  });
+
+  it('the set is non-empty (a truncated copy must not read as "in sync")', () => {
+    assert.ok(INFERRER_SET.size >= 3, 'indicator set unexpectedly small');
+  });
+});


### PR DESCRIPTION
## Problem

A wrapped route producer

```ts
export const GET = withApiWrapper({
  handler: async () => {
    const data = await fetchPayload();
    return { response: Response.json(data), error: undefined };
  },
});
```

had its handler's literal return **envelope** — `{ response: Response; error?: undefined } | { response: Response; error: Error }` — captured as the response contract instead of the JSON payload (`data`). The consumer anchors the real payload, so `check_compatibility` reported a stable **false `incompatible`** (observed live, two consecutive scans). Framework machinery emitted as a comparable contract is a fail-closed violation — the producer-side mirror of the consumer `machineryIndicators` problem (raw `fetch` `Response` as a non-contract).

## Mechanism: mirror the consumer machinery detection

Detection is **structural + origin-gated**, the same two mechanisms the consumer `ExtractionConfig` path already uses — `typeHasMachineryIndicators` (property indicators) + `symbolOriginatesFromModules` (origin gate) — never a hardcoded framework name:

- **Indicators:** a strong subset of the shared HTTP-message member surface (`ok`, `redirected`, `bodyUsed`, `arrayBuffer`, `blob`, `formData`, `clone`, `json`, `statusText`, `statusCode`, `setHeader`, `writeHead`, ...) — the names no JSON payload carries. Threshold ≥3.
- **Origin gate:** the machinery symbol must declare in a lib (`lib.*.d.ts`) or `node_modules` origin, so a user object that merely shares a member name can never trip it (works on a bare checkout: the DOM `Response`/`Request` resolve from the bundled `lib.dom.d.ts`).
- **IS or CONTAINS:** the type itself, a union/intersection member (the envelope union), a direct property's type (`{ response: Response }`), or a call signature's awaited return (the wrapper function) — one structural level deep.

There is no static shared indicator set to extend (the consumer's is agent-generated per scan), so the canonical set is duplicated across the capture seam with a lockstep-mirror doc comment — the same pattern by which `BUILTIN_ANCHOR_SYMBOLS` mirrors `socket_io.rs`.

## Unwrap vs. degrade (two fail-closed guards)

Empirically, the envelope reaches the surface by two paths, both now closed:

1. **`type-inferrer.ts`** (the primary production path): the response paths (`buildFunctionReturnInferredType`, `inferResponseBody`) **abstain** (return `null`) when the resolved return IS or CONTAINS machinery *and no unwrap rule recovered a payload*. So the envelope never rides a Literal capture anchor. A rule-unwrapped payload, or a plain `res.json(payload)`, is unaffected — that is the **unwrap** side (the real payload is captured as before).
2. **`capture/anchors.ts` + `capture/machinery.ts`** (the fallback): once v1 abstains, `derive_capture_anchors` re-routes the alias to a locator-based Infer anchor, which resolves the **wrapper function** `(req: Request) => Promise<Response>`. The capture guard **degrades it to `unknown`**. No source locator points at a distinct clean payload here, so degrade — never a concrete verdict off the machinery.

The `response_expression_text` locator remains the re-aim path for the cases where it points at a clean payload (unchanged); the guard only engages when machinery would otherwise survive.

## Fail-closed guarantee

Acceptable outcomes: the unwrapped payload, or `unknown`. The forbidden outcome — any concrete verdict derived from the machinery envelope — can no longer be emitted. The verdict moves from a false `incompatible` to `unverifiable`.

## Tests

New `src/sidecar/test/capture-v2-response-machinery.test.ts` (8 tests) exercises all three layers on a synthetic wrapped-envelope fixture + a consumer anchoring the payload:

- v1 inference **abstains** on the envelope; control: a plain payload still resolves.
- capture **degrades** the wrapper function type and the envelope object literal to `unknown`; control: a real payload literal is captured as-is; no machinery type text survives the surface.
- end-to-end `runCheck`: the wrapped producer verdict is **`unverifiable`, never `incompatible`**; control: the raw envelope vs. the payload IS the `incompatible` the fix avoids.

Pre-fix on `origin/main` the 5 machinery assertions fail (v1 emits the envelope, capture emits the wrapper fn, verdict is `incompatible`); the controls pass. Full sidecar suite (282 pass, 0 fail) and full `cargo fmt`/`clippy`/`test` green via the pre-commit hook.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)