### PR TITLE
feat(routing): derive endpoints for flat file-based route modules

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -2938,10 +2938,17 @@ impl FileOrchestrator {
             MethodSource::ExportName => scanner
                 .exported_handlers(file_path, content)
                 .into_iter()
-                .filter(|h| is_http_method(&h.name))
-                .map(|h| {
-                    let method = h.name.to_uppercase();
-                    EndpointResult {
+                .filter_map(|h| {
+                    // An export named for a method *is* that method; a
+                    // convention whose route modules name their handlers for a
+                    // role instead (a read export, a write export) maps those
+                    // names itself. Either way the endpoint is anchored on the
+                    // export's own span, so an exported binding initialized
+                    // from a call — a handler built by a route-builder factory
+                    // rather than declared as a function — anchors exactly like
+                    // a function declaration does (carrick#473).
+                    let method = route.http_method_for_export(&h.name)?;
+                    Some(EndpointResult {
                         candidate_id: format!("file-route:{}:{}", method, h.span_start),
                         line_number: h.line_number as i32,
                         owner_node: FILE_BASED_ROUTE_OWNER.to_string(),
@@ -2958,7 +2965,7 @@ impl FileOrchestrator {
                         emission_style: None,
                         primary_type_symbol: None,
                         type_import_source: None,
-                    }
+                    })
                 })
                 .collect(),
             // Pages-router style: a single default export serves every method. The
@@ -6749,6 +6756,137 @@ export const prerender = false;
             endpoints.is_empty(),
             "non-route files should yield no file-based endpoints"
         );
+    }
+
+    fn flat_conventions() -> Vec<RoutingConvention> {
+        builtin_conventions(&["remix".to_string()])
+    }
+
+    #[test]
+    fn test_file_based_endpoints_flat_route_factory_export() {
+        // carrick#473: the route module's handler is the *result of a call*
+        // (a route-builder factory), not a function declaration. It raises no
+        // call-site candidate, so the endpoint has to be anchored on the
+        // export itself — exactly as a declared handler would be.
+        let scanner = SwcScanner::new();
+        let content = r#"
+import { makeRoute } from "~/lib/routeBuilders.server";
+export const action = makeRoute({ body: WidgetSchema }, async ({ body }) => {
+  return json({ ok: true });
+});
+"#;
+        let endpoints = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            Path::new("app/routes/api.v1.widgets.$widgetId.activate.ts"),
+            Path::new("app/routes/api.v1.widgets.$widgetId.activate.ts"),
+            content,
+            &flat_conventions(),
+        );
+        assert_eq!(endpoints.len(), 1, "expected one endpoint for the action");
+        let ep = &endpoints[0];
+        assert_eq!(ep.method, "POST");
+        assert_eq!(ep.path, "/api/v1/widgets/:widgetId/activate");
+        assert_eq!(ep.handler_name, "action");
+        assert_eq!(ep.owner_node, FILE_BASED_ROUTE_OWNER);
+        assert_eq!(ep.pattern_matched, "remix-flat");
+        // Span-anchored on the export, so the normal candidate join applies.
+        assert!(ep.call_expression_span_start.is_some());
+        assert!(ep.call_expression_span_end.is_some());
+    }
+
+    #[test]
+    fn test_file_based_endpoints_flat_route_loader_is_get() {
+        let scanner = SwcScanner::new();
+        let content = r#"
+export const loader = makeRoute({}, async () => json([]));
+"#;
+        let endpoints = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            Path::new("app/routes/api.v1.widgets.$widgetId.ts"),
+            Path::new("app/routes/api.v1.widgets.$widgetId.ts"),
+            content,
+            &flat_conventions(),
+        );
+        assert_eq!(endpoints.len(), 1);
+        assert_eq!(endpoints[0].method, "GET");
+        assert_eq!(endpoints[0].path, "/api/v1/widgets/:widgetId");
+    }
+
+    #[test]
+    fn test_file_based_endpoints_flat_route_declared_and_called_forms_agree() {
+        // The declared-function form and the factory-call form of the same
+        // route module must produce the same endpoint: the discriminator is
+        // the export name, never the shape of its initializer.
+        let scanner = SwcScanner::new();
+        let rel = Path::new("app/routes/api.v1.widgets.$widgetId.activate.ts");
+        let declared = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            rel,
+            rel,
+            "export async function action({ request }) { return json({}); }\n",
+            &flat_conventions(),
+        );
+        let called = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            rel,
+            rel,
+            "export const action = makeRoute({}, async () => json({}));\n",
+            &flat_conventions(),
+        );
+        assert_eq!(declared.len(), 1);
+        assert_eq!(called.len(), 1);
+        assert_eq!(declared[0].method, called[0].method);
+        assert_eq!(declared[0].path, called[0].path);
+    }
+
+    #[test]
+    fn test_file_based_endpoints_flat_route_non_handler_exports_ignored() {
+        // A route module also exports helpers and config. Only the exports the
+        // convention names as handlers become endpoints.
+        let scanner = SwcScanner::new();
+        let content = r#"
+export const config = makeConfig({ runtime: "node" });
+export const schema = buildSchema({});
+export function serializeWidget(w) { return w; }
+"#;
+        let endpoints = FileOrchestrator::file_based_endpoints(
+            &scanner,
+            Path::new("app/routes/api.v1.widgets.ts"),
+            Path::new("app/routes/api.v1.widgets.ts"),
+            content,
+            &flat_conventions(),
+        );
+        assert!(
+            endpoints.is_empty(),
+            "non-handler exports must not become endpoints, got {endpoints:?}"
+        );
+    }
+
+    #[test]
+    fn test_file_based_endpoints_flat_route_gate_is_the_route_plane() {
+        // The same call-expression export outside the route plane yields
+        // nothing: the recall fix is scoped to files a convention claims.
+        let scanner = SwcScanner::new();
+        let content = "export const action = makeRoute({}, async () => json({}));\n";
+        for rel in [
+            // Not under the route root.
+            "app/services/widgets.server.ts",
+            "src/lib/api.v1.widgets.$widgetId.activate.ts",
+            // Under the route root, but the UI page plane, not an API surface.
+            "app/routes/api.v1.widgets.$widgetId.activate.tsx",
+        ] {
+            let endpoints = FileOrchestrator::file_based_endpoints(
+                &scanner,
+                Path::new(rel),
+                Path::new(rel),
+                content,
+                &flat_conventions(),
+            );
+            assert!(
+                endpoints.is_empty(),
+                "{rel} is not a route module; expected no endpoints, got {endpoints:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/file_based_router.rs
+++ b/src/file_based_router.rs
@@ -14,14 +14,19 @@
 //! or by `carrick.json` overrides them. This keeps framework knowledge out of
 //! the scanner core while still shipping value today.
 
+use crate::type_manifest::is_http_method;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::Path;
 
 /// How the HTTP method of a file-based endpoint is determined.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MethodSource {
     /// The HTTP method is the name of an exported handler function, e.g.
-    /// Next.js app-router `export async function GET(...) {}`.
+    /// Next.js app-router `export async function GET(...) {}`. Conventions
+    /// whose route modules name their exports for a *role* rather than a
+    /// method (a read export and a write export) map those names to methods
+    /// through [`RoutingConvention::method_exports`].
     ExportName,
     /// A single default-exported handler serves every method and branches on the
     /// request at runtime (e.g. pages-router `req.method`). The concrete method
@@ -39,7 +44,16 @@ pub enum SegmentSource {
     DirectoryChain { terminal_files: Vec<String> },
     /// Pages-router style: the filename (minus extension) is the final path
     /// segment. `index` collapses to its directory.
-    FileName { extensions: Vec<String> },
+    ///
+    /// When `segment_separator` is set, the filename is not one segment but a
+    /// *flattened chain* of them: the stem is split on that separator and each
+    /// piece becomes its own path segment (`a.b.$id.ts` -> `/a/b/:id`). This is
+    /// how "flat route" schemes encode nesting without directories.
+    FileName {
+        extensions: Vec<String>,
+        #[serde(default)]
+        segment_separator: Option<String>,
+    },
 }
 
 /// A declarative description of a file-based routing scheme. Executed by
@@ -69,6 +83,15 @@ pub struct RoutingConvention {
     pub group_close: String,
     /// How the HTTP method is determined for endpoints under this convention.
     pub method_source: MethodSource,
+    /// Conventional route-module export names that are not themselves HTTP
+    /// method names, mapped to the method they serve (e.g. a read export ->
+    /// `GET`, a write export -> `POST`). Consulted only for
+    /// [`MethodSource::ExportName`], and only for exports whose own name is not
+    /// already a method. Plain data on the convention — the executor never
+    /// branches on a framework, and an export not listed here yields no
+    /// endpoint.
+    #[serde(default)]
+    pub method_exports: BTreeMap<String, String>,
 }
 
 /// A route successfully derived from a file's location.
@@ -81,6 +104,28 @@ pub struct DerivedRoute {
     pub method_source: MethodSource,
     /// The convention name that matched (diagnostic).
     pub convention: String,
+    /// The matched convention's role-export -> method map (see
+    /// [`RoutingConvention::method_exports`]).
+    pub method_exports: BTreeMap<String, String>,
+}
+
+impl DerivedRoute {
+    /// The HTTP method an exported binding serves, or `None` when the export is
+    /// not a route handler under this convention.
+    ///
+    /// An export named for a method *is* that method (app-router style
+    /// `export function GET`); otherwise the convention's `method_exports` map
+    /// names the conventional handler exports. Everything else — helpers,
+    /// types, config objects a route module also exports — yields no endpoint.
+    pub fn http_method_for_export(&self, export: &str) -> Option<String> {
+        if is_http_method(export) {
+            return Some(export.to_uppercase());
+        }
+        self.method_exports
+            .get(export)
+            .filter(|m| is_http_method(m))
+            .map(|m| m.to_uppercase())
+    }
 }
 
 impl RoutingConvention {
@@ -104,6 +149,7 @@ impl RoutingConvention {
             group_open: "(".to_string(),
             group_close: ")".to_string(),
             method_source: MethodSource::ExportName,
+            method_exports: BTreeMap::new(),
         }
     }
 
@@ -120,6 +166,7 @@ impl RoutingConvention {
                     "tsx".to_string(),
                     "jsx".to_string(),
                 ],
+                segment_separator: None,
             },
             path_prefix: "/api".to_string(),
             dynamic_open: "[".to_string(),
@@ -128,6 +175,7 @@ impl RoutingConvention {
             group_open: "(".to_string(),
             group_close: ")".to_string(),
             method_source: MethodSource::DefaultExport,
+            method_exports: BTreeMap::new(),
         }
     }
 
@@ -150,6 +198,7 @@ impl RoutingConvention {
                 // `.mjs` are not Astro route extensions, and the SWC handler
                 // extractor doesn't parse TS syntax in `.mts` anyway.
                 extensions: vec!["ts".to_string(), "js".to_string()],
+                segment_separator: None,
             },
             path_prefix: String::new(),
             dynamic_open: "[".to_string(),
@@ -160,6 +209,49 @@ impl RoutingConvention {
             group_open: String::new(),
             group_close: String::new(),
             method_source: MethodSource::ExportName,
+            method_exports: BTreeMap::new(),
+        }
+    }
+
+    /// Flat file-based routes: the whole route chain is encoded in one
+    /// dot-separated filename under `app/routes` (`a.b.$id.ts` -> `/a/b/:id`),
+    /// dynamic segments are `$`-prefixed, a bare `$` is the splat, and the
+    /// route module exports a *read* handler and a *write* handler rather than
+    /// one export per HTTP method (carrick#473).
+    ///
+    /// Only `.ts`/`.js` files are treated as endpoints. That exclusion is the
+    /// precision wall of this convention: in these stacks `.tsx` route modules
+    /// are the UI page plane, which shares the same directory and the same
+    /// export names but is not an API surface.
+    pub fn flat_routes() -> Self {
+        Self {
+            name: "remix-flat".to_string(),
+            root_globs: vec!["app/routes".to_string(), "src/app/routes".to_string()],
+            segment_source: SegmentSource::FileName {
+                extensions: vec!["ts".to_string(), "js".to_string()],
+                segment_separator: Some(".".to_string()),
+            },
+            path_prefix: String::new(),
+            dynamic_open: "$".to_string(),
+            // The dynamic segment has no closing delimiter — `$id` runs to the
+            // end of the segment.
+            dynamic_close: String::new(),
+            // No catch-all marker: the splat is an *unnamed* dynamic segment
+            // (a bare `$`), which `transform_segment` maps to `**`.
+            catch_all_marker: String::new(),
+            // A `_`-prefixed segment is a pathless layout: it nests the module
+            // but contributes no path segment, exactly like a route group.
+            group_open: "_".to_string(),
+            group_close: String::new(),
+            method_source: MethodSource::ExportName,
+            method_exports: BTreeMap::from([
+                ("loader".to_string(), "GET".to_string()),
+                // The write export serves every non-GET method the route
+                // accepts; only POST is claimed, because emitting the whole
+                // write family would fabricate endpoints the module may not
+                // serve.
+                ("action".to_string(), "POST".to_string()),
+            ]),
         }
     }
 
