### PR TITLE
fix(type-compat): stop guessing array-ness when the inference came back blind

### DIFF
--- a/src/engine/type_compat_v2.rs
+++ b/src/engine/type_compat_v2.rs
@@ -142,6 +142,45 @@ fn usable_inferred_text(text: &str) -> Option<&str> {
     }
 }
 
+/// True when an inference for an alias came back BLIND: tsc resolved the use
+/// site to a bare `any`/`unknown` — no anchor symbol, no array depth, no
+/// shape. This is not "the type is scalar"; it is "the compiler could not see
+/// the type at all", the routine CI shape whenever a payload flowed through an
+/// unresolved third-party import on a bare checkout (#349).
+///
+/// Deliberately narrower than [`contains_disqualifying_top_type`]: a partially
+/// decayed shape (`{ ok: boolean; count: any }`) still witnesses the use
+/// site's array-ness, so it is NOT blindness and must not demote anything.
+/// Only the bare top types mean the inference saw nothing.
+fn inference_was_blind(inf: &crate::services::type_sidecar::InferredType) -> bool {
+    inf.primary_type_symbol.is_none()
+        && inf.array_depth.is_none()
+        && matches!(
+            inf.type_string.trim().trim_end_matches(';').trim(),
+            "any" | "unknown"
+        )
+}
+
+/// Aliases whose deterministic inference ran and came back blind for EVERY
+/// result it produced. A single sighted inference for the alias clears it: the
+/// depth join (`apply_inferred_array_depth`) is first-anchor-carrying-wins, so
+/// blindness is only meaningful when nothing else saw the use site.
+fn blind_inference_aliases(
+    inferred: &[crate::services::type_sidecar::InferredType],
+) -> HashSet<&str> {
+    let mut blind: HashSet<&str> = HashSet::new();
+    let mut sighted: HashSet<&str> = HashSet::new();
+    for inf in inferred {
+        if inference_was_blind(inf) {
+            blind.insert(inf.alias.as_str());
+        } else {
+            sighted.insert(inf.alias.as_str());
+        }
+    }
+    blind.retain(|alias| !sighted.contains(alias));
+    blind
+}
+
 /// Derive one capture anchor per alias from the collected v1 type requests.
 ///
 /// Precedence mirrors the v1 bundle: an explicit symbol request wins over an
@@ -179,12 +218,38 @@ pub(crate) fn derive_capture_anchors(
             inferred_text.entry(inf.alias.as_str()).or_insert(text);
         }
     }
+    let blind = blind_inference_aliases(inferred);
 
     for request in explicit {
         let Some(alias) = request.alias.as_deref() else {
             // No alias means no manifest entry to join; nothing to capture.
             continue;
         };
+        // An LLM symbol anchor is a BARE element identifier by schema contract
+        // (`Order[]` -> `Order`), so the use-site's array-ness rides only on
+        // `array_depth`, which `apply_inferred_array_depth` copies from the
+        // deterministic inference for the same alias. When that inference came
+        // back blind there is no depth to copy — and no way to tell "the type
+        // is scalar" from "nothing was seen". Capturing the bare symbol anyway
+        // publishes a CONFIDENT contract whose array-ness was guessed, which is
+        // how a correct `Order[]` producer renders as `Order` and reads
+        // incompatible against a correct `Order[]` consumer.
+        //
+        // Fail closed: emit no symbol anchor and leave the alias to its own
+        // infer anchor below, which captures the decayed use site (`any`),
+        // self-checks `decayed_internal`, and routes through the check's
+        // IsAny gate to unverifiable. A depth the caller already knows (the
+        // GraphQL SDL list marker, or a depth the join did land) is evidence
+        // in its own right and keeps the anchor.
+        if request.array_depth.is_none() && blind.contains(alias) {
+            debug!(
+                "v2 capture: alias {} has an explicit '{}' anchor but its inference \
+                 resolved to a bare top type; skipping the symbol anchor so the \
+                 array-ness is not guessed (pair verdicts unverifiable)",
+                alias, request.symbol_name
+            );
+            continue;
+        }
         if !seen.insert(alias.to_string()) {
             continue;
         }
@@ -1171,6 +1236,230 @@ mod tests {
             }
             other => panic!("expected literal anchor, got {:?}", other),
         }
