### PR TITLE
fix: normalize joined route paths (missing leading slash drops endpoints from the type manifest)

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -4537,25 +4537,30 @@ impl FileOrchestrator {
             } else {
                 format!("/{}", trimmed_path)
             }
-        } else if trimmed_path.is_empty() {
-            trimmed_prefix.to_string()
         } else {
+            // Every emitted path must be absolute. A mount prefix reaches here
+            // exactly as extracted (only trimmed), so a slashless one would
+            // otherwise emit a slashless full path, which the type-manifest
+            // writer drops on its `starts_with('/')` guard.
+            let pfx = if trimmed_prefix.starts_with('/') {
+                trimmed_prefix.to_string()
+            } else {
+                format!("/{}", trimmed_prefix)
+            };
+            if trimmed_path.is_empty() {
+                return pfx;
+            }
             // Idempotent guard: if the endpoint path already carries this prefix,
             // don't apply it twice. This happens when a constructor-carried prefix
             // is baked into the endpoint path AND also (redundantly) emitted as the
             // mount's path_prefix — without the guard that doubled to
             // `/api/v1/api/v1/status`. Match on a segment boundary so `/api` does
             // not spuriously swallow `/apixyz`. Framework-agnostic.
-            let pfx = if trimmed_prefix.starts_with('/') {
-                trimmed_prefix.to_string()
-            } else {
-                format!("/{}", trimmed_prefix)
-            };
             let full = format!("/{}", trimmed_path);
             match full.strip_prefix(&pfx) {
                 // Already prefixed (exact, or at a segment boundary) — don't double it.
                 Some(rest) if rest.is_empty() || rest.starts_with('/') => full,
-                _ => format!("{}/{}", trimmed_prefix, trimmed_path),
+                _ => format!("{}/{}", pfx, trimmed_path),
             }
         }
     }
@@ -5114,6 +5119,37 @@ export * from "./aFetch.js";"#,
         );
         // Empty prefix passes the path through.
         assert_eq!(FileOrchestrator::join_paths("", "/users"), "/users");
+    }
+
+    /// A mount prefix that arrives without a leading slash must still produce
+    /// an absolute full path. Nothing between the extraction pass and
+    /// `resolve_endpoint_paths` guarantees the slash (the mount path is only
+    /// trimmed), and a slashless full path is dropped outright by the
+    /// `starts_with('/')` guards in the type-manifest writer, so the endpoint
+    /// gets no SymbolRequest and no bundled types.
+    #[test]
+    fn join_paths_normalizes_a_slashless_prefix() {
+        // Nested path under a slashless prefix: the join must not leak the raw
+        // prefix through (pre-fix this emitted `field/document/field/create-many`).
+        assert_eq!(
+            FileOrchestrator::join_paths("field", "/document/field/create-many"),
+            "/field/document/field/create-many"
+        );
+        // Root route on a slashless-prefixed router (`router.get('/')`).
+        assert_eq!(FileOrchestrator::join_paths("field", "/"), "/field");
+        // Empty endpoint path is the same branch.
+        assert_eq!(FileOrchestrator::join_paths("field", ""), "/field");
+        // The idempotent guard still holds when the prefix has no leading slash.
+        assert_eq!(
+            FileOrchestrator::join_paths("api/v1", "/api/v1/status"),
+            "/api/v1/status"
+        );
+        // A slashless prefix with a trailing slash must not double the separator.
+        assert_eq!(
+            FileOrchestrator::join_paths("field/", "/create"),
+            "/field/create"
+        );
+        assert_eq!(FileOrchestrator::join_paths("field/", "/"), "/field");
     }
 
     /// Regression: `tsconfig.json` with `"baseUrl": "."` makes


### PR DESCRIPTION
## Symptom

`FileOrchestrator::join_paths` could emit a relative route path. Given a mount prefix of `field` and an endpoint path of `/document/field/create-many`, it returned `field/document/field/create-many` instead of `/field/document/field/create-many`.

## Root cause

The function already computes a slash-normalized prefix (`pfx`) for its idempotent double-prefix guard, but neither return site used it. The empty-endpoint-path branch returned `trimmed_prefix` directly, and the join branch formatted `trimmed_prefix` rather than `pfx`. So the normalization existed purely as a comparison key and never reached the output. A prefix that already began with a slash masked the defect, which is why the existing tests passed.

Nothing upstream guarantees the leading slash. The mount path is extracted by the analyzer pass, the response schema does not require a slash, and `canonicalize_endpoint_paths` only trims whitespace from it. There is an explicit `starts_with('/')` filter on the deterministic prefix-extraction path in `agent_service.rs`, so the invariant is enforced there but not at the join.

## Downstream consequence

A relative full path is not merely cosmetic. The type-manifest writer in `engine/mod.rs` skips any endpoint or call whose path fails `starts_with('/')`. An endpoint that picked up a slashless prefix therefore got no manifest entry, no `SymbolRequest`, and no bundled types, and `get_endpoint_types` returns nothing for it. The endpoint is dropped silently, with no warning on the way out. Whether any endpoints are being lost this way in practice is worth re-measuring on the live eval after this merges.

## Fix

Hoist the existing `pfx` normalization above the branch split and return it from both sites. `pfx` is guaranteed to have exactly one leading slash and no trailing slash, and the endpoint path has already had its leading slashes trimmed, so no double separator can appear. The idempotent double-prefix guard is untouched, as is the one-level-prefix limitation, which is a separate known gap.

## Tests

A new unit test sits beside the existing `join_paths` cases and covers the nested slashless-prefix join, the router-root case (`router.get('/')`, which reaches the empty-path branch), the empty endpoint path, the idempotent guard under a slashless prefix, and a slashless prefix carrying a trailing slash. Written first, confirmed failing on the nested case with the exact reported output, then green after the fix.

Full suite is green: 1581 passed, 0 failed. No fixtures changed. The frozen-cassette hard gate matches its golden unchanged, which confirms the fix produces no output drift on the mocked corpus.

## Issue references

#285 and #286 in this repository are merged pull requests about pub/sub type resolution, not issue reports, so this PR carries no `Fixes` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
