### PR TITLE
fix(cloud): enable reqwest gzip so large-project reads inflate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310c9bcae737a48ef5cdee3174184e6d548b292739ede61a1f955ef76a738861"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +225,7 @@ dependencies = [
  "carrick-match",
  "chrono",
  "dirs",
+ "flate2",
  "futures",
  "graphql-parser",
  "indicatif",
@@ -343,6 +357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +490,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -1095,6 +1128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1803,6 +1837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,6 +2410,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2390,13 +2443,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,15 @@ indicatif = "0.17"
 
 matchit = "0.8.6"
 regex = "1.11.1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# `gzip` is load-bearing, not an optimisation. The cloud's `get-cross-repo-data`
+# response inlines every repo's index blob, and past ~5.8 MB it breaches AWS
+# Lambda's 6,291,556-byte synchronous-response cap. The cloud gzips that
+# response, but only for callers that advertise `Accept-Encoding: gzip`;
+# without this feature reqwest advertises nothing, so the scanner was served
+# (and size-checked against) the uncompressed body and got a 413 it correctly
+# refuses to retry. With the feature on, reqwest sets the header and inflates
+# the response transparently.
+reqwest = { version = "0.12", default-features = false, features = ["gzip", "json", "rustls-tls"] }
 semver = "1.0"
 serde = "1.0.219"
 serde_json = "1.0.140"
@@ -41,3 +49,7 @@ walkdir = "2.5.0"
 [dev-dependencies]
 tempfile = "3.0"
 serial_test = "3.0"
+# Test-only gzip encoder, so the cloud-client test can serve a real
+# `Content-Encoding: gzip` response. Adds nothing to the dependency graph:
+# reqwest's `gzip` feature already pulls flate2 in transitively.
+flate2 = "1"

--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -125,6 +125,24 @@ struct GetCrossRepoRequest {
     action: String,
 }
 