+    }
+
+    fn inferred(
+        alias: &str,
+        type_string: &str,
+        primary_type_symbol: Option<&str>,
+        array_depth: Option<u32>,
+    ) -> crate::services::type_sidecar::InferredType {
+        crate::services::type_sidecar::InferredType {
+            alias: alias.to_string(),
+            type_string: type_string.to_string(),
+            is_explicit: false,
+            source_location: crate::services::type_sidecar::SourceLocation {
+                file_path: "/repo/src/handler.ts".to_string(),
+                start_line: 7,
+                end_line: 7,
+                start_column: Some(0),
+                end_column: Some(0),
+            },
+            infer_kind: InferKind::ResponseBody,
+            primary_type_symbol: primary_type_symbol.map(str::to_string),
+            array_depth,
+            primary_type_symbol_source: None,
+        }
+    }
+
+    fn order_explicit(alias: &str) -> SymbolRequest {
+        SymbolRequest {
+            symbol_name: "Order".to_string(),
+            source_file: "src/types.ts".to_string(),
+            alias: Some(alias.to_string()),
+            // The join found no depth to copy — the LLM anchor is bare by
+            // schema contract, so this is the state every unjoined alias is in.
+            array_depth: None,
+            payload_borrow_witness: false,
+        }
+    }
+
+    fn response_body_infer(alias: &str) -> InferRequestItem {
+        InferRequestItem {
+            file_path: "/repo/src/handler.ts".to_string(),
+            line_number: 7,
+            span_start: Some(10),
+            span_end: Some(20),
+            expression_text: None,
+            expression_line: None,
+            infer_kind: InferKind::ResponseBody,
+            alias: Some(alias.to_string()),
+            param_name: None,
+        }
+    }
+
+    /// A blind inference must never let the LLM's bare element symbol ride as
+    /// a confident contract.
+    ///
+    /// Live repro (carrick-demo, scanner v0.3.7): user-service's
+    /// `GET /api/users/:id/orders` does `res.json(userOrders)` where
+    /// `userOrders` came from `(await axios.get<Order[]>(...)).data.filter(...)`.
+    /// CI scans a bare checkout (#349), so `axios` is unresolved and the whole
+    /// expression decays to `any`: the `response_body` inference returns
+    /// `type_string: "any"` with NO `primary_type_symbol` and NO `array_depth`
+    /// (measured offline against the real source). `apply_inferred_array_depth`
+    /// then has nothing to copy, the `Order` symbol anchor captures at depth 0,
+    /// and the surface line is `import('./types/order').Order` — so the correct
+    /// `Order[]` producer reads incompatible against the correct `Order[]`
+    /// consumer and ships a CAUTION type_mismatch on every PR.
+    ///
+    /// The array-ness cannot be recovered here (nothing deterministic witnesses
+    /// it), so the only honest outcome is to stop claiming it: no symbol anchor,
+    /// the alias falls to its own infer anchor, which captures `any`,
+    /// self-checks `decayed_internal`, and verdicts unverifiable.
+    #[test]
+    fn derive_anchors_drops_symbol_anchor_when_the_inference_was_blind() {
+        let explicit = vec![order_explicit("Endpoint_blind_Response")];
+        let infer = vec![response_body_infer("Endpoint_blind_Response")];
+        let inferred_types = vec![inferred("Endpoint_blind_Response", "any", None, None)];
+
+        let anchors = derive_capture_anchors(&explicit, &infer, &[], &inferred_types, "/repo");
+
+        assert_eq!(
+            anchors.len(),
+            1,
+            "expected exactly the infer anchor, got {:?}",
+            anchors
+        );
+        match &anchors[0] {
+            CaptureAnchor::Infer { alias, .. } => {
+                assert_eq!(alias, "Endpoint_blind_Response")
+            }
+            other => panic!(
+                "a blind inference must demote the LLM symbol anchor to its \
+                 locator-based infer anchor, got {:?}",
+                other
+            ),
+        }
+    }
+
+    /// `unknown` is the scrubbers' failed-inference placeholder and means the
+    /// same thing as `any` here: nothing was seen.
+    #[test]
+    fn derive_anchors_drops_symbol_anchor_on_blind_unknown() {
+        let explicit = vec![order_explicit("Endpoint_blind_Response")];
+        let infer = vec![response_body_infer("Endpoint_blind_Response")];
+        let inferred_types = vec![inferred("Endpoint_blind_Response", "unknown", None, None)];
+
+        let anchors = derive_capture_anchors(&explicit, &infer, &[], &inferred_types, "/repo");
+        assert!(
+            matches!(anchors.as_slice(), [CaptureAnchor::Infer { .. }]),
+            "got {:?}",
+            anchors
+        );
+    }
+
+    /// The guard is blindness-only, and every other state keeps the anchor —
+    /// this is what bounds the recall cost of the demotion.
+    #[test]
+    fn derive_anchors_keeps_symbol_anchor_whenever_the_inference_saw_anything() {
+        // (a) Sighted inference that resolved a real shape: the depth join
+        //     already ran upstream (depth Some(1) here), anchor kept.
+        let sighted = derive_capture_anchors(
+            &[SymbolRequest {
+                array_depth: Some(1),
+                ..order_explicit("Endpoint_a_Response")
+            }],
+            &[response_body_infer("Endpoint_a_Response")],
+            &[],
+            &[inferred(
+                "Endpoint_a_Response",
+                "{ id: number; }[]",
+                Some("Order"),
+                Some(1),
+            )],
+            "/repo",
+        );
+        assert!(
+            matches!(
+                sighted.as_slice(),
+                [CaptureAnchor::Symbol {
+                    array_depth: Some(1),
+                    ..
+                }]
+            ),
+            "got {:?}",
+            sighted
+        );
+
+        // (b) PARTIAL decay: a shape with an `any` member still witnesses the
+        //     use site's array-ness, so it is not blindness. Using
+        //     `contains_disqualifying_top_type` here instead would demote it
+        //     and widen the blast radius well past the defect.
+        let partial = derive_capture_anchors(
+            &[order_explicit("Endpoint_b_Response")],
+            &[response_body_infer("Endpoint_b_Response")],
+            &[],
+            &[inferred(
+                "Endpoint_b_Response",
+                "{ ok: boolean; count: any; }",
+                None,
+                None,
+            )],
+            "/repo",
+        );
+        assert!(
+            matches!(partial.as_slice(), [CaptureAnchor::Symbol { .. }]),
+            "partial decay is not blindness; got {:?}",
+            partial
+        );
+
+        // (c) No inference at all for the alias (socket/pub-sub explicit-only
+        //     anchors): the guard is structurally inert.
+        let no_inference = derive_capture_anchors(
+            &[order_explicit("Endpoint_c_Response")],
+            &[],
+            &[],
+            &[],
+            "/repo",
+        );
+        assert!(
+            matches!(no_inference.as_slice(), [CaptureAnchor::Symbol { .. }]),
+            "got {:?}",
+            no_inference
+        );
+
+        // (d) One blind result but another sighted one for the SAME alias:
+        //     something saw the use site, so the anchor is kept.
+        let mixed = derive_capture_anchors(
+            &[order_explicit("Endpoint_d_Response")],
+            &[response_body_infer("Endpoint_d_Response")],
+            &[],
+            &[
+                inferred("Endpoint_d_Response", "any", None, None),
+                inferred("Endpoint_d_Response", "Order[]", Some("Order"), Some(1)),
+            ],
+            "/repo",
+        );
+        assert!(
+            matches!(mixed.as_slice(), [CaptureAnchor::Symbol { .. }]),
+            "got {:?}",
+            mixed
+        );
+
+        // (e) A caller-supplied depth (the GraphQL SDL list marker, #248) is
+        //     evidence in its own right and survives a blind inference.
+        let sdl_depth = derive_capture_anchors(
+            &[SymbolRequest {
+                array_depth: Some(1),
+                ..order_explicit("Endpoint_e_Response")
+            }],
+            &[response_body_infer("Endpoint_e_Response")],
+            &[],
+            &[inferred("Endpoint_e_Response", "any", None, None)],
+            "/repo",
+        );
+        assert!(
+            matches!(
+                sdl_depth.as_slice(),
+                [CaptureAnchor::Symbol {
+                    array_depth: Some(1),
+                    ..
+                }]
+            ),
+            "got {:?}",
+            sdl_depth
+        );
     }
 
     // ---- contains_disqualifying_top_type ----------------------------------

