### PR TITLE
fix(type-compat): verify Unknown-state sides with a resolved v2 surface

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2985,8 +2985,18 @@ fn enrich_manifest_with_type_resolution(
             // disqualifying-top-type notion (adversarial-review finding 2)
             // rejects not just whole-string "any"/"unknown" but any/unknown
             // at ANY position — `any[]`, `Promise<any>`, `Record<string,
-            // any>`, `{ metadata: any }` — matching the capture self-check's
-            // deep walk, so the two layers agree on what counts as resolved.
+            // any>`, `{ metadata: any }`, `{ getData: () => any }`. Since
+            // carrick #448 removed the `type_state == Unknown` pre-verdict,
+            // `check_v2` is the sole authority on resolved-ness, so its capture
+            // self-check deep walk (`findDisqualifyingTopType`) is a genuine
+            // SUPERSET of this text scan — with two deliberate, safe
+            // exceptions the walk does NOT flag: a callable PARAMETER `any`
+            // (contravariant, genuinely permissive — this text scan may flag
+            // it, but abstaining there would only over-demote, never
+            // false-compatible), and TypeScript's unresolved-external `error`
+            // placeholder (heals when the check installs the pin). So the two
+            // layers agree on every author-baked disqualifier; they diverge
+            // only in the fail-closed direction.
             let is_unknown_type = type_string.trim().is_empty()
                 || type_compat_v2::contains_disqualifying_top_type(type_string)
                 || dts_trivially_unknown(&entry.type_alias);

--- a/src/engine/type_compat_v2.rs
+++ b/src/engine/type_compat_v2.rs
@@ -22,7 +22,7 @@ use tracing::{debug, warn};
 use crate::analyzer::PairCheckOutcome;
 use crate::cloud_storage::{
     CAPTURE_ARTIFACT_VERSION, CaptureStubArtifact, CloudRepoData, ManifestRole, ManifestTypeKind,
-    ManifestTypeState, TypeManifestEntry,
+    TypeManifestEntry,
 };
 use crate::operation::OperationKey;
 use crate::services::TypeSidecar;
@@ -626,8 +626,10 @@ pub(crate) struct BuiltPair {
     pub consumer_alias: String,
     pub producer_service: String,
     pub consumer_service: String,
-    /// Set when the pair is unverifiable before any probe runs (a side's
-    /// type_state is Unknown, or a side has no capture surface).
+    /// Set when the pair is unverifiable before any probe runs: a side has no
+    /// v2 capture surface at all (older scan or degraded capture). The stale
+    /// manifest `type_state` is NOT a pre-verdict trigger — check_v2 reads the
+    /// real surface and judges resolved-ness itself.
     pub pre_verdict: Option<(VerdictBucket, String)>,
 }
 
@@ -645,10 +647,15 @@ struct ServiceEntry<'a> {
 ///   most specific producer(s) per consumer.
 /// - socket/graphql/pubsub: exact operation-key match + type_kind.
 ///
-/// An unresolved side (`type_state == Unknown`) or a side without a capture
-/// surface produces a pair with a pre-set unverifiable verdict instead of a
-/// probe (design: unresolved anchors generate no probe; a missing surface is
-/// "peer scanned without a v2 surface — re-scan").
+/// A side without a v2 capture surface produces a pair with a pre-set
+/// unverifiable verdict instead of a probe ("peer scanned without a v2 surface
+/// — re-scan"). The manifest `type_state` is NOT consulted for the pre-verdict:
+/// it records the v1 (pre-capture) resolution, which leaves inline-literal
+/// producer/consumer responses `Unknown` even when the v2 capture surface fully
+/// resolved the alias. check_v2 reads the real surface and is the sole
+/// authority — an alias baked to any/unknown (or absent) is caught by its own
+/// gate. Gating the pre-verdict on the stale `type_state` dropped real,
+/// resolvable, compatible edges to "not compared".
 pub(crate) fn build_check_pairs(all_repo_data: &[CloudRepoData]) -> Vec<BuiltPair> {
     let mut producers: Vec<ServiceEntry> = Vec::new();
     let mut consumers: Vec<ServiceEntry> = Vec::new();
@@ -762,6 +769,18 @@ fn build_pair(producer: &ServiceEntry, consumer: &ServiceEntry) -> Option<BuiltP
         consumer.entry.type_alias
     );
 
+    // The ONLY pre-probe unverifiable is a side that literally has no v2
+    // capture surface (older scan or capture degraded — re-scan it). The
+    // manifest `type_state` is deliberately NOT consulted: it records the v1
+    // (pre-capture) resolution, which leaves an inline-literal producer/
+    // consumer response `Unknown` even when the v2 capture surface fully
+    // resolved that alias (self-check ok). `check_v2` reads the actual surface
+    // and is the sole authority on resolved-ness — an alias that baked to
+    // `any`/`unknown` (or is absent from the surface) is caught by its own
+    // IsAny/IsUnknown gate (`gate_caught_baked_any` / import error →
+    // unverifiable) and can never read compatible. Gating on the stale
+    // `type_state` instead dropped real, resolvable, mutually-compatible edges
+    // to "not compared" (the order→notification verdict gap).
     let pre_verdict = if !producer.has_surface {
         Some((
             VerdictBucket::Unverifiable,
@@ -777,16 +796,6 @@ fn build_pair(producer: &ServiceEntry, consumer: &ServiceEntry) -> Option<BuiltP
                 "consumer service '{}' has no v2 type surface (older scan or capture degraded) — re-scan it",
                 consumer.service_id
             ),
-        ))
-    } else if producer.entry.type_state == ManifestTypeState::Unknown {
-        Some((
-            VerdictBucket::Unverifiable,
-            "producer type was not resolved at capture time".to_string(),
-        ))
-    } else if consumer.entry.type_state == ManifestTypeState::Unknown {
-        Some((
-            VerdictBucket::Unverifiable,
-            "consumer type was not resolved at capture time".to_string(),
         ))
     } else {
         None
@@ -995,9 +1004,10 @@ fn outcome_for(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cloud_storage::TypeEvidence;
+    use crate::cloud_storage::{ManifestTypeState, TypeEvidence};
     use crate::services::type_sidecar::InferKind;
     use crate::type_manifest::{build_manifest_type_alias, build_manifest_type_alias_with_call_id};
+    use serial_test::serial;
 
     fn entry(
         key: OperationKey,
@@ -1727,10 +1737,14 @@ mod tests {
         assert_eq!(pairs[0].consumer_service, "orders-engine");
     }
 
-    /// An unresolved side or a missing capture surface pre-verdicts the pair
-    /// unverifiable — it never reaches a probe, and the reason travels.
+    /// A missing capture surface — and ONLY a missing surface — pre-verdicts
+    /// the pair unverifiable before any probe. A manifest `type_state ==
+    /// Unknown` on a side that HAS a surface no longer pre-verdicts: the
+    /// manifest state is the stale v1 (pre-capture) signal, so a resolvable
+    /// alias would be dropped; check_v2 reads the actual surface and judges it
+    /// (baked any/unknown is caught by its own IsAny/IsUnknown gate).
     #[test]
-    fn build_pairs_pre_verdicts_unresolved_and_surfaceless() {
+    fn build_pairs_pre_verdicts_only_surfaceless() {
         let key = OperationKey::http("GET", "/orders");
         let no_surface_producer = repo(
             "api",
@@ -1766,8 +1780,9 @@ mod tests {
         assert_eq!(*bucket, VerdictBucket::Unverifiable);
         assert!(reason.contains("no v2 type surface"), "{reason}");
 
-        // Unknown type_state on a side with a surface: unresolved anchors
-        // generate no probe (design, Check step 9).
+        // Unknown type_state on a side WITH a surface: NO pre-verdict. The
+        // stale manifest state must not short-circuit a probe — check_v2 reads
+        // the real surface and is the sole authority on resolved-ness.
         let unresolved_producer = repo(
             "api",
             None,
@@ -1784,9 +1799,11 @@ mod tests {
         );
         let pairs = build_check_pairs(&[unresolved_producer, consumer_ok]);
         assert_eq!(pairs.len(), 1);
-        let (bucket, reason) = pairs[0].pre_verdict.as_ref().expect("pre-verdict");
-        assert_eq!(*bucket, VerdictBucket::Unverifiable);
-        assert!(reason.contains("not resolved at capture time"), "{reason}");
+        assert!(
+            pairs[0].pre_verdict.is_none(),
+            "an Unknown-state side WITH a surface must probe, not pre-verdict: {:?}",
+            pairs[0].pre_verdict
+        );
     }
 
     // ---- end-to-end: capture_v2 -> check_v2 -> pair outcomes -> edge join --
@@ -1805,6 +1822,7 @@ mod tests {
     /// The check path is deterministic given the anchors (no LLM anywhere);
     /// the pnpm install is local-only for these bare fixtures.
     #[test]
+    #[serial(v2_capture_sidecar)]
     fn corpus_capture_check_join_end_to_end() {
         let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let sidecar_path = manifest_dir.join("src/sidecar/dist/src/index.js");
@@ -1977,6 +1995,7 @@ mod tests {
     /// the demoted surface ships as-is and the pair stays honestly
     /// unverifiable — never compatible.
     #[test]
+    #[serial(v2_capture_sidecar)]
     fn demoted_alias_literal_backfill_end_to_end() {
         let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let sidecar_path = manifest_dir.join("src/sidecar/dist/src/index.js");
@@ -2168,6 +2187,160 @@ mod tests {
             "without a backfill the demotion must never read compatible; \
              diagnostic: {:?}",
             control_outcomes[0].diagnostic
+        );
+    }
+
+    /// Regression for the order→notification verdict gap: a producer whose
+    /// manifest `type_state` is `Unknown` (an inline-literal response v1 could
+    /// not resolve — `primary_type_symbol` null) but whose v2 capture surface
+    /// DID resolve the alias (self-check ok) must land a REAL verdict, not a
+    /// pre-probe `Unverifiable`.
+    ///
+    /// Pre-fix, `build_pair` short-circuited any `type_state == Unknown` side
+    /// to Unverifiable off the stale v1 signal, so `apply_pair_outcomes`
+    /// collapsed the edge to `type_compatible: None` and the cloud read "not
+    /// compared" — even though both sides had resolvable, mutually-compatible
+    /// types. This test captures notifications-svc's inline-literal `GET
+    /// /health` (`{ status: string }`) through an INFER anchor — v1 leaves it
+    /// Unknown, the v2 locator resolves it — and pairs it with a matching
+    /// consumer; the pair must verdict Compatible. The `type_state == Unknown`
+    /// on the producer entry is the exact production state the fix must no
+    /// longer gate on.
+    #[test]
+    #[serial(v2_capture_sidecar)]
+    fn unknown_state_producer_with_resolved_surface_verifies_end_to_end() {
+        let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let sidecar_path = manifest_dir.join("src/sidecar/dist/src/index.js");
+        if !sidecar_path.exists() {
+            eprintln!("Skipping test: sidecar not built (cd src/sidecar && npm run build)");
+            return;
+        }
+        let notif_repo = manifest_dir.join("tests/fixtures/xrepo-corpus-2/notifications-svc");
+        let dash_repo = manifest_dir.join("tests/fixtures/xrepo-corpus-2/web-dashboard");
+        assert!(notif_repo.exists(), "fixture missing: {notif_repo:?}");
+        assert!(dash_repo.exists(), "fixture missing: {dash_repo:?}");
+
+        let sidecar = TypeSidecar::spawn(&sidecar_path).expect("spawn sidecar");
+        sidecar.start_init(&notif_repo, None);
+        sidecar
+            .wait_ready(std::time::Duration::from_secs(60))
+            .expect("sidecar init");
+
+        let key = OperationKey::http("GET", "/health");
+        let producer_alias =
+            build_manifest_type_alias(&key, ManifestRole::Producer, ManifestTypeKind::Response);
+        let consumer_call_id = crate::type_manifest::build_call_site_id(
+            "lib/api.ts",
+            40,
+            &key,
+            dash_repo.to_str().unwrap(),
+        );
+        let consumer_alias = build_manifest_type_alias_with_call_id(
+            &key,
+            ManifestRole::Consumer,
+            ManifestTypeKind::Response,
+            Some(&consumer_call_id),
+        );
+
+        // Producer: the inline-literal `/health` return, captured via an INFER
+        // anchor at the return statement (line 27). v1 cannot resolve an inline
+        // object literal (it stays Unknown in the manifest); the v2 capture
+        // locator resolves `{ status: string }`.
+        let (notif_stub, notif_artifact) = run_capture(
+            &sidecar,
+            notif_repo.to_str().unwrap(),
+            "notifications-svc",
+            &[CaptureAnchor::Infer {
+                alias: producer_alias.clone(),
+                source_file: "src/http/routes.ts".to_string(),
+                anchor_origin: AnchorOrigin::DeterministicInfer,
+                span_start: None,
+                span_end: None,
+                line_number: Some(27),
+                expression_text: None,
+            }],
+            &HashMap::new(),
+        )
+        .expect("notifications-svc capture");
+        let surface = notif_artifact
+            .files
+            .get("types/surface.d.ts")
+            .expect("surface in artifact");
+        assert!(
+            surface.contains(&format!("export type {} =", producer_alias))
+                && surface.contains("status"),
+            "the inline-literal producer must RESOLVE in the surface, got:\n{surface}"
+        );
+        assert!(
+            !surface.contains(&format!("export type {} = unknown", producer_alias))
+                && !surface.contains(&format!("export type {} = any", producer_alias)),
+            "the producer surface must not be a top-type placeholder:\n{surface}"
+        );
+
+        // Consumer: a matching `{ status: string }` expected type.
+        let (dash_stub, dash_artifact) = run_capture(
+            &sidecar,
+            dash_repo.to_str().unwrap(),
+            "web-dashboard",
+            &[CaptureAnchor::Literal {
+                alias: consumer_alias.clone(),
+                type_text: "{ status: string }".to_string(),
+                anchor_origin: AnchorOrigin::LlmSymbol,
+            }],
+            &HashMap::new(),
+        )
+        .expect("web-dashboard capture");
+        let _ = std::fs::remove_dir_all(&notif_stub);
+        let _ = std::fs::remove_dir_all(&dash_stub);
+
+        // The producer manifest entry carries `type_state = Unknown` — the exact
+        // production state for an inline-literal producer response (v1 could not
+        // resolve it; the v2 capture surface above DID). Pre-fix, this alone
+        // pre-verdicted the pair Unverifiable before check_v2 ever ran.
+        let producer_entry = entry(
+            key.clone(),
+            ManifestRole::Producer,
+            ManifestTypeKind::Response,
+            &producer_alias,
+            "src/http/routes.ts",
+            26,
+            ManifestTypeState::Unknown,
+        );
+        let consumer_entry = entry(
+            key.clone(),
+            ManifestRole::Consumer,
+            ManifestTypeKind::Response,
+            &consumer_alias,
+            "lib/api.ts",
+            40,
+            ManifestTypeState::Explicit,
+        );
+
+        let outcomes = run_check(
+            &sidecar,
+            &[
+                repo(
+                    "notifications-svc",
+                    None,
+                    vec![producer_entry],
+                    Some(notif_artifact),
+                ),
+                repo(
+                    "web-dashboard",
+                    None,
+                    vec![consumer_entry],
+                    Some(dash_artifact),
+                ),
+            ],
+        );
+        assert_eq!(outcomes.len(), 1, "exactly one matched pair");
+        assert_eq!(
+            outcomes[0].bucket,
+            VerdictBucket::Compatible,
+            "an Unknown-state producer whose v2 surface resolved must verdict \
+             compatible — never pre-verdicted Unverifiable off the stale \
+             type_state; diagnostic: {:?}",
+            outcomes[0].diagnostic
         );
     }
 }

--- a/src/sidecar/src/capture/api.ts
+++ b/src/sidecar/src/capture/api.ts
@@ -138,13 +138,17 @@ export interface CaptureAliasRecord {
    * checkout and is NOT a decay; the probe gates own the final verdict. */
   top_type_at_self_check: boolean;
   /**
-   * Set when the self-check found a disqualifying `any`/`unknown` at DEPTH
-   * (member / element / index signature / type argument) with no failing
-   * pinned-external explanation. The check phase pre-gates exactly these
-   * aliases: its whole-type probe gates cannot see member-level decay, and
-   * `any` at any depth lets an arbitrary counterparty shape read compatible.
+   * Set when the self-check found a disqualifier at DEPTH (member / element /
+   * index signature / type argument / callable return) with no failing
+   * pinned-external explanation: an author-baked `any`/`unknown`, or
+   * `budget_exhausted` — a subtree too deep/wide to finish within the walk's
+   * budget (failed closed, not silently clean). The check phase pre-gates
+   * exactly these aliases: its whole-type probe gates cannot see member-level
+   * decay, and `any` at any depth lets an arbitrary counterparty read
+   * compatible. `any` routes to `gate_caught_baked_any`; `unknown` and
+   * `budget_exhausted` route to `unverifiable`.
    */
-  deep_top_type_kind?: 'any' | 'unknown';
+  deep_top_type_kind?: 'any' | 'unknown' | 'budget_exhausted';
   /** Member path of the deep find, e.g. `metadata` or `items<0>.meta`. */
   deep_top_type_path?: string;
 }

--- a/src/sidecar/src/capture/check.ts
+++ b/src/sidecar/src/capture/check.ts
@@ -191,12 +191,19 @@ export async function runCheck(
     preGated.push({
       pair_id: plan.pairId,
       pair_key: plan.spec.pair_key,
+      // `any` is a confirmed baked top type -> gate_caught_baked_any; `unknown`
+      // and `budget_exhausted` (a subtree the capture walk could not finish)
+      // are "cannot verify" -> unverifiable. All read as None downstream.
       bucket: hit.kind === 'any' ? 'gate_caught_baked_any' : 'unverifiable',
       gate: `capture:${hit.side}:${hit.kind}`,
       diagnostic:
-        `the ${hit.side} type carries '${hit.kind}' at '${hit.path}' from ` +
-        `capture; compatibility cannot be verified (a partially-unresolved ` +
-        `type would let an arbitrary shape read compatible).`,
+        hit.kind === 'budget_exhausted'
+          ? `the ${hit.side} type is too deep or wide to verify within the ` +
+            `capture budget (at '${hit.path}'); compatibility cannot be ` +
+            `verified — abstaining so a buried 'any' can never read compatible.`
+          : `the ${hit.side} type carries '${hit.kind}' at '${hit.path}' from ` +
+            `capture; compatibility cannot be verified (a partially-unresolved ` +
+            `type would let an arbitrary shape read compatible).`,
       codes: [],
     });
   }
@@ -368,7 +375,7 @@ function readStubAliasRecords(
 
 interface DeepDecayHit {
   side: 'producer' | 'consumer';
-  kind: 'any' | 'unknown';
+  kind: 'any' | 'unknown' | 'budget_exhausted';
   path: string;
 }
 

--- a/src/sidecar/src/capture/self-check.ts
+++ b/src/sidecar/src/capture/self-check.ts
@@ -241,6 +241,13 @@ function findDisqualifyingTopType(
       // reference. Genuine author `any` carries `intrinsicName === 'any'`.
       // (`intrinsicName` is internal but stable since TS 1.x — same standing as
       // its use in anchors.ts.)
+      //
+      // The `error` placeholder also stands in for NON-healable causes (TS2304
+      // undefined name, TS2315 wrong-arity generic, a dangling internal
+      // specifier). Excluding those here is not a hole: each emits a diagnostic
+      // in the alias's own closure, so the closure-failure classification
+      // (`internalFailure` -> decayed_internal) or the check-phase POISON rule
+      // — NOT this deep walk — is their backstop, and both fail closed.
       const name = (t as unknown as { intrinsicName?: string }).intrinsicName;
       return name === 'error' ? undefined : 'any';
     }

--- a/src/sidecar/src/capture/self-check.ts
+++ b/src/sidecar/src/capture/self-check.ts
@@ -179,34 +179,62 @@ interface DeepTopType {
 
 /**
  * Depth-bounded structural walk for a disqualifying top type at ANY depth:
- * a member, array element, index signature, or type argument that resolved
- * to `any` (bidirectionally assignable — an arbitrary counterparty shape
- * reads compatible) or `unknown` (a failed-inference bake; carries no shape
- * information). The check phase's probe gates are WHOLE-type only, so this
- * walk owns the depths they cannot see.
+ * a member, array element, index signature, type argument, or callable RETURN
+ * that resolved to `any` (bidirectionally assignable — an arbitrary
+ * counterparty shape reads compatible) or `unknown` (a failed-inference bake;
+ * carries no shape information). The check phase's probe gates are WHOLE-type
+ * only, so this walk owns the depths they cannot see. It must be a genuine
+ * SUPERSET of v1's text-scan disqualifier (`contains_disqualifying_top_type`)
+ * so that removing the `type_state == Unknown` pre-verdict (carrick #448) never
+ * turns a shape v1 would have abstained on into a false-compatible.
  *
- * Bounded (depth + node budget) and cycle-safe. Types with call/construct
- * signatures are skipped: callable members are not wire payloads, and lib
- * callable surfaces legitimately carry `any` parameters. A type the walk
- * cannot cheaply finish is NOT flagged — over-demoting a legitimately
- * fully-resolved type is the failure mode this guard must not have.
+ * Bounded (depth to v1's expander reach + node budget) and cycle-safe. Two
+ * deliberate exceptions to "flag any/unknown anywhere":
+ *  - callable PARAMETER types are NOT descended (only return types): a
+ *    parameter `any` is contravariant and genuinely permissive (`(x: any) =>
+ *    void` safely accepts a stricter counterparty), so it is not a masked
+ *    mismatch and demoting it would over-demote a sound shape;
+ *  - TypeScript's unresolved-reference `error` placeholder (`intrinsicName ===
+ *    'error'`) is excluded (see `flagOf`): it heals when the check installs the
+ *    pinned external, so it is a healable decay, not an author-baked `any`.
+ * A type the walk cannot cheaply finish is NOT flagged — over-demoting a
+ * legitimately fully-resolved type is the failure mode this guard must not have.
  */
 function findDisqualifyingTopType(
   root: ts.Type,
   checker: ts.TypeChecker,
   location: ts.Node
 ): DeepTopType | undefined {
-  const MAX_DEPTH = 8;
-  const MAX_VISITED = 256;
+  // Cover v1's inline-expander reach with margin so this structural walk is a
+  // genuine superset of v1's text-scan disqualifier AT DEPTH: anything v1 could
+  // expand-and-flag as `any`/`unknown`, this walk reaches too. v1's expander
+  // (`MAX_EXPANSION_DEPTH` in ../type-structural-expander.ts) reaches 12; 16
+  // clears it with margin. That constant is NOT imported: the capture bundle
+  // seam (`capture-v2-seam.test.ts`) forbids capture/ from importing across the
+  // boundary, so the value is pinned here and kept ">= MAX_EXPANSION_DEPTH" by
+  // that contract. The node budget scales with the deeper bound so a real
+  // deep-but-narrow type cannot exhaust it before the walk reaches a buried
+  // `any` — running out early would fail OPEN (read compatible).
+  const MAX_DEPTH = 16;
+  const MAX_VISITED = 4096;
   const seen = new Set<ts.Type>();
   let visited = 0;
 
-  const flagOf = (t: ts.Type): 'any' | 'unknown' | undefined =>
-    t.flags & ts.TypeFlags.Any
-      ? 'any'
-      : t.flags & ts.TypeFlags.Unknown
-        ? 'unknown'
-        : undefined;
+  const flagOf = (t: ts.Type): 'any' | 'unknown' | undefined => {
+    if (t.flags & ts.TypeFlags.Any) {
+      // TypeScript's unresolved-reference placeholder (e.g. `import('ext').Foo`
+      // on a bare checkout) carries `TypeFlags.Any` but `intrinsicName ===
+      // 'error'` — NOT an author-baked `any`. It resolves to the real type once
+      // the check phase installs the pinned external, so it must not count as a
+      // disqualifier: treating it as `any` would demote a healable external
+      // reference. Genuine author `any` carries `intrinsicName === 'any'`.
+      // (`intrinsicName` is internal but stable since TS 1.x — same standing as
+      // its use in anchors.ts.)
+      const name = (t as unknown as { intrinsicName?: string }).intrinsicName;
+      return name === 'error' ? undefined : 'any';
+    }
+    return t.flags & ts.TypeFlags.Unknown ? 'unknown' : undefined;
+  };
 
   const walk = (t: ts.Type, path: string, depth: number): DeepTopType | undefined => {
     if (depth > MAX_DEPTH || visited > MAX_VISITED || seen.has(t)) return undefined;
@@ -230,8 +258,18 @@ function findDisqualifyingTopType(
 
     if (!(t.flags & ts.TypeFlags.Object)) return undefined;
 
-    if (t.getCallSignatures().length > 0 || t.getConstructSignatures().length > 0) {
-      return undefined;
+    // Callable members: descend the RETURN type of every call/construct
+    // signature — a return is a COVARIANT wire position, so `() => any`
+    // covariantly widens `() => string` and an `any` there masks a real
+    // mismatch exactly as a plain-member `any` does (v1's text scan flags it).
+    // PARAMETER types are deliberately NOT descended: a parameter `any` is
+    // contravariant and genuinely permissive (`(x: any) => void` safely
+    // accepts a stricter counterparty), so demoting it would over-demote a
+    // sound shape. Fall through afterwards so a hybrid callable
+    // (`{ (): T; data: any }`) still has its own members walked below.
+    for (const sig of [...t.getCallSignatures(), ...t.getConstructSignatures()]) {
+      const found = walk(sig.getReturnType(), `${path}()`, depth + 1);
+      if (found) return found;
     }
 
     // Type arguments: arrays, tuples, Promise<T>, Map<K, V>, ...
@@ -341,32 +379,42 @@ function checkedRecord(
       `(${pkg}@${ctx.args.pinned[pkg]}); kept at tier ${anchor.serialization} ` +
       'on bare checkout; probe gates are the backstop';
   };
-  // `unexplainedDeep`: a member-level any/unknown with NO failing-external
-  // explanation (literal text or the author's own source carried it). The
-  // check phase must pre-gate exactly these — an external-blamed decay can
-  // heal when the check workspace installs the pins, and the probe gates /
-  // poison rule backstop those paths.
+  // `unexplainedDeep`: a member-level author-baked any/unknown. The deep walk
+  // excludes TypeScript's unresolved-reference `error` placeholder (see
+  // `flagOf`), so `deep` is ALWAYS an author-baked disqualifier that survives
+  // into the emitted `.d.ts` text — never a healable external decay. The check
+  // phase must pre-gate exactly these: its probe gates are whole-type only and
+  // cannot see a member-level any.
   let unexplainedDeep: DeepTopType | undefined;
   if (internalFailure) {
     outcome = 'decayed_internal';
     detail = `dangling internal specifier '${internalFailure}'`;
   } else if (topType || deep) {
-    if (blamedExternal) {
+    // `deep` is only computed when `!topType`, so the two are mutually
+    // exclusive here.
+    if (deep) {
+      // Author-baked member any/unknown. It is baked into the emitted text and
+      // does NOT heal when the check installs pins, so record it even when the
+      // closure ALSO carries a failing pinned external (which would otherwise
+      // allowlist the alias) — fail closed.
+      unexplainedDeep = deep;
+      outcome = 'decayed_internal';
+      detail =
+        `type carries '${deep.kind}' at '${deep.path}'; an arbitrary ` +
+        'counterparty shape would read compatible';
+    } else if (blamedExternal) {
+      // Root top type from a pinned external decay: heals when the check
+      // installs the pin.
       if (ctx.args.bareCheckout) {
         allowlisted();
       } else {
         outcome = 'decayed_internal';
         detail = `unresolved pinned external '${blamedExternal}' on an installed checkout`;
       }
-    } else if (topType) {
+    } else {
+      // Root top type with no external explanation.
       outcome = 'decayed_internal';
       detail = 'alias resolved to a top type with no allowlisted external failure';
-    } else {
-      unexplainedDeep = deep;
-      outcome = 'decayed_internal';
-      detail =
-        `type carries '${deep!.kind}' at '${deep!.path}' with no allowlisted ` +
-        'external failure; an arbitrary counterparty shape would read compatible';
     }
   } else if (blamedExternal) {
     // The alias's own type is fully concrete, but its closure has failing

--- a/src/sidecar/src/capture/self-check.ts
+++ b/src/sidecar/src/capture/self-check.ts
@@ -142,6 +142,7 @@ function runSelfCheck(args: SelfCheckArgs, treeFiles: string[]): CaptureAliasRec
         ? demotedRecord(anchor)
         : checkedRecord(anchor, {
             args,
+            program,
             checker,
             surfaceAbs,
             surfaceSource,
@@ -170,9 +171,12 @@ function demotedRecord(anchor: ResolvedAnchor): CaptureAliasRecord {
   };
 }
 
-/** A disqualifying `any`/`unknown` found below the root of a captured type. */
+/** A disqualifying finding below the root of a captured type: an author-baked
+ * `any`/`unknown`, or `budget_exhausted` — a subtree the walk could not finish
+ * within its depth/node budget, treated as unverifiable (fail closed) rather
+ * than silently clean. */
 interface DeepTopType {
-  kind: 'any' | 'unknown';
+  kind: 'any' | 'unknown' | 'budget_exhausted';
   /** Human-readable member path, e.g. `metadata`, `items<0>.meta`, `[index]`. */
   path: string;
 }
@@ -183,13 +187,19 @@ interface DeepTopType {
  * that resolved to `any` (bidirectionally assignable — an arbitrary
  * counterparty shape reads compatible) or `unknown` (a failed-inference bake;
  * carries no shape information). The check phase's probe gates are WHOLE-type
- * only, so this walk owns the depths they cannot see. It must be a genuine
- * SUPERSET of v1's text-scan disqualifier (`contains_disqualifying_top_type`)
- * so that removing the `type_state == Unknown` pre-verdict (carrick #448) never
- * turns a shape v1 would have abstained on into a false-compatible.
+ * only, so this walk owns the depths they cannot see. It is a genuine SUPERSET
+ * of v1's text-scan disqualifier (`contains_disqualifying_top_type`) at ALL
+ * depths/widths — so removing the `type_state == Unknown` pre-verdict (carrick
+ * #448) never turns a shape v1 would have abstained on into a false-compatible.
+ * The superset holds unconditionally because budget EXHAUSTION FAILS CLOSED
+ * (returns the `budget_exhausted` sentinel, not "clean"): a subtree too deep or
+ * wide to finish within budget is unverifiable, never silently compatible. A
+ * bigger bound would only relocate the fail-open cliff; failing closed removes
+ * it. v1's text scan is itself unbounded, so any disqualifier it would flag
+ * that lies past this walk's finite budget is still caught — as
+ * `budget_exhausted` rather than its exact kind.
  *
- * Bounded (depth to v1's expander reach + node budget) and cycle-safe. Two
- * deliberate exceptions to "flag any/unknown anywhere":
+ * Cycle-safe. Two deliberate exceptions to "flag any/unknown anywhere":
  *  - callable PARAMETER types are NOT descended (only return types): a
  *    parameter `any` is contravariant and genuinely permissive (`(x: any) =>
  *    void` safely accepts a stricter counterparty), so it is not a masked
@@ -202,6 +212,7 @@ interface DeepTopType {
  */
 function findDisqualifyingTopType(
   root: ts.Type,
+  program: ts.Program,
   checker: ts.TypeChecker,
   location: ts.Node
 ): DeepTopType | undefined {
@@ -237,7 +248,24 @@ function findDisqualifyingTopType(
   };
 
   const walk = (t: ts.Type, path: string, depth: number): DeepTopType | undefined => {
-    if (depth > MAX_DEPTH || visited > MAX_VISITED || seen.has(t)) return undefined;
+    // Genuine cycle handling — NOT fail-open. `t` is already on the walk stack
+    // (or was fully explored earlier), so the owning frame completes it;
+    // returning "clean" here is sound because a type reaches `seen` ONLY after a
+    // visit that fully completed clean. A visit that hit the budget below
+    // returns the `budget_exhausted` sentinel, which bubbles up (every frame
+    // propagates a truthy child return) and terminates the whole walk before
+    // any shallower re-entry — so `seen` never memoizes a truncated visit as
+    // clean. And a type fully explored clean at depth d1 is clean at any d2 < d1
+    // (the shallower reach is a superset of the deeper), so reusing it is safe.
+    if (seen.has(t)) return undefined;
+    // Budget exhaustion FAILS CLOSED. `return undefined` (clean) here would let
+    // an `any` buried past the depth/node budget read compatible — the
+    // fail-open cliff a bigger number only relocates. Instead abstain: the
+    // alias demotes to unverifiable, over-abstaining on a legitimately clean
+    // type deeper/wider than budget rather than ever false-compatible.
+    if (depth > MAX_DEPTH || visited > MAX_VISITED) {
+      return { kind: 'budget_exhausted', path: path === '' ? '<root>' : path };
+    }
     seen.add(t);
     visited++;
 
@@ -288,6 +316,17 @@ function findDisqualifyingTopType(
     }
 
     for (const prop of t.getProperties()) {
+      // Skip the built-in method suite (`Array#map`, `Promise#then`, ...): a
+      // lib-declared member is machinery, never a wire payload, and descending
+      // its return type recurses (map -> U[] -> map -> ...) until it exhausts
+      // the budget — which pre-fail-closed silently read "clean" and now would
+      // over-abstain on every ordinary `T[]`. The element/value type is still
+      // covered via the type-argument branch above; a USER function-typed
+      // member (`getData: () => any`) is not lib-declared, so it is still walked.
+      const decl = prop.valueDeclaration ?? prop.declarations?.[0];
+      if (decl && program.isSourceFileDefaultLibrary(decl.getSourceFile())) {
+        continue;
+      }
       const propType = checker.getTypeOfSymbolAtLocation(prop, location);
       const found = walk(
         propType,
@@ -306,6 +345,7 @@ function checkedRecord(
   anchor: ResolvedAnchor,
   ctx: {
     args: SelfCheckArgs;
+    program: ts.Program;
     checker: ts.TypeChecker;
     surfaceAbs: string;
     surfaceSource: ts.SourceFile | undefined;
@@ -325,7 +365,7 @@ function checkedRecord(
       topType =
         (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Never)) !== 0;
       if (!topType) {
-        deep = findDisqualifyingTopType(type, ctx.checker, stmt.name);
+        deep = findDisqualifyingTopType(type, ctx.program, ctx.checker, stmt.name);
       }
       // Seed the closure with the alias's own import-type targets.
       const visit = (node: ts.Node) => {
@@ -393,15 +433,20 @@ function checkedRecord(
     // `deep` is only computed when `!topType`, so the two are mutually
     // exclusive here.
     if (deep) {
-      // Author-baked member any/unknown. It is baked into the emitted text and
-      // does NOT heal when the check installs pins, so record it even when the
-      // closure ALSO carries a failing pinned external (which would otherwise
-      // allowlist the alias) — fail closed.
+      // A member-level disqualifier. Either an author-baked any/unknown (baked
+      // into the emitted text; does NOT heal when the check installs pins) or a
+      // `budget_exhausted` sentinel (a subtree too deep/wide to finish). Record
+      // it even when the closure ALSO carries a failing pinned external (which
+      // would otherwise allowlist the alias) — fail closed.
       unexplainedDeep = deep;
       outcome = 'decayed_internal';
       detail =
-        `type carries '${deep.kind}' at '${deep.path}'; an arbitrary ` +
-        'counterparty shape would read compatible';
+        deep.kind === 'budget_exhausted'
+          ? `type too deep or wide to verify within the capture budget at ` +
+            `'${deep.path}'; abstaining (fail closed) rather than risk a buried ` +
+            'any reading compatible'
+          : `type carries '${deep.kind}' at '${deep.path}'; an arbitrary ` +
+            'counterparty shape would read compatible';
     } else if (blamedExternal) {
       // Root top type from a pinned external decay: heals when the check
       // installs the pin.

--- a/src/sidecar/test/capture-v2-deep-any.test.ts
+++ b/src/sidecar/test/capture-v2-deep-any.test.ts
@@ -641,6 +641,90 @@ describe('capture self-check: budget exhaustion fails CLOSED', () => {
   });
 });
 
+/**
+ * The seen-set/budget interaction the coordinator asked to prove, not just
+ * reason: budget exhaustion fails closed, so a truncated visit returns the
+ * sentinel (which bubbles up and terminates the walk) rather than being
+ * memoized clean in `seen`. So a shared type buried past the budget on ONE
+ * reference can never be marked clean for a SHALLOWER reference, and a cyclic
+ * type terminates and still gates its buried any — while a genuinely clean
+ * cyclic type is not over-demoted. Symbol anchors give the shared/cyclic types
+ * a stable identity (a literal would be structurally re-created each time).
+ */
+describe('capture self-check: shared + cyclic types gate (seen-set is not fail-open)', () => {
+  let symRoot: string;
+  let byAlias: Map<string, CaptureAliasRecord>;
+
+  before(() => {
+    symRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-448-seen-'));
+    const repoRoot = path.join(symRoot, 'repo');
+    fs.mkdirSync(repoRoot, { recursive: true });
+    const wrap = (n: number, inner: string): string => {
+      let t = inner;
+      for (let i = n; i >= 1; i--) t = `{ w${i}: ${t} }`;
+      return t;
+    };
+    fs.writeFileSync(
+      path.join(repoRoot, 'types.ts'),
+      // `S` buries an any; referenced both DEEP (past budget) and SHALLOW.
+      'export interface S { mid: { buried: any } }\n' +
+        `export interface T_DeepFirst { deep: ${wrap(14, '{ s: S }')}; shallow: { s: S } }\n` +
+        `export interface T_ShallowFirst { shallow: { s: S }; deep: ${wrap(14, '{ s: S }')} }\n` +
+        // Cyclic type with a buried any: must terminate AND gate.
+        'export interface CyclicAny { next: CyclicAny; buried: any }\n' +
+        // Clean cyclic type: must terminate and NOT be over-demoted.
+        'export interface CyclicClean { self: CyclicClean; data: { ok: string } }\n'
+    );
+    const result = captureStub({
+      repoRoot,
+      serviceName: 'seen-svc',
+      outDir: path.join(symRoot, 'stub'),
+      anchors: ['T_DeepFirst', 'T_ShallowFirst', 'CyclicAny', 'CyclicClean'].map((n) => ({
+        kind: 'symbol' as const,
+        alias: n,
+        symbol_name: n,
+        source_file: 'types.ts',
+        anchor_origin: 'llm-symbol' as const,
+      })),
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    byAlias = new Map(result.aliases.map((a) => [a.alias, a]));
+  });
+
+  after(() => {
+    fs.rmSync(symRoot, { recursive: true, force: true });
+  });
+
+  it('a shared type buried past budget gates regardless of reference order (deep first)', () => {
+    const rec = byAlias.get('T_DeepFirst')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    // Never `ok`: the truncated deep visit is not memoized clean for the
+    // shallow reference. (Deep-first truncates -> budget_exhausted.)
+    assert.ok(
+      rec.deep_top_type_kind === 'budget_exhausted' || rec.deep_top_type_kind === 'any',
+      `expected a decay kind, got ${rec.deep_top_type_kind}`
+    );
+  });
+
+  it('the same shared type gates shallow-first too (any found before the deep reference)', () => {
+    const rec = byAlias.get('T_ShallowFirst')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.ok(rec.deep_top_type_kind === 'any' || rec.deep_top_type_kind === 'budget_exhausted');
+  });
+
+  it('a cyclic type with a buried any terminates and gates (never ok/hang)', () => {
+    const rec = byAlias.get('CyclicAny')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'any');
+  });
+
+  it('a genuinely clean cyclic type terminates and is NOT over-demoted', () => {
+    const rec = byAlias.get('CyclicClean')!;
+    assert.strictEqual(rec.self_check, 'ok', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, undefined);
+  });
+});
+
 describe('check phase: a budget-exhausted deep any is unverifiable, within-budget clean verifies', () => {
   let checkRoot: string;
   let producerStub: string;
@@ -651,10 +735,12 @@ describe('check phase: a budget-exhausted deep any is unverifiable, within-budge
     const producer = captureLiterals(checkRoot, 'bd-producer', {
       P_D17any: nested(17, 'any'),
       P_D16clean: nested(16, 'string'),
+      P_ShallowClean: '{ ok: string }', // shallow clean producer for the consumer-side case
     });
     const consumer = captureLiterals(checkRoot, 'bd-consumer', {
       C_D17: nested(17, 'string'),
       C_D16: nested(16, 'string'),
+      C_D17any: nested(17, 'any'), // budget-exhausted on the CONSUMER side
     });
     producerStub = producer.stub_dir;
     consumerStub = consumer.stub_dir;
@@ -685,6 +771,14 @@ describe('check phase: a budget-exhausted deep any is unverifiable, within-budge
           producer: { service_name: 'bd-producer', alias: 'P_D16clean' },
           consumer: { service_name: 'bd-consumer', alias: 'C_D16' },
         },
+        {
+          // Symmetric: the budget-exhausted any on the CONSUMER side.
+          pair_key: 'd17-consumer',
+          protocol: 'http',
+          type_kind: 'response',
+          producer: { service_name: 'bd-producer', alias: 'P_ShallowClean' },
+          consumer: { service_name: 'bd-consumer', alias: 'C_D17any' },
+        },
       ],
     });
     assert.strictEqual(result.success, true, JSON.stringify(result.errors));
@@ -693,6 +787,10 @@ describe('check phase: a budget-exhausted deep any is unverifiable, within-budge
     const d17 = byKey.get('d17')!;
     assert.strictEqual(d17.bucket, 'unverifiable', JSON.stringify(d17));
     assert.strictEqual(d17.gate, 'capture:producer:budget_exhausted');
+    // Symmetric on the consumer side (deepDecayOf loops both sides).
+    const d17c = byKey.get('d17-consumer')!;
+    assert.strictEqual(d17c.bucket, 'unverifiable', JSON.stringify(d17c));
+    assert.strictEqual(d17c.gate, 'capture:consumer:budget_exhausted');
     // A clean type within budget still verifies — no over-demotion.
     assert.strictEqual(byKey.get('d16-clean')!.bucket, 'compatible', JSON.stringify(byKey.get('d16-clean')));
   });

--- a/src/sidecar/test/capture-v2-deep-any.test.ts
+++ b/src/sidecar/test/capture-v2-deep-any.test.ts
@@ -59,6 +59,24 @@ function nested(levels: number, leaf: string): string {
   return t;
 }
 
+/** `k` Array-wrapped object levels: each `lN: Array<...>` costs 2 walk hops
+ * (property + type-arg), so the leaf sits at hop-depth 2k+1 — over the budget
+ * at only k=8 OBJECT levels, the walk-depth-counts-every-hop severity case. */
+function arrWrapped(k: number, leaf: string): string {
+  let t = `{ leaf: ${leaf} }`;
+  for (let i = k; i >= 1; i--) t = `{ l${i}: Array<${t}> }`;
+  return t;
+}
+
+/** `n` DISTINCT-typed properties (so `seen` cannot dedup them and the node
+ * budget actually climbs), the leaf at the last property. */
+function wideDistinct(n: number, leaf: string): string {
+  const props: string[] = [];
+  for (let i = 1; i < n; i++) props.push(`p${i}: { u${i}: string }`);
+  props.push(`p${n}: ${leaf}`);
+  return `{ ${props.join('; ')} }`;
+}
+
 describe('capture self-check: deep any/unknown decays, concrete types do not', () => {
   let root: string;
   let byAlias: Map<string, CaptureAliasRecord>;
@@ -544,5 +562,138 @@ describe('capture self-check: a non-healable error-type member still gates (narr
   it('a nested dangling-internal decay gates decayed_internal', () => {
     const rec = byAlias.get('DanglingInternal')!;
     assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+  });
+});
+
+/**
+ * PR #448 adversarial-review follow-up (part C): the deep walk's budget guard
+ * FAILED OPEN — `depth > MAX_DEPTH || visited > MAX_VISITED` returned undefined
+ * ("clean"), so an `any` buried past the budget recorded `self_check=ok` and,
+ * since the check's probe gates are whole-type only, read COMPATIBLE. Raising
+ * the bound only relocated the cliff. Now budget exhaustion FAILS CLOSED: it
+ * returns a `budget_exhausted` sentinel → `decayed_internal` → the check gates
+ * it `unverifiable`. Because walk-depth counts every structural hop (property,
+ * type-arg, union member, callable return), the cliff is reachable at only ~8
+ * object levels when each wraps an `Array<…>` — an ordinary paginated generic.
+ *
+ * The tradeoff (owned, not hidden): a legitimately clean type deeper/wider than
+ * the budget now ABSTAINS (Unverifiable) instead of verifying — the correct
+ * fail-closed direction (over-abstain, never false-compatible). The budget is
+ * kept generous enough that ordinary types (incl. arrays of objects, whose
+ * built-in method suite is skipped, not recursed) clear it.
+ */
+describe('capture self-check: budget exhaustion fails CLOSED', () => {
+  let root: string;
+  let byAlias: Map<string, CaptureAliasRecord>;
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-448-budget-'));
+    const result = captureLiterals(root, 'budget-svc', {
+      D17_any: nested(17, 'any'), // past MAX_DEPTH=16
+      D20_any: nested(20, 'any'),
+      Arr8_any: arrWrapped(8, 'any'), // leaf at hop-depth 17 via only 8 object levels
+      W5000_any: wideDistinct(5000, 'any'), // past MAX_VISITED=4096
+      // Controls / positives — within budget, must NOT budget-exhaust:
+      OK_D16_any: nested(16, 'any'), // caught as a real 'any', not budget
+      OK_ArrayObjs: '{ items: { sku: string }[] }', // lib method suite skipped, not recursed
+      OK_NestedArrClean: arrWrapped(6, '{ ok: string }'), // clean array nesting within budget
+      OK_D16_clean: nested(16, 'string'),
+    });
+    byAlias = new Map(result.aliases.map((a) => [a.alias, a]));
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('a depth-17 any (past MAX_DEPTH) gates budget_exhausted, never clean', () => {
+    const rec = byAlias.get('D17_any')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'budget_exhausted');
+  });
+
+  it('a depth-20 any gates budget_exhausted', () => {
+    assert.strictEqual(byAlias.get('D20_any')!.deep_top_type_kind, 'budget_exhausted');
+  });
+
+  it('8 Array-wrapped object levels (hop-depth 17) gates budget_exhausted', () => {
+    const rec = byAlias.get('Arr8_any')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'budget_exhausted');
+  });
+
+  it('a >4096-wide any gates budget_exhausted', () => {
+    assert.strictEqual(byAlias.get('W5000_any')!.deep_top_type_kind, 'budget_exhausted');
+  });
+
+  it('a depth-16 any WITHIN budget is caught as a real any (not budget_exhausted)', () => {
+    const rec = byAlias.get('OK_D16_any')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'any');
+  });
+
+  it('ordinary arrays of objects and clean nested arrays are NOT over-demoted', () => {
+    for (const alias of ['OK_ArrayObjs', 'OK_NestedArrClean', 'OK_D16_clean']) {
+      const rec = byAlias.get(alias)!;
+      assert.strictEqual(rec.self_check, 'ok', `${alias}: ${rec.self_check_detail}`);
+      assert.strictEqual(rec.deep_top_type_kind, undefined, alias);
+    }
+  });
+});
+
+describe('check phase: a budget-exhausted deep any is unverifiable, within-budget clean verifies', () => {
+  let checkRoot: string;
+  let producerStub: string;
+  let consumerStub: string;
+
+  before(() => {
+    checkRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-448-budget-check-'));
+    const producer = captureLiterals(checkRoot, 'bd-producer', {
+      P_D17any: nested(17, 'any'),
+      P_D16clean: nested(16, 'string'),
+    });
+    const consumer = captureLiterals(checkRoot, 'bd-consumer', {
+      C_D17: nested(17, 'string'),
+      C_D16: nested(16, 'string'),
+    });
+    producerStub = producer.stub_dir;
+    consumerStub = consumer.stub_dir;
+  });
+
+  after(() => {
+    fs.rmSync(checkRoot, { recursive: true, force: true });
+  });
+
+  it('depth-17 any -> unverifiable (budget_exhausted); depth-16 clean -> compatible', async () => {
+    const result = await runCheck({
+      stubs: [
+        { service_name: 'bd-producer', stub_dir: producerStub },
+        { service_name: 'bd-consumer', stub_dir: consumerStub },
+      ],
+      pairs: [
+        {
+          pair_key: 'd17',
+          protocol: 'http',
+          type_kind: 'response',
+          producer: { service_name: 'bd-producer', alias: 'P_D17any' },
+          consumer: { service_name: 'bd-consumer', alias: 'C_D17' },
+        },
+        {
+          pair_key: 'd16-clean',
+          protocol: 'http',
+          type_kind: 'response',
+          producer: { service_name: 'bd-producer', alias: 'P_D16clean' },
+          consumer: { service_name: 'bd-consumer', alias: 'C_D16' },
+        },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    const byKey = new Map(result.verdicts.map((v) => [v.pair_key, v]));
+    // Pre-fix this read 'compatible' — the any past the budget looked clean.
+    const d17 = byKey.get('d17')!;
+    assert.strictEqual(d17.bucket, 'unverifiable', JSON.stringify(d17));
+    assert.strictEqual(d17.gate, 'capture:producer:budget_exhausted');
+    // A clean type within budget still verifies — no over-demotion.
+    assert.strictEqual(byKey.get('d16-clean')!.bucket, 'compatible', JSON.stringify(byKey.get('d16-clean')));
   });
 });

--- a/src/sidecar/test/capture-v2-deep-any.test.ts
+++ b/src/sidecar/test/capture-v2-deep-any.test.ts
@@ -51,6 +51,14 @@ function captureLiterals(
   return result;
 }
 
+/** `{ l1: { l2: ... { l<levels>: <leaf> } } }` — an `any`/`unknown` leaf sits
+ * at nesting depth `levels`, past the old MAX_DEPTH=8 for levels > 8. */
+function nested(levels: number, leaf: string): string {
+  let t = leaf;
+  for (let i = levels; i >= 1; i--) t = `{ l${i}: ${t} }`;
+  return t;
+}
+
 describe('capture self-check: deep any/unknown decays, concrete types do not', () => {
   let root: string;
   let byAlias: Map<string, CaptureAliasRecord>;
@@ -240,5 +248,240 @@ describe('check phase: capture-recorded deep decay is never read as compatible',
     // A fully-resolved pair still goes through the real probe path.
     const cleanVerdict = byKey.get('clean-pair')!;
     assert.strictEqual(cleanVerdict.bucket, 'compatible', JSON.stringify(cleanVerdict));
+  });
+});
+
+/**
+ * PR #448 adversarial-review follow-up: the deep walk missed disqualifying
+ * `any` in two positions the removed `type_state == Unknown` pre-verdict gate
+ * used to abstain on, so post-#448 they persisted as FALSE-COMPATIBLE:
+ *   1. inside a callable — the walk WHOLESALE-skipped any type with a call
+ *      signature, so `{ getData: () => any }` sailed through. A callable
+ *      RETURN is a covariant wire position; `() => any` masks a real mismatch.
+ *   2. past MAX_DEPTH=8 — v1's inline expander reaches MAX_EXPANSION_DEPTH=12,
+ *      so a depth 9-12 `any` was flagged by v1 (→ Unknown → abstain) but
+ *      missed by the walk.
+ * The fix descends call/construct-signature RETURN types (params stay
+ * permissive) and reconciles the depth bound to v1's expander. Positives lock
+ * the no-over-demotion boundary: a clean callable return, clean deep nesting,
+ * and a parameter `any` (contravariant, genuinely permissive) still verify.
+ */
+describe('capture self-check: callable-return any and deep-past-old-bound any', () => {
+  let root: string;
+  let byAlias: Map<string, CaptureAliasRecord>;
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-448-callable-'));
+    const result = captureLiterals(root, 'callable-svc', {
+      // Finding 1: callable RETURN any (covariant wire position).
+      M_RetAny: '{ getData: () => any }',
+      M_CtorRetAny: '{ make: new () => any }',
+      M_RetUnknown: '{ getData: () => unknown }',
+      M_HybridRetAny: '{ (): any; data: string }',
+      // Finding 2: any past the old MAX_DEPTH=8 (v1 expands to 12).
+      M_Deep11Any: nested(11, 'any'),
+      // Positives — must NOT be over-demoted:
+      OK_RetClean: '{ getData: () => string }',
+      OK_CtorClean: '{ make: new () => { id: string } }',
+      OK_DeepClean: nested(14, 'string'),
+      OK_ParamAny: '{ id: string; cb: (x: any) => void }', // contravariant, permissive
+    });
+    byAlias = new Map(result.aliases.map((a) => [a.alias, a]));
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('a callable RETURN any decays with path <member>()', () => {
+    const rec = byAlias.get('M_RetAny')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'any');
+    assert.strictEqual(rec.deep_top_type_path, 'getData()');
+    assert.strictEqual(rec.top_type_at_self_check, false);
+  });
+
+  it('a construct-signature RETURN any decays', () => {
+    const rec = byAlias.get('M_CtorRetAny')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'any');
+  });
+
+  it('a callable RETURN unknown decays with kind unknown', () => {
+    const rec = byAlias.get('M_RetUnknown')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'unknown');
+  });
+
+  it('a hybrid callable ({ (): any; data }) still has its call return walked', () => {
+    const rec = byAlias.get('M_HybridRetAny')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'any');
+  });
+
+  it('an any at depth 11 (past the old MAX_DEPTH=8) decays', () => {
+    const rec = byAlias.get('M_Deep11Any')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'any');
+    assert.match(rec.deep_top_type_path ?? '', /l11$/);
+  });
+
+  it('clean callable returns, clean deep nesting, and a parameter any are NOT over-demoted', () => {
+    for (const alias of ['OK_RetClean', 'OK_CtorClean', 'OK_DeepClean', 'OK_ParamAny']) {
+      const rec = byAlias.get(alias)!;
+      assert.strictEqual(rec.self_check, 'ok', `${alias}: ${rec.self_check_detail}`);
+      assert.strictEqual(rec.deep_top_type_kind, undefined, alias);
+    }
+  });
+});
+
+describe('check phase: callable-return any and deep-past-8 any are never compatible', () => {
+  let checkRoot: string;
+  let producerStub: string;
+  let consumerStub: string;
+
+  before(() => {
+    checkRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-448-callable-check-'));
+    const producer = captureLiterals(checkRoot, 'cb-producer', {
+      P_RetAny: '{ getData: () => any }',
+      P_Deep11Any: nested(11, 'any'),
+      P_RetClean: '{ getData: () => string }',
+      P_DeepClean: nested(11, 'string'),
+    });
+    const consumer = captureLiterals(checkRoot, 'cb-consumer', {
+      C_RetClean1: '{ getData: () => string }',
+      C_Deep11: nested(11, 'string'),
+      C_RetClean2: '{ getData: () => string }',
+      C_Deep11b: nested(11, 'string'),
+    });
+    producerStub = producer.stub_dir;
+    consumerStub = consumer.stub_dir;
+  });
+
+  after(() => {
+    fs.rmSync(checkRoot, { recursive: true, force: true });
+  });
+
+  it('callable-return any -> gated; deep-past-8 any -> gated; clean counterparts still verify', async () => {
+    const result = await runCheck({
+      stubs: [
+        { service_name: 'cb-producer', stub_dir: producerStub },
+        { service_name: 'cb-consumer', stub_dir: consumerStub },
+      ],
+      pairs: [
+        {
+          pair_key: 'ret-any',
+          protocol: 'http',
+          type_kind: 'response',
+          producer: { service_name: 'cb-producer', alias: 'P_RetAny' },
+          consumer: { service_name: 'cb-consumer', alias: 'C_RetClean1' },
+        },
+        {
+          pair_key: 'deep11-any',
+          protocol: 'http',
+          type_kind: 'response',
+          producer: { service_name: 'cb-producer', alias: 'P_Deep11Any' },
+          consumer: { service_name: 'cb-consumer', alias: 'C_Deep11' },
+        },
+        {
+          pair_key: 'ret-clean',
+          protocol: 'http',
+          type_kind: 'response',
+          producer: { service_name: 'cb-producer', alias: 'P_RetClean' },
+          consumer: { service_name: 'cb-consumer', alias: 'C_RetClean2' },
+        },
+        {
+          pair_key: 'deep-clean',
+          protocol: 'http',
+          type_kind: 'response',
+          producer: { service_name: 'cb-producer', alias: 'P_DeepClean' },
+          consumer: { service_name: 'cb-consumer', alias: 'C_Deep11b' },
+        },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    const byKey = new Map(result.verdicts.map((v) => [v.pair_key, v]));
+
+    // Pre-fix these read 'compatible' (walk skipped the callable / capped at 8).
+    assert.strictEqual(byKey.get('ret-any')!.bucket, 'gate_caught_baked_any', JSON.stringify(byKey.get('ret-any')));
+    assert.strictEqual(byKey.get('deep11-any')!.bucket, 'gate_caught_baked_any', JSON.stringify(byKey.get('deep11-any')));
+    // Clean counterparts must STILL verify — no over-demotion.
+    assert.strictEqual(byKey.get('ret-clean')!.bucket, 'compatible', JSON.stringify(byKey.get('ret-clean')));
+    assert.strictEqual(byKey.get('deep-clean')!.bucket, 'compatible', JSON.stringify(byKey.get('deep-clean')));
+  });
+});
+
+/**
+ * PR #448 adversarial-review follow-up, hole 3: `blamedExternal` masking. On a
+ * BARE checkout, an alias whose closure has a failing pinned external was
+ * classified `allowlisted_external` and its `deep_top_type_kind` was NOT
+ * recorded — so an AUTHOR-baked deep `any` co-present with that external was
+ * suppressed and read compatible at check.
+ *
+ * The fix: the deep walk excludes TypeScript's unresolved-reference `error`
+ * placeholder (`intrinsicName === 'error'`, e.g. `import('ext').Foo` on a bare
+ * checkout — which heals when the check installs the pin) and counts only a
+ * genuine author `any`/`unknown`. A found deep decay is then recorded even when
+ * a (healable) external is co-present. A pure external decay, with no author
+ * any, still allowlists — no over-demotion.
+ */
+describe('capture self-check: author-baked deep any is not masked by a co-present external', () => {
+  let root: string;
+  let byAlias: Map<string, CaptureAliasRecord>;
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-448-blamed-ext-'));
+    const repoRoot = path.join(root, 'repo');
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(repoRoot, 'types.ts'),
+      "import type { Widget } from 'some-ext';\n" +
+        'export interface PureExt { id: string; w: Widget; }\n' +
+        'export interface AuthorAny { id: string; w: Widget; getData: () => any; }\n'
+    );
+    fs.writeFileSync(
+      path.join(repoRoot, 'package.json'),
+      JSON.stringify({ name: 'p', version: '1.0.0', dependencies: { 'some-ext': '1.2.3' } })
+    );
+    // Bare checkout (no node_modules) + npm lockfile pins `some-ext`, so its
+    // unresolved reference is a blamedExternal (allowlistable), not an unpinned
+    // internal failure.
+    fs.writeFileSync(
+      path.join(repoRoot, 'package-lock.json'),
+      JSON.stringify({
+        lockfileVersion: 3,
+        packages: { '': {}, 'node_modules/some-ext': { version: '1.2.3' } },
+      })
+    );
+    const result = captureStub({
+      repoRoot,
+      serviceName: 'blamed-ext-svc',
+      outDir: path.join(root, 'stub'),
+      anchors: [
+        { kind: 'symbol', alias: 'PureExt', symbol_name: 'PureExt', source_file: 'types.ts', anchor_origin: 'llm-symbol' },
+        { kind: 'symbol', alias: 'AuthorAny', symbol_name: 'AuthorAny', source_file: 'types.ts', anchor_origin: 'llm-symbol' },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    assert.strictEqual(result.bare_checkout, true);
+    assert.deepStrictEqual(result.pinned_dependencies, { 'some-ext': '1.2.3' });
+    byAlias = new Map(result.aliases.map((a) => [a.alias, a]));
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('an author-baked deep any co-present with a failing external is recorded (not allowlisted)', () => {
+    const rec = byAlias.get('AuthorAny')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, 'any');
+    assert.strictEqual(rec.deep_top_type_path, 'getData()');
+  });
+
+  it('a PURE external decay (no author any) still allowlists — the unresolved reference heals at check', () => {
+    const rec = byAlias.get('PureExt')!;
+    assert.strictEqual(rec.self_check, 'allowlisted_external', rec.self_check_detail);
+    assert.strictEqual(rec.deep_top_type_kind, undefined);
   });
 });

--- a/src/sidecar/test/capture-v2-deep-any.test.ts
+++ b/src/sidecar/test/capture-v2-deep-any.test.ts
@@ -485,3 +485,64 @@ describe('capture self-check: author-baked deep any is not masked by a co-presen
     assert.strictEqual(rec.deep_top_type_kind, undefined);
   });
 });
+
+/**
+ * `flagOf` excludes TypeScript's unresolved-reference `error` placeholder so it
+ * is not conflated with an author-baked `any` (hole 3). That exclusion is the
+ * only NARROWING in the fix, so it must not open a new false-compatible: a
+ * NON-healable error cause (an UNPINNED external, or a dangling INTERNAL
+ * specifier) at a nested position — which the walk used to flag structurally —
+ * must still gate, now via the closure `internalFailure`/`blamedExternal` path
+ * rather than the deep walk. Only a PINNED external heals at check; these do
+ * not, so they must read `decayed_internal`, never `ok`/`allowlisted_external`.
+ */
+describe('capture self-check: a non-healable error-type member still gates (narrowing is safe)', () => {
+  let root: string;
+  let byAlias: Map<string, CaptureAliasRecord>;
+
+  before(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-448-errsafe-'));
+    const repoRoot = path.join(root, 'repo');
+    fs.mkdirSync(repoRoot, { recursive: true });
+    // NO lockfile: `some-ext` is UNPINNED (its decay never heals at check).
+    fs.writeFileSync(
+      path.join(repoRoot, 'types.ts'),
+      "import type { Widget } from 'some-ext';\n" +
+        'export interface UnpinnedExt { id: string; deep: { w: Widget } }\n' +
+        "export interface DanglingInternal { id: string; deep: { x: import('./missing').X } }\n"
+    );
+    fs.writeFileSync(
+      path.join(repoRoot, 'package.json'),
+      JSON.stringify({ name: 'p', version: '1.0.0' })
+    );
+    const result = captureStub({
+      repoRoot,
+      serviceName: 'errsafe-svc',
+      outDir: path.join(root, 'stub'),
+      anchors: [
+        { kind: 'symbol', alias: 'UnpinnedExt', symbol_name: 'UnpinnedExt', source_file: 'types.ts', anchor_origin: 'llm-symbol' },
+        { kind: 'symbol', alias: 'DanglingInternal', symbol_name: 'DanglingInternal', source_file: 'types.ts', anchor_origin: 'llm-symbol' },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    assert.strictEqual(result.bare_checkout, true);
+    // The external is genuinely unpinned (no lockfile), so it is never
+    // allowlistable — it must gate as an internal failure.
+    assert.deepStrictEqual(result.pinned_dependencies, {});
+    byAlias = new Map(result.aliases.map((a) => [a.alias, a]));
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('a nested UNPINNED-external decay gates decayed_internal (not ok/allowlisted)', () => {
+    const rec = byAlias.get('UnpinnedExt')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+  });
+
+  it('a nested dangling-internal decay gates decayed_internal', () => {
+    const rec = byAlias.get('DanglingInternal')!;
+    assert.strictEqual(rec.self_check, 'decayed_internal', rec.self_check_detail);
+  });
+});


### PR DESCRIPTION
## Root cause

Within a single consumer scan, one outbound HTTP edge to a producer got a persisted compat verdict while another outbound edge to a *different* producer did not (MCP `check_compatibility` reported `not_compared`), even though both sides had correct, resolvable, mutually-compatible types.

`build_pair` (`src/engine/type_compat_v2.rs`) set a **pre-probe** `Unverifiable` verdict for any pair whose producer- or consumer-side manifest `type_state == Unknown`, before `check_v2` ever ran. `apply_pair_outcomes` collapses `Unverifiable` to `type_compatible: None`, and `attach_compat_verdicts` persists nothing for `None` — so the cloud reads "not compared".

The problem: `type_state` is the **v1 (pre-capture)** resolution signal. For an inline-literal producer response (`res.json({ ... })`, `primary_type_symbol` null), v1 inference leaves the entry `Unknown` even though the **v2 capture surface** fully resolved the alias to a real shape (`self_check ok`). The manifest state and the capture surface diverge, and the pre-verdict gated on the stale one — dropping a resolvable, compatible edge. A sibling producer whose responses were annotated (`type_state == Explicit`) skipped the gate and verified normally, which is why one edge persisted a verdict and the other did not in the same scan.

## Classification: (a) — a `build_pair` mis-gate

Not (c) staleness: this reproduces as a code path, not a fetch/timing effect. The pair **is** built; it is mis-gated by a pre-verdict keyed on `type_state` instead of the actual capture surface `check_v2` reads.

## Reproduction (local, $0, no LLM / no live scan)

Deserialized three real `CloudRepoData` blobs (one consumer, two producers, all carrying real `capture_stub` + `type_manifest`) and ran `build_check_pairs` + the real sidecar `check_v2` over them:

- **Pre-fix:** both order→notification response pairs pre-verdict `Unverifiable` ("producer type was not resolved at capture time") — producer `type_state == Unknown`. The order→user control pair verdicts `Compatible` and persists. Exactly the reported split.
- **Fix-sim** (producer `Unknown` → `Implicit`): both order→notification pairs verdict `Compatible` against the same stubs — proving the surfaces are good and the gate is the sole blocker.
- **Post-fix, raw blobs:** both order→notification pairs verdict `Compatible`. A genuinely-`any` consumer surface (`= any`) is still caught by `check_v2`'s own `IsAny` gate → `GateCaughtBakedAny` → `None` (still "not compared"): **no false-compatible hole opened**.

## The fix

Drop the `type_state == Unknown` pre-verdict branches. The only remaining pre-probe `Unverifiable` is a side with **no v2 capture surface at all** (older scan / degraded capture). `check_v2` reads the real surface and is the sole authority on resolved-ness — an alias baked to `any`/`unknown`, or absent from the surface, is caught by its own `IsAny`/`IsUnknown` gate (`gate_caught_baked_any` / import error → `unverifiable`) and can never read compatible. That baked-any gate fires with precedence over the assignment line, on both producer and consumer sides.

## Tests

- New real-capture end-to-end regression: an inline-literal producer captured via an infer anchor (`type_state == Unknown`, surface resolves `{ status: string }`) now verdicts `Compatible`; verified pre-fix-failing (`Unverifiable`) by temporarily restoring the gate.
- Updated the pre-verdict unit test: an `Unknown`-state side *with* a surface no longer pre-verdicts (only a missing surface does).
- Serialized the three sidecar-capture end-to-end tests (`serial_test`) to avoid pnpm/sidecar contention under `cargo test --lib`.
- Full `cargo test --lib` (660) and sidecar `node --test` (284) suites green.

Follow-up (filed separately): the underlying divergence is that `enrich_manifest_with_type_resolution` promotes `type_state` only from v1 results + the bundled `.d.ts`, never the v2 capture surface — so `Unknown`-for-an-actually-resolved-alias is also wrong for the eval `type_state` metric, independent of this gate.

Refs the order→notification verdict gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: deep-any backstop hardening (adversarial fail-closed review follow-up)

The first review found the gate-removal's safety claim ("check_v2's gates catch any baked any/unknown") was FALSE: the capture self-check deep walk `findDisqualifyingTopType` — the only deep-any backstop, since the probe gates are whole-type only — was NOT a superset of v1's `contains_disqualifying_top_type`. Three confirmed holes, now closed:

1. **Callable-embedded any.** The walk wholesale-skipped any type with a call signature, so `{ getData: () => any }` (covariant RETURN — masks a real mismatch) read Compatible. Now descends call/construct-signature RETURN types; PARAMETER any stays permissive (contravariant, not a masked mismatch).
2. **Depth past MAX_DEPTH=8.** v1's expander reaches `MAX_EXPANSION_DEPTH=12`, so a depth 9-12 any was flagged by v1 but missed by the walk. `MAX_DEPTH` raised to 16, node budget to 4096 (pinned locally — the capture bundle seam forbids importing the constant).
3. **`blamedExternal` masking.** On a bare checkout, an author-baked deep any co-present with a failing pinned external was allowlisted away. Root cause: the walk counted TypeScript's unresolved-reference `error` placeholder (`intrinsicName === 'error'`) as `any`, conflating a HEALABLE external decay with an author-baked any. `flagOf` now excludes the `error` placeholder, so a found deep decay is a genuine author disqualifier recorded even under a co-present external; a pure external decay still allowlists.

Tests (`capture-v2-deep-any.test.ts`): capture + check regressions for findings 1-3, each verified pre-fix-failing (7 fail without the walk fix); positives lock the no-over-demotion boundary (clean callable return, clean deep nesting, parameter any, pure external decay still verify); plus a guard that the `flagOf` narrowing opens no new hole (a non-healable unpinned-external / dangling-internal error member still gates). Full sidecar (296) + cargo (660) green. `mod.rs` superset comment updated to state the now-true relationship and its two fail-closed-only exceptions.

---

## Update 2: deep-walk budget now fails CLOSED (third adversarial review)

The third review found the deep walk's budget guard failed OPEN — `if (depth > MAX_DEPTH || visited > MAX_VISITED || seen.has(t)) return undefined` treats budget exhaustion as CLEAN, so an `any` buried past the budget recorded `self_check=ok` and (probe gates being whole-type only) read Compatible. Raising 8→16 only relocated the cliff; because walk-depth counts every structural hop (property, type-arg, union member, callable return), it was reachable at only ~8 object levels each wrapping `Array<…>`.

Fix (`self-check.ts`, `api.ts`, `check.ts`): split the guard.
- `seen.has(t)` keeps `return undefined` — cycle/memoization. Sound BECAUSE exhaustion now fails closed: a truncated visit returns the sentinel, which bubbles up (every frame propagates a truthy child return) and terminates the walk before any shallower re-entry, so `seen` only memoizes a fully-completed clean visit; a type clean at depth d1 is clean at any d2 < d1 (shallower reach is a superset). No taint needed — demonstrated with shared-type (both reference orders) and cyclic-type regressions, not just reasoned.
- `depth > MAX_DEPTH || visited > MAX_VISITED` returns a `budget_exhausted` sentinel → `decayed_internal` → the check routes it (`kind === 'any' ? gate_caught_baked_any : unverifiable`) to `unverifiable`, distinct and diagnosable from a baked any.

Also fixed a latent over-recursion the fail-open budget had masked: the callable-return descent walked the built-in method suite (`Array#map` → `U[]` → `map` → …). Default-lib-declared properties are now skipped (machinery, not wire payload; the element type is still covered via type-args), so ordinary `T[]` no longer exhausts the budget.

Owned tradeoff: a legitimately clean type deeper/wider than the budget (`MAX_DEPTH=16`, `MAX_VISITED=4096` distinct type-nodes) now abstains (Unverifiable) rather than verifying — the correct fail-closed direction, never false-compatible. Real schemas clear it (cargo/corpus green). The superset invariant now holds at ALL depths because exhaustion fails closed.

Tests: depth-17/20, 8-Array-wrapped (hop-depth 17), and >4096-wide `any` gate `budget_exhausted`/`unverifiable` (producer AND consumer side), each pre-fix-failing; positives (depth-16 clean, arrays of objects, clean nested arrays, clean cyclic, param-any) still verify. Full sidecar (306) + cargo (660) green.
