### PR TITLE
fix(capture): anchor subscriber payloads on the handler parameter (#498)

### DIFF
--- a/src/engine/type_compat_v2.rs
+++ b/src/engine/type_compat_v2.rs
@@ -28,8 +28,8 @@ use crate::operation::OperationKey;
 use crate::services::TypeSidecar;
 use crate::services::type_sidecar::{
     AnchorOrigin, CaptureAliasRecord, CaptureAnchor, CheckPairEndpoint, CheckPairSpec,
-    CheckStubInput, InferRequestItem, ManifestEntry, ProbeProtocol, ProbeTypeKind, SymbolRequest,
-    VerdictBucket,
+    CheckStubInput, InferKind, InferRequestItem, ManifestEntry, ProbeProtocol, ProbeTypeKind,
+    SymbolRequest, VerdictBucket,
 };
 
 // ===========================================================================
@@ -286,6 +286,18 @@ pub(crate) fn derive_capture_anchors(
             .filter(|l| *l > 0)
             .or(Some(request.line_number))
             .filter(|l| *l > 0);
+        // #498: a `function_param` request names what a HANDLER RECEIVES, and
+        // that is the whole locator a subscriber carries (its collector sends
+        // no expression text on purpose). Dropping it here left the capture
+        // with a bare line, whose locator resolves the enclosing registration
+        // CALL — so every subscriber alias captured that call's return type
+        // (`void`, a subscription handle) as its payload contract, self-checked
+        // clean, and read incompatible against every correctly-typed publisher.
+        // Gated on the kind: an expression-kind request must never carry one.
+        let param_name = match request.infer_kind {
+            InferKind::FunctionParam => request.param_name.clone(),
+            _ => None,
+        };
         anchors.push(CaptureAnchor::Infer {
             alias: alias.to_string(),
             source_file: repo_relative(&request.file_path, repo_root),
@@ -294,6 +306,7 @@ pub(crate) fn derive_capture_anchors(
             span_end: request.span_end,
             line_number,
             expression_text: request.expression_text.clone(),
+            param_name,
         });
     }
 
@@ -1580,6 +1593,59 @@ mod tests {
         }
     }
 
+    /// #498: a subscriber's request is a `function_param` locator — a payload
+    /// PARAMETER name, with no expression text (its collector sends none on
+    /// purpose). That locator must reach the capture anchor. Dropping it left
+    /// a bare line, whose capture locator resolves the enclosing registration
+    /// CALL and captures that call's return type as the payload contract.
+    ///
+    /// An expression-kind request must never carry one: the gate is the kind,
+    /// not the presence of the field.
+    #[test]
+    fn derive_anchors_carry_function_param_locator_for_subscribers() {
+        let request = |alias: &str, kind: InferKind, param: Option<&str>| {
+            crate::services::type_sidecar::InferRequestItem {
+                file_path: "src/subscriber.ts".to_string(),
+                line_number: 12,
+                span_start: None,
+                span_end: None,
+                expression_text: None,
+                expression_line: None,
+                infer_kind: kind,
+                alias: Some(alias.to_string()),
+                param_name: param.map(str::to_string),
+            }
+        };
+
+        let infer = vec![
+            request("Sub_Producer", InferKind::FunctionParam, Some("msg")),
+            request(
+                "Sub_Destructured",
+                InferKind::FunctionParam,
+                Some("{ orderId, total }"),
+            ),
+            // Same field set on a non-param kind: must be dropped.
+            request("Pub_Consumer", InferKind::Expression, Some("msg")),
+        ];
+
+        let anchors = derive_capture_anchors(&[], &infer, &[], &[], ".");
+        assert_eq!(anchors.len(), 3);
+        let param_of = |index: usize| match &anchors[index] {
+            CaptureAnchor::Infer {
+                param_name,
+                line_number,
+                ..
+            } => {
+                assert_eq!(*line_number, Some(12));
+                param_name.clone()
+            }
+            other => panic!("expected an infer anchor, got {other:?}"),
+        };
+        assert_eq!(param_of(0).as_deref(), Some("msg"));
+        assert_eq!(param_of(1).as_deref(), Some("{ orderId, total }"));
+        assert_eq!(param_of(2), None);
+    }
+
     /// An infer-request alias whose v1 inference produced a real shape rides
     /// a LITERAL anchor carrying that text (the kind-aware inference result);
     /// a placeholder text (`unknown`) keeps the locator-based infer anchor.
@@ -2548,6 +2614,7 @@ mod tests {
                 span_end: None,
                 line_number: Some(27),
                 expression_text: None,
+                param_name: None,
             }],
             &HashMap::new(),
         )

