### PR TITLE
fix(scanner): resolve NodeNext `.js` import specifiers to their TS source

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -2417,6 +2417,19 @@ impl FileOrchestrator {
             return None;
         }
         let base = importer.parent()?.join(spec);
+        // NodeNext/ESM: `./helper.js` names the emitted JS but the source on
+        // disk is `helper.ts`. Reuse the one substitution table
+        // (`ts_sibling_candidates`, carrick#148) that `canonicalize_or_probe`
+        // already resolves through, so the two resolvers cannot drift again
+        // (#468). Same early return as `canonicalize_or_probe`: for a
+        // JS-family specifier the TS sources are the whole candidate set, with
+        // the literal JS last for genuinely JS-only modules.
+        if let Some(siblings) = base.to_str().and_then(Self::ts_sibling_candidates) {
+            return siblings
+                .into_iter()
+                .map(PathBuf::from)
+                .find_map(|c| c.is_file().then(|| c.canonicalize().ok())?);
+        }
         let mut candidates: Vec<PathBuf> = Vec::new();
         if base.extension().is_some() {
             candidates.push(base.clone());
@@ -4326,6 +4339,66 @@ mod tests {
         assert!(FileOrchestrator::resolve_relative_import(&importer, "@/lib/client").is_none());
         // Nonexistent target resolves to nothing.
         assert!(FileOrchestrator::resolve_relative_import(&importer, "./missing").is_none());
+    }
+
+    /// #468: under `moduleResolution: nodenext` a relative import names the
+    /// EMITTED JS (`./helper.js`) while the source on disk is `helper.ts`.
+    /// `resolve_relative_import` must apply the same `.js`→`.ts` rewrite the
+    /// scanner already does in `ts_sibling_candidates`/`canonicalize_or_probe`
+    /// (carrick#148), otherwise #369/#370 wrapper resolution and cross-file env
+    /// aliasing are inert on every NodeNext repo.
+    #[test]
+    fn resolve_relative_import_rewrites_js_specifier_to_ts_source() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        let src = root.join("src");
+        // Only the TS-family sources exist on disk — exactly what a NodeNext
+        // repo looks like before `tsc` has emitted anything.
+        std::fs::write(src.join("helper.ts"), "export {}").unwrap();
+        std::fs::write(src.join("widget.tsx"), "export {}").unwrap();
+        std::fs::write(src.join("typed.d.ts"), "export {}").unwrap();
+        std::fs::write(src.join("modern.mts"), "export {}").unwrap();
+        std::fs::write(src.join("legacyCjs.cts"), "export {}").unwrap();
+        // A genuine JS-only module: no TS sibling, so the literal file wins.
+        std::fs::write(src.join("vendored.js"), "module.exports = {}").unwrap();
+        let importer = src.join("caller.ts");
+        std::fs::write(&importer, "import {} from './helper.js';").unwrap();
+
+        let cases = [
+            ("./helper.js", "src/helper.ts"),
+            ("./widget.js", "src/widget.tsx"),
+            ("./typed.js", "src/typed.d.ts"),
+            ("./modern.mjs", "src/modern.mts"),
+            ("./legacyCjs.cjs", "src/legacyCjs.cts"),
+            // Regression guard for the probe-order change: a real emitted/
+            // vendored `.js` with no TS sibling still resolves to itself.
+            ("./vendored.js", "src/vendored.js"),
+        ];
+        for (spec, expected) in cases {
+            let resolved = FileOrchestrator::resolve_relative_import(&importer, spec)
+                .unwrap_or_else(|| panic!("{spec} should resolve to {expected}"));
+            assert!(
+                resolved.ends_with(expected),
+                "{spec} resolved to {resolved:?}, expected it to end with {expected}"
+            );
+        }
+
+        // A parent-relative `.js` specifier resolves the same way (the live
+        // shape is `../../helper.js`).
+        let nested = root.join("src/nodes/deep.ts");
+        std::fs::create_dir_all(nested.parent().unwrap()).unwrap();
+        std::fs::write(&nested, "import {} from '../helper.js';").unwrap();
+        let resolved = FileOrchestrator::resolve_relative_import(&nested, "../helper.js")
+            .expect("../helper.js should resolve to the .ts source");
+        assert!(resolved.ends_with("src/helper.ts"));
+
+        // TS-family specifiers are probed exactly — no extension swapping, and
+        // a dangling one still resolves to nothing.
+        let resolved = FileOrchestrator::resolve_relative_import(&importer, "./helper.ts")
+            .expect("explicit .ts specifier should resolve");
+        assert!(resolved.ends_with("src/helper.ts"));
+        assert!(FileOrchestrator::resolve_relative_import(&importer, "./missing.js").is_none());
     }
 
     /// Pub/sub Part B: a NATS pub/sub-only file produces ZERO SWC candidates,