@@ -205,19 +297,36 @@ impl RoutingConvention {
         // catch-all (see `path_matches_with_wildcards` in src/mount_graph.rs).
         // The param name plays no part in matching, so it is dropped. Catch-alls
         // are always terminal in these conventions, so `**` lands at the end.
+        // The doubled form only exists in schemes that bracket their dynamic
+        // segments; a delimiter-free scheme has no such spelling.
         let double_open = format!("{}{}", self.dynamic_open, self.dynamic_open);
         let double_close = format!("{}{}", self.dynamic_close, self.dynamic_close);
-        if raw.starts_with(&double_open) && raw.ends_with(&double_close) {
+        if !self.dynamic_close.is_empty()
+            && raw.starts_with(&double_open)
+            && raw.ends_with(&double_close)
+        {
             return Some("**".to_string());
         }
 
         // Dynamic segment "[id]" or catch-all "[...slug]".
-        if raw.starts_with(&self.dynamic_open) && raw.ends_with(&self.dynamic_close) {
+        if !self.dynamic_open.is_empty()
+            && raw.starts_with(&self.dynamic_open)
+            && raw.ends_with(&self.dynamic_close)
+            && raw.len() >= self.dynamic_open.len() + self.dynamic_close.len()
+        {
             let inner = &raw[self.dynamic_open.len()..raw.len() - self.dynamic_close.len()];
-            if inner.starts_with(&self.catch_all_marker) {
+            // An empty marker would make *every* dynamic segment a catch-all,
+            // so a convention without one opts out of the marker check.
+            if !self.catch_all_marker.is_empty() && inner.starts_with(&self.catch_all_marker) {
                 return Some("**".to_string());
             }
-            return Some(format!(":{}", sanitize_param(inner)));
+            // An unnamed dynamic segment (a bare `$`) matches whatever remains
+            // and is the splat of the delimiter-free flat schemes.
+            let param = sanitize_param(inner);
+            if param.is_empty() {
+                return Some("**".to_string());
+            }
+            return Some(format!(":{}", param));
         }
 
         // Literal segment.
@@ -241,7 +350,10 @@ impl RoutingConvention {
                 }
                 Some(dirs.iter().map(|s| s.to_string()).collect())
             }
-            SegmentSource::FileName { extensions } => {
+            SegmentSource::FileName {
+                extensions,
+                segment_separator,
+            } => {
                 // Skip framework-private files like _app / _document / _middleware.
                 if file.starts_with('_') {
                     return None;
@@ -251,10 +363,22 @@ impl RoutingConvention {
                     return None;
                 }
                 let mut segs: Vec<String> = dirs.iter().map(|s| s.to_string()).collect();
-                // `index` collapses to its directory; otherwise the stem is the
-                // final segment.
-                if stem != "index" {
-                    segs.push(stem.to_string());
+                // A flat scheme packs the whole chain into the stem; otherwise
+                // the stem is one segment.
+                let stem_segs: Vec<&str> = match segment_separator {
+                    Some(sep) if !sep.is_empty() => {
+                        stem.split(sep.as_str()).filter(|s| !s.is_empty()).collect()
+                    }
+                    _ => vec![stem],
+                };
+                // A trailing `index` collapses to its parent; every other piece
+                // is a path segment.
+                let last = stem_segs.len().saturating_sub(1);
+                for (i, seg) in stem_segs.iter().enumerate() {
+                    if i == last && *seg == "index" {
+                        continue;
+                    }
+                    segs.push((*seg).to_string());
                 }
                 Some(segs)
             }
@@ -304,6 +428,7 @@ pub fn derive_route(rel_path: &Path, conventions: &[RoutingConvention]) -> Optio
             path: full,
             method_source: convention.method_source.clone(),
             convention: convention.name.clone(),
+            method_exports: convention.method_exports.clone(),
         });
     }
     None
@@ -321,6 +446,9 @@ pub fn builtin_conventions(frameworks: &[String]) -> Vec<RoutingConvention> {
     }
     if mentions("astro") {
         out.push(RoutingConvention::astro());
+    }
+    if mentions("remix") {
+        out.push(RoutingConvention::flat_routes());
     }
     out
 }
@@ -516,6 +644,122 @@ mod tests {
         let astro = builtin_conventions(&["Astro".to_string()]);
         assert_eq!(astro.len(), 1);
         assert_eq!(astro[0].name, "astro");
+    }
+
+    // --- Flat routes (dot-separated filename) ---
+
+    fn flat_route(p: &str) -> Option<DerivedRoute> {
+        derive_route(&PathBuf::from(p), &[RoutingConvention::flat_routes()])
+    }
+
+    #[test]
+    fn flat_routes_filename_dots_become_segments() {
+        let r = flat_route("app/routes/api.v1.widgets.ts").unwrap();
+        assert_eq!(r.path, "/api/v1/widgets");
+        assert_eq!(r.method_source, MethodSource::ExportName);
+        assert_eq!(r.convention, "remix-flat");
+    }
+
+    #[test]
+    fn flat_routes_dollar_params_become_colon_params() {
+        assert_eq!(
+            flat_route("app/routes/api.v1.widgets.$widgetId.activate.ts")
+                .unwrap()
+                .path,
+            "/api/v1/widgets/:widgetId/activate"
+        );
+        // Several params in one filename, including adjacent ones.
+        assert_eq!(
+            flat_route("app/routes/api.v1.projects.$projectRef.$env.ts")
+                .unwrap()
+                .path,
+            "/api/v1/projects/:projectRef/:env"
+        );
+    }
+
+    #[test]
+    fn flat_routes_bare_dollar_is_a_splat() {
+        // An unnamed dynamic segment matches everything that remains.
+        assert_eq!(
+            flat_route("app/routes/api.v1.packets.$.ts").unwrap().path,
+            "/api/v1/packets/**"
+        );
+    }
+
+    #[test]
+    fn flat_routes_pathless_layout_segments_contribute_no_path() {
+        // `_`-prefixed segments nest the module without adding a path segment.
+        assert_eq!(
+            flat_route("app/routes/widgets._layout.$widgetId.ts")
+                .unwrap()
+                .path,
+            "/widgets/:widgetId"
+        );
+    }
+
+    #[test]
+    fn flat_routes_trailing_index_collapses() {
+        assert_eq!(
+            flat_route("app/routes/api.v1.widgets.index.ts")
+                .unwrap()
+                .path,
+            "/api/v1/widgets"
+        );
+    }
+
+    #[test]
+    fn flat_routes_src_prefixed_root() {
+        assert_eq!(
+            flat_route("src/app/routes/api.health.ts").unwrap().path,
+            "/api/health"
+        );
+    }
+
+    #[test]
+    fn flat_routes_exclude_the_ui_page_plane() {
+        // `.tsx` route modules under the same directory are UI pages, not API
+        // endpoints — this exclusion is the convention's precision wall.
+        assert!(flat_route("app/routes/api.v1.widgets.$widgetId.tsx").is_none());
+        assert!(flat_route("app/routes/widgets.$widgetId.jsx").is_none());
+    }
+
+    #[test]
+    fn flat_routes_ignore_non_route_files_and_private_files() {
+        assert!(flat_route("app/services/widgets.server.ts").is_none());
+        assert!(flat_route("app/lib/api.v1.widgets.ts").is_none());
+        // Leading-underscore *files* stay excluded (framework-private).
+        assert!(flat_route("app/routes/_app.widgets.ts").is_none());
+    }
+
+    #[test]
+    fn flat_routes_gated_on_framework_detection() {
+        assert!(builtin_conventions(&["express".to_string()]).is_empty());
+        let flat = builtin_conventions(&["Remix".to_string()]);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(flat[0].name, "remix-flat");
+    }
+
+    #[test]
+    fn flat_routes_map_role_exports_to_methods() {
+        let r = flat_route("app/routes/api.v1.widgets.ts").unwrap();
+        assert_eq!(r.http_method_for_export("loader").as_deref(), Some("GET"));
+        assert_eq!(r.http_method_for_export("action").as_deref(), Some("POST"));
+        // Anything the convention doesn't name is not a handler.
+        assert_eq!(r.http_method_for_export("config"), None);
+        assert_eq!(r.http_method_for_export("default"), None);
+        // A method-named export is still its own method.
+        assert_eq!(r.http_method_for_export("GET").as_deref(), Some("GET"));
+    }
+
+    #[test]
+    fn method_named_exports_need_no_alias_map() {
+        // The app-router conventions carry no alias map; method-named exports
+        // resolve on their own name, and nothing else resolves at all.
+        let r = route("app/users/route.ts").unwrap();
+        assert!(r.method_exports.is_empty());
+        assert_eq!(r.http_method_for_export("POST").as_deref(), Some("POST"));
+        assert_eq!(r.http_method_for_export("loader"), None);
+        assert_eq!(r.http_method_for_export("runtime"), None);
     }
 
     // --- Negative / boundary ---

--- a/tests/file_based_routing_test.rs
+++ b/tests/file_based_routing_test.rs
@@ -2,7 +2,7 @@
 //!
 //! The unit tests in `src/file_based_router.rs` and `src/agents/file_orchestrator.rs`
 //! feed synthetic string paths into the deriver. These tests instead walk the
-//! actual fixture trees under `tests/fixtures/{nextjs-app,astro}` and run them
+//! actual fixture trees under `tests/fixtures/{nextjs-app,astro,remix-flat}` and run them
 //! through the same deterministic synthesis the orchestrator uses in production
 //! (`FileOrchestrator::file_based_endpoints` over `builtin_conventions`), so a
 //! regression in route derivation, the SWC handler extractor, or the framework
@@ -152,6 +152,76 @@ fn astro_fixture_derives_expected_routes() {
         "astro fixture should yield endpoints from .ts/.js files only — \
          skipping index.astro, _helpers.ts, and the `prerender` export"
     );
+}
+
+/// carrick#473: flat routes pack the whole route chain into one dot-separated
+/// filename, and their route modules export a *read* handler and a *write*
+/// handler rather than one export per HTTP method. Crucially, those handlers
+/// are often the RESULT OF A CALL — a route-builder factory owns auth, parsing
+/// and the response envelope — so the module contains no HTTP registration and
+/// no path literal at all. Measured on a large OSS TypeScript monorepo, 86 of
+/// its 140 internal route files were `Skipped (no API patterns)` for exactly
+/// this reason.
+///
+/// The fixture locks both the recall and the precision side: the declared and
+/// called forms must derive identically, while the UI page plane (`.tsx`),
+/// framework-private files, and non-handler exports must derive nothing.
+#[test]
+fn flat_routes_fixture_derives_expected_routes() {
+    let routes = synthesized_routes("remix-flat", &builtin_conventions(&["Remix".to_string()]));
+
+    let expected: BTreeSet<String> = [
+        // Call-expression export, dot-separated path, `$param` -> `:param`.
+        "POST /api/v1/widgets/:widgetId/activate",
+        "GET /api/v1/widgets/:widgetId",
+        // Declared-function exports derive exactly the same way.
+        "GET /api/v1/widgets",
+        "POST /api/v1/widgets",
+        // Bare `$` is the splat; a trailing `index` collapses onto its parent
+        // (which is why `/api/v1/widgets` above is not duplicated).
+        "GET /api/v1/blobs/**",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+
+    assert_eq!(
+        routes, expected,
+        "flat-route fixture should yield the .ts route handlers only — \
+         skipping the .tsx page plane, the `_`-prefixed module, and the \
+         `config`/helper exports, and never deriving from the route builder \
+         module itself"
+    );
+}
+
+#[test]
+fn flat_route_convention_rejects_a_non_flat_layout() {
+    // The convention must be scoped by its own root and grammar, not merely by
+    // the framework gate: run a non-empty flat convention over the app-router
+    // and astro trees and expect nothing.
+    let conventions = builtin_conventions(&["Remix".to_string()]);
+    for fixture in ["nextjs-app", "astro"] {
+        let routes = synthesized_routes(fixture, &conventions);
+        assert!(
+            routes.is_empty(),
+            "flat-route conventions must not match {fixture} files, got {routes:?}"
+        );
+    }
+}
+
+#[test]
+fn other_conventions_reject_the_flat_route_layout() {
+    // The reverse containment: the app-router/astro conventions must not claim
+    // flat-route files, so adding this convention cannot re-interpret a repo
+    // that another convention already covers.
+    for framework in ["Next.js", "Astro"] {
+        let routes =
+            synthesized_routes("remix-flat", &builtin_conventions(&[framework.to_string()]));
+        assert!(
+            routes.is_empty(),
+            "{framework} conventions must not match flat-route files, got {routes:?}"
+        );
+    }
 }
 
 #[test]

--- a/tests/fixtures/remix-flat/app/routes/_app.widgets.$widgetId.ts
+++ b/tests/fixtures/remix-flat/app/routes/_app.widgets.$widgetId.ts
@@ -1,0 +1,6 @@
+// A framework-private (leading `_`) route file: excluded, like every other
+// `_`-prefixed module under a filename-derived convention.
+
+export const loader = makeLayoutRoute(async () => ({}));
+
+declare function makeLayoutRoute(handler: () => Promise<unknown>): unknown;

--- a/tests/fixtures/remix-flat/app/routes/api.v1.blobs.$.ts
+++ b/tests/fixtures/remix-flat/app/routes/api.v1.blobs.$.ts
@@ -1,0 +1,5 @@
+// A bare `$` segment is the splat: it matches everything that remains.
+
+export const loader = makeStreamRoute(async () => new Response("blob"));
+
+declare function makeStreamRoute(handler: () => Promise<Response>): unknown;

--- a/tests/fixtures/remix-flat/app/routes/api.v1.widgets.$widgetId.activate.ts
+++ b/tests/fixtures/remix-flat/app/routes/api.v1.widgets.$widgetId.activate.ts
@@ -1,0 +1,20 @@
+// Flat route module: the path is the filename
+// (api.v1.widgets.$widgetId.activate.ts -> /api/v1/widgets/:widgetId/activate)
+// and the handler is the RESULT OF A CALL, not a declared function. There is
+// no HTTP registration and no path literal anywhere in these bytes, so the
+// endpoint can only come from the export's name + the module's location.
+
+import { makeApiRoute } from "~/services/routeBuilders/apiBuilder.server";
+
+type ActivateResponse = { widgetId: string; active: boolean };
+
+const ActivateBody = {
+  parse: (input: unknown) => input as { reason: string },
+};
+
+export const action = makeApiRoute(
+  { body: ActivateBody },
+  async ({ params }): Promise<ActivateResponse> => {
+    return { widgetId: String(params.widgetId), active: true };
+  },
+);

--- a/tests/fixtures/remix-flat/app/routes/api.v1.widgets.$widgetId.ts
+++ b/tests/fixtures/remix-flat/app/routes/api.v1.widgets.$widgetId.ts
@@ -1,0 +1,17 @@
+// The read half of the same shape: a call-expression export named for the
+// read role, which serves GET.
+
+import { makeReadRoute } from "~/services/routeBuilders/apiBuilder.server";
+
+type Widget = { id: string; name: string };
+
+export const loader = makeReadRoute({}, async ({ params }): Promise<Widget> => {
+  return { id: String(params.widgetId), name: "hex-key" };
+});
+
+// Not a handler — a route module may export helpers and config alongside its
+// handlers, and those must never become endpoints.
+export const config = { maxDuration: 30 };
+export function serializeWidget(widget: Widget): string {
+  return JSON.stringify(widget);
+}

--- a/tests/fixtures/remix-flat/app/routes/api.v1.widgets.index.ts
+++ b/tests/fixtures/remix-flat/app/routes/api.v1.widgets.index.ts
@@ -1,0 +1,5 @@
+// A trailing `index` segment collapses onto its parent path.
+
+export const loader = makeIndexRoute(async () => []);
+
+declare function makeIndexRoute(handler: () => Promise<unknown[]>): unknown;

--- a/tests/fixtures/remix-flat/app/routes/api.v1.widgets.ts
+++ b/tests/fixtures/remix-flat/app/routes/api.v1.widgets.ts
@@ -1,0 +1,13 @@
+// The declared-function form of the same convention: it must derive exactly
+// like the call-expression form above.
+
+type Widget = { id: string; name: string };
+
+export async function loader(): Promise<Widget[]> {
+  return [{ id: "1", name: "hex-key" }];
+}
+
+export async function action({ request }: { request: Request }): Promise<Widget> {
+  const body = (await request.json()) as { name: string };
+  return { id: "2", name: body.name };
+}

--- a/tests/fixtures/remix-flat/app/routes/widgets.$widgetId.tsx
+++ b/tests/fixtures/remix-flat/app/routes/widgets.$widgetId.tsx
@@ -1,0 +1,11 @@
+// The UI page plane shares the directory, the filename grammar AND the export
+// names with the API plane. Excluding `.tsx` is what keeps every page in the
+// app out of the endpoint index.
+
+export const loader = makePageLoader(async () => ({ title: "Widget" }));
+
+export default function WidgetPage() {
+  return null;
+}
+
+declare function makePageLoader(handler: () => Promise<unknown>): unknown;

--- a/tests/fixtures/remix-flat/app/services/routeBuilders/apiBuilder.server.ts
+++ b/tests/fixtures/remix-flat/app/services/routeBuilders/apiBuilder.server.ts
@@ -1,0 +1,28 @@
+// A route-builder factory: it owns auth, body parsing and the response
+// envelope, and returns the handler the route module exports. Nothing here is
+// an HTTP registration a call-site scan can see — the route's path lives in
+// the *filename* of the module that calls this, and its method in the name of
+// the export that holds the result.
+
+type Schema = { parse: (input: unknown) => unknown };
+
+type RouteOptions = {
+  body?: Schema;
+  params?: Schema;
+};
+
+type Handler<T> = (args: {
+  body: unknown;
+  params: Record<string, string>;
+}) => Promise<T>;
+
+export function makeApiRoute<T>(options: RouteOptions, handler: Handler<T>) {
+  return async (request: Request) => {
+    const parsed = options.body ? options.body.parse(await request.json()) : {};
+    return handler({ body: parsed, params: {} });
+  };
+}
+
+export function makeReadRoute<T>(options: RouteOptions, handler: Handler<T>) {
+  return makeApiRoute(options, handler);
+}


### PR DESCRIPTION
## The defect

Measured on a large OSS TypeScript monorepo: 86 of its 140 internal API route files were `Skipped (no API patterns)`, never reaching the file analyzer, so their endpoints could not enter the index by any downstream policy (#463).

Those route modules encode the whole route chain in one dot-separated filename, and export a read handler and a write handler rather than one export per HTTP method. The handlers are typically the result of a route-builder factory call, so the module holds no HTTP registration and no path literal anywhere — zero SWC candidates, skipped before analysis.

## Mechanism (the issue's framing, corrected by measurement)

The issue attributed the skip to the handler being a *call expression* rather than a function declaration. Probing the evidence repo offline shows that is a correlation, not the cause:

- `SwcScanner::exported_handlers` already reports `export const action = factory(...)` — the call-expression export was never invisible (`export: action line 8 span 410..1115` on the evidence file).
- A sibling module with a plain `export async function loader` raised **0 candidates too**. The declared/called distinction is not the discriminator.

The real gap: **no convention claimed the route plane at all**, so `derive_route` returned `None` and the file-based synthesis path was dead for every one of the 140 files. The ~54 that did index got in on *incidental* candidates (one had a `request.json()` call at line 45), after which the analyzer derived the path from the file path in the prompt. Recall was hostage to whether a route module happened to contain an unrelated recognizable call.

## The fix

Everything added is plain convention data, executed by the existing deriver — no framework branch in the executor, no factory or helper names anywhere:

- `SegmentSource::FileName` gains `segment_separator`: the stem splits into a segment chain (`a.b.$id.ts` → `/a/b/:id`) instead of being one segment.
- `RoutingConvention::method_exports` maps conventional handler export names to the method they serve. `DerivedRoute::http_method_for_export` resolves an export through it — an export named for a method still *is* that method, and an export the convention does not name yields nothing.
- `transform_segment` treats an unnamed dynamic segment as a splat and ignores an empty catch-all marker, so a delimiter-free dynamic syntax (`$id`, bare `$`) needs no special-casing.
- `builtin_conventions` gains the flat-routes bootstrap entry, alongside the existing app-router/pages-router/astro ones (the module's designated — and only — place for a framework name; a convention supplied by detection or `carrick.json` still overrides).

`file_based_endpoints` now resolves the method through the convention instead of filtering on `is_http_method`, so a factory-built handler anchors on its export's span exactly as a declared one does.

### Precision guards

- Only files an existing convention claims derive anything — the same gate, not a parallel one.
- `.ts`/`.js` only. The UI page plane (`.tsx`) shares the directory, the filename grammar *and* the export names; excluding it is what keeps every page in the app out of the endpoint index.
- Endpoints stay span-anchored on the export, so the normal candidate join applies downstream; no unanchored entries.
- Non-handler exports (`config`, helpers, types) derive nothing.
- No prompt or response-schema changes.

## Offline repro (`CARRICK_MOCK_ALL=1`, no LLM spend, no network)

Both arms run the **same** config — a mock fixture pinning framework detection — over a route module from the evidence repo, so the only variable is the code:

Before (`origin/main`):
```
Detected frameworks: ["remix"]
Skipped (no API patterns): <repro-repo>/app/routes/engine.v1.worker-actions.runs.$runFriendlyId.snapshots.$snapshotFriendlyId.attempts.complete.ts [0 candidates]
Indexed **0 endpoints** and **0 cross-service calls**.
```

After (this branch):
```
Detected frameworks: ["remix"]
Structural route(s) (no call-site candidates): <repro-repo>/app/routes/engine.v1.worker-actions.runs.$runFriendlyId.snapshots.$snapshotFriendlyId.attempts.complete.ts [1 file-based, 0 route-descriptor]
Indexed **1 endpoints** and **0 cross-service calls**.
```
```
| `POST` | `/engine/v1/worker-actions/runs/:runFriendlyId/snapshots/:snapshotFriendlyId/attempts/complete` |
```

Across the evidence repo's whole route plane the same synthesis derives 308 endpoints from its 262 top-level `.ts` route modules, where previously this path derived nothing. That 308 is not the recall gain against the issue's census: it includes the plain-function `loader`/`action` resource routes that were never among the 140 internal API route files. The 86 measured skips are a subset of it.

## Tests

Invented fixture tree `tests/fixtures/remix-flat/`, wired into `tests/file_based_routing_test.rs` alongside the app-router and astro cases. `flat_routes_fixture_derives_expected_routes` fails on `main` (derives `{}`) and passes here.

- Path derivation unit tests: dots → segments, `$param` → `:param`, bare `$` → splat, pathless `_` segments, trailing `index` collapse, `src/`-prefixed root, framework gate, role-export → method resolution.
- Synthesis unit tests: factory-call export → `POST` + derived path; `loader` → `GET`; declared and called forms of the same module derive identically; non-handler exports ignored.
- Negative: the same call-expression export outside the route root, and in the `.tsx` page plane, derives nothing. Two containment tests assert the new convention rejects the app-router/astro trees and that those conventions reject this one.

Gate: `cargo test` (sidecar built), `cargo fmt`, `cargo clippy --all-targets -D warnings` all clean.

## Residuals (not covered by this fix)

- **Framework-gated.** The convention is inert unless framework detection reports a string containing `remix`. That is the cloud's call and cannot be verified from this repo.
- **`_`-prefixed route files stay excluded.** `raw_segments` rejects them as framework-private, which is right for the layout plane but also drops 2 of the 86 measured files (and a number of the declared-handler siblings). Deliberate: relaxing it would pull the whole `_app.*` UI plane in.
- **Only `POST` is claimed for the write export.** It serves the whole non-GET family; emitting `PUT`/`PATCH`/`DELETE` as well would fabricate endpoints the module may not serve.
- **Flat-*folder* modules (`some.route.name/route.ts`) are not claimed** by the filename rule. On the evidence repo one such module is a `.ts`; the other 149 are `route.tsx` and would be excluded by the page-plane rule regardless (their classification was not enumerated).
- **Double-counting is likely, not hypothetical.** The ~54 files that already indexed via the analyzer now also derive structurally. `merge_file_based_endpoints` dedupes on exact (method, path), and `canonicalize_route_path` normalizes `[id]` -> `:id` but does nothing to `$id` or to dots. #463 measured the analyzer's filename-echo as unreliable in exactly this grammar (layout prefix retained, params unconverted, dots not slashes), so a divergent analyzer path — and therefore two entries for one route — should be expected. The next full run of such a repo should be checked for paired entries; if they show up, the canonicalizer is the place to fix it.
- **#474 (alias import resolution) is unaffected** and still open; this fix removes the need for the wrapper rescue on this shape rather than fixing that resolver.

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
