### PR TITLE
feat(visitor): index class methods as first-class functions (#483)

### DIFF
--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -115,19 +115,21 @@ fn body_references_identifier(body: &str, name: &str) -> bool {
 /// Does `body` (the body of the function keyed `caller_key`) reference the
 /// local function keyed `candidate_key`?
 ///
-/// Class members are keyed as `Class.member` (see FunctionDefinitionExtractor),
+/// Class members are keyed as `Class.member` (see FunctionDefinitionExtractor;
+/// a static colliding with a same-named instance member is `Class.static.member`),
 /// but call sites reference the bare member name (`foo(...)`, `this.foo(...)`,
 /// `Class.foo(...)`) — never the dotted key as one identifier. So identifier
-/// matching runs on the bare name, and a method callee additionally requires
-/// either the same enclosing class as the caller (the `this.foo()` case) or a
-/// reference to its class name in the body (the `Class.foo()` case).
+/// matching runs on the bare name (the LAST segment), and a method callee
+/// additionally requires class evidence from the FIRST segment: either the same
+/// enclosing class as the caller (the `this.foo()` case) or a reference to its
+/// class name in the body (the `Class.foo()` case).
 /// Module-level functions keep the exact pre-existing behaviour.
 fn is_local_callee(caller_key: &str, body: &str, candidate_key: &str) -> bool {
     fn bare_name(key: &str) -> &str {
         key.rsplit_once('.').map_or(key, |(_, tail)| tail)
     }
     fn class_of(key: &str) -> Option<&str> {
-        key.rsplit_once('.').map(|(head, _)| head)
+        key.split_once('.').map(|(head, _)| head)
     }
     candidate_key != caller_key
         && body_references_identifier(body, bare_name(candidate_key))
@@ -936,6 +938,29 @@ mod tests {
             "OrderController.submit",
             "return UserService.create(payload);",
             "UserService.create"
+        ));
+    }
+
+    #[test]
+    fn collision_qualified_static_keys_resolve_class_from_first_segment() {
+        // `Counter.static.create` (a static colliding with an instance member):
+        // bare name is the LAST segment, class evidence the FIRST.
+        assert!(is_local_callee(
+            "main",
+            "return Counter.create(1);",
+            "Counter.static.create"
+        ));
+        // Same-class caller links too.
+        assert!(is_local_callee(
+            "Counter.report",
+            "return Counter.create(1);",
+            "Counter.static.create"
+        ));
+        // No class evidence, no edge.
+        assert!(!is_local_callee(
+            "Other.run",
+            "return this.create(1);",
+            "Counter.static.create"
         ));
     }
 

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -112,6 +112,34 @@ fn body_references_identifier(body: &str, name: &str) -> bool {
     false
 }
 
+/// Does `body` (the body of the function keyed `caller_key`) reference the
+/// local function keyed `candidate_key`?
+///
+/// Class members are keyed as `Class.member` (see FunctionDefinitionExtractor),
+/// but call sites reference the bare member name (`foo(...)`, `this.foo(...)`,
+/// `Class.foo(...)`) — never the dotted key as one identifier. So identifier
+/// matching runs on the bare name, and a method callee additionally requires
+/// either the same enclosing class as the caller (the `this.foo()` case) or a
+/// reference to its class name in the body (the `Class.foo()` case).
+/// Module-level functions keep the exact pre-existing behaviour.
+fn is_local_callee(caller_key: &str, body: &str, candidate_key: &str) -> bool {
+    fn bare_name(key: &str) -> &str {
+        key.rsplit_once('.').map_or(key, |(_, tail)| tail)
+    }
+    fn class_of(key: &str) -> Option<&str> {
+        key.rsplit_once('.').map(|(head, _)| head)
+    }
+    candidate_key != caller_key
+        && body_references_identifier(body, bare_name(candidate_key))
+        && match class_of(candidate_key) {
+            None => true,
+            Some(callee_class) => {
+                class_of(caller_key) == Some(callee_class)
+                    || body_references_identifier(body, callee_class)
+            }
+        }
+}
+
 /// Generate intents for every function with a non-trivial body source,
 /// regardless of export status. The only exclusion is a trivial body
 /// (single line, at most [`TRIVIAL_BODY_MAX_CHARS`] chars), which keeps
@@ -167,9 +195,7 @@ pub async fn generate_function_intents(
         {
             let called: Vec<String> = local_fn_names
                 .iter()
-                .filter(|&&fn_name| {
-                    fn_name != name.as_str() && body_references_identifier(body, fn_name)
-                })
+                .filter(|&&fn_name| is_local_callee(name, body, fn_name))
                 .map(|&s| s.to_string())
                 .collect();
             deps.insert(name.clone(), called);
@@ -868,5 +894,58 @@ mod tests {
             Some("Mock intent: function does something.")
         );
         assert!(defs["main"].intent_input_hash.is_some());
+    }
+
+    #[test]
+    fn method_callee_matches_this_calls_within_the_same_class() {
+        // `Presenter.toJson` calls `this.isFinished(...)`: same class, so the
+        // bare-name match is enough.
+        assert!(is_local_callee(
+            "Presenter.toJson",
+            "return { done: this.isFinished(status) };",
+            "Presenter.isFinished"
+        ));
+        // Private members work the same way (`this.#reload()`).
+        assert!(is_local_callee(
+            "Job.run",
+            "await this.#reload();",
+            "Job.#reload"
+        ));
+    }
+
+    #[test]
+    fn method_callee_matches_static_calls_via_class_name() {
+        assert!(is_local_callee(
+            "serialiseRun",
+            "return Presenter.isFinished(status);",
+            "Presenter.isFinished"
+        ));
+    }
+
+    #[test]
+    fn method_callee_requires_class_evidence_across_classes() {
+        // Another class has a same-named method; a bare `this.create(...)`
+        // in an unrelated class must not link to it.
+        assert!(!is_local_callee(
+            "OrderController.submit",
+            "return this.create(payload);",
+            "UserService.create"
+        ));
+        // ...but naming the class is evidence enough.
+        assert!(is_local_callee(
+            "OrderController.submit",
+            "return UserService.create(payload);",
+            "UserService.create"
+        ));
+    }
+
+    #[test]
+    fn module_level_callees_keep_pre_existing_behaviour() {
+        assert!(is_local_callee("main", "return helper();", "helper"));
+        assert!(!is_local_callee("main", "return userHelper();", "helper"));
+        // Self-reference is never an edge.
+        assert!(!is_local_callee("helper", "return helper();", "helper"));
+        // A method body referencing a module-level function links normally.
+        assert!(is_local_callee("Svc.run", "return helper();", "helper"));
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -312,6 +312,10 @@ pub struct FunctionDefinitionExtractor {
     /// are indexed as `Class.member`; None inside anonymous class expressions,
     /// whose members cannot be given a stable name.
     current_class: Option<String>,
+    /// Member names of the current class that exist as BOTH a static and an
+    /// instance member — the one case where `Class.member` would collide on a
+    /// single key. The static side is keyed `Class.static.member` instead.
+    current_class_collisions: HashSet<String>,
 }
 
 impl FunctionDefinitionExtractor {
@@ -325,6 +329,7 @@ impl FunctionDefinitionExtractor {
             source_map,
             exported_names: HashSet::new(),
             current_class: None,
+            current_class_collisions: HashSet::new(),
         }
     }
 
@@ -497,11 +502,55 @@ impl FunctionDefinitionExtractor {
     }
 
     /// Resolve a class-member key to its name, if it has a statically-known one.
+    /// String-literal names containing `.` are rejected: they would make the
+    /// `Class.member` key ambiguous for everything that parses it
+    /// (`finalize_exports`, the intent generator's class-evidence check).
     fn prop_name_to_string(key: &PropName) -> Option<String> {
         match key {
             PropName::Ident(ident) => Some(ident.sym.to_string()),
-            PropName::Str(s) => Some(s.value.to_string()),
+            PropName::Str(s) if !s.value.contains('.') => Some(s.value.to_string()),
             _ => None,
+        }
+    }
+
+    /// Member names defined as BOTH a static and an instance member of the
+    /// class — the one shape where `Class.member` would collide on a single
+    /// map key. Private members are tracked with their `#` prefix, so they
+    /// can never collide with a same-named public member.
+    fn static_instance_collisions(class: &Class) -> HashSet<String> {
+        let mut static_names = HashSet::new();
+        let mut instance_names = HashSet::new();
+        for member in &class.body {
+            let (name, is_static) = match member {
+                ClassMember::Method(m) => (Self::prop_name_to_string(&m.key), m.is_static),
+                ClassMember::ClassProp(p) => (Self::prop_name_to_string(&p.key), p.is_static),
+                ClassMember::PrivateMethod(m) => (Some(format!("#{}", m.key.name)), m.is_static),
+                _ => continue,
+            };
+            if let Some(name) = name {
+                if is_static {
+                    static_names.insert(name);
+                } else {
+                    instance_names.insert(name);
+                }
+            }
+        }
+        static_names
+            .intersection(&instance_names)
+            .cloned()
+            .collect()
+    }
+
+    /// Key for a class member. The instance member keeps `Class.member`; when
+    /// a same-named static member also exists, the static side is keyed
+    /// `Class.static.member` so neither definition silently overwrites the
+    /// other. Parsers of these keys take the class from the FIRST `.` and the
+    /// member from the LAST, so both forms resolve correctly.
+    fn member_key(&self, class_name: &str, member_name: &str, is_static: bool) -> String {
+        if is_static && self.current_class_collisions.contains(member_name) {
+            format!("{class_name}.static.{member_name}")
+        } else {
+            format!("{class_name}.{member_name}")
         }
     }
 
@@ -804,8 +853,13 @@ impl Visit for FunctionDefinitionExtractor {
     /// Track the enclosing class name so members can be indexed as `Class.member`.
     fn visit_class_decl(&mut self, class: &ClassDecl) {
         let prev = self.current_class.replace(class.ident.sym.to_string());
+        let prev_collisions = std::mem::replace(
+            &mut self.current_class_collisions,
+            Self::static_instance_collisions(&class.class),
+        );
         class.visit_children_with(self);
         self.current_class = prev;
+        self.current_class_collisions = prev_collisions;
     }
 
     /// Class expressions (`const Foo = class { ... }`, `export default class Foo`).
@@ -816,11 +870,17 @@ impl Visit for FunctionDefinitionExtractor {
             Some(ident) => self.current_class.replace(ident.sym.to_string()),
             None => self.current_class.take(),
         };
+        let prev_collisions = std::mem::replace(
+            &mut self.current_class_collisions,
+            Self::static_instance_collisions(&class.class),
+        );
         class.visit_children_with(self);
         self.current_class = prev;
+        self.current_class_collisions = prev_collisions;
     }
 
-    /// Index class methods (static and instance) as `Class.method`.
+    /// Index class methods (static and instance) as `Class.method` (see
+    /// `member_key` for the static/instance collision case).
     /// Getters are included (`Class.name` — they carry real logic surprisingly
     /// often); setters are skipped so a getter/setter pair doesn't collide on
     /// one key.
@@ -829,7 +889,8 @@ impl Visit for FunctionDefinitionExtractor {
             && !matches!(method.kind, MethodKind::Setter)
             && let Some(member_name) = Self::prop_name_to_string(&method.key)
         {
-            self.insert_method_definition(format!("{class_name}.{member_name}"), &method.function);
+            let name = self.member_key(&class_name, &member_name, method.is_static);
+            self.insert_method_definition(name, &method.function);
         }
         method.visit_children_with(self);
     }
@@ -839,7 +900,8 @@ impl Visit for FunctionDefinitionExtractor {
         if let Some(class_name) = self.current_class.clone()
             && !matches!(method.kind, MethodKind::Setter)
         {
-            let name = format!("{class_name}.#{}", method.key.name);
+            let member_name = format!("#{}", method.key.name);
+            let name = self.member_key(&class_name, &member_name, method.is_static);
             self.insert_method_definition(name, &method.function);
         }
         method.visit_children_with(self);
@@ -853,7 +915,7 @@ impl Visit for FunctionDefinitionExtractor {
             && let Some(member_name) = Self::prop_name_to_string(&prop.key)
             && let Some(init) = &prop.value
         {
-            let name = format!("{class_name}.{member_name}");
+            let name = self.member_key(&class_name, &member_name, prop.is_static);
             match &**init {
                 Expr::Arrow(arrow) => self.insert_arrow_definition(name, arrow),
                 Expr::Fn(fn_expr) => self.insert_method_definition(name, &fn_expr.function),
@@ -1676,6 +1738,57 @@ mod tests {
         assert!(defs.contains_key("Svc.run"));
         let helper = defs.get("helper").expect("module function still indexed");
         assert!(!helper.name.contains('.'));
+    }
+
+    #[test]
+    fn static_instance_collision_gets_distinct_keys() {
+        let defs = extract(
+            "export class Counter {\n\
+               static create(seed: number): Counter { return new Counter(); }\n\
+               create(step: number): number { return step + 1; }\n\
+             }",
+        );
+        let instance = defs
+            .get("Counter.create")
+            .expect("instance member keeps the plain key");
+        assert_eq!(instance.arguments[0].name, "step");
+        let stat = defs
+            .get("Counter.static.create")
+            .expect("colliding static member gets the qualified key");
+        assert_eq!(stat.arguments[0].name, "seed");
+        assert!(
+            stat.is_exported && instance.is_exported,
+            "export propagation parses the class from the FIRST dot"
+        );
+    }
+
+    #[test]
+    fn non_colliding_static_keeps_plain_key() {
+        let defs = extract(
+            "class Presenter { static isFinished(s: string): boolean { return s === \"DONE\"; } }",
+        );
+        assert!(defs.contains_key("Presenter.isFinished"));
+        assert!(!defs.keys().any(|k| k.contains(".static.")));
+    }
+
+    #[test]
+    fn string_literal_member_containing_dot_is_skipped() {
+        let defs = extract(
+            "class Api {\n\
+               \"a.b\"(): number { return 1; }\n\
+               \"plain\"(): number { return 2; }\n\
+             }",
+        );
+        assert!(
+            defs.contains_key("Api.plain"),
+            "dot-free string keys are indexed"
+        );
+        assert_eq!(
+            defs.len(),
+            1,
+            "a string key containing '.' would break the Class.member invariant; got {:?}",
+            defs.keys().collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -308,6 +308,10 @@ pub struct FunctionDefinitionExtractor {
     source_map: swc_common::sync::Lrc<swc_common::SourceMap>,
     /// Names of functions that are exported (populated by visit_export_decl / visit_named_export)
     exported_names: HashSet<String>,
+    /// Name of the class whose body is currently being visited. Class members
+    /// are indexed as `Class.member`; None inside anonymous class expressions,
+    /// whose members cannot be given a stable name.
+    current_class: Option<String>,
 }
 
 impl FunctionDefinitionExtractor {
@@ -320,6 +324,7 @@ impl FunctionDefinitionExtractor {
             current_file_path: file_path,
             source_map,
             exported_names: HashSet::new(),
+            current_class: None,
         }
     }
 
@@ -478,12 +483,98 @@ impl FunctionDefinitionExtractor {
 
     /// Mark functions as exported based on collected export names.
     /// Call this after `module.visit_with()` completes.
+    /// A class member (`Class.member`) is exported iff its class is.
     pub fn finalize_exports(&mut self) {
         for (name, def) in self.function_definitions.iter_mut() {
-            if self.exported_names.contains(name) {
+            let exported = self.exported_names.contains(name)
+                || name
+                    .split_once('.')
+                    .is_some_and(|(class_name, _)| self.exported_names.contains(class_name));
+            if exported {
                 def.is_exported = true;
             }
         }
+    }
+
+    /// Resolve a class-member key to its name, if it has a statically-known one.
+    fn prop_name_to_string(key: &PropName) -> Option<String> {
+        match key {
+            PropName::Ident(ident) => Some(ident.sym.to_string()),
+            PropName::Str(s) => Some(s.value.to_string()),
+            _ => None,
+        }
+    }
+
+    /// Insert a definition for a class member backed by a `Function` node
+    /// (methods, private methods, and function-expression class props). The
+    /// node is wrapped as an anonymous `FnExpr` so every downstream consumer
+    /// of `FunctionNodeType` works unchanged.
+    fn insert_method_definition(&mut self, name: String, function: &Function) {
+        let arguments = self.extract_arguments(&function.params);
+        let body_source = function
+            .body
+            .as_ref()
+            .and_then(|b| self.extract_source(b.span));
+        let line_number = self.line_number(function.span);
+        let end_line = self.end_line(function.span);
+        let return_type = function
+            .return_type
+            .as_ref()
+            .and_then(|t| self.type_ann_to_string(t));
+        self.function_definitions.insert(
+            name.clone(),
+            FunctionDefinition {
+                name,
+                file_path: self.current_file_path.clone(),
+                node_type: FunctionNodeType::FunctionExpression(Box::new(FnExpr {
+                    ident: None,
+                    function: Box::new(function.clone()),
+                })),
+                arguments,
+                body_source,
+                is_exported: false, // Updated in a post-pass
+                line_number,
+                end_line,
+                intent: None,
+                calls: vec![],
+                return_is_explicit: return_type.is_some(),
+                return_type,
+                signature: None,
+                intent_input_hash: None,
+            },
+        );
+    }
+
+    /// Insert a definition for an arrow-initialized class prop
+    /// (`handle = () => { ... }`).
+    fn insert_arrow_definition(&mut self, name: String, arrow: &ArrowExpr) {
+        let arguments = self.extract_arrow_arguments(&arrow.params);
+        let body_source = self.extract_source(arrow.span);
+        let line_number = self.line_number(arrow.span);
+        let end_line = self.end_line(arrow.span);
+        let return_type = arrow
+            .return_type
+            .as_ref()
+            .and_then(|t| self.type_ann_to_string(t));
+        self.function_definitions.insert(
+            name.clone(),
+            FunctionDefinition {
+                name,
+                file_path: self.current_file_path.clone(),
+                node_type: FunctionNodeType::ArrowFunction(Box::new(arrow.clone())),
+                arguments,
+                body_source,
+                is_exported: false, // Updated in a post-pass
+                line_number,
+                end_line,
+                intent: None,
+                calls: vec![],
+                return_is_explicit: return_type.is_some(),
+                return_type,
+                signature: None,
+                intent_input_hash: None,
+            },
+        );
     }
 }
 
@@ -500,6 +591,9 @@ impl Visit for FunctionDefinitionExtractor {
                         self.exported_names.insert(ident.id.sym.to_string());
                     }
                 }
+            }
+            Decl::Class(class_decl) => {
+                self.exported_names.insert(class_decl.ident.sym.to_string());
             }
             _ => {}
         }
@@ -705,6 +799,68 @@ impl Visit for FunctionDefinitionExtractor {
 
         // Continue visiting child nodes
         var_decl.visit_children_with(self);
+    }
+
+    /// Track the enclosing class name so members can be indexed as `Class.member`.
+    fn visit_class_decl(&mut self, class: &ClassDecl) {
+        let prev = self.current_class.replace(class.ident.sym.to_string());
+        class.visit_children_with(self);
+        self.current_class = prev;
+    }
+
+    /// Class expressions (`const Foo = class { ... }`, `export default class Foo`).
+    /// An anonymous class expression clears the tracked name: its members have
+    /// no stable qualified name and must not be attributed to an outer class.
+    fn visit_class_expr(&mut self, class: &ClassExpr) {
+        let prev = match &class.ident {
+            Some(ident) => self.current_class.replace(ident.sym.to_string()),
+            None => self.current_class.take(),
+        };
+        class.visit_children_with(self);
+        self.current_class = prev;
+    }
+
+    /// Index class methods (static and instance) as `Class.method`.
+    /// Getters are included (`Class.name` — they carry real logic surprisingly
+    /// often); setters are skipped so a getter/setter pair doesn't collide on
+    /// one key.
+    fn visit_class_method(&mut self, method: &ClassMethod) {
+        if let Some(class_name) = self.current_class.clone()
+            && !matches!(method.kind, MethodKind::Setter)
+            && let Some(member_name) = Self::prop_name_to_string(&method.key)
+        {
+            self.insert_method_definition(format!("{class_name}.{member_name}"), &method.function);
+        }
+        method.visit_children_with(self);
+    }
+
+    /// Index private methods as `Class.#method`.
+    fn visit_private_method(&mut self, method: &PrivateMethod) {
+        if let Some(class_name) = self.current_class.clone()
+            && !matches!(method.kind, MethodKind::Setter)
+        {
+            let name = format!("{class_name}.#{}", method.key.name);
+            self.insert_method_definition(name, &method.function);
+        }
+        method.visit_children_with(self);
+    }
+
+    /// Index function-valued class props (`handle = () => { ... }`) as
+    /// `Class.prop` — the common controller idiom that is not a
+    /// `VarDeclarator` and so never reaches `visit_var_declarator`.
+    fn visit_class_prop(&mut self, prop: &ClassProp) {
+        if let Some(class_name) = self.current_class.clone()
+            && let Some(member_name) = Self::prop_name_to_string(&prop.key)
+            && let Some(init) = &prop.value
+        {
+            let name = format!("{class_name}.{member_name}");
+            match &**init {
+                Expr::Arrow(arrow) => self.insert_arrow_definition(name, arrow),
+                Expr::Fn(fn_expr) => self.insert_method_definition(name, &fn_expr.function),
+                _ => {}
+            }
+        }
+        prop.visit_children_with(self);
     }
 
     /// Capture anonymous closures passed as arguments to method calls.
@@ -1411,5 +1567,141 @@ mod tests {
             "on_data_handler"
         );
         assert_eq!(super::derive_handler_name("use", None), "use_handler");
+    }
+
+    #[test]
+    fn captures_static_and_instance_class_methods() {
+        let defs = extract(
+            "export class OrderPresenter {\n\
+               static isFinished(status: string): boolean { return status === \"DONE\"; }\n\
+               public static async findOrder(id: string): Promise<string> { return id; }\n\
+               format(count: number): string { return `count: ${count}`; }\n\
+             }",
+        );
+        let is_finished = defs
+            .get("OrderPresenter.isFinished")
+            .expect("static method should be indexed");
+        assert!(
+            is_finished.is_exported,
+            "member of an exported class is exported"
+        );
+        assert_eq!(is_finished.return_type.as_deref(), Some("boolean"));
+        assert_eq!(is_finished.arguments.len(), 1);
+        assert_eq!(is_finished.arguments[0].name, "status");
+        assert_eq!(
+            is_finished.arguments[0].type_string.as_deref(),
+            Some("string")
+        );
+        assert!(is_finished.body_source.as_ref().unwrap().contains("DONE"));
+        assert!(is_finished.line_number > 0);
+        assert!(is_finished.end_line >= is_finished.line_number);
+        assert!(
+            defs.contains_key("OrderPresenter.findOrder"),
+            "public static async method should be indexed"
+        );
+        assert!(
+            defs.contains_key("OrderPresenter.format"),
+            "instance method should be indexed"
+        );
+    }
+
+    #[test]
+    fn members_of_unexported_class_are_not_exported() {
+        let defs = extract("class Local { run(): number { return 1; } }");
+        let def = defs
+            .get("Local.run")
+            .expect("instance method should be indexed");
+        assert!(!def.is_exported);
+    }
+
+    #[test]
+    fn captures_arrow_class_props_and_private_methods() {
+        let defs = extract(
+            "export class JobController {\n\
+               handle = async (req: string): Promise<void> => { console.log(req); };\n\
+               #reload(): void { console.log(\"reloading\"); }\n\
+             }",
+        );
+        let handle = defs
+            .get("JobController.handle")
+            .expect("arrow-valued class prop should be indexed");
+        assert_eq!(handle.arguments.len(), 1);
+        assert_eq!(handle.arguments[0].name, "req");
+        assert!(handle.is_exported);
+        assert!(
+            defs.contains_key("JobController.#reload"),
+            "private method should be indexed"
+        );
+    }
+
+    #[test]
+    fn getter_is_indexed_and_setter_is_skipped() {
+        let defs = extract(
+            "class Run {\n\
+               get finished(): boolean { return this.status === \"DONE\"; }\n\
+               set finished(v: boolean) { console.log(v); }\n\
+             }",
+        );
+        let def = defs.get("Run.finished").expect("getter should be indexed");
+        assert_eq!(def.return_type.as_deref(), Some("boolean"));
+        assert!(
+            def.body_source.as_ref().unwrap().contains("this.status"),
+            "getter body, not setter body, should win the key"
+        );
+    }
+
+    #[test]
+    fn default_exported_class_members_are_exported() {
+        let defs = extract("export default class Worker { run(): number { return 1; } }");
+        let def = defs.get("Worker.run").expect("method should be indexed");
+        assert!(def.is_exported);
+    }
+
+    #[test]
+    fn anonymous_class_expression_members_are_skipped() {
+        let defs = extract("const Foo = class { run(): number { return 1; } };");
+        assert!(
+            defs.is_empty(),
+            "anonymous class members have no stable name; got {:?}",
+            defs.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn module_functions_inside_and_after_class_are_unaffected() {
+        let defs = extract(
+            "class Svc { run(): number { return helper(); } }\n\
+             function helper(): number { return 2; }",
+        );
+        assert!(defs.contains_key("Svc.run"));
+        let helper = defs.get("helper").expect("module function still indexed");
+        assert!(!helper.name.contains('.'));
+    }
+
+    #[test]
+    fn nestjs_controller_fixture_yields_class_methods() {
+        // In-tree reproduction of carrick#483: this fixture previously
+        // produced zero function definitions.
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/nestjs-api/users.controller.ts"
+        ))
+        .expect("fixture should exist");
+        let defs = extract(&source);
+        for name in [
+            "UsersController.findAll",
+            "UsersController.findOne",
+            "UsersController.create",
+        ] {
+            assert!(
+                defs.contains_key(name),
+                "missing {name}; got {:?}",
+                defs.keys().collect::<Vec<_>>()
+            );
+        }
+        assert!(
+            defs.get("UsersController.findAll").unwrap().is_exported,
+            "exported controller's methods are exported"
+        );
     }
 }


### PR DESCRIPTION
Closes #483.

## What

`FunctionDefinitionExtractor` now enumerates class members as first-class entries in the function/intent index, keyed and named `Class.member`:

- static and instance methods (including `public static async`)
- private methods (`Class.#method`)
- getters (setters skipped so a getter/setter pair doesn't collide on one key)
- function-valued class props (`handle = () => {}`) — the common controller idiom, which is not a `VarDeclarator` and never reached the existing paths

`export class` / `export default class` now propagate `is_exported` to members via `finalize_exports`. Anonymous class expressions are skipped (members have no stable qualified name).

## Why the intent generator changed too

Call-graph matching previously matched full map keys as identifiers in function bodies. Method keys are dotted (`Class.method`), which can never match as one identifier, so every method's `calls[]` and intent-cache context would have silently vanished. Matching now runs on the bare member name, and a method callee additionally requires class evidence: same enclosing class as the caller (`this.foo()`) or the class name referenced in the body (`Class.foo()`). Module-level functions keep the exact pre-existing behaviour (covered by tests).

## What doesn't change

- Wire shape: map key and `name` are plain strings; `FunctionNodeType` gains no variant (methods wrap as anonymous `FnExpr`). No carrick-cloud change or migration; new entries appear on a repo's next scan.
- Sidecar: signature inference already accepts `MethodDeclaration` nodes, so method signatures resolve with zero sidecar changes.

## Measured motivation

The deep-arm benchmark (feasibility doc §14) root-caused its treatment-arm losses to exactly this gap: the functions defining the producer's status semantics are static class methods, absent from the index, while search_by_intent's best hit for the concept was a client-side helper whose logic is the wrong answer. This fix is the prerequisite for re-running that frozen case as a before/after.

## Cost note

First post-fix scan of a class-heavy repo misses both intent caches for every newly-visible method (new name ⇒ new cache key). One-time, expected.

## Out of scope (follow-up candidates)

Object-literal methods (`const api = { getUser() {} }`), constructors, static blocks, private props with function initializers, and `const Foo = class { ... }`.

## Tests

13 new unit tests across `visitor.rs` and `intent_generator.rs`, including an in-tree reproduction: `tests/fixtures/nestjs-api/users.controller.ts` previously produced zero function definitions and now yields all three qualified controller methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)