### PR DESCRIPTION
## Mechanism

`FileOrchestrator::resolve_relative_import` (`src/agents/file_orchestrator.rs:2415`) did not implement TypeScript's NodeNext/ESM extension rewrite. Given `"../../helper.js"` it probed:

1. `helper.js` — the literal base, because `base.extension().is_some()`
2. `helper.js.ts`, `helper.js.tsx`, `helper.js.js`, … — extensions **appended to the full base**, never substituted
3. `helper.js/index.ts`, …

`helper.ts` — the file that actually exists — was never probed, so the function returned `None` for every relative import written the way `moduleResolution: nodenext` requires.

All three consumers took the hit, so this was not confined to rescued files:

- `:987` — #370 cross-file wrapper-context attachment for files that *did* raise candidates
- `:1011` — the #369 wrapper rescue for zero-candidate files
- `:3333` — `merge_cross_file_env_aliases`

A NodeNext repo lost wrapper-site resolution and cross-file env aliasing across the board.

## Fix

Reuse `ts_sibling_candidates` (`:3669`) — the substitution table added under carrick#148 that already backs `resolve_import_path`/`canonicalize_or_probe`. No duplication: it is an associated fn on the same impl, so `resolve_relative_import` just calls it and early-returns on a match, the same shape as `canonicalize_or_probe:3709`. The two resolvers now share one table and cannot drift again.

Covered by the shared table: `.js → .ts/.tsx/.d.ts`, `.jsx → .tsx/.ts/.d.ts`, `.mjs → .mts/.d.mts`, `.cjs → .cts/.d.cts`, with the literal emitted JS as last resort. No new mappings invented.

One order note for reviewers: for a JS-family specifier the TS sources are tried **before** the literal `.js`, which is what `tsc` does and what `canonicalize_or_probe` already shipped. The orders differ only when both `helper.js` and `helper.ts` sit side by side, and for a source scanner the `.ts` is the right target. A genuinely JS-only module still resolves to itself (regression-guarded by a test case). Extensionless and directory specifiers keep their existing behaviour untouched, as do explicit `.ts` specifiers.

## Evidence

**Failing test first.** New `resolve_relative_import_rewrites_js_specifier_to_ts_source`, on current `main`:

```
test agents::file_orchestrator::tests::resolve_relative_import_extension_order_and_scope ... ok
test agents::file_orchestrator::tests::resolve_relative_import_rewrites_js_specifier_to_ts_source ... FAILED

thread '…' panicked at src/agents/file_orchestrator.rs:4367:36:
./helper.js should resolve to src/helper.ts
```

Cases: `.js→.ts`, `.js→.tsx`, `.js→.d.ts`, `.mjs→.mts`, `.cjs→.cts`, a `.js`-only module resolving to itself (probe-order regression guard), a parent-relative `../helper.js`, an explicit `./helper.ts` probed exactly, and a dangling `./missing.js` still resolving to nothing. All pass after the fix.

**Offline A/B, mock mode, zero LLM spend.** The issue's three-file repro (invented names), `CARRICK_MOCK_ALL=1 carrick -v --no-cache`. `noExt.ts` and `withExt.ts` are identical apart from `"./wrapper"` vs `"./wrapper.js"`.

Before:

```
Analyzing: …/src/wrapper.ts [1 HTTP candidate(s), 0 unrouted]
Force-analyzing wrapper-importing file (no HTTP candidates): …/src/noExt.ts
Skipped (no API patterns): …/src/withExt.ts [0 candidates]
```

After:

```
Analyzing: …/src/wrapper.ts [1 HTTP candidate(s), 0 unrouted]
Force-analyzing wrapper-importing file (no HTTP candidates): …/src/noExt.ts
Force-analyzing wrapper-importing file (no HTTP candidates): …/src/withExt.ts
```

Full `cargo test` green (including the cassette hard gate, so no full-pipeline drift), `cargo fmt --check` and `cargo clippy --all-targets --all-features -D warnings` clean.

## Residual (deliberately not chased)

The second gate documented in #468 stands: `wrapper_map` is built only from files that raised HTTP candidates (`:949`), so when a `.js` specifier now resolves to a re-export barrel (`export * from "./…"`), the rescue reaches the barrel and stops — the module defining the helper is one hop further and stays invisible. Following one-hop `export *` re-exports is a separate decision and out of scope here.

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
