### PR TITLE
fix(engine): bump CACHE_VERSION so 0.3.5 extraction changes reach unchanged files

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -44,11 +44,18 @@ use swc_ecma_visit::VisitWith;
 
 mod type_compat_v2;
 
-/// Current cache format version. Increment when FileAnalysisResult schema changes.
+/// Current cache format version. Increment when FileAnalysisResult schema
+/// changes — or when extraction itself changes what an unchanged file yields
+/// (#478: a previously-skipped file is cached as an empty result, so routing
+/// improvements never reach it; the durable per-file re-routing design is
+/// tracked there).
 /// 4: EndpointResult gained `emission_style` — pre-4 cached results would
 /// replay with `None` forever and never take the return-value/no-payload
 /// inference paths for unchanged files.
-const CACHE_VERSION: u32 = 4;
+/// 5: routing/extraction changes (file-based route conventions from declared
+/// dependencies, wrapper barrel-following, injected-base canonical keys) alter
+/// what unchanged files produce; cached skips from ≤0.3.4 must not pin them.
+const CACHE_VERSION: u32 = 5;
 
 // Type aliases to reduce complexity
 type FileDiscoveryResult = Result<


### PR DESCRIPTION
Interim mechanism for #478: cached empty results from the zero-candidate skip path pin old routing decisions forever — a "same bytes, better scanner" release never re-examines them. Measured consequence on a large OSS TypeScript monorepo: the 0.3.4 re-scan produced zero change from the #469/#470/#475/#476 fixes (8 analyzer calls, everything else replayed from cache).

One version bump invalidates the incremental cache so the next scan of every repo re-analyzes under current routing. Cost: one full-analysis scan per repo, once. The durable design (re-route cached skips every scan, analyze only files whose routing outcome changed) remains tracked on #478 — this PR deliberately does not attempt it.

Refs #478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)