+/// The shared configuration of every cloud-call client.
+///
+/// Transparent gzip is not configured here — it comes from reqwest's `gzip`
+/// crate feature (see Cargo.toml), which makes every client this builder
+/// produces send `Accept-Encoding: gzip` and inflate a `Content-Encoding:
+/// gzip` response before the body is read. That matters for
+/// `get-cross-repo-data`, whose response inlines every repo's index blob and
+/// breaches AWS Lambda's 6,291,556-byte synchronous-response cap on large
+/// projects; the cloud gzips it, but only for callers that advertise gzip.
+///
+/// Exists as a builder rather than a finished `Client` so tests can add
+/// `.no_proxy()` and still exercise the production configuration.
+fn http_client_builder() -> reqwest::ClientBuilder {
+    Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .connect_timeout(CONNECT_TIMEOUT)
+}
+
 impl AwsStorage {
     pub fn new() -> Result<Self, StorageError> {
         let api_endpoint = env!("CARRICK_API_ENDPOINT");
@@ -134,13 +152,9 @@ impl AwsStorage {
         // from the signed OIDC claims, so there is no other way to authenticate.
         OidcProvider::global().map_err(|e| StorageError::ConnectionError(e.to_string()))?;
 
-        let http_client = Client::builder()
-            .timeout(REQUEST_TIMEOUT)
-            .connect_timeout(CONNECT_TIMEOUT)
-            .build()
-            .map_err(|e| {
-                StorageError::ConnectionError(format!("Failed to build HTTP client: {}", e))
-            })?;
+        let http_client = http_client_builder().build().map_err(|e| {
+            StorageError::ConnectionError(format!("Failed to build HTTP client: {}", e))
+        })?;
 
         Ok(Self {
             lambda_url,
@@ -628,5 +642,83 @@ mod tests {
         assert_eq!(v["pr_number"], 7);
         assert_eq!(v["stats"]["calls"], 2);
         assert!(v.get("payload").is_none());
+    }
+
+    /// The cloud gzips `get-cross-repo-data` only for callers that advertise
+    /// gzip, so a scanner that stays silent is served — and size-checked
+    /// against — the uncompressed aggregate, and past ~5.8 MB the response
+    /// breaches Lambda's synchronous cap and comes back as a 413 that
+    /// `is_transient_status` correctly refuses to retry. Both halves of the
+    /// fix are properties of the client, not of any call site, so pin them
+    /// both here: the request must advertise gzip, and a gzipped response
+    /// must deserialize as if it had never been compressed.
+    ///
+    /// Guards the reqwest `gzip` crate feature specifically: drop it from
+    /// Cargo.toml and this test fails on the `accept-encoding` assertion.
+    #[tokio::test]
+    async fn cloud_client_advertises_gzip_and_inflates_the_response() {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 8192];
+            let n = stream.read(&mut buf).unwrap();
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+
+            let body = r#"{"repos":[{"repo":"api-server","hash":"deadbeef",
+                "s3Url":"https://example.invalid/api-server.json",
+                "filename":"api-server.json","metadata":null,
+                "lastUpdated":"2026-07-27T00:00:00Z"}]}"#;
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(body.as_bytes()).unwrap();
+            let gzipped = encoder.finish().unwrap();
+
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                 Content-Encoding: gzip\r\nContent-Length: {}\r\n\
+                 Connection: close\r\n\r\n",
+                gzipped.len()
+            );
+            stream.write_all(head.as_bytes()).unwrap();
+            stream.write_all(&gzipped).unwrap();
+            stream.flush().unwrap();
+            request
+        });
+
+        // The production builder, plus no_proxy so CI proxy env vars can't
+        // intercept the localhost call (same guard as the OIDC tests).
+        let client = http_client_builder().no_proxy().build().unwrap();
+        let response = client
+            .post(format!("http://{}/types/check-or-upload", addr))
+            .json(&GetCrossRepoRequest {
+                action: "get-cross-repo-data".to_string(),
+            })
+            .send()
+            .await
+            .unwrap();
+
+        // Inflated transparently: no manual decode, no `Content-Encoding`
+        // left on the response for a caller to have to notice.
+        assert!(response.headers().get("content-encoding").is_none());
+        let parsed: CrossRepoResponse = response.json().await.unwrap();
+        assert_eq!(parsed.repos.len(), 1);
+        assert_eq!(parsed.repos[0].repo, "api-server");
+        assert_eq!(parsed.repos[0].hash, "deadbeef");
+        assert!(parsed.repos[0].s3_url.ends_with("api-server.json"));
+
+        let request = server.join().unwrap();
+        assert!(
+            request
+                .to_lowercase()
+                .lines()
+                .any(|l| l.starts_with("accept-encoding:") && l.contains("gzip")),
+            "client did not advertise gzip; the reqwest `gzip` feature is off: {request}"
+        );
     }
 }


### PR DESCRIPTION
## What broke

A scan died at `▸ Downloading cross-repo data...` with the cloud's explicit 413:

```json
{"error":"Project index is too large...","body_bytes":6002847,
 "limit_bytes":6291556,"compressed":false}
```

`compressed: false` is the whole story. `get-cross-repo-data` inlines every repo's index blob, so its response grows with the project, and AWS Lambda caps a synchronous response at 6,291,556 bytes. carrick-cloud already gzips that response (carrick-cloud#284) — a 6.0 MB aggregate compresses to ~1.0 MB, 6x under the cap — but only for a caller that advertises `Accept-Encoding: gzip`. Compressing unconditionally would hand a non-inflating client binary garbage, so the gate is deliberate.

The scanner's reqwest was built `default-features = false, features = ["json", "rustls-tls"]`. No `gzip` feature, so it advertised nothing, the gate stayed shut, and the cloud served — and size-checked — the uncompressed body. The resulting 413 is `PAYLOAD_TOO_LARGE`, which `is_transient_status` correctly declines to retry (`aws_storage.rs:26-30`), so the scan does not recover.

