### PR TITLE
fix(eval): make Tier-A scans hermetic + surface raw call targets in the projection

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -2350,6 +2350,33 @@ impl Analyzer {
         }
     }
 
+    /// Raw call targets for the eval projection, keyed by the same identity a
+    /// consumer `ApiEndpointDetails` carries: `(canonical key, file location)`.
+    /// The canonical key path is host-free by design (`consumer_call_path`
+    /// strips a literal origin so the match key can join a producer route), so
+    /// the raw source target (`http://comment-service/api/comments?...`) is the
+    /// only place the host survives. The Tier-A scorer's `host_contains`
+    /// labels assert against it; nothing in the product path reads this.
+    pub fn call_raw_targets(&self) -> HashMap<(String, String), String> {
+        self.mount_graph
+            .as_ref()
+            .map(|g| {
+                g.get_data_calls()
+                    .iter()
+                    .map(|c| {
+                        (
+                            (
+                                OperationKey::http(&c.method, c.canonical_path.clone()).canonical(),
+                                c.file_location.clone(),
+                            ),
+                            c.target_url.clone(),
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     /// Overlay the type-compatibility verdict onto each captured cross-repo
     /// edge, keyed by the producer's `(METHOD, identity)` AND the consumer's
     /// source location — so each `(producer, consumer)` pair gets ITS OWN

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -452,8 +452,11 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     // an eval run wants only the JSON, no upload or comment side effects. (Eval
     // mode never uploads, so `upload_payloads` is always `None` here.)
     if std::env::var("CARRICK_OUTPUT_JSON").is_ok() {
-        let projection =
-            crate::eval_output::EvalProjection::from_results(&results, &eval_type_manifest);
+        let projection = crate::eval_output::EvalProjection::from_results(
+            &results,
+            &eval_type_manifest,
+            &analyzer.call_raw_targets(),
+        );
         println!("{}", serde_json::to_string_pretty(&projection)?);
         return Ok(());
     }

--- a/src/eval_output.rs
+++ b/src/eval_output.rs
@@ -47,6 +47,14 @@ pub struct EvalOp {
     pub handler: Option<String>,
     pub request_type: Option<String>,
     pub response_type: Option<String>,
+    /// Consumer ops only: the raw call target as written in source
+    /// (`http://comment-service/api/comments?userId=${id}`). `path` above is
+    /// the canonical MATCH key and is host-free for literal-origin URLs, so
+    /// this is the only field that still carries the host. The Tier-A
+    /// scorer's `host_contains` labels assert against it. `None` for
+    /// producer ops and for calls with no mount-graph raw target.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_url: Option<String>,
     pub file: String,
     pub line: u32,
     // --- Type-manifest fields (contract §3), joined by OperationKey ---
@@ -125,8 +133,16 @@ pub struct EvalDependencyConflict {
 impl EvalProjection {
     /// Build the projection from analyzer results plus the merged type manifest.
     /// The manifest is joined per op by `OperationKey`; deps come straight from
-    /// `result.dependency_conflicts`; matches from `result.cross_repo_matches`.
-    pub fn from_results(result: &ApiAnalysisResult, type_manifest: &[TypeManifestEntry]) -> Self {
+    /// `result.dependency_conflicts`; matches from `result.cross_repo_matches`;
+    /// `raw_targets` (from [`ApiAnalyzer::call_raw_targets`], keyed
+    /// `(canonical key, file location)`) attaches each consumer op's raw source
+    /// target so host-asserting eval labels can still see a literal origin the
+    /// canonical key deliberately strips.
+    pub fn from_results(
+        result: &ApiAnalysisResult,
+        type_manifest: &[TypeManifestEntry],
+        raw_targets: &HashMap<(String, String), String>,
+    ) -> Self {
         let manifest_index = ManifestIndex::build(type_manifest);
         // Canonical ordering so the projection is deterministic across runs:
         // the matcher's edge order and analyze_dependencies' conflict order are
@@ -194,7 +210,16 @@ impl EvalProjection {
                 .calls
                 .iter()
                 .filter(|d| !is_self_loop_op(d))
-                .map(|d| EvalOp::from_details(d, &manifest_index, ManifestRole::Consumer))
+                .map(|d| {
+                    let mut op = EvalOp::from_details(d, &manifest_index, ManifestRole::Consumer);
+                    op.target_url = raw_targets
+                        .get(&(
+                            d.key.canonical(),
+                            d.file_path.to_string_lossy().into_owned(),
+                        ))
+                        .cloned();
+                    op
+                })
                 .collect(),
             cross_repo_matches,
             dependency_conflicts,
@@ -441,6 +466,7 @@ impl EvalOp {
                 .response_type
                 .as_ref()
                 .map(|t| t.composite_type_string.clone()),
+            target_url: None,
             file,
             line,
             type_alias: fields.as_ref().and_then(|f| f.type_alias.clone()),
@@ -692,7 +718,7 @@ mod tests {
             cross_repo_matches: vec![],
         };
 
-        let projection = EvalProjection::from_results(&result, &[]);
+        let projection = EvalProjection::from_results(&result, &[], &HashMap::new());
         let endpoint_keys: Vec<&str> = projection
             .endpoints
             .iter()
@@ -752,7 +778,7 @@ mod tests {
             cross_repo_matches: vec![],
         };
 
-        let projection = EvalProjection::from_results(&result, &[]);
+        let projection = EvalProjection::from_results(&result, &[], &HashMap::new());
         let surviving: Vec<(&str, &str)> = projection
             .endpoints
             .iter()
@@ -860,7 +886,7 @@ mod tests {
             Some("OrderResponse"),
         )];
 
-        let projection = EvalProjection::from_results(&result, &manifest);
+        let projection = EvalProjection::from_results(&result, &manifest, &HashMap::new());
         let json: Value =
             serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
 
@@ -935,7 +961,7 @@ mod tests {
             cross_repo_matches: vec![],
         };
 
-        let projection = EvalProjection::from_results(&result, &[]);
+        let projection = EvalProjection::from_results(&result, &[], &HashMap::new());
         let json: Value =
             serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
         let op = &json["endpoints"].as_array().unwrap()[0];
@@ -1008,7 +1034,7 @@ mod tests {
             Some("Payment"),
         )];
 
-        let projection = EvalProjection::from_results(&result, &manifest);
+        let projection = EvalProjection::from_results(&result, &manifest, &HashMap::new());
         let json: Value =
             serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
         let op = &json["calls"].as_array().unwrap()[0];
@@ -1085,7 +1111,7 @@ mod tests {
             ),
         ];
 
-        let projection = EvalProjection::from_results(&result, &manifest);
+        let projection = EvalProjection::from_results(&result, &manifest, &HashMap::new());
         let json: Value =
             serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
 
@@ -1160,7 +1186,7 @@ mod tests {
             ),
         ];
 
-        let projection = EvalProjection::from_results(&result, &manifest);
+        let projection = EvalProjection::from_results(&result, &manifest, &HashMap::new());
         let json: Value =
             serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
         let op = &json["endpoints"].as_array().unwrap()[0];
@@ -1217,7 +1243,7 @@ mod tests {
             None,
         )];
 
-        let projection = EvalProjection::from_results(&result, &manifest);
+        let projection = EvalProjection::from_results(&result, &manifest, &HashMap::new());
         let json: Value =
             serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
         let op = &json["calls"].as_array().unwrap()[0];
@@ -1294,7 +1320,7 @@ mod tests {
             ),
         ];
 
-        let projection = EvalProjection::from_results(&result, &manifest);
+        let projection = EvalProjection::from_results(&result, &manifest, &HashMap::new());
         let json: Value =
             serde_json::from_str(&serde_json::to_string(&projection).unwrap()).unwrap();
         let calls = json["calls"].as_array().unwrap();

--- a/tests/eval_tier_a.rs
+++ b/tests/eval_tier_a.rs
@@ -123,10 +123,24 @@ fn mean_sd(xs: &[f64]) -> (f64, f64) {
 /// `dump_dir`, when set (capture mode), is passed to the scanner as
 /// `CARRICK_EVAL_DUMP_DIR` so the file-analyzer persists its raw input/output
 /// there for prompt-hardening diagnostics.
+///
+/// Each scan runs HERMETIC: `CARRICK_LOCAL_STORAGE_DIR` (a per-scan temp dir)
+/// selects `LocalDirStorage` over the real cloud store, and
+/// `CARRICK_LOCAL_STORAGE_ISOLATE=1` makes sibling-repo download return empty
+/// (the xrepo harness's Phase-A isolation). Without this, the scan joins
+/// whatever the CI identity's live project holds — when dogfood scans populated
+/// that project, every fixture's projection inherited its endpoints and calls,
+/// collapsing precision while recall stayed 1.0 (#505). The LLM extraction
+/// path is unaffected: file-analyzer calls go to the compile-time API endpoint
+/// regardless of the storage backend.
 fn run_scanner(bin: &Path, fixture_dir: &Path, dump_dir: Option<&Path>) -> Option<EvalProjection> {
     for attempt in 1..=2 {
+        let hermetic_store = tempfile::tempdir().expect("create hermetic storage dir");
         let mut cmd = Command::new(bin);
-        cmd.arg(fixture_dir).env("CARRICK_OUTPUT_JSON", "1");
+        cmd.arg(fixture_dir)
+            .env("CARRICK_OUTPUT_JSON", "1")
+            .env("CARRICK_LOCAL_STORAGE_DIR", hermetic_store.path())
+            .env("CARRICK_LOCAL_STORAGE_ISOLATE", "1");
         if let Some(d) = dump_dir {
             cmd.env("CARRICK_EVAL_DUMP_DIR", d);
         }
@@ -189,21 +203,29 @@ fn score_run(
     let ep_hits: Vec<bool> = expected_eps.iter().map(|e| found_eps.contains(e)).collect();
 
     // Calls: fuzzy match on method + host_contains + path_contains, HTTP only.
-    let found_calls: Vec<(String, String)> = proj
+    // `path` is the canonical MATCH key and is host-free for literal-origin
+    // URLs (`consumer_call_path` strips `scheme://host`), so `host_contains`
+    // is checked against the raw source target (`target_url`) with the
+    // canonical path as fallback — the host would otherwise be unmatchable
+    // by construction and every host-asserting label would MISS.
+    let found_calls: Vec<(String, String, String)> = proj
         .calls
         .iter()
         .filter(|o| o.protocol == "http")
         .filter_map(|o| {
+            let path = o.path.clone()?;
+            let raw = o.target_url.clone().unwrap_or_else(|| path.clone());
             Some((
                 o.method.clone().unwrap_or_default().to_uppercase(),
-                o.path.clone()?,
+                path,
+                raw,
             ))
         })
         .collect();
-    let matches = |e: &ExpCall, c: &(String, String)| {
+    let matches = |e: &ExpCall, c: &(String, String, String)| {
         c.0 == e.method.to_uppercase()
-            && c.1.contains(&e.host_contains)
-            && c.1.contains(&e.path_contains)
+            && (c.1.contains(&e.host_contains) || c.2.contains(&e.host_contains))
+            && (c.1.contains(&e.path_contains) || c.2.contains(&e.path_contains))
     };
     let call_hits: Vec<bool> = expected
         .calls

--- a/tests/fixtures/llm-mocked-api/__golden__.json
+++ b/tests/fixtures/llm-mocked-api/__golden__.json
@@ -90,6 +90,7 @@
       "handler": "fetch(",
       "request_type": null,
       "response_type": null,
+      "target_url": "https://orders.internal/api/orders?user=${userId}",
       "file": "tests/fixtures/llm-mocked-api/src/client.ts",
       "line": 4,
       "type_alias": "Endpoint_4022e5b76e4552db_Response_Calle64c9717ada550f1",


### PR DESCRIPTION
Root-causes and fixes #505 (Tier-A monitor all-red on main). The scanner itself was never regressing — the identical, zero-variance scores on main and an unrelated dependency-bump branch were two eval-harness defects:

## 1. Live-project pollution (endpoint precision collapse)

The Tier-A runner scanned each fixture against the real cloud store. CI's OIDC identity maps to the scanner-evals project, and cross-repo download merged that project's contents into every fixture's projection. Harmless while the project was empty — then dogfood scans populated it (carrick-site 2026-08-05, carrick-cloud 2026-08-08: 33 endpoints, ~80 calls), and koa-api's endpoint precision became exactly 4/36 with recall 1.00.

Fix: each scan now runs with `CARRICK_LOCAL_STORAGE_DIR` (per-scan temp dir) + `CARRICK_LOCAL_STORAGE_ISOLATE=1` — the same Phase-A isolation the xrepo harness uses — so sibling downloads return empty while LLM extraction stays live.

## 2. Host loss in the call projection (call F1 exactly 0.00)

Since the type-compat v2 flip (#429), calls are keyed on the host-free canonical path and the projection carried no field containing a literal origin, so `expected.json` `host_contains` labels could never match, by construction. A capture run (31254837866) proves the file-analyzer still extracts the full target: `http://comment-service/api/comments?userId=${id}`.

Fix: the raw source target is threaded from the mount graph's data calls into `EvalOp.target_url` (additive, eval-only, `skip_serializing_if None`), and the scorer checks `host_contains`/`path_contains` against it with the canonical path as fallback. Ground-truth labels are unchanged.

The cassette hard gate caught the projection shape change on frozen input (now emitting `target_url` — the fix working); the golden is re-recorded per its procedure.

## Verification

- Full suite: 1579 passed / 0 failed; fmt + clippy clean.
- Attribution evidence in #505: main run 31245864670 and PR-branch run 31245557579 scored bit-identically, and xrepo (same SHA) scored call-set F1 1.00 — extraction was demonstrably fine.
- A Tier-A dispatch against this branch is the acceptance test: expected back at baseline (F1 1.00 across fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)