--- a/src/services/type_sidecar.rs
+++ b/src/services/type_sidecar.rs
@@ -224,6 +224,13 @@ pub enum CaptureAnchor {
         line_number: Option<u32>,
         #[serde(skip_serializing_if = "Option::is_none")]
         expression_text: Option<String>,
+        /// #498: the anchor names a handler PARAMETER, not an expression —
+        /// the `InferKind::FunctionParam` locator carried through to capture.
+        /// A subscriber's contract is what its handler receives, and without
+        /// this the line-only locator resolves the registration CALL and
+        /// captures that call's return type instead.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        param_name: Option<String>,
     },
     /// Inline literal type text (the v1 inline-alias path).
     Literal {
@@ -1756,6 +1763,7 @@ mod tests {
             span_end: Some(20),
             line_number: None,
             expression_text: None,
+            param_name: None,
         };
         let json = serde_json::to_string(&infer).unwrap();
         assert!(json.contains(r#""kind":"infer""#));

--- a/src/sidecar/src/capture/anchors.ts
+++ b/src/sidecar/src/capture/anchors.ts
@@ -572,7 +572,11 @@ function locateHandlerParam(
  *
  *  1. the LAST function-typed argument of a call starting on the anchor's
  *     line — the handler slot of a registration call, structurally (a
- *     registration passes its routing key first and its handler last);
+ *     registration passes its routing key first and its handler last).
+ *     Several calls can start on one line (`wrap(bus.subscribe(t, h), g)`),
+ *     so they are ordered INNERMOST first: the innermost is the registration
+ *     the anchor's own line most nearly denotes, and it is the same
+ *     innermost-wins tie-break the v1 inferrer's `findFunctionByLine` uses;
  *  2. any function whose declaration starts within
  *     `HANDLER_LINE_TOLERANCE` lines of the anchor, innermost first — the
  *     locator may name a binding on the handler's own signature lines rather
@@ -613,7 +617,12 @@ function callsStartingOnLine(
     node.forEachChild(visit);
   };
   visit(sourceFile);
-  return calls;
+  // Innermost (smallest span) first: a pre-order walk would otherwise hand
+  // back the OUTER call of a same-line nest, whose handler is not the one the
+  // anchor's line denotes.
+  return calls.sort(
+    (a, b) => a.getEnd() - a.getStart() - (b.getEnd() - b.getStart())
+  );
 }
 
 /**

--- a/src/sidecar/src/capture/anchors.ts
+++ b/src/sidecar/src/capture/anchors.ts
@@ -195,6 +195,29 @@ export function resolveAnchor(
   }
 
   // kind === 'infer'
+  // #498: a `param_name` anchor targets what a handler RECEIVES. Resolve the
+  // parameter before anything else and treat the outcome as final — the
+  // expression locator below resolves the enclosing registration call, whose
+  // return type (`void`, a subscription handle) is not the payload, and it
+  // self-checks clean, so falling through would ship a confidently wrong
+  // contract instead of an honest `unknown`.
+  if (request.param_name !== undefined) {
+    const param = locateHandlerParam(sourceFile, request, request.param_name);
+    if (!param) {
+      return demote(
+        `no handler parameter '${request.param_name}' resolved in ` +
+          `${request.source_file} (${paramLocatorHints(request)})`
+      );
+    }
+    return finishInferAnchor(
+      program,
+      sourceFile,
+      request,
+      param,
+      args.placeholder,
+      undefined
+    );
+  }
   let located = locateNode(sourceFile, request);
   if (!located) {
     return demote(locatorFailureReason(request));
@@ -214,6 +237,37 @@ export function resolveAnchor(
     located = builderReaim.node;
     reaimNote = builderReaim.note;
   }
+  return finishInferAnchor(
+    program,
+    sourceFile,
+    request,
+    located,
+    args.placeholder,
+    reaimNote
+  );
+}
+
+/**
+ * Shared tail of the infer paths (locator-resolved node and #498
+ * parameter-resolved node alike): read the type at the node, unwrap the
+ * transport layer, run the #433 recovery and the carrick#371 machinery guard,
+ * and print through the node builder.
+ */
+function finishInferAnchor(
+  program: ts.Program,
+  sourceFile: ts.SourceFile,
+  request: InferAnchorRequest,
+  located: ts.Node,
+  placeholder: ts.TypeAliasDeclaration | undefined,
+  reaimNote: string | undefined
+): ResolvedAnchor {
+  const checker = program.getTypeChecker();
+  const demote = (reason: string): ResolvedAnchor => ({
+    request,
+    aliasText: 'unknown',
+    serialization: 'structural_fallback',
+    failureReason: reason,
+  });
   let type = checker.getTypeAtLocation(located);
   if ((request.unwrap ?? 'awaited') === 'awaited') {
     type = checker.getAwaitedType(type) ?? type;
@@ -251,10 +305,10 @@ export function resolveAnchor(
         'degraded to unknown rather than emit a wrapper envelope as a response contract'
     );
   }
-  if (!args.placeholder) {
+  if (!placeholder) {
     return demote('internal: no placeholder destination for infer anchor');
   }
-  const printed = printTypeForDestination(program, type, args.placeholder);
+  const printed = printTypeForDestination(program, type, placeholder);
   if (!printed.text) {
     return demote(printed.failure ?? 'node builder print failed');
   }
@@ -480,6 +534,189 @@ function literalResolvesLocally(
   };
   visit(literal);
   return resolves;
+}
+
+// ===========================================================================
+// carrick#498: handler-parameter anchors.
+//
+// A subscriber's contract is what its handler RECEIVES, so its anchor carries
+// a `param_name` locator instead of an expression. Resolving it needs the
+// handler function, and the only locator upstream can supply for an anonymous
+// inline handler is a line. Everything below is STRUCTURAL — argument
+// position and binding shape, never a method name, library, or topic string.
+// ===========================================================================
+
+/** v1's `findFunctionByLine` tolerance, mirrored so the two paths agree. */
+const HANDLER_LINE_TOLERANCE = 2;
+
+/**
+ * The payload parameter named by `paramName` on the handler this anchor
+ * points at, or undefined when neither the handler nor the parameter can be
+ * picked. The caller demotes on undefined: an unresolved parameter must never
+ * fall back to the expression locator.
+ */
+function locateHandlerParam(
+  sourceFile: ts.SourceFile,
+  request: InferAnchorRequest,
+  paramName: string
+): ts.Node | undefined {
+  for (const fn of handlerCandidates(sourceFile, request)) {
+    const target = resolveParamTarget(fn, paramName);
+    if (target) return target;
+  }
+  return undefined;
+}
+
+/**
+ * Handler functions this anchor could be naming, most specific first:
+ *
+ *  1. the LAST function-typed argument of a call starting on the anchor's
+ *     line — the handler slot of a registration call, structurally (a
+ *     registration passes its routing key first and its handler last);
+ *  2. any function whose declaration starts within
+ *     `HANDLER_LINE_TOLERANCE` lines of the anchor, innermost first — the
+ *     locator may name a binding on the handler's own signature lines rather
+ *     than the registration line;
+ *  3. the innermost function ENCLOSING the node the expression locator
+ *     resolves — covers a locator that landed in the handler body.
+ */
+function handlerCandidates(
+  sourceFile: ts.SourceFile,
+  request: InferAnchorRequest
+): ts.SignatureDeclaration[] {
+  const out: ts.SignatureDeclaration[] = [];
+  const push = (fn: ts.SignatureDeclaration | undefined) => {
+    if (fn && !out.includes(fn)) out.push(fn);
+  };
+
+  const line = request.line_number;
+  if (line !== undefined) {
+    for (const call of callsStartingOnLine(sourceFile, line)) {
+      const handlerArgs = call.arguments.filter(isFunctionArgument);
+      push(handlerArgs[handlerArgs.length - 1]);
+    }
+    for (const fn of functionsNearLine(sourceFile, line)) push(fn);
+  }
+  push(enclosingFunction(locateNode(sourceFile, request)));
+  return out;
+}
+
+function callsStartingOnLine(
+  sourceFile: ts.SourceFile,
+  line: number
+): ts.CallExpression[] {
+  const calls: ts.CallExpression[] = [];
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && startLineOf(sourceFile, node) === line) {
+      calls.push(node);
+    }
+    node.forEachChild(visit);
+  };
+  visit(sourceFile);
+  return calls;
+}
+
+/**
+ * Functions declared within the line tolerance of `line`, ordered innermost
+ * (smallest span) first so a nested handler wins over its enclosing function.
+ */
+function functionsNearLine(
+  sourceFile: ts.SourceFile,
+  line: number
+): ts.SignatureDeclaration[] {
+  const found: ts.SignatureDeclaration[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      isHandlerFunctionLike(node) &&
+      Math.abs(startLineOf(sourceFile, node) - line) <= HANDLER_LINE_TOLERANCE
+    ) {
+      found.push(node);
+    }
+    node.forEachChild(visit);
+  };
+  visit(sourceFile);
+  return found.sort(
+    (a, b) => a.getEnd() - a.getStart() - (b.getEnd() - b.getStart())
+  );
+}
+
+function startLineOf(sourceFile: ts.SourceFile, node: ts.Node): number {
+  return (
+    sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1
+  );
+}
+
+function isHandlerFunctionLike(node: ts.Node): node is ts.SignatureDeclaration {
+  return (
+    ts.isArrowFunction(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isFunctionDeclaration(node) ||
+    ts.isMethodDeclaration(node)
+  );
+}
+
+function enclosingFunction(
+  node: ts.Node | undefined
+): ts.SignatureDeclaration | undefined {
+  let current: ts.Node | undefined = node;
+  while (current) {
+    if (isHandlerFunctionLike(current)) return current;
+    current = current.parent;
+  }
+  return undefined;
+}
+
+/**
+ * The three binding shapes a `function_param` locator can name, mirroring the
+ * v1 inferrer's `resolveParamTarget` so both anchor paths answer identically:
+ *
+ *  1. an exact parameter name (`(payload) => …` <- "payload");
+ *  2. a whole destructured binding pattern under whitespace normalisation
+ *     (`({ id, total }) => …` <- "{ id, total }") — the pattern's own type IS
+ *     the payload;
+ *  3. one named binding element inside a destructured parameter
+ *     (`({ payload }) => …` <- "payload") — the payload is a property of an
+ *     envelope parameter, and the checker projects the element's type.
+ */
+function resolveParamTarget(
+  fn: ts.SignatureDeclaration,
+  paramName: string
+): ts.Node | undefined {
+  const params = fn.parameters;
+
+  for (const param of params) {
+    if (ts.isIdentifier(param.name) && param.name.text === paramName) {
+      return param;
+    }
+  }
+
+  const wanted = paramName.replace(/\s+/g, ' ').trim();
+  for (const param of params) {
+    if (
+      (ts.isObjectBindingPattern(param.name) ||
+        ts.isArrayBindingPattern(param.name)) &&
+      param.name.getText().replace(/\s+/g, ' ').trim() === wanted
+    ) {
+      return param;
+    }
+  }
+
+  for (const param of params) {
+    if (!ts.isObjectBindingPattern(param.name)) continue;
+    for (const element of param.name.elements) {
+      if (ts.isIdentifier(element.name) && element.name.text === paramName) {
+        return element;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function paramLocatorHints(request: InferAnchorRequest): string {
+  return request.line_number !== undefined
+    ? `line ${request.line_number}`
+    : 'no line hint';
 }
 
 function locatorFailureReason(request: InferAnchorRequest): string {

--- a/src/sidecar/src/capture/api.ts
+++ b/src/sidecar/src/capture/api.ts
@@ -100,6 +100,17 @@ export interface InferAnchorRequest {
   /** Exact source text of the target expression (locator fallback). */
   expression_text?: string;
   /**
+   * carrick#498: the anchor targets a handler PARAMETER, not an expression.
+   * Carries the upstream `function_param` locator (a parameter name, a whole
+   * destructured binding pattern, or one binding element inside it), so the
+   * capture resolves the payload the handler RECEIVES. Without it a line-only
+   * subscriber anchor resolves the enclosing registration CALL and captures
+   * that call's return type (`void`, a subscription handle) as the contract.
+   * When present the parameter resolution is authoritative: a failure demotes
+   * rather than falling back to the expression locator.
+   */
+  param_name?: string;
+  /**
    * Transport unwrapping applied to the located type before printing
    * (design doc, Capture step 6: machinery unwrapping stays at capture time).
    * Default 'awaited': Promise / thenable layers are unwrapped.

--- a/src/sidecar/test/capture-v2-handler-param.test.ts
+++ b/src/sidecar/test/capture-v2-handler-param.test.ts
@@ -87,7 +87,13 @@ voidClient.subscribe(
   }
 );
 
-// 6. No such parameter anywhere: must abstain, never fall back to the call.
+// 6. Two registrations nested on one line, each with a \`msg\` parameter. The
+//    anchor's line denotes the INNER one; the outer handler takes a different
+//    payload, so picking it would be a confident wrong answer.
+declare function wrap(value: void, after: (msg: Envelope) => void): void;
+wrap(voidClient.subscribe('orders.nested', async (msg: OrderEvent) => { console.log(msg.total); }), (msg: Envelope) => { console.log(msg.receivedAt); });
+
+// 7. No such parameter anywhere: must abstain, never fall back to the call.
 voidClient.subscribe('orders.archived', async (msg: OrderEvent) => {
   console.log(msg.orderId);
 });
@@ -152,6 +158,7 @@ describe('capture v2: subscriber anchors capture the handler payload parameter (
         // Anchored on the topic argument line; the handler starts one line below,
         // inside the tolerance the fix mirrors from the v1 inferrer.
         anchor('NextLine_Producer_Response', lineOf("'orders.refunded'"), 'msg'),
+        anchor('Nested_Producer_Response', lineOf("'orders.nested'"), 'msg'),
         anchor('Missing_Producer_Response', lineOf("'orders.archived'"), 'nosuchparam'),
       ],
     });
@@ -195,6 +202,12 @@ describe('capture v2: subscriber anchors capture the handler payload parameter (
 
   it('a handler whose signature starts below the registration line resolves', () => {
     assert.match(aliasLine('NextLine_Producer_Response'), /OrderEvent/);
+  });
+
+  it('same-line nested registrations resolve the innermost handler', () => {
+    const text = aliasLine('Nested_Producer_Response');
+    assert.match(text, /OrderEvent/);
+    assert.doesNotMatch(text, /Envelope|receivedAt/);
   });
 
   it('no surface line captures the registration call type', () => {

--- a/src/sidecar/test/capture-v2-handler-param.test.ts
+++ b/src/sidecar/test/capture-v2-handler-param.test.ts
@@ -1,0 +1,223 @@
+/**
+ * carrick#498: a subscriber anchor must capture the payload its handler
+ * RECEIVES, not the type of the registration call it sits on.
+ *
+ * Pre-fix, the subscriber side of a pub/sub pair reached capture as a
+ * LINE-ONLY infer anchor (its collector deliberately sends no expression
+ * text). `locateNode`'s line fallback then resolved the first expression on
+ * that line, which is the enclosing `client.subscribe(...)` CALL — so the
+ * alias captured that call's return type. With a `void`-returning subscribe
+ * the surface line read `void`; with one returning a subscription handle it
+ * read that handle. Both self-check clean, so nothing downstream caught it and
+ * every correctly-typed publisher/subscriber pair read incompatible.
+ *
+ * The fix carries the `function_param` locator through to capture as
+ * `param_name` and resolves the handler's parameter structurally: the last
+ * function-typed argument of the call on the anchor's line (or a function
+ * declared within two lines of it), then the parameter by name, by whole
+ * destructured binding pattern, or by binding element. No method name,
+ * library, or topic string is consulted anywhere.
+ *
+ * Fixtures are synthetic and generically named.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { captureStub } from '../src/capture/index.js';
+import type { CaptureStubResult } from '../src/capture/api.js';
+
+let repoDir: string;
+let outRoot: string;
+
+const SUBSCRIBER_TS = `export interface OrderEvent {
+  orderId: string;
+  total: number;
+}
+
+export interface Envelope {
+  receivedAt: string;
+  body: OrderEvent;
+}
+
+export interface Subscription {
+  readonly id: string;
+  close(): void;
+}
+
+interface VoidBroker {
+  subscribe(topic: string, handler: (msg: unknown) => void | Promise<void>): void;
+}
+
+interface HandleBroker {
+  subscribe(topic: string, handler: (msg: unknown) => void | Promise<void>): Subscription;
+}
+
+declare const voidClient: VoidBroker;
+declare const handleClient: HandleBroker;
+
+// 1. Plain named parameter on an inline handler.
+voidClient.subscribe('orders.placed', async (msg: OrderEvent) => {
+  console.log(msg.orderId);
+});
+
+// 2. Whole destructured binding pattern: the pattern's own type IS the payload.
+voidClient.subscribe('orders.shipped', async ({ orderId, total }: OrderEvent) => {
+  console.log(orderId, total);
+});
+
+// 3. One binding element inside a destructured envelope parameter.
+voidClient.subscribe('orders.settled', async ({ body }: Envelope) => {
+  console.log(body.orderId);
+});
+
+// 4. The registration returns a handle rather than void: pre-fix this captured
+//    the handle, which is the same bug wearing a non-void type.
+handleClient.subscribe('orders.cancelled', async (msg: OrderEvent) => {
+  console.log(msg.orderId);
+});
+
+// 5. Handler signature starts a line below the registration call.
+voidClient.subscribe(
+  'orders.refunded',
+  async (msg: OrderEvent) => {
+    console.log(msg.total);
+  }
+);
+
+// 6. No such parameter anywhere: must abstain, never fall back to the call.
+voidClient.subscribe('orders.archived', async (msg: OrderEvent) => {
+  console.log(msg.orderId);
+});
+`;
+
+function writeRepo(): void {
+  fs.mkdirSync(path.join(repoDir, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoDir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        rootDir: 'src',
+        module: 'esnext',
+        moduleResolution: 'bundler',
+        target: 'es2022',
+        skipLibCheck: true,
+      },
+      include: ['src'],
+    })
+  );
+  fs.writeFileSync(path.join(repoDir, 'src', 'subscriber.ts'), SUBSCRIBER_TS);
+}
+
+/** 1-based line of the first source line containing `needle`. */
+function lineOf(needle: string): number {
+  const lines = SUBSCRIBER_TS.split('\n');
+  const index = lines.findIndex((l) => l.includes(needle));
+  assert.ok(index >= 0, `fixture line not found: ${needle}`);
+  return index + 1;
+}
+
+describe('capture v2: subscriber anchors capture the handler payload parameter (carrick#498)', () => {
+  let result: CaptureStubResult;
+  let surface: string;
+
+  before(() => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-498-repo-'));
+    outRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'carrick-498-stub-'));
+    writeRepo();
+    const anchor = (alias: string, line: number, param: string) => ({
+      kind: 'infer' as const,
+      alias,
+      source_file: 'src/subscriber.ts',
+      anchor_origin: 'deterministic-infer' as const,
+      line_number: line,
+      param_name: param,
+    });
+    result = captureStub({
+      repoRoot: repoDir,
+      serviceName: 'subscriber-svc',
+      outDir: path.join(outRoot, 'stub'),
+      anchors: [
+        anchor('Plain_Producer_Response', lineOf("'orders.placed'"), 'msg'),
+        anchor(
+          'Pattern_Producer_Response',
+          lineOf("'orders.shipped'"),
+          '{ orderId, total }'
+        ),
+        anchor('Element_Producer_Response', lineOf("'orders.settled'"), 'body'),
+        anchor('Handle_Producer_Response', lineOf("'orders.cancelled'"), 'msg'),
+        // Anchored on the topic argument line; the handler starts one line below,
+        // inside the tolerance the fix mirrors from the v1 inferrer.
+        anchor('NextLine_Producer_Response', lineOf("'orders.refunded'"), 'msg'),
+        anchor('Missing_Producer_Response', lineOf("'orders.archived'"), 'nosuchparam'),
+      ],
+    });
+    assert.strictEqual(result.success, true, JSON.stringify(result.errors));
+    surface = fs.readFileSync(
+      path.join(result.stub_dir, 'types', 'surface.d.ts'),
+      'utf8'
+    );
+  });
+
+  after(() => {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    fs.rmSync(outRoot, { recursive: true, force: true });
+  });
+
+  const aliasLine = (alias: string): string => {
+    const match = surface.match(new RegExp(`export type ${alias} = ([^;]+);`));
+    assert.ok(match, `no surface line for ${alias} in:\n${surface}`);
+    return match[1].trim();
+  };
+
+  it('a plain named handler parameter captures the payload, not the call', () => {
+    assert.match(aliasLine('Plain_Producer_Response'), /OrderEvent/);
+  });
+
+  it('a whole destructured binding pattern captures the payload', () => {
+    const text = aliasLine('Pattern_Producer_Response');
+    assert.match(text, /OrderEvent|orderId/);
+    assert.doesNotMatch(text, /^void$/);
+  });
+
+  it('a binding element inside an envelope parameter captures that property', () => {
+    assert.match(aliasLine('Element_Producer_Response'), /OrderEvent/);
+  });
+
+  it('a registration returning a handle still captures the payload', () => {
+    const text = aliasLine('Handle_Producer_Response');
+    assert.match(text, /OrderEvent/);
+    assert.doesNotMatch(text, /Subscription/);
+  });
+
+  it('a handler whose signature starts below the registration line resolves', () => {
+    assert.match(aliasLine('NextLine_Producer_Response'), /OrderEvent/);
+  });
+
+  it('no surface line captures the registration call type', () => {
+    for (const alias of [
+      'Plain_Producer_Response',
+      'Pattern_Producer_Response',
+      'Element_Producer_Response',
+      'Handle_Producer_Response',
+      'NextLine_Producer_Response',
+    ]) {
+      assert.notStrictEqual(
+        aliasLine(alias),
+        'void',
+        `${alias} captured the registration call's return type`
+      );
+    }
+  });
+
+  it('an unresolvable parameter abstains rather than capturing the call', () => {
+    assert.strictEqual(aliasLine('Missing_Producer_Response'), 'unknown');
+    const record = result.aliases.find(
+      (a) => a.alias === 'Missing_Producer_Response'
+    );
+    assert.ok(record?.capture_failure_reason?.includes('nosuchparam'));
+  });
+});


### PR DESCRIPTION
Fixes #498.

## Symptom

Every pub/sub subscriber-side alias (the producer role under the pubsub direction convention) captured `void`, so every real publisher/subscriber pair read incompatible: a typed publisher payload against a subscriber `void`. #440's void-vs-void pre-verdict gate cannot help here, because only one side is void.

## Confirmed mechanism

Not the `handler_return` anchor kind (never constructed), and not the handler function's awaited return type either. Measured against the real capture bundle:

`collect_pubsub_infer_requests` builds the subscriber request as `InferKind::FunctionParam` with `param_name` set and `expression_text: None` (deliberate, so the containing-function search is not text-terminal). `derive_capture_anchors` then dropped both the kind and the param name and emitted `CaptureAnchor::Infer` with nothing but a line number. `locateNode`'s line fallback resolves the first expression on that line, which is the enclosing registration CALL, so the alias captured that call's result.

Node identity, measured by calling `locateNode` directly on a synthetic subscriber file:

```
LOCATOR line 18 -> CallExpression: voidClient.subscribe('orders.placed', async (msg: OrderEvent) => { ...
```

The surface lines the same anchors produced, pre-fix:

| handler shape | subscribe returns | captured |
|---|---|---|
| `(msg: OrderEvent) => ...` | `void` | `void` |
| `({ orderId, total }: OrderEvent) => ...` | `void` | `void` |
| `({ body }: Envelope) => ...` | `void` | `void` |
| `(msg: OrderEvent) => ...` | `Subscription` | `import("./subscriber").Subscription` |
| handler on the line below the call | `void` | `"orders.refunded"` (the topic argument) |

The non-void rows settle it: the captured type tracks the registration call, not the handler. Every one of those aliases recorded `self_check: 'ok'` and `top_type_at_self_check: false`, so `void` shipped as a confident contract with nothing downstream able to catch it.

The bug only surfaces when v1 inference did not resolve the alias first. When it does, `derive_capture_anchors` routes the alias to a literal anchor carrying the v1 text and the locator is never reached, which is why the existing `pubsub_wrapper_type_capture_test` fixture stayed green throughout.

## Fix

Scoped to subscriber anchor derivation and capture. The direction table is untouched.

- `param_name` is added to the infer anchor on the wire (`CaptureAnchor::Infer`, `InferAnchorRequest`), skipped when absent so every existing anchor stays byte-identical.
- `derive_capture_anchors` carries `request.param_name` through, gated on `InferKind::FunctionParam`. An expression-kind request never carries one.
- `resolveAnchor` resolves a `param_name` anchor before the expression locator and treats the outcome as final. Handler selection is structural: the last function-typed argument of a call starting on the anchor's line, or a function declared within two lines of it (mirroring the v1 inferrer's tolerance), or the innermost function enclosing the located node. Candidates are tried in that order and the first with a matching parameter wins; where several calls start on one line (`wrap(bus.subscribe(t, h), g)`) they are ordered innermost first, which is the tie-break the v1 inferrer's `findFunctionByLine` already uses. Parameter selection mirrors the v1 inferrer's three shapes: exact name, whole destructured binding pattern under whitespace normalisation, or one binding element inside a destructured parameter.
- An unresolvable parameter demotes to `unknown` rather than falling through to the expression locator. Falling through is what produced the wrong concrete type, and a guaranteed abstain is never worse than a confident wrong answer.

No method name, library, or topic string is consulted anywhere in the new code.

## Tests, verified failing pre-fix

`src/sidecar/test/capture-v2-handler-param.test.ts` (new, 8 cases: plain parameter, whole binding pattern, binding element, handle-returning registration, handler starting below the registration line, same-line nested registrations, no alias capturing the call type, and the abstain case). With the fix reverted and the wire field kept so the test still compiles, all fail with the table above; with the fix, all pass.

The same-line nesting case is its own pin: with the innermost ordering removed the pre-order walk resolves the OUTER handler's parameter of the same name, measured as `import("./subscriber").Envelope` where the payload is `OrderEvent`.

`derive_anchors_carry_function_param_locator_for_subscribers` in `type_compat_v2.rs` pins the wire half: a `FunctionParam` request carries its param name onto the anchor, an `Expression` request with the same field set does not.

## Regression runs

- `cd src/sidecar && npm run build && npm test`: 318 tests, 0 fail (1 pre-existing skip).
- #440's gate and its neighbours, named explicitly: `check-v2*.test.ts`, `gap-regression.test.ts`, `infer-pubsub-anchor-source.test.ts`, `infer-function-param-binding.test.ts`, 67 tests, 0 fail.
- `cargo test --lib`: 726 pass. `cargo test --test pubsub_wrapper_type_capture_test`: pass. Plus every other suite CI runs (output contract, mock storage, dependency analysis, integration, file-centric, sidecar integration, url alias, cassette hard gate, xrepo harness, eval_xrepo, carrick-match): all pass.
- `cargo fmt --all -- --check` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Limitation

A subscriber whose handler is a named function declared far from the registration line still abstains: the line-based candidates cannot reach it, and following a named handler reference from the registration site is a separate piece of work. That case degrades to `unknown` (unverifiable) rather than to a wrong verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