## The fix

Add `"gzip"` to reqwest's feature list. That is the whole behavioural change; there are no call-site edits.

Verified against reqwest 0.12.28's source rather than assumed:

- `Accepts::default()` sets `gzip: true` under `#[cfg(feature = "gzip")]` (`src/async_impl/client.rs:114,127`), so every client built from `Client::builder()` opts in — nothing has to call `.gzip(true)`.
- The builder installs tower-http's `Decompression` layer with `.gzip(config.accepts.gzip)` (`client.rs:1040`).
- Documented contract: the request gets `Accept-Encoding: gzip` unless it already carries `Accept-Encoding` **or** `Range`; on a `Content-Encoding: gzip` response, both `Content-Encoding` and `Content-Length` are removed and the body is inflated (`client.rs:1225-1235`).

Neither exemption applies — `grep -rn "ACCEPT_ENCODING\|accept-encoding\|content_length\|bytes_stream" src/ crates/` finds nothing in the crate. No code reads `Content-Length`, streams a body, or inflates manually, so the header reqwest strips is unused and there is no double-decompression risk. The blast radius is crate-wide by design: the OIDC clients (`oidc.rs:88,192`) and the LLM client (`agent_service.rs:78`) also start advertising gzip. That is benign — same transparent inflate, smaller responses.

`Cargo.lock` gains only compression crates: `async-compression`, `flate2`, `crc32fast`, `simd-adler32`, `tokio-util`. Nothing else moves.

## Test

`http_client_builder()` factors out the client configuration that `AwsStorage::new()` was building inline, so a test can exercise the production settings while adding `.no_proxy()` (the same guard the OIDC tests use against CI proxy env vars).

The repo already had a raw-`TcpListener` HTTP harness pattern in `oidc.rs`'s tests, so the new case reuses it rather than adding a mock-HTTP dev-dependency. It serves a real gzipped `CrossRepoResponse` and pins both halves of the fix:

- the request advertises `accept-encoding: gzip`;
- the gzipped response deserializes into `CrossRepoResponse` as if it had never been compressed, with no `Content-Encoding` left on the response for a caller to have to notice.

Negative control run: remove `"gzip"` from `Cargo.toml` and the test fails on the transparent-inflate assertion. The only new dev-dependency is `flate2` (a gzip encoder for the fake server), which adds nothing to the dependency graph — reqwest's `gzip` feature pulls it in transitively anyway.

Full local verification: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and every test binary CI runs, all green (`--lib` 671 passed, including the new case).

## Cloud side

**No carrick-cloud change is needed, and none is included here** (different repo; this is scanner-side only).

The compression gate lives in `handleGetCrossRepoData` and takes the header path for `auth.kind === "action"` — the scanner — so advertising gzip is sufficient to open it. The header does survive the hop, which is the one thing that could have made this a no-op: API Gateway's payload format 2.0 lowercases every key in `event.headers`, reqwest emits the name lowercase (`http::HeaderName` normalizes), and the lambda reads `event.headers?.["accept-encoding"] ?? event.headers?.["Accept-Encoding"]`, so it matches either way. It is also confirmed deployed, not merely merged: the structured `compressed: false` error above is emitted by the `exceedsLambdaResponseLimit` branch that carrick-cloud#284 introduced, so the live lambda is running that code.

The issue's other half is already gone: carrick-cloud#289 removed the `adjacent[]` aggregate from the `check-or-upload` response entirely, so the write path no longer ships a size-scaling body at all.

Deliberately out of scope, per the issue's own comment ("delete the field at the next release"): `LambdaResponse.adjacent` is now dead on the wire as well as in the code. It carries `#[serde(default)]`, so nothing breaks while the cloud omits the key. Its `AdjacentRepo` type must stay — it is shared with `CrossRepoResponse.repos`, which the live `get-cross-repo-data` path iterates.

Takes effect for CI scans on the next scanner release.

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)

