### PR TITLE
chore(deps): fix all open Dependabot security alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1300,7 +1300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1468,9 +1468,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -1733,18 +1733,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.224"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.224"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.224"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2316,30 +2326,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/src/sidecar/package-lock.json
+++ b/src/sidecar/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "pnpm": "9.15.9",
+        "pnpm": "10.34.5",
         "typescript": "^5.8.0"
       },
       "engines": {
@@ -83,9 +83,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/pnpm": {
-      "version": "9.15.9",
-      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz",
-      "integrity": "sha512-aARhQYk8ZvrQHAeSMRKOmvuJ74fiaR1p5NQO7iKJiClf1GghgbrlW1hBjDolO95lpQXsfF+UA+zlzDzTfc8lMQ==",
+      "version": "10.34.5",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-10.34.5.tgz",
+      "integrity": "sha512-pO4F8vc2WCVb1qiYWcBlpFwopX2u+uLIk6Fo7itzFow3uR6D5X6mdlStA/AwMXRkMOi84442LgQmBfuKvIAZLg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/src/sidecar/package.json
+++ b/src/sidecar/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "pnpm": "9.15.9",
+    "pnpm": "10.34.5",
     "typescript": "^5.8.0"
   },
   "engines": {


### PR DESCRIPTION
Closes all 28 open Dependabot alerts.

## Bumps

| Dependency | Before | After | Advisories |
|---|---|---|---|
| `pnpm` (sidecar devDependency) | 9.15.9 | 10.34.5 | 24 alerts, all fixed at >=10.34.4 |
| `brace-expansion` (transitive, sidecar) | 2.1.0 | 2.1.4 | GHSA-mh99-v99m-4gvg, GHSA-3jxr-9vmj-r5cp |
| `time` | 0.3.44 | 0.3.47 | GHSA-r6v5-fh4h-64xc |
| `rand` (0.8.x) | 0.8.5 | 0.8.6 | GHSA-cq8v-f236-94qc |

## pnpm 9 -> 10 (major) verification

No sidecar code changes were needed. Each v10 behaviour change that touches the capture path was verified empirically, not assumed:

- Root-manifest `pnpm.overrides` (written by `check-workspace.ts`) still honoured — verified with a two-package repro using the exact `.npmrc`/workspace shape the sidecar emits.
- All emitted `.npmrc` keys remain valid in v10.
- Dependency lifecycle scripts are now off by default: installs still exit 0 and packages still ship their `.d.ts`, which is all the tsc judge needs. For a sidecar installing untrusted third-party code this default is a security improvement.
- `node_modules/.bin/pnpm` path unchanged; the live suites assert `isolation === 'pnpm'` and pass.

Sidecar tests: 313 pass, identical to the pre-bump baseline. `npm audit`: 0 vulnerabilities.

## serde held at 1.0.224

`time` 0.3.47 requires `serde_core ^1.0.220`, but serde 1.0.225+ removes the plain `serde::__private` module that the pinned `swc_common` 12.0.1 imports, breaking the build. 1.0.224 satisfies both. A bare `cargo update` will re-break main until the swc stack moves to >=14 — tracked in #503.

Full Rust suite (726 lib + 741 bin + all integration targets), fmt, clippy `-D warnings`, the wasm-match build, and `cargo audit` (now exit 0) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)