--- a/src/sidecar/test/capture-v2-blind-array-anchor.test.ts
+++ b/src/sidecar/test/capture-v2-blind-array-anchor.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Why a bare LLM symbol anchor cannot be trusted to carry array-ness.
+ *
+ * Live repro (carrick-demo trio, scanner v0.3.7): user-service's
+ * `GET /api/users/:id/orders` answers `res.json(userOrders)` where
+ * `userOrders` is `(await axios.get<Order[]>(...)).data.filter(...)`. The
+ * producer is a correct `Order[]`; the consumer types a correct `Order[]`;
+ * the scan reported a CAUTION type_mismatch — "Order missing properties from
+ * Order[]: length, pop, push, concat, and 29 more".
+ *
+ * The two facts behind that, both pinned here:
+ *
+ *  1. On the bare checkout CI actually scans (#349) the client library is
+ *     unresolved, so the payload decays to a BARE `any` and the
+ *     `response_body` inference reports no `primary_type_symbol` and no
+ *     `array_depth`. That is the only channel through which the use-site's
+ *     `[]` can reach the capture — an LLM `primary_type_symbol` is a bare
+ *     element identifier by schema contract.
+ *
+ *  2. A symbol anchor captured with no depth emits the ELEMENT as a confident
+ *     surface line. Nothing downstream can tell that apart from a genuinely
+ *     scalar contract.
+ *
+ * Together they mean array-ness was GUESSED, so the scanner-side fix
+ * (`derive_capture_anchors`, engine/type_compat_v2.rs) declines to emit the
+ * symbol anchor at all when the inference came back blind, leaving the alias
+ * to its own infer anchor — which, as pinned below, captures `any` and
+ * self-checks `decayed_internal`, routing the pair to unverifiable instead of
+ * a false mismatch.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { captureStub } from '../src/capture/index.js';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const BARE = path.join(FIXTURES_PATH, '..', 'capture-v2-bare');
+const SOURCE_REL = 'src/http/decayed-array-response.ts';
+const SOURCE = path.join(BARE, SOURCE_REL);
+
+/** Byte span of `text` in the fixture (ASCII-only, so byte == char offsets). */
+function spanOf(text: string): { start: number; end: number; line: number } {
+  const source = fs.readFileSync(SOURCE, 'utf-8');
+  const start = source.indexOf(text);
+  assert.ok(start >= 0, `fixture must contain: ${text}`);
+  assert.strictEqual(
+    source.indexOf(text, start + 1),
+    -1,
+    `fixture must contain exactly one occurrence of: ${text}`
+  );
+  return {
+    start,
+    end: start + text.length,
+    line: source.slice(0, start).split('\n').length,
+  };
+}
+
+interface InferResponseShape {
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    primary_type_symbol?: string;
+    array_depth?: number;
+  }>;
+  errors?: string[];
+}
+
+describe('a payload decayed through an unresolved dependency reports no array depth', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    assert.ok(
+      !fs.existsSync(path.join(BARE, 'node_modules')),
+      'precondition: capture-v2-bare must have no node_modules'
+    );
+    client = new SidecarClient();
+    await client.start();
+    await client.send({ action: 'init', request_id: 'blind-init', repo_root: BARE });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('response_body inference over an unresolved client resolves to a bare `any`', async () => {
+    const payload = spanOf('send(inStock)');
+    const response = await client.send<InferResponseShape>({
+      action: 'infer',
+      request_id: 'blind-infer',
+      requests: [
+        {
+          file_path: SOURCE,
+          line_number: payload.line,
+          span_start: payload.start,
+          span_end: payload.end,
+          infer_kind: 'response_body',
+          alias: 'Endpoint_blind_Response',
+        },
+      ],
+    });
+
+    const inferred = response.inferred_types?.find(
+      (t) => t.alias === 'Endpoint_blind_Response'
+    );
+    assert.ok(
+      inferred,
+      `expected an inferred type, got errors: ${JSON.stringify(response.errors)}`
+    );
+    // Bare `any`, not a partially decayed shape: nothing about the use site
+    // was seen, which is exactly what the scanner-side guard keys on.
+    assert.strictEqual(inferred.type_string.trim(), 'any');
+    assert.strictEqual(
+      inferred.primary_type_symbol,
+      undefined,
+      'a decayed payload has no anchor symbol to agree with the LLM symbol'
+    );
+    assert.strictEqual(
+      inferred.array_depth,
+      undefined,
+      'the `[]` the caller wrote is unrecoverable here — there is no depth to ' +
+        'copy onto the explicit SymbolRequest for this alias'
+    );
+  });
+
+  it('a symbol anchor with no depth emits the bare element as a confident line', () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-blind-'));
+    const result = captureStub({
+      repoRoot: BARE,
+      serviceName: 'blind-depth',
+      outDir,
+      anchors: [
+        {
+          kind: 'symbol',
+          alias: 'Endpoint_no_depth_Response',
+          symbol_name: 'Item',
+          source_file: 'src/app/models/item.ts',
+          anchor_origin: 'llm-symbol',
+        },
+        {
+          kind: 'symbol',
+          alias: 'Endpoint_depth_Response',
+          symbol_name: 'Item',
+          source_file: 'src/app/models/item.ts',
+          anchor_origin: 'llm-symbol',
+          array_depth: 1,
+        },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+
+    const surface = fs.readFileSync(
+      path.join(result.stub_dir, 'types', 'surface.d.ts'),
+      'utf-8'
+    );
+    // Depth is the ONLY difference between a correct `Item[]` contract and a
+    // wrong `Item` one, and both record self_check 'ok' — the wrong one is
+    // indistinguishable downstream, which is why the guard must sit upstream.
+    assert.match(surface, /Endpoint_no_depth_Response = import\('[^']+'\)\.Item;/);
+    assert.match(surface, /Endpoint_depth_Response = import\('[^']+'\)\.Item\[\];/);
+    for (const alias of result.aliases) {
+      assert.strictEqual(alias.self_check, 'ok', JSON.stringify(alias));
+    }
+  });
+
+  it('the infer anchor the guard falls back to captures `any` and self-checks decayed', () => {
+    const payload = spanOf('send(inStock)');
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-blind-'));
+    const result = captureStub({
+      repoRoot: BARE,
+      serviceName: 'blind-infer-anchor',
+      outDir,
+      anchors: [
+        {
+          kind: 'infer',
+          alias: 'Endpoint_blind_Response',
+          source_file: SOURCE_REL,
+          anchor_origin: 'deterministic-infer',
+          span_start: payload.start + 'send('.length,
+          span_end: payload.end - 1,
+        },
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+
+    const record = result.aliases.find((a) => a.alias === 'Endpoint_blind_Response');
+    assert.ok(record, JSON.stringify(result.aliases));
+    assert.strictEqual(record.self_check, 'decayed_internal');
+    assert.strictEqual(record.top_type_at_self_check, true);
+    // No capture_failure_reason: the literal backfill (`backfill_anchors`,
+    // engine/type_compat_v2.rs) keys on that field, so it cannot silently
+    // re-anchor this alias with the v1 bundle's bare-element text.
+    assert.strictEqual(record.capture_failure_reason, undefined);
+  });
+});

--- a/src/sidecar/test/fixtures/capture-v2-bare/src/http/decayed-array-response.ts
+++ b/src/sidecar/test/fixtures/capture-v2-bare/src/http/decayed-array-response.ts
@@ -1,0 +1,19 @@
+// A response payload that reaches the handler THROUGH an uninstalled
+// dependency. `fakelib` is declared in package.json and never installed (this
+// fixture repo is the bare-checkout shape CI actually scans, #349), so
+// `client.get<Item[]>(...)` types as `any` and everything downstream of it
+// decays with it — including the array-ness the caller wrote out.
+//
+// The LLM's `primary_type_symbol` for this endpoint is the bare element
+// (`Item`) by schema contract, so the ONLY witness to the `[]` is the
+// deterministic inference — and here it has nothing to report.
+import { client } from 'fakelib';
+import type { Item } from '@app/models/item';
+
+declare function send(body: unknown): void;
+
+export async function listInStockItems(minQty: number): Promise<void> {
+  const response = await client.get<Item[]>('/items');
+  const inStock = response.data.filter((i: Item) => i.qty > minQty);
+  send(inStock);
+}


### PR DESCRIPTION
Root-causes the CAUTION `type_mismatch` false positives on the demo trio where array-ness is lost on one side of a compat pair. Reproduced offline and deterministically against the real demo sources — no live scan, no LLM call, $0.

## Root cause

An LLM `primary_type_symbol` is a **bare element identifier by schema contract** (`Order[]` → `Order`). The use-site's array-ness therefore reaches the v2 capture through exactly one channel: `array_depth`, which `apply_inferred_array_depth` (`src/services/type_sidecar.rs:1544`) copies onto the `SymbolRequest` from the deterministic inference for the same alias. Every HTTP producer/consumer path hardcodes `array_depth: None` at collection time (`src/agents/file_orchestrator.rs:1350`, `:2311`), so that copy is the whole mechanism.

Nothing distinguished the two states that leave `array_depth: None`:

1. the inference resolved the use site and the type is genuinely scalar, and
2. the inference **saw nothing at all**.

`derive_capture_anchors` (`src/engine/type_compat_v2.rs:189`) emitted a confident symbol anchor either way, and the symbol anchor wins over the same alias's infer anchor via the `seen` set — so the abstention was discarded. `anchors.ts:125` then renders `'[]'.repeat(0)` and the surface line is the bare element.

State 2 is not exotic. CI scans a bare checkout (#349), so any payload that reached the handler through an unresolved third-party import decays to `any` and the inference reports no symbol and no depth.

## Evidence: the live instances

`GET /api/users/:id/orders`, rendered as `producer Order vs consumer Order: Order missing properties from Order[]: length, pop, push, concat, and 29 more`.

Producer, `user-service/server.ts`:

```ts
const ordersResponse = await axios.get<Order[]>(`${ORDER_SERVICE_URL}/api/orders`);
const userOrders = ordersResponse.data.filter((o) => o.userId === userId);
return res.json(userOrders);
```

Running the sidecar's `infer` over that exact file with `node_modules` removed (the CI shape):

```
alias ProducerUserOrders      type_string "any"   primary_type_symbol —      array_depth —
alias ConsumerOrdersInUserSvc type_string "any"   primary_type_symbol Order  array_depth 1
```

The consumer is fine — #348's call-generic fallback recovers `Order[]` syntactically from `axios.get<Order[]>`. The producer has no such syntactic witness: `userOrders` is a value that flowed through the unresolved client, so tsc is blind and the `[]` is unrecoverable.

Feeding that state into `capture_v2` against the same repo reproduces the shipped artifact exactly:

```
export type A_symbol_nodepth = import('./types/order').Order;      // array_depth absent
export type A_symbol_depth1  = import('./types/order').Order[];    // array_depth: 1
```

Both record `self_check: 'ok'`. The wrong one is indistinguishable from the right one downstream, which is why the guard has to sit upstream of the capture.

The other reported instance (`GET /api/orders`, consumer-side array-ness lost) does **not** reproduce on the current Express-era sources — all three of the other sides probe clean (`primary_type_symbol: Order, array_depth: 1`). It appeared on a Hono-conversion PR scan under v0.3.7 against a v0.3.2-built index, and neither the Hono-era source nor the stored index entry is available offline, so it is left unexplained rather than guessed at. Filed separately.

## The fix

When **every** inference for an alias came back blind — `type_string` is a bare `any`/`unknown`, no `primary_type_symbol`, no `array_depth` — and the caller supplied no depth of its own, emit no symbol anchor. The alias falls through to its own locator-based infer anchor, which captures the decayed use site as `any`, self-checks `decayed_internal`, and routes through the check's IsAny gate to `gate_caught_baked_any` → unverifiable in the overlay (`src/analyzer/mod.rs:462`), which `get_type_mismatch_findings` filters out.

This can only move a verdict toward unverifiable. It cannot manufacture a new false-incompatible.

Three things were verified before settling on the demotion rather than assumed:

- the fallback infer anchor really does capture `any` and record `decayed_internal` / `top_type_at_self_check: true` (pinned in the new sidecar test);
- it records **no** `capture_failure_reason`, so `backfill_anchors` cannot silently re-anchor it with the v1 bundle's bare-element text and undo the fix (also pinned);
- `GateCaughtBakedAny` is folded into `unverifiable` in the overlay and the finding projection filters strictly on `Incompatible`, so no CAUTION row survives in a different flavour.

### Scope of the guard

Deliberately narrower than `contains_disqualifying_top_type`. Only a **bare** top type counts as blindness; a partially decayed shape (`{ ok: boolean; count: any }`) still witnesses the use site's array-ness and keeps its anchor. The other states that keep the anchor, all covered by a control test: a sighted inference, no inference at all for the alias (socket/pub-sub explicit-only anchors — the guard is structurally inert there), a mix of one blind and one sighted result for the same alias, and a caller-supplied depth (the GraphQL SDL list marker, #248).

### Recall trade-off — worth an eval A/B before merge

A producer whose payload decays to `any`, whose LLM symbol happens to be correct **and** scalar, and whose consumer genuinely mismatches, moves from incompatible to unverifiable. That is a real if narrow recall cost, and it is the one thing here that offline tests cannot size. Verdict-moving, so it wants a live eval A/B on the corpora rather than my word for it.

## Tests

Pre-fix-failing, in `src/engine/type_compat_v2.rs`:

- `derive_anchors_drops_symbol_anchor_when_the_inference_was_blind` — the `any` case (the live repro's exact state)
- `derive_anchors_drops_symbol_anchor_on_blind_unknown` — the scrubbers' failed-inference placeholder
- `derive_anchors_keeps_symbol_anchor_whenever_the_inference_saw_anything` — the five keep-cases above; passes before and after, so it bounds the change

Characterization, in `src/sidecar/test/capture-v2-blind-array-anchor.test.ts` over a new `capture-v2-bare` fixture: the decay itself (bare `any`, no symbol, no depth), depth-0 vs depth-1 surface lines both self-checking `ok`, and the fallback infer anchor's `decayed_internal` record with no failure reason.

`cargo test` (737 + 722 + integration suites) and `npm test` in `src/sidecar` (309) both green; `cargo fmt --check` and `cargo clippy --all-targets` clean.

## Also worth noting

The finding row labels **both** sides from `primary_type_symbol` (`src/analyzer/mod.rs:2402-2412`), which is why it renders the unreadable "producer `Order` vs consumer `Order`" while the diagnostic underneath says `Order` vs `Order[]`. That is what made this hard to read off the PR comment, and it will keep printing that way after this fix. Cosmetic, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsCZvpFwZYGh2jH4LYb5m3
