### PR TITLE
fix(sidecar): recognise a referenced builder-chain descriptor (#497)

### DIFF
--- a/src/sidecar/src/capture/anchors.ts
+++ b/src/sidecar/src/capture/anchors.ts
@@ -732,6 +732,17 @@ function typeQueryMatchesSymbol(
 // chain argument whose RESOLVED type has object/payload meaning (a schema
 // resolves to an object; a string/number tag does not).
 //
+// #497 widened the descriptor test one step: the descriptor also counts when it
+// is REFERENCED by name (`.meta(createWidgetMeta)`, the const declared in a
+// sibling module) rather than written inline. The reference is resolved through
+// its symbol to its declaration's initialiser and tested there. That reference
+// test is deliberately STRICTER than the inline one, for the reason set out on
+// `isMetadataDescriptor`: an inline all-literal object argument is never a
+// payload here, while a reference is an ordinary identifier that would
+// otherwise be a payload candidate. The descriptor argument is then excluded
+// from the candidate set by NODE IDENTITY, never by shape: a payload schema
+// that happens to be an all-literal const must stay a candidate.
+//
 // SAFETY of the two outcomes:
 //   - the DEMOTE branches (no object candidate, or several) are no-worse-than
 //     the descriptor: within this trigger the locator already sat on the
@@ -747,7 +758,15 @@ function typeQueryMatchesSymbol(
 // silent brittleness is not): a chain carrying two object-typed arguments —
 // e.g. both an input and an output schema — cannot be disambiguated as request
 // vs response without method-name knowledge, so it demotes rather than risk
-// the wrong side.
+// the wrong side. Three further descriptor spellings are deliberately NOT
+// recognised, none of them backed by an observed repro and each of them a
+// widening of the trigger on guesswork: a descriptor produced by a call
+// (`.meta(buildMeta())`, which would need the callee's return analysed); a
+// descriptor literal carrying a spread (`{ ...base, openapi }`, which
+// `isAllLiteralMetadata` rejects along with every other non-property member);
+// and a FLAT referenced descriptor (`const m = { tag: "x" }`), excluded by the
+// stricter reference test below. All three keep the pre-#497 behaviour: no
+// re-aim, descriptor captured.
 // ===========================================================================
 
 type BuilderReaim =
@@ -759,12 +778,12 @@ function reaimBuilderChainPayload(
   checker: ts.TypeChecker,
   located: ts.Node
 ): BuilderReaim {
-  const descriptorCall = enclosingChainDescriptorCall(located);
-  if (!descriptorCall) return { kind: 'none' };
-  const chain = fluentChainCalls(descriptorCall);
+  const descriptor = enclosingChainDescriptorArgument(checker, located);
+  if (!descriptor) return { kind: 'none' };
+  const chain = fluentChainCalls(descriptor.call);
   if (chain.length < 2) return { kind: 'none' };
 
-  const candidates = payloadCandidates(checker, chain);
+  const candidates = payloadCandidates(checker, chain, descriptor.argument);
   if (candidates.length === 1) {
     return {
       kind: 'reaim',
@@ -789,28 +808,93 @@ function reaimBuilderChainPayload(
 }
 
 /**
- * Walk up from the located node to the enclosing object literal that is (a) a
- * direct argument of a call and (b) all-literal metadata (the descriptor
- * signature). Returns that call, or undefined when the located node is not
- * inside such a descriptor.
+ * Walk up from the located node to the enclosing call argument that carries the
+ * descriptor signature: all-literal metadata, written inline or referenced by
+ * name (#497). Returns the call and the descriptor argument itself, or
+ * undefined when the located node is not inside such a descriptor. The argument
+ * comes back so the caller can exclude exactly that node from the payload
+ * candidates by identity.
  */
-function enclosingChainDescriptorCall(
+function enclosingChainDescriptorArgument(
+  checker: ts.TypeChecker,
   located: ts.Node
-): ts.CallExpression | undefined {
+): { call: ts.CallExpression; argument: ts.Expression } | undefined {
   let node: ts.Node | undefined = located;
   while (node) {
+    const parent: ts.Node | undefined = node.parent;
     if (
-      ts.isObjectLiteralExpression(node) &&
-      node.parent &&
-      ts.isCallExpression(node.parent) &&
-      (node.parent.arguments as readonly ts.Node[]).includes(node) &&
-      isAllLiteralMetadata(node)
+      parent &&
+      ts.isCallExpression(parent) &&
+      (parent.arguments as readonly ts.Node[]).includes(node) &&
+      isMetadataDescriptor(checker, node as ts.Expression)
     ) {
-      return node.parent;
+      return { call: parent, argument: node as ts.Expression };
     }
-    node = node.parent;
+    node = parent;
   }
   return undefined;
+}
+
+/**
+ * A config-descriptor argument: a non-empty, all-literal object literal, either
+ * written inline or named by a reference whose declaration initialises it to
+ * one (#497 — `.meta(createWidgetMeta)` with the const in a sibling module).
+ *
+ * The REFERENCE spelling is deliberately STRICTER than the inline one, and the
+ * asymmetry is load-bearing. In this file's model an inline all-literal object
+ * argument is never a payload, so the inline test can stay loose. A reference is
+ * an ordinary identifier that `payloadCandidates` otherwise treats as a payload
+ * candidate, so classifying one as a descriptor takes it out of the running: a
+ * flat hand-rolled const (`const s = { id: 0, name: "" }` passed to `.input`)
+ * would be misread as the descriptor and the capture would re-aim onto the
+ * metadata beside it — manufacturing the exact defect #497 fixes. Requiring a
+ * nested object-literal property (the `{ openapi: { ... } }` shape both observed
+ * variants carry) separates a descriptor from a flat payload const without
+ * consulting a single method or library name.
+ */
+function isMetadataDescriptor(checker: ts.TypeChecker, arg: ts.Expression): boolean {
+  if (ts.isObjectLiteralExpression(arg)) return isAllLiteralMetadata(arg);
+  const literal = referencedObjectLiteral(checker, arg);
+  return (
+    literal !== undefined &&
+    isAllLiteralMetadata(literal) &&
+    literal.properties.some(
+      (p) => ts.isPropertyAssignment(p) && ts.isObjectLiteralExpression(p.initializer)
+    )
+  );
+}
+
+/**
+ * The object literal a reference ultimately initialises to, or undefined. Only
+ * plain name references are followed (an identifier or a property access);
+ * re-export aliases are resolved so an imported const reaches its declaration,
+ * and `as const` / `satisfies` / parenthesised initialisers are unwrapped.
+ */
+function referencedObjectLiteral(
+  checker: ts.TypeChecker,
+  arg: ts.Expression
+): ts.ObjectLiteralExpression | undefined {
+  if (!ts.isIdentifier(arg) && !ts.isPropertyAccessExpression(arg)) return undefined;
+  const symbol = checker.getSymbolAtLocation(arg);
+  if (!symbol) return undefined;
+  const declaration = resolveSymbolAliases(checker, symbol).valueDeclaration;
+  if (!declaration) return undefined;
+  let initializer: ts.Expression | undefined;
+  if (ts.isVariableDeclaration(declaration) || ts.isPropertyAssignment(declaration)) {
+    initializer = declaration.initializer;
+  }
+  while (
+    initializer &&
+    (ts.isAsExpression(initializer) ||
+      ts.isSatisfiesExpression(initializer) ||
+      ts.isParenthesizedExpression(initializer) ||
+      ts.isTypeAssertionExpression(initializer))
+  ) {
+    initializer = initializer.expression;
+  }
+  return initializer && ts.isObjectLiteralExpression(initializer)
+    ? initializer
+    : undefined;
 }
 
 /**
@@ -862,14 +946,22 @@ function fluentChainCalls(anyCall: ts.CallExpression): ts.CallExpression[] {
  *    argument is a real schema.
  * With this filter the single-candidate re-aim fires only on a genuine schema,
  * and a non-object, ambiguous (>1), or absent candidate abstains via demote.
+ *
+ * `descriptor` is the argument the anchor landed in, excluded by NODE IDENTITY
+ * (#497). Identity, not shape: an inline descriptor was already excluded by the
+ * syntactic filter, but a descriptor named by reference is an identifier like
+ * any other, and excluding it by shape would also strike out a payload schema
+ * that happens to be an all-literal const.
  */
 function payloadCandidates(
   checker: ts.TypeChecker,
-  chain: ts.CallExpression[]
+  chain: ts.CallExpression[],
+  descriptor: ts.Expression
 ): ts.Expression[] {
   const out: ts.Expression[] = [];
   for (const call of chain) {
     for (const arg of call.arguments) {
+      if (arg === descriptor) continue;
       if (
         (ts.isIdentifier(arg) ||
           ts.isPropertyAccessExpression(arg) ||

--- a/src/sidecar/test/capture-v2-builder-chain.test.ts
+++ b/src/sidecar/test/capture-v2-builder-chain.test.ts
@@ -13,6 +13,12 @@
  * all-literal object literal argument of a chain of >=2 fluent calls; the
  * payload is the lone non-literal, non-inline-function chain argument. All
  * fixtures are synthetic and generically named.
+ *
+ * #497 extends the same suite to the descriptor written as a REFERENCE
+ * (`.meta(createWidgetMeta)`, the const declared in a sibling module), which
+ * has no object literal ancestor for the walk-up to find, plus the two
+ * over-trigger controls that keep the widened trigger from firing on an
+ * ordinary schema argument.
  */
 
 import { describe, it, before, after } from 'node:test';
@@ -26,7 +32,22 @@ import type { CaptureStubResult } from '../src/capture/api.js';
 let repoDir: string;
 let outRoot: string;
 
+// #497: a sibling module exporting a metadata descriptor by reference plus the
+// payload schema the chain really carries.
+const TYPES_TS = `
+// An all-literal metadata descriptor exported as a const, referenced by name at
+// the chain instead of being written inline.
+export const createWidgetMeta = {
+  openapi: { method: "POST", path: "/widgets/create", summary: "create a widget" },
+};
+
+// The payload schema the chain's input argument carries.
+export declare const ZWidgetSchema: { widgetId: number; label: string };
+`;
+
 const ROUTER_TS = `
+import { createWidgetMeta, ZWidgetSchema } from './widget.types';
+
 interface Builder {
   meta(config: object): Builder;
   input(schema: unknown): Builder;
@@ -91,6 +112,35 @@ export const literalPayloadRoute = procedure
   .input({ orderId: 1, label: "x" })
   .tag(routeTag)
   .mutation(() => ({}));
+
+// #497: the descriptor is an IMPORTED reference, not an inline literal. There
+// is no object literal ancestor to walk up to, so the pre-fix re-aim never
+// fired and the meta descriptor's own shape was captured as the request type.
+export const importedMetaRoute = procedure
+  .meta(createWidgetMeta)
+  .input(ZWidgetSchema)
+  .mutation(() => ({}));
+
+// #497: same shape with a LOCALLY declared descriptor const. The payload here
+// is itself an all-literal const, which is why the descriptor argument has to
+// be excluded from the candidate set by node identity rather than by shape.
+const localWidgetMeta = {
+  openapi: { method: "PATCH", path: "/widgets/rename", summary: "rename" },
+};
+const localRenameSchema = { renameId: 1, newLabel: "x" };
+export const localMetaRoute = procedure
+  .meta(localWidgetMeta)
+  .input(localRenameSchema)
+  .mutation(() => ({}));
+
+// #497 over-trigger control: the locator lands on the SCHEMA identifier of a
+// chain, not on a descriptor. The generalised trigger must not fire, and the
+// schema type must be captured exactly as it stands.
+declare const controlSchema: { controlId: number };
+export const controlRoute = procedure
+  .meta({ openapi: { method: "GET", path: "/widgets/control" } })
+  .input(controlSchema)
+  .mutation(() => ({}));
 `;
 
 function writeRepo(): void {
@@ -109,7 +159,20 @@ function writeRepo(): void {
       include: ['src'],
     })
   );
+  fs.writeFileSync(path.join(repoDir, 'src', 'widget.types.ts'), TYPES_TS);
   fs.writeFileSync(path.join(repoDir, 'src', 'router.ts'), ROUTER_TS);
+}
+
+/**
+ * 1-based line of the first line of ROUTER_TS containing `needle`. The
+ * reference-descriptor anchors need a `line_number` floor so the locator skips
+ * the identifier in the import declaration and lands on the chain argument.
+ */
+function routerLine(needle: string): number {
+  const lines = ROUTER_TS.split('\n');
+  const idx = lines.findIndex((l) => l.includes(needle));
+  assert.ok(idx >= 0, `fixture line not found: ${needle}`);
+  return idx + 1;
 }
 
 describe('capture v2: builder-chain payload selection over config descriptor', () => {
@@ -182,6 +245,49 @@ describe('capture v2: builder-chain payload selection over config descriptor', (
           expression_text: '{ openapi: { method: "POST", path: "/documents/create" } }',
           unwrap: 'none',
         },
+        // #497: descriptor referenced by an IMPORTED identifier -> re-aim at
+        // the chain's schema argument, exactly as for the inline literal.
+        {
+          kind: 'infer',
+          alias: 'ImportedMeta_Request',
+          source_file: 'src/router.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: 'createWidgetMeta',
+          line_number: routerLine('.meta(createWidgetMeta)'),
+          unwrap: 'none',
+        },
+        // #497: descriptor referenced by a LOCAL const identifier.
+        {
+          kind: 'infer',
+          alias: 'LocalMeta_Request',
+          source_file: 'src/router.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: 'localWidgetMeta',
+          line_number: routerLine('.meta(localWidgetMeta)'),
+          unwrap: 'none',
+        },
+        // #497 over-trigger control: locator on a FLAT all-literal payload
+        // const. Treating it as a descriptor would re-aim onto the metadata
+        // reference beside it, manufacturing the very defect #497 fixes.
+        {
+          kind: 'infer',
+          alias: 'FlatPayload_Request',
+          source_file: 'src/router.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: 'localRenameSchema',
+          line_number: routerLine('.input(localRenameSchema)'),
+          unwrap: 'none',
+        },
+        // #497 over-trigger control: locator on the schema identifier itself.
+        {
+          kind: 'infer',
+          alias: 'Control_Request',
+          source_file: 'src/router.ts',
+          anchor_origin: 'deterministic-infer',
+          expression_text: 'controlSchema',
+          line_number: routerLine('.input(controlSchema)'),
+          unwrap: 'none',
+        },
       ],
     });
     assert.strictEqual(result.success, true, JSON.stringify(result.errors));
@@ -195,6 +301,20 @@ describe('capture v2: builder-chain payload selection over config descriptor', (
     fs.rmSync(repoDir, { recursive: true, force: true });
     fs.rmSync(outRoot, { recursive: true, force: true });
   });
+
+  /**
+   * Just the one alias's surface line. The suite's older assertions match
+   * `Alias = [\s\S]*needle` against the whole surface, which reaches past the
+   * alias into every line below it; the #497 assertions stay bounded so a
+   * later fixture cannot make them pass or fail for the wrong reason.
+   */
+  function surfaceFor(alias: string): string {
+    const m = surface.match(
+      new RegExp(`export type ${alias} =[\\s\\S]*?(?=\\nexport type |$)`)
+    );
+    assert.ok(m, `no surface line for ${alias}:\n${surface}`);
+    return m[0];
+  }
 
   function record(alias: string) {
     const r = result.aliases.find((a) => a.alias === alias);
@@ -250,6 +370,65 @@ describe('capture v2: builder-chain payload selection over config descriptor', (
     assert.match(surface, /Tag_Request = unknown;/);
     // Never captures the string constant as a payload.
     assert.ok(!/Tag_Request = string;/.test(surface), surface);
+  });
+
+  it('#497: re-aims when the descriptor is an imported identifier reference', () => {
+    // Pre-fix there was no ObjectLiteralExpression ancestor to walk up to, so
+    // the re-aim never fired and the meta descriptor's own shape was captured.
+    const r = record('ImportedMeta_Request');
+    assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
+    const line = surfaceFor('ImportedMeta_Request');
+    assert.match(line, /widgetId/);
+    assert.match(line, /label/);
+    assert.ok(!/openapi/.test(line), `descriptor metadata must not be captured:\n${line}`);
+    // Pins the full fix: a generalised trigger without the descriptor-argument
+    // identity skip would abstain here instead of re-aiming.
+    assert.ok(!/= unknown;/.test(line), `must re-aim, not abstain:\n${line}`);
+    assert.match(r.self_check_detail ?? '', /re-aimed at the chain schema argument/);
+  });
+
+  it('#497: re-aims when the descriptor is a locally declared const', () => {
+    const r = record('LocalMeta_Request');
+    assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
+    const line = surfaceFor('LocalMeta_Request');
+    assert.match(line, /renameId/);
+    assert.match(line, /newLabel/);
+    assert.ok(!/openapi/.test(line), `descriptor metadata must not be captured:\n${line}`);
+    assert.ok(!/= unknown;/.test(line), `must re-aim, not abstain:\n${line}`);
+    assert.match(r.self_check_detail ?? '', /re-aimed at the chain schema argument/);
+  });
+
+  it('#497 control: a flat all-literal payload const is never read as a descriptor', () => {
+    // The reference spelling of the descriptor test has to be stricter than the
+    // inline one. Without that, this flat const is classified as the descriptor
+    // and the chain's lone remaining candidate is the metadata reference beside
+    // it, so the capture re-aims ONTO the descriptor.
+    const r = record('FlatPayload_Request');
+    assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
+    const line = surfaceFor('FlatPayload_Request');
+    assert.match(line, /renameId/);
+    assert.match(line, /newLabel/);
+    assert.ok(
+      !/openapi/.test(line),
+      `must not re-aim onto the metadata descriptor:\n${line}`
+    );
+    assert.ok(!/= unknown;/.test(line), line);
+    assert.ok(
+      !/re-aimed at the chain schema argument/.test(r.self_check_detail ?? ''),
+      `a flat payload const must not trigger the re-aim: ${r.self_check_detail}`
+    );
+  });
+
+  it('#497 control: a locator on the schema identifier does not trigger a re-aim', () => {
+    const r = record('Control_Request');
+    assert.strictEqual(r.self_check, 'ok', r.self_check_detail);
+    const line = surfaceFor('Control_Request');
+    assert.match(line, /controlId/);
+    assert.ok(!/= unknown;/.test(line), line);
+    assert.ok(
+      !/re-aimed at the chain schema argument/.test(r.self_check_detail ?? ''),
+      `an ordinary reference argument must not trigger the re-aim: ${r.self_check_detail}`
+    );
   });
 
   it('abstains when a literal-object payload sits beside a non-schema identifier', () => {


### PR DESCRIPTION
Closes #497.

## What was broken

A producer request anchor landing in a fluent builder chain captured the route metadata shape instead of the payload schema, for every procedure whose descriptor is passed by reference:

```ts
procedure.meta(createWidgetMeta).input(ZWidgetSchema).mutation(handler)
```

The captured Request type came out as the descriptor, identical across every endpoint on the pattern, never the `.input()` schema type.

## Root cause

`enclosingChainDescriptorCall` in `src/sidecar/src/capture/anchors.ts` walked up from the located node looking for an `ObjectLiteralExpression` that is a direct call argument. When the descriptor is an identifier referring to a const in a sibling module there is no object literal ancestor at all, so the helper returned `undefined`, `reaimBuilderChainPayload` returned `{kind: 'none'}`, and the anchor kept the metadata-shaped type the locator originally landed on. #439 fixed the inline-literal spelling; this is the spelling next to it.

## The fix

Two changes, both structural. No method name and no library name is consulted anywhere.

1. A referenced argument is resolved through its symbol to its declaration's initialiser (re-export aliases followed, `as const` / `satisfies` / parentheses unwrapped) and the same all-literal metadata test is applied there. The reference spelling additionally requires the literal to carry a nested object-literal property. That extra requirement is load-bearing rather than cosmetic: an inline all-literal object argument is never a payload in this file's model, but a reference is an ordinary identifier that `payloadCandidates` otherwise treats as a payload candidate, so without it a flat hand-rolled const passed to `.input()` is misread as the descriptor and the capture re-aims onto the metadata beside it, manufacturing the very defect this issue reports.

2. The descriptor argument is excluded from the payload candidates by node identity, not by shape. Excluding by shape would also strike out a payload schema that happens to be an all-literal const, turning a correct concrete capture into `unknown`.

Deliberately not recognised, each documented in the comment block and each keeping the pre-existing behaviour: a descriptor produced by a call (`.meta(buildMeta())`), a descriptor literal carrying a spread, and a flat referenced descriptor.

## Tests

Four cases added to `src/sidecar/test/capture-v2-builder-chain.test.ts`, over a fixture with a sibling module. All fixtures are synthetic and generically named.

Verified failing before the fix, passing after:

- `#497: re-aims when the descriptor is an imported identifier reference`. Pre-fix the surface carried `ImportedMeta_Request = { openapi: { method: string; path: string; summary: string } }`, exactly the second variant reported in the issue.
- `#497: re-aims when the descriptor is a locally declared const`, failing the same way.

Verified failing against an intermediate version of the fix that had the widened trigger without the nested-property requirement, passing after:

- `#497 control: a flat all-literal payload const is never read as a descriptor`. That intermediate version re-aimed the flat payload const onto the metadata descriptor and captured the `openapi` shape.

Passing throughout, as an over-trigger control:

- `#497 control: a locator on the schema identifier does not trigger a re-aim`.

The three positive assertions also pin `self_check_detail` against `re-aimed at the chain schema argument`, so a version that abstains rather than re-aiming cannot pass them. The #497 assertions are bounded to a single surface line, since the older assertions in the suite match against the whole surface and reach past their own alias.

Suites run: sidecar unit tests (314, 0 failures), `cargo test --test sidecar_integration_test`, `cargo test --test pubsub_wrapper_type_capture_test`, plus the full Rust suite with fmt and clippy via the pre-commit hook. The change touches TypeScript only.

## Left out

The MCP-side symptom tracked in carrick-cloud#285 is not re-verified here, and the endpoint-derivation gaps for the same split-meta-module shape remain with #374.

The nested-property requirement narrows the misclassification class without closing it. A payload const that is both all-literal and carries a nested object property, as in `const requestPayload = { filter: { status: "active" }, limit: 10 }`, is still read as the descriptor, and on a chain that also carries an output schema the capture would re-aim onto the response side. That is left as it stands rather than chased, because a real `.input()` argument is a validator call or a declared const, neither of which yields an object-literal initialiser for `referencedObjectLiteral` to find. The `Control_Request` fixture is the declared-const half of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
