### PR TITLE
fix(scanner): strip a dependency-injected base from the consumer match key (#467)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1261,12 +1261,20 @@ impl Analyzer {
             // #378: casing is not identity. ANY leading variable followed by
             // a path remainder is structurally a base URL — the call cannot
             // be located without knowing it, so it must be classified
-            // (internalEnvVars/externalEnvVars) before it may match. This is
-            // the same policy the persisted consumer key already applies
-            // (`consumer_call_path` keeps an undeclared `${var}` base
-            // verbatim); previously the matcher silently stripped lowercase
-            // bases and paired third-party calls with in-org producers that
-            // happened to share a generic path.
+            // (internalEnvVars/externalEnvVars) before it may match;
+            // previously the matcher silently stripped lowercase bases and
+            // paired third-party calls with in-org producers that happened to
+            // share a generic path.
+            //
+            // #467 narrowed the persisted consumer key: `consumer_call_path`
+            // now keeps only an ENV-VAR-SHAPED undeclared base
+            // (`process.env.*` / `SCREAMING_SNAKE`) verbatim and strips an
+            // injected one (`${this.apiUrl}/…`), because no `internalEnvVars`
+            // entry could ever classify a class property. This gate is
+            // deliberately left as-is: it runs on the ALREADY-canonicalized
+            // key, so an injected base no longer reaches it as a `${var}`
+            // prefix, and the branch still guards any other route shape that
+            // does.
             if route[end + 1..].starts_with('/') {
                 return true;
             }

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -780,6 +780,43 @@ mod tests {
     }
 
     #[test]
+    fn injected_base_consumer_key_matches_producer_endpoint() {
+        // #467: an internal HTTP client whose base URL is dependency-injected
+        // onto a class property (`this.apiUrl = opts.apiUrl`) is the ordinary
+        // shape of a sibling-service client in a TS monorepo. Its canonical key
+        // must reduce to the bare route so it joins the sibling's producer
+        // endpoint; keeping `${this.apiUrl}` on the key made the join impossible.
+        let mut graph = MountGraph::new();
+        graph.endpoints.push(ResolvedEndpoint {
+            method: "GET".to_string(),
+            path: "/api/v1/widgets/:id".to_string(),
+            full_path: "/api/v1/widgets/:id".to_string(),
+            handler: Some("getWidget".to_string()),
+            owner: "widgetRouter".to_string(),
+            file_location: "services/widget-plane/src/routes.ts:12:1".to_string(),
+            middleware_chain: vec![],
+            repo_name: None,
+            service_name: None,
+            provenance: Default::default(),
+            evidence: carrick_match::MatchEvidence::RouteDefinition,
+        });
+
+        // No env vars declared: the injected base cannot be classified through
+        // `internalEnvVars`, which is exactly the point.
+        let normalizer = UrlNormalizer::new(&Config::default());
+        let canonical = normalizer.consumer_call_path("${this.someBase}/api/v1/widgets/${id}");
+        assert_eq!(canonical, "/api/v1/widgets/:id");
+        assert!(UrlNormalizer::canonical_path_has_literal_segment(
+            &canonical
+        ));
+
+        let result = graph.find_matching_endpoints_with_normalizer(&canonical, "GET", &normalizer);
+        let matched = result.expect("injected-base consumer key must reach the matcher");
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].full_path, "/api/v1/widgets/:id");
+    }
+
+    #[test]
     fn test_url_normalized_matching_template_literal() {
         let mut graph = MountGraph::new();
 

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -577,7 +577,9 @@ impl UrlNormalizer {
         let Some(end) = inner_start.find('}') else {
             return false;
         };
-        let base = &inner_start[..end];
+        // `${ PAYMENTS_URL }` is valid JS: trim before the shape test so a
+        // spaced env-var base is not misread as injected.
+        let base = inner_start[..end].trim();
         if !inner_start[end + 1..].starts_with('/') {
             return false;
         }
@@ -1107,6 +1109,12 @@ mod tests {
         assert_eq!(
             normalizer.consumer_call_path("${PAYMENTS_URL}/charges"),
             "${PAYMENTS_URL}/charges"
+        );
+        // `${ PAYMENTS_URL }` is valid JS — internal whitespace must not
+        // reclassify an env-var-shaped base as injected (Copilot review find).
+        assert_eq!(
+            normalizer.consumer_call_path("${ PAYMENTS_URL }/charges"),
+            "${ PAYMENTS_URL }/charges"
         );
         // A DECLARED-external base stays verbatim regardless of its shape.
         let external = Config {

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -517,11 +517,26 @@ impl UrlNormalizer {
     /// path and match its own endpoint (a literal origin that survived into the
     /// key could match nothing and evaded the self-call / decoy checks).
     ///
-    /// An UNKNOWN/undeclared env-var BASE (`${SOME_URL}/charges`, not in
-    /// `internalEnvVars`) is still returned VERBATIM: there is no concrete origin
-    /// to strip, so keeping the raw `${VAR}` (a) prevents a third-party call from
-    /// colliding with an internal producer's path and (b) lets the "unclassified
-    /// env var" config-suggestion still see the raw var.
+    /// An UNKNOWN/undeclared ENV-VAR base (`${SOME_URL}/charges`,
+    /// `${process.env.STRIPE_URL}/charges` — not in `internalEnvVars`) is still
+    /// returned VERBATIM: there is no concrete origin to strip, so keeping the
+    /// raw `${VAR}` (a) prevents a third-party call from colliding with an
+    /// internal producer's path and (b) lets the "unclassified env var"
+    /// config-suggestion still see the raw var. A DECLARED-external base
+    /// (`externalEnvVars`) is kept verbatim whatever its shape.
+    ///
+    /// A leading interpolation that is NOT env-var-shaped is a different animal
+    /// (#467): a base held on a class property or a local binding
+    /// (`${this.apiUrl}/api/v1/widgets`, `${opts.baseUrl}/catalog`) is
+    /// dependency-injected, not read from the environment, so there is no env
+    /// var for the user to declare and no `internalEnvVars` entry that could
+    /// ever rescue the key — the "declare it to classify it" escape hatch the
+    /// verbatim rule assumes simply does not exist. That is the ordinary shape
+    /// of an internal client in a TS monorepo, so the base is stripped and the
+    /// bare route becomes the key. The residual collision risk is bounded by
+    /// shape: third-party bases are overwhelmingly `SCREAMING_SNAKE` or
+    /// `process.env.*`, both of which still stay verbatim, and the #307
+    /// literal-segment gate still drops keys with nothing to match on.
     ///
     /// The raw target is always retained separately on the call (`target_url`)
     /// for per-call classification/display; only the MATCH key is canonicalized.
@@ -533,10 +548,50 @@ impl UrlNormalizer {
             || trimmed.starts_with("//");
         let normalized = self.normalize(url);
         if normalized.is_internal || is_relative_path || is_absolute_url {
-            normalized.path
-        } else {
-            url.to_string()
+            return normalized.path;
         }
+        // A base the user DECLARED external stays verbatim whatever its shape —
+        // `externalEnvVars` is tested against the raw interpolation text, so it
+        // can name a property base just as well as an env var.
+        if !normalized.is_external && Self::has_injected_base(trimmed) {
+            return normalized.path;
+        }
+        url.to_string()
+    }
+
+    /// Whether `url` is `${<base>}/<route…>` where `<base>` is NOT env-var-shaped
+    /// — i.e. a dependency-injected base (class property, local binding) rather
+    /// than an environment variable the user could classify in carrick.json.
+    ///
+    /// Env-var shape is defined POSITIVELY, so no property name is special-cased:
+    /// a `process.env.` / `import.meta.env.` read, or a bare `SCREAMING_SNAKE`
+    /// identifier. Everything else — `this.apiUrl`, `opts.baseUrl`, `clientBase`
+    /// — is an injected base. A route remainder (a leading `/` after the closing
+    /// brace) is required, which is the same structural test #378 applies: a
+    /// whole-URL opaque variable (`${url}`, `${base}${path}`) has no path to key
+    /// on and stays raw.
+    fn has_injected_base(url: &str) -> bool {
+        let Some(inner_start) = url.strip_prefix("${") else {
+            return false;
+        };
+        let Some(end) = inner_start.find('}') else {
+            return false;
+        };
+        let base = &inner_start[..end];
+        if !inner_start[end + 1..].starts_with('/') {
+            return false;
+        }
+        // A `process.env.X` anywhere else in the target routes `normalize`
+        // through `normalize_process_env_pattern` rather than the template
+        // branch, so its `path` is not this base's remainder. Leave those raw.
+        if url.contains("process.env.") || url.contains("import.meta.env.") {
+            return false;
+        }
+        let is_screaming_snake = !base.is_empty()
+            && base
+                .chars()
+                .all(|c| c.is_ascii_uppercase() || c == '_' || c.is_ascii_digit());
+        !is_screaming_snake
     }
 
     /// Whether a canonical consumer path carries at least one LITERAL segment —
@@ -1010,6 +1065,69 @@ mod tests {
         assert!(
             !param.contains("process.env"),
             "internal base var must be stripped, got {param}"
+        );
+    }
+
+    #[test]
+    fn consumer_call_path_strips_non_env_var_base_keeps_env_shaped_base_raw() {
+        // #467: a dependency-injected base held on a class property
+        // (`this.apiUrl = opts.apiUrl`) is NOT an environment variable, so it
+        // can never be classified through `internalEnvVars` — keeping it on the
+        // match key made every such call permanently unmatchable.
+        let config = create_test_config();
+        let normalizer = UrlNormalizer::new(&config);
+
+        assert_eq!(
+            normalizer.consumer_call_path("${this.someBase}/api/v1/widgets/${id}"),
+            "/api/v1/widgets/:id"
+        );
+        assert_eq!(
+            normalizer.consumer_call_path("${this.apiUrl}/engine/v1/worker-actions/heartbeat"),
+            "/engine/v1/worker-actions/heartbeat"
+        );
+        // A plain camelCase local/injected base behaves the same — the rule is
+        // about SHAPE, not about the `this.` receiver.
+        assert_eq!(
+            normalizer.consumer_call_path("${opts.baseUrl}/catalog/items"),
+            "/catalog/items"
+        );
+        assert_eq!(
+            normalizer.consumer_call_path("${clientBase}/catalog/items"),
+            "/catalog/items"
+        );
+
+        // The env-var carve-out is unchanged: an UNDECLARED env-var base stays
+        // VERBATIM so a third-party call can't collide with an internal
+        // producer's path and the "unclassified env var" config suggestion
+        // still sees the raw var name.
+        assert_eq!(
+            normalizer.consumer_call_path("${process.env.STRIPE_URL}/charges"),
+            "${process.env.STRIPE_URL}/charges"
+        );
+        assert_eq!(
+            normalizer.consumer_call_path("${PAYMENTS_URL}/charges"),
+            "${PAYMENTS_URL}/charges"
+        );
+        // A DECLARED-external base stays verbatim regardless of its shape.
+        let external = Config {
+            external_env_vars: ["billing.baseUrl".to_string()].into_iter().collect(),
+            ..Default::default()
+        };
+        let external_normalizer = UrlNormalizer::new(&external);
+        assert_eq!(
+            external_normalizer.consumer_call_path("${billing.baseUrl}/charges"),
+            "${billing.baseUrl}/charges"
+        );
+
+        // A whole-URL opaque variable has no route remainder to key on and is
+        // still returned verbatim (the #307 literal-segment gate drops it).
+        assert_eq!(
+            normalizer.consumer_call_path("${this.someBase}"),
+            "${this.someBase}"
+        );
+        assert_eq!(
+            normalizer.consumer_call_path("${this.someBase}${path}"),
+            "${this.someBase}${path}"
         );
     }
 


### PR DESCRIPTION
## Mechanism

`UrlNormalizer::consumer_call_path` returns the canonical key every consumer→producer join uses. Its fall-through returned the **raw** target:

```rust
if normalized.is_internal || is_relative_path || is_absolute_url {
    normalized.path
} else {
    url.to_string()   // raw target becomes the MATCH key
}
```

For `${this.apiUrl}/api/v1/widgets/${id}` all three conditions are false — no leading `/`, no scheme, and `is_internal` is false because the interpolation text `this.apiUrl` is not in `internalEnvVars`. So the key kept the `${this.apiUrl}` prefix and could never equal a producer's `/api/v1/widgets/:id`.

The correct answer was already computed and thrown away: `normalize_template_literal` strips *any* leading `${…}` unconditionally and only consults the env-var sets to set the `is_internal`/`is_external` *flags*. The stripped path was sitting in `normalized.path`.

Observed on a live scan of a large OSS TypeScript monorepo: 12 consumer calls from one internal HTTP client class reached the index with correct method/file/line, the matching producer endpoints were in the same project's index, and **zero edges matched**.

## Fix

The fall-through now strips a leading interpolation when it is **not env-var-shaped**, and returns `normalized.path`.

Env-var shape is defined *positively*, so no property name is special-cased:

- a `process.env.` / `import.meta.env.` read, or
- a bare `SCREAMING_SNAKE` identifier

Everything else — `this.apiUrl`, `opts.baseUrl`, `clientBase` — is an injected base and gets stripped. Three guards keep the change narrow:

- **Declared-external stays verbatim.** `externalEnvVars` is tested against raw interpolation text, so a user can declare a property-shaped base; `is_external` short-circuits before the shape test.
- **A route remainder is required** (a `/` after the closing brace) — the same structural test #378 applies. A whole-URL opaque variable (`${url}`, `${base}${path}`) is untouched and still dropped by the #307 literal-segment gate.
- **No `process.env.` anywhere in the target**, because that routes `normalize` through `normalize_process_env_pattern` rather than the template branch, so `normalized.path` would not be this base's remainder.

`target_url` is unchanged — it stays raw for per-call classification and display. Only the match key moves.

### Why the verbatim rule does not cover this case

The rule's rationale is that an undeclared `${VAR}` base must be classified in `carrick.json` before it may match, so a third-party call cannot collide with an internal producer path. That argument assumes there *is* an env var to declare. For a base assigned in a constructor from an injected option there is none — no `internalEnvVars` entry could ever legitimately classify it, and adding the literal string `this.apiUrl` would silently apply to every unrelated class in the repo sharing that property name. The escape hatch the rule depends on does not exist for this shape.

The collision risk the rule guards against is bounded by shape rather than removed: third-party bases are overwhelmingly `SCREAMING_SNAKE` or `process.env.*`, both of which still key verbatim.

The one input class where that argument is weakest is a **bare lowercase identifier** (`${apiBase}/orders`), which unlike `this.x` / `opts.x` may well be a local assigned from `process.env.SERVICE_URL` a few lines up. In practice `resolve_env_var_aliases` → `EnvAliasExtractor` visits `VarDecl`s and rewrites that target to `${SERVICE_URL}/orders` *before* canonicalization, so the env-var carve-out still fires for it. An env-derived local that escaped alias resolution will now strip — that is the tradeoff fix direction 2 in the issue explicitly accepts, and it is bounded by the same #307 gate.

I deliberately did **not** add a new path-specificity floor — the existing `canonical_path_has_literal_segment` gate (#307) already drops keys with nothing to match on, and stripping can never make a path fail that gate that previously passed, since it already strips leading `${…}` per segment.

## Key-join audit

`canonical_path` is computed at exactly three sites, all via `consumer_call_path` on a `UrlNormalizer` built from the same `Config`:

| Site | Role |
| --- | --- |
| `src/agents/file_orchestrator.rs:4023` | mount-graph build — the one that populates `DataFetchingCall::canonical_path` |
| `src/agents/file_orchestrator.rs:1651` | type-manifest lookup fallback (documented as "same canonicalization") |
| `src/engine/mod.rs:3766` | test-only mount-graph construction |

Every other join reads the **stored** field, so all move together:

- `src/mount_graph.rs:78` — field definition and its contract doc.
- `src/agents/file_orchestrator.rs:1417` — type-manifest join key.
- `src/agents/file_orchestrator.rs:4089, 4248` — sidecar-side endpoint matching, incl. `carrick_match::paths_match`.
- `src/engine/mod.rs:2760` — consumer type-manifest entries. Note the `!path.starts_with('/')` guard there: an injected-base call now passes it, so these calls gain type anchors they previously could not have. That is the intended consequence.
- `src/cloud_storage/mod.rs:410` (`mount_graph_to_api_details`) — the single projection both cloud paths use; `OperationKey::http(method, canonical_path)`.
- `src/cloud_storage/mod.rs:131` — `CompatVerdict::consumer_key`'s "equal to the persisted `canonical_path`" invariant holds: both sides read the stored field.
- `src/analyzer/mod.rs:1586` — the `(METHOD, canonical_path, file_location)` consumer-id triple. Both sides derive from the same stored field (`self.calls[].key` is built from `canonical_path` via `mount_graph_to_api_details`), so they stay aligned.
- `crates/carrick-match/src/lib.rs:247` — doc reference only, no key derivation.

Not keyed on `canonical_path`, checked and unaffected:

- `src/engine/mod.rs:1373` (`fold_graphql_transport_calls`) — deliberately shape-tests the **raw** `target_url`.
- `src/env_alias.rs` / `resolve_env_var_aliases` — operates before canonicalization, on `VarDecl` and config-object bindings.

## Behaviour left conservative

`Finding::EnvVarCall` emission is unchanged **for env-var bases**: `${SOME_URL}/…` and `${process.env.X}/…` still key verbatim, still hit `is_env_var_base_url`, and still produce the "unclassified env var" config suggestion.

For an **injected** base the suggestion now disappears as a consequence of the key change: the analyzer-local matcher runs on the already-canonicalized key, so `${this.apiUrl}/api/v1/…` reaches it as `/api/v1/…` and is matched normally instead of being diverted into an env-var suggestion. #467 calls that suggestion "actively misleading" for property bases, so I let it fall out rather than adding code to preserve it — but I did not redesign anything around it. `is_env_var_base_url` / `is_valid_route_shape` are untouched; the #378 gate still guards every other route shape that reaches it, and I updated its now-stale parenthetical claiming the persisted key keeps *any* undeclared `${var}` base verbatim.

Structural resolution of the base (fix direction 1 in the issue — a class-property alias pass analogous to `EnvAliasExtractor`) is not attempted here. This is the smallest change that unblocks the join; a real classification pass would be a separate piece of work.

## Tests

Written failing first, confirmed failing against main behaviour (`left: "${this.someBase}/api/v1/widgets/${id}"`, `right: "/api/v1/widgets/:id"`), then fixed.

- `url_normalizer::tests::consumer_call_path_strips_non_env_var_base_keeps_env_shaped_base_raw` — pins both halves in one place: property/local bases strip, and `${process.env.STRIPE_URL}/charges`, `${PAYMENTS_URL}/charges`, a declared-external base, and whole-URL opaque variables all stay verbatim.
- `mount_graph::tests::injected_base_consumer_key_matches_producer_endpoint` — matching-level proof that the key actually joins a producer `/api/v1/widgets/:id` through `find_matching_endpoints_with_normalizer`.

Full CI gate set green locally: `cargo test` (all targets incl. the LLM cassette hard gate, which is byte-identical to its golden), `cargo test -p carrick-match`, `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`.

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)

