### PR TITLE
feat(scanner): deterministic SDK-mediated external call candidates

### DIFF
--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -565,6 +565,7 @@ impl CloudStorage for AwsStorage {
                     type_extraction_status: None,
                     compat_verdicts: None,
                     capture_stub: None,
+                    external_call_candidates: None,
                 };
                 repo_s3_urls.insert(adjacent.repo.clone(), adjacent.s3_url);
                 all_repo_data.push(repo_data);

--- a/src/cloud_storage/mock_storage.rs
+++ b/src/cloud_storage/mock_storage.rs
@@ -114,6 +114,7 @@ impl CloudStorage for MockStorage {
                     type_extraction_status: None,
                     compat_verdicts: None,
                     capture_stub: None,
+                    external_call_candidates: None,
                 },
                 CloudRepoData {
                     repo_name: "repo-b".to_string(),
@@ -141,6 +142,7 @@ impl CloudStorage for MockStorage {
                     type_extraction_status: None,
                     compat_verdicts: None,
                     capture_stub: None,
+                    external_call_candidates: None,
                 },
             ];
             result.extend(mock_repos);
@@ -183,6 +185,7 @@ impl MockStorage {
             dependencies,
             dev_dependencies: HashMap::new(),
             peer_dependencies: HashMap::new(),
+            optional_dependencies: HashMap::new(),
             resolutions: HashMap::new(),
         };
 
@@ -211,6 +214,7 @@ impl MockStorage {
             dependencies,
             dev_dependencies: HashMap::new(),
             peer_dependencies: HashMap::new(),
+            optional_dependencies: HashMap::new(),
             resolutions: HashMap::new(),
         };
 

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -2,6 +2,7 @@ use crate::{
     agents::{file_analyzer_agent::FileAnalysisResult, framework_guidance_agent::ProtocolGuidance},
     analyzer::ApiEndpointDetails,
     app_context::AppContext,
+    external_call_candidates::ExternalCallCandidate,
     framework_detector::DetectionResult,
     mount_graph::MountGraph,
     multi_agent_orchestrator::MultiAgentAnalysisResult,
@@ -211,6 +212,18 @@ pub struct CloudRepoData {
     /// pairs verdict unverifiable with a re-scan reason, never compatible.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capture_stub: Option<CaptureStubArtifact>,
+    /// Deterministic, AST-only outbound call candidates for this service
+    /// (carrick#510). A parallel data channel, not part of the operation
+    /// index: these rows are never projected into `endpoints` or `calls`, and
+    /// nothing in matching or type compatibility reads them. The downstream
+    /// consumer is an egress-inventory surface that enumerates where a service
+    /// talks to something it does not own.
+    ///
+    /// Additive and optional: blobs scanned before the field existed carry
+    /// `None`, which reads as "this scan predates the channel", not as "this
+    /// service makes no external calls".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_call_candidates: Option<Vec<ExternalCallCandidate>>,
 }
 
 /// Version of the v2 capture stub artifact schema. Bumped on incompatible
@@ -367,6 +380,7 @@ impl CloudRepoData {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         }
     }
 }
@@ -687,6 +701,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         }
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1154,6 +1154,7 @@ async fn analyze_current_repo_incremental(
                 &protocol_extractions,
                 &merged_results,
             );
+            attach_external_call_candidates(&mut cloud_data, repo_path, &files, packages);
 
             // Populate cache fields
             let mut cached_file_results = merged_results.clone();
@@ -2171,6 +2172,38 @@ fn relativize_function_definition_paths(
     }
 }
 
+/// Run the deterministic external-call candidate scan and attach its rows to
+/// the payload (carrick#510).
+///
+/// Called on both analysis paths and deliberately outside the incremental
+/// cache: the scan is pure AST over the service's already-discovered file list,
+/// costs nothing, and `files` is always the full set on both paths, so a cached
+/// run and a full run produce the same rows.
+///
+/// `None` rather than an empty vector when there is nothing to report, so the
+/// cloud can tell "no candidates" apart from "scanned before this channel
+/// existed".
+fn attach_external_call_candidates(
+    cloud_data: &mut CloudRepoData,
+    repo_path: &str,
+    files: &[PathBuf],
+    packages: &Packages,
+) {
+    let candidates = crate::external_call_candidates::scan_files(
+        files,
+        std::path::Path::new(repo_path),
+        packages,
+    );
+    debug!(
+        "External call candidates: {} row(s) for {}",
+        candidates.len(),
+        cloud_data.repo_name
+    );
+    if !candidates.is_empty() {
+        cloud_data.external_call_candidates = Some(candidates);
+    }
+}
+
 fn build_cloud_data_from_mount_graph(
     repo_name: &str,
     repo_path: &str,
@@ -2240,6 +2273,7 @@ fn build_cloud_data_from_mount_graph(
         type_extraction_status: None,
         compat_verdicts: None,
         capture_stub: None,
+        external_call_candidates: None,
     }
 }
 
@@ -3178,6 +3212,7 @@ async fn analyze_current_repo(
         &protocol_extractions,
         &analysis_result.file_results,
     );
+    attach_external_call_candidates(&mut cloud_data, repo_path, &files, packages);
 
     let mut manifest_entries =
         build_type_manifest_entries(&analysis_result.mount_graph, config, repo_path);
@@ -3557,6 +3592,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         };
 
         // Verify strip_ast_nodes removes AST nodes
@@ -3599,6 +3635,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         }];
 
         // Test Config merging
@@ -3678,6 +3715,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         }];
 
         // Test that cross-repo builder doesn't fail with SourceMap issues
@@ -4271,6 +4309,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         };
 
         let stripped = strip_ast_nodes(data);
@@ -4316,6 +4355,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         };
 
         let stripped = strip_ast_nodes(data);
@@ -4364,6 +4404,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         };
 
         // Size the file_results filler so the payload lands just UNDER the 5MB
@@ -4575,6 +4616,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         };
 
         let json = serde_json::to_string(&data).expect("should serialize");
@@ -4595,6 +4637,68 @@ mod tests {
             deserialized.package_json_hash,
             Some("abc123hash".to_string())
         );
+    }
+
+    /// The deterministic candidate scan reaches the payload, and it reaches it
+    /// as its own channel: endpoints and calls are untouched, so SDK rows can
+    /// never leak into HTTP endpoint matching.
+    #[test]
+    fn attach_external_call_candidates_populates_only_the_new_field() {
+        let fixture =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/external-call-candidates");
+        let fixture_str = fixture.to_string_lossy().to_string();
+        let service = Config {
+            directory: Some("apps/api".to_string()),
+            ..Default::default()
+        };
+        let ignore_patterns = service_ignore_patterns(&service);
+        let (files, package_json) =
+            crate::file_finder::find_service_files(&fixture_str, &service, &ignore_patterns);
+        let mut packages = Packages::new(package_json.into_iter().collect()).expect("packages");
+        packages.internal_names = crate::packages::collect_internal_package_names(&fixture);
+
+        let mut data = CloudRepoData {
+            repo_name: "svc".to_string(),
+            service_name: None,
+            endpoints: vec![],
+            calls: vec![],
+            mounts: vec![],
+            apps: HashMap::new(),
+            imported_handlers: vec![],
+            function_definitions: HashMap::new(),
+            config_json: None,
+            package_json: None,
+            packages: None,
+            last_updated: chrono::Utc::now(),
+            commit_hash: "abc123".to_string(),
+            mount_graph: None,
+            bundled_types: None,
+            type_manifest: None,
+            file_results: None,
+            cached_detection: None,
+            cached_guidance: None,
+            cached_extraction_config: None,
+            package_json_hash: None,
+            cache_version: None,
+            type_extraction_status: None,
+            compat_verdicts: None,
+            capture_stub: None,
+            external_call_candidates: None,
+        };
+
+        attach_external_call_candidates(&mut data, &fixture_str, &files, &packages);
+
+        let rows = data
+            .external_call_candidates
+            .as_ref()
+            .expect("fixture yields candidates");
+        assert!(!rows.is_empty());
+        assert!(
+            rows.iter()
+                .all(|row| row.mechanism == crate::external_call_candidates::CallMechanism::Sdk)
+        );
+        assert!(data.endpoints.is_empty(), "endpoints must not be touched");
+        assert!(data.calls.is_empty(), "calls must not be touched");
     }
 
     #[test]
@@ -4649,6 +4753,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         };
 
         let json = serde_json::to_string(&data).expect("should serialize");
@@ -6951,6 +7056,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         }
     }
 }

--- a/src/engine/type_compat_v2.rs
+++ b/src/engine/type_compat_v2.rs
@@ -1156,6 +1156,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub,
+            external_call_candidates: None,
         }
     }
 

--- a/src/external_call_candidates.rs
+++ b/src/external_call_candidates.rs
@@ -1,0 +1,801 @@
+//! Deterministic, AST-only detection of SDK-mediated outbound call candidates.
+//!
+//! The scanner's existing outbound-call candidates are HTTP-shaped: `fetch` /
+//! axios-style calls, env-var-anchored URLs, absolute URLs. A call made through
+//! a service client imported from an npm package never looks like that, so it
+//! is invisible to candidate generation and to every surface downstream of it.
+//!
+//! This module adds a parallel data channel for that class. It is intentionally
+//! narrow:
+//!
+//! - **Structural, not name-based.** A call becomes a candidate when its callee
+//!   traces, through this file's own imports, to a package that the service's
+//!   `package.json` declares as a runtime dependency. There is no allowlist and
+//!   no denylist of SDK or vendor names anywhere in this module — the
+//!   dependency set comes from the repo's own manifests.
+//! - **No type checking.** Resolution is limited to what the AST proves:
+//!   an import binding, and a variable whose initializer is rooted at one. A
+//!   receiver obtained any other way (returned from a helper, read off a DI
+//!   container, a class field) is not resolved and emits nothing. Recording
+//!   less than the truth is the deliberate choice over guessing.
+//! - **Never merged into HTTP matching.** These rows are their own mechanism
+//!   and their own payload field. They are not endpoints, they are not consumer
+//!   calls, and nothing here touches extraction, matching, or type
+//!   compatibility. Folding SDK traffic into HTTP endpoint matching is the
+//!   known false-positive class this design exists to avoid.
+//!
+//! These are candidates, not verified egress. Any declared dependency
+//! qualifies, so a web framework, a local crypto library, and a validation
+//! library all produce rows alongside genuine service clients, which is the
+//! intended trade of recall in the scanner against classification downstream.
+//!
+//! Known limitations, all deliberate for this slice and all silent rather than
+//! guessed:
+//!
+//! - ESM `import` declarations only. `require()` and TypeScript `import =`
+//!   bindings produce no rows.
+//! - Type-only imports are excluded, both `import type ...` and per-specifier
+//!   `import { type Foo }`.
+//! - Destructuring off a resolved binding (`const { charges } = client`) is not
+//!   followed.
+//! - Constructor calls (`new Client(...)`) resolve the receiver without becoming
+//!   rows themselves, because constructing a client is not egress.
+
+use crate::packages::Packages;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use swc_common::{FileName, GLOBALS, Globals, Mark, SourceMap, sync::Lrc};
+use swc_ecma_ast::*;
+use swc_ecma_parser::{EsSyntax, Parser, StringInput, Syntax, TsSyntax, lexer::Lexer};
+use swc_ecma_transforms_base::resolver;
+use swc_ecma_visit::{Visit, VisitMutWith, VisitWith};
+use tracing::warn;
+
+/// Upper bound on the rows one service contributes to the upload payload.
+/// Rows are sorted before truncation, so a repo over the cap yields a stable
+/// prefix rather than an arbitrary sample. The cap exists so a very large
+/// monorepo cannot push the payload towards the Lambda request limit; it is
+/// generous enough that no realistic service reaches it.
+pub const MAX_CANDIDATES_PER_SERVICE: usize = 5000;
+
+/// How the scanner established that a call site leaves the service.
+///
+/// Only [`CallMechanism::Sdk`] is produced today. The env-var-URL and
+/// external-domain HTTP classes are detected elsewhere in the scanner and are
+/// not yet projected into this channel; the enum is shaped so they join without
+/// changing the row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CallMechanism {
+    /// The callee resolves, through an import, to a declared runtime dependency.
+    Sdk,
+}
+
+/// One outbound call candidate.
+///
+/// Ordering is `(file, line, callee, package)`, which is also the sort key the
+/// scan emits in, so the row list is byte-identical across runs of the same
+/// tree.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ExternalCallCandidate {
+    /// Repo-relative path of the file containing the call.
+    pub file: String,
+    /// 1-based line number of the call expression.
+    pub line: usize,
+    /// The callee as written, dotted (`ledger.payments.create`). Computed from
+    /// the AST, so it carries no whitespace or comments from the source.
+    pub callee: String,
+    /// The declared dependency the callee resolves to, exactly as the
+    /// `package.json` names it (a subpath import such as `pkg/edge` resolves to
+    /// `pkg`).
+    pub package: String,
+    /// Always [`CallMechanism::Sdk`] for now.
+    pub mechanism: CallMechanism,
+}
+
+/// Scan `files` for SDK-mediated call candidates.
+///
+/// `files` is expected to be the service's already-filtered source list from
+/// [`crate::file_finder::find_service_files`], so test trees, story files, and
+/// vendored/build directories are excluded by the scanner's existing rules
+/// rather than by anything invented here.
+pub fn scan_files(
+    files: &[PathBuf],
+    repo_root: &Path,
+    packages: &Packages,
+) -> Vec<ExternalCallCandidate> {
+    let dependencies = runtime_dependency_names(packages);
+    if dependencies.is_empty() {
+        return Vec::new();
+    }
+
+    let mut rows: BTreeSet<ExternalCallCandidate> = BTreeSet::new();
+    for file in files {
+        let Ok(content) = std::fs::read_to_string(file) else {
+            continue;
+        };
+        let relative = relative_path(file, repo_root);
+        rows.extend(scan_content(&relative, file, &content, &dependencies));
+    }
+
+    let mut rows: Vec<ExternalCallCandidate> = rows.into_iter().collect();
+    if rows.len() > MAX_CANDIDATES_PER_SERVICE {
+        warn!(
+            "External call candidates truncated to {} of {} rows for this service",
+            MAX_CANDIDATES_PER_SERVICE,
+            rows.len()
+        );
+        rows.truncate(MAX_CANDIDATES_PER_SERVICE);
+    }
+    rows
+}
+
+/// Package names that count as external runtime dependencies of this service.
+///
+/// `dependencies`, `peerDependencies`, and `optionalDependencies` — the three
+/// maps whose contents can be present at runtime. `devDependencies` is excluded:
+/// carrick#510 asks for calls into "the repo's package.json dependency set" and
+/// says nothing about dev dependencies, and a test harness or build tool calling
+/// out is not service egress.
+///
+/// Workspace-internal packages are subtracted. A monorepo member is normally
+/// declared as a dependency of its siblings (`"workspace:*"`), and a call into
+/// one is an internal call, not egress. `Packages::internal_names` holds the
+/// name of every `package.json` in the repo tree, which is what makes this
+/// structural rather than a naming convention.
+fn runtime_dependency_names(packages: &Packages) -> HashSet<String> {
+    packages
+        .package_jsons
+        .iter()
+        .flat_map(|pkg| {
+            pkg.dependencies
+                .keys()
+                .chain(pkg.peer_dependencies.keys())
+                .chain(pkg.optional_dependencies.keys())
+        })
+        .filter(|name| !packages.internal_names.contains(*name))
+        .cloned()
+        .collect()
+}
+
+/// Rows are cloud-bound, so `file` must be repo-relative.
+///
+/// A file the scan root does not contain is reported verbatim rather than
+/// dropped, but loudly: an absolute path in the inventory means the walk root
+/// and the payload root have diverged, and that is a bug worth seeing rather
+/// than a row worth silently mangling.
+fn relative_path(file: &Path, repo_root: &Path) -> String {
+    match file.strip_prefix(repo_root) {
+        Ok(relative) => relative.to_string_lossy().to_string(),
+        Err(_) => {
+            warn!(
+                "External call candidate file {} is not under the scan root {}; \
+                 reporting the path as-is",
+                file.display(),
+                repo_root.display()
+            );
+            file.to_string_lossy().to_string()
+        }
+    }
+}
+
+/// Which declared dependency does this module specifier import from?
+///
+/// Exact match, or a subpath under it (`"pkg/edge"` resolves to `"pkg"`). This
+/// is the same matching convention the messaging-client and data-fetcher import
+/// gates use, kept identical so a package is recognized the same way
+/// everywhere. A relative specifier (`"./x"`), a bare Node builtin (`"fs"`,
+/// `"node:fs"`), and a workspace-internal package all fail it, because none of
+/// them appears in the dependency set.
+fn resolve_specifier<'a>(specifier: &str, dependencies: &'a HashSet<String>) -> Option<&'a String> {
+    if let Some(exact) = dependencies.get(specifier) {
+        return Some(exact);
+    }
+    dependencies
+        .iter()
+        .filter(|dep| specifier.starts_with(&format!("{}/", dep)))
+        // A specifier can only match one declared package by prefix in
+        // practice, but pick the longest deterministically rather than relying
+        // on HashSet order.
+        .max_by_key(|dep| dep.len())
+}
+
+fn syntax_for(file_path: &Path) -> (Syntax, bool) {
+    match file_path.extension().and_then(|e| e.to_str()) {
+        Some("ts") => (
+            Syntax::Typescript(TsSyntax {
+                decorators: true,
+                ..Default::default()
+            }),
+            true,
+        ),
+        Some("tsx") => (
+            Syntax::Typescript(TsSyntax {
+                tsx: true,
+                decorators: true,
+                ..Default::default()
+            }),
+            true,
+        ),
+        Some("jsx") => (
+            Syntax::Es(EsSyntax {
+                jsx: true,
+                ..Default::default()
+            }),
+            false,
+        ),
+        _ => (Syntax::Es(Default::default()), false),
+    }
+}
+
+fn scan_content(
+    relative_file: &str,
+    file_path: &Path,
+    content: &str,
+    dependencies: &HashSet<String>,
+) -> Vec<ExternalCallCandidate> {
+    let (syntax, is_typescript) = syntax_for(file_path);
+
+    // A fresh SourceMap per file keeps byte offsets — and therefore the line
+    // lookups below — file-local.
+    let source_map: Lrc<SourceMap> = Default::default();
+    let source_file = source_map.new_source_file(
+        Lrc::new(FileName::Real(file_path.to_path_buf())),
+        content.to_string(),
+    );
+
+    let lexer = Lexer::new(
+        syntax,
+        Default::default(),
+        StringInput::from(&*source_file),
+        None,
+    );
+    let mut parser = Parser::new_from(lexer);
+    let Ok(mut module) = parser.parse_module() else {
+        // An unparseable file contributes nothing. The scanner already reports
+        // parse failures on its own path; this channel stays quiet.
+        return Vec::new();
+    };
+
+    // The resolver stamps syntax contexts, so bindings are compared by
+    // (symbol, context) rather than by name. A local `const stripe = ...`
+    // inside a function therefore does not collide with a module-level import
+    // of the same name.
+    GLOBALS.set(&Globals::new(), || {
+        let unresolved_mark = Mark::new();
+        let top_level_mark = Mark::new();
+        let mut pass = resolver(unresolved_mark, top_level_mark, is_typescript);
+        module.visit_mut_with(&mut pass);
+    });
+
+    let mut bindings = import_bindings(&module, dependencies);
+    if bindings.is_empty() {
+        return Vec::new();
+    }
+    propagate_aliases(&module, &mut bindings);
+
+    let mut visitor = CandidateVisitor {
+        source_map: source_map.clone(),
+        file: relative_file.to_string(),
+        bindings: &bindings,
+        rows: Vec::new(),
+    };
+    module.visit_with(&mut visitor);
+    visitor.rows
+}
+
+/// Local binding -> declared package, for every value import from a dependency.
+fn import_bindings(module: &Module, dependencies: &HashSet<String>) -> HashMap<Id, String> {
+    let mut bindings = HashMap::new();
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
+            continue;
+        };
+        // `import type { X } from 'pkg'` binds nothing at runtime.
+        if import.type_only {
+            continue;
+        }
+        let Some(package) = resolve_specifier(import.src.value.as_ref(), dependencies) else {
+            continue;
+        };
+        for specifier in &import.specifiers {
+            let local = match specifier {
+                // `import { type X, y }` — the inline type specifier is erased.
+                ImportSpecifier::Named(named) if named.is_type_only => continue,
+                ImportSpecifier::Named(named) => named.local.to_id(),
+                ImportSpecifier::Default(default) => default.local.to_id(),
+                ImportSpecifier::Namespace(namespace) => namespace.local.to_id(),
+            };
+            bindings.insert(local, package.clone());
+        }
+    }
+    bindings
+}
+
+/// Extend `bindings` with variables whose initializer is rooted at an existing
+/// binding, so an instance held in a local resolves to the package that
+/// produced it.
+///
+/// Covers the shapes static resolution can actually prove:
+/// `const c = new Client()`, `const c = createClient()`,
+/// `const c = sdk.clients.build()`, `const c = sdk.storage`. The declarator
+/// name must be a plain identifier; destructuring is not followed.
+///
+/// Runs to a fixed point so a chain declared out of order resolves the same way
+/// as one declared in order, and so the result does not depend on traversal
+/// order. Each round can only add bindings, and the binding set is bounded by
+/// the number of declarators, so this terminates.
+fn propagate_aliases(module: &Module, bindings: &mut HashMap<Id, String>) {
+    let mut collector = AliasCollector {
+        aliases: Vec::new(),
+    };
+    module.visit_with(&mut collector);
+
+    loop {
+        let mut added = false;
+        for (local, init) in &collector.aliases {
+            if bindings.contains_key(local) {
+                continue;
+            }
+            if let Some((root, _)) = callee_chain(init)
+                && let Some(package) = bindings.get(&root).cloned()
+            {
+                bindings.insert(local.clone(), package);
+                added = true;
+            }
+        }
+        if !added {
+            break;
+        }
+    }
+}
+
+struct AliasCollector {
+    /// `(bound identifier, expression it is initialized from)`, in source order.
+    aliases: Vec<(Id, Box<Expr>)>,
+}
+
+impl Visit for AliasCollector {
+    fn visit_var_declarator(&mut self, declarator: &VarDeclarator) {
+        if let (Pat::Ident(name), Some(init)) = (&declarator.name, &declarator.init) {
+            let source = match &**init {
+                // `new Client(...)` and `createClient(...)` both hand back an
+                // instance owned by whatever the callee resolves to.
+                Expr::New(new_expr) => Some(new_expr.callee.clone()),
+                Expr::Call(call) => match &call.callee {
+                    Callee::Expr(callee) => Some(callee.clone()),
+                    _ => None,
+                },
+                // `const storage = sdk.storage` — a handle reached off a
+                // resolved binding stays owned by the same package.
+                other @ (Expr::Member(_) | Expr::Ident(_)) => Some(Box::new(other.clone())),
+                _ => None,
+            };
+            if let Some(source) = source {
+                self.aliases.push((name.id.to_id(), source));
+            }
+        }
+        declarator.visit_children_with(self);
+    }
+}
+
+/// Split a callee expression into its root identifier and the property names
+/// applied to it, or `None` when any part is not statically nameable
+/// (computed access, a call in the middle of the chain, a literal receiver).
+fn callee_chain(expr: &Expr) -> Option<(Id, Vec<String>)> {
+    match expr {
+        Expr::Ident(ident) => Some((ident.to_id(), Vec::new())),
+        Expr::Paren(paren) => callee_chain(&paren.expr),
+        Expr::TsNonNull(non_null) => callee_chain(&non_null.expr),
+        Expr::TsAs(as_expr) => callee_chain(&as_expr.expr),
+        Expr::Member(member) => {
+            let MemberProp::Ident(prop) = &member.prop else {
+                return None;
+            };
+            let (root, mut props) = callee_chain(&member.obj)?;
+            props.push(prop.sym.to_string());
+            Some((root, props))
+        }
+        Expr::OptChain(opt_chain) => match &*opt_chain.base {
+            // `a?.b.c()` — the receiver chain is nameable even though it is
+            // guarded. A call inside the chain is not.
+            OptChainBase::Member(member) => {
+                let MemberProp::Ident(prop) = &member.prop else {
+                    return None;
+                };
+                let (root, mut props) = callee_chain(&member.obj)?;
+                props.push(prop.sym.to_string());
+                Some((root, props))
+            }
+            OptChainBase::Call(_) => None,
+        },
+        _ => None,
+    }
+}
+
+fn format_callee(root: &Id, props: &[String]) -> String {
+    let mut text = root.0.to_string();
+    for prop in props {
+        text.push('.');
+        text.push_str(prop);
+    }
+    text
+}
+
+struct CandidateVisitor<'a> {
+    source_map: Lrc<SourceMap>,
+    file: String,
+    bindings: &'a HashMap<Id, String>,
+    rows: Vec<ExternalCallCandidate>,
+}
+
+impl CandidateVisitor<'_> {
+    fn record(&mut self, callee: &Expr, span: swc_common::Span) {
+        let Some((root, props)) = callee_chain(callee) else {
+            return;
+        };
+        let Some(package) = self.bindings.get(&root) else {
+            return;
+        };
+        self.rows.push(ExternalCallCandidate {
+            file: self.file.clone(),
+            line: self.source_map.lookup_char_pos(span.lo).line,
+            callee: format_callee(&root, &props),
+            package: package.clone(),
+            mechanism: CallMechanism::Sdk,
+        });
+    }
+}
+
+impl Visit for CandidateVisitor<'_> {
+    fn visit_call_expr(&mut self, call: &CallExpr) {
+        if let Callee::Expr(callee) = &call.callee {
+            self.record(callee, call.span);
+        }
+        call.visit_children_with(self);
+    }
+
+    fn visit_opt_chain_expr(&mut self, opt_chain: &OptChainExpr) {
+        // `client?.send(...)` is an optional call, not a `CallExpr`, so it
+        // needs its own arm or the row is silently lost.
+        if let OptChainBase::Call(call) = &*opt_chain.base {
+            let callee = call.callee.clone();
+            self.record(&callee, opt_chain.span);
+        }
+        opt_chain.visit_children_with(self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::file_finder::find_service_files;
+    use crate::packages::{Packages, collect_internal_package_names};
+
+    const IGNORE_PATTERNS: &[&str] = &["node_modules", "dist", "build", ".next"];
+
+    fn fixture_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/external-call-candidates")
+    }
+
+    /// The fixture is a workspace whose scanned service is `apps/api`, matching
+    /// the monorepo shape `carrick.json` declares.
+    fn fixture_service() -> Config {
+        Config {
+            directory: Some("apps/api".to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Run the scan exactly as the engine does: the service's file list comes
+    /// from `find_service_files`, so the scanner's own test-file and
+    /// artifact-directory exclusions are what filter the input, and the
+    /// dependency set comes from the service's `package.json` plus the
+    /// repo-wide internal-name sweep.
+    fn scan_fixture() -> Vec<ExternalCallCandidate> {
+        let root = fixture_root();
+        let root_str = root.to_string_lossy().to_string();
+        let (files, package_json) =
+            find_service_files(&root_str, &fixture_service(), IGNORE_PATTERNS);
+        let mut packages =
+            Packages::new(package_json.into_iter().collect()).expect("fixture package.json parses");
+        packages.internal_names = collect_internal_package_names(&root);
+        scan_files(&files, &root, &packages)
+    }
+
+    fn rows_for(rows: &[ExternalCallCandidate], file: &str) -> Vec<(usize, String, String)> {
+        rows.iter()
+            .filter(|row| row.file == file)
+            .map(|row| (row.line, row.callee.clone(), row.package.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn fixture_scan_matches_expected_rows() {
+        let rows = scan_fixture();
+        let actual: Vec<(String, usize, String, String)> = rows
+            .iter()
+            .map(|row| {
+                (
+                    row.file.clone(),
+                    row.line,
+                    row.callee.clone(),
+                    row.package.clone(),
+                )
+            })
+            .collect();
+
+        let expected: Vec<(String, usize, String, String)> = vec![
+            (
+                "apps/api/src/direct-call.ts",
+                4,
+                "sendNotice",
+                "courier-sdk",
+            ),
+            (
+                "apps/api/src/member-call.ts",
+                6,
+                "ledger.payments.create",
+                "ledger-client",
+            ),
+            (
+                "apps/api/src/member-call.ts",
+                10,
+                "createInvoice",
+                "ledger-client",
+            ),
+            (
+                "apps/api/src/namespace-call.ts",
+                3,
+                "telemetry.createSink",
+                "telemetry-sink",
+            ),
+            (
+                "apps/api/src/namespace-call.ts",
+                6,
+                "telemetry.emit",
+                "telemetry-sink",
+            ),
+            (
+                "apps/api/src/namespace-call.ts",
+                7,
+                "sink.flush",
+                "telemetry-sink",
+            ),
+            (
+                "apps/api/src/optional-dep.ts",
+                6,
+                "uplink.put",
+                "storage-uplink",
+            ),
+            (
+                "apps/api/src/subpath-import.ts",
+                4,
+                "publishEdge",
+                "courier-sdk",
+            ),
+        ]
+        .into_iter()
+        .map(|(file, line, callee, package)| {
+            (
+                file.to_string(),
+                line,
+                callee.to_string(),
+                package.to_string(),
+            )
+        })
+        .collect();
+
+        assert_eq!(actual, expected);
+        assert!(rows.iter().all(|row| row.mechanism == CallMechanism::Sdk));
+    }
+
+    #[test]
+    fn direct_imported_function_call_emits_a_row() {
+        let rows = scan_fixture();
+        assert_eq!(
+            rows_for(&rows, "apps/api/src/direct-call.ts"),
+            vec![(4, "sendNotice".to_string(), "courier-sdk".to_string())]
+        );
+    }
+
+    /// The receiver is a local holding a client constructed from an imported
+    /// class, which is as far as static resolution reaches.
+    #[test]
+    fn member_call_on_constructed_client_emits_a_row() {
+        let rows = scan_fixture();
+        let member = rows_for(&rows, "apps/api/src/member-call.ts");
+        assert!(
+            member.contains(&(
+                6,
+                "ledger.payments.create".to_string(),
+                "ledger-client".to_string()
+            )),
+            "expected the instance member call, got {:?}",
+            member
+        );
+    }
+
+    #[test]
+    fn namespace_import_call_emits_a_row() {
+        let rows = scan_fixture();
+        let namespace = rows_for(&rows, "apps/api/src/namespace-call.ts");
+        assert!(
+            namespace.contains(&(
+                6,
+                "telemetry.emit".to_string(),
+                "telemetry-sink".to_string()
+            )),
+            "expected the namespace call, got {:?}",
+            namespace
+        );
+        assert!(
+            namespace.contains(&(7, "sink.flush".to_string(), "telemetry-sink".to_string())),
+            "a handle returned from a namespace call keeps its package: {:?}",
+            namespace
+        );
+    }
+
+    /// `peerDependencies` and `optionalDependencies` count as runtime
+    /// dependencies; `telemetry-sink` is a peer, `storage-uplink` optional.
+    #[test]
+    fn peer_and_optional_dependencies_resolve() {
+        let rows = scan_fixture();
+        assert!(rows.iter().any(|row| row.package == "telemetry-sink"));
+        assert_eq!(
+            rows_for(&rows, "apps/api/src/optional-dep.ts"),
+            vec![(6, "uplink.put".to_string(), "storage-uplink".to_string())]
+        );
+    }
+
+    /// `courier-sdk/edge` resolves to the declared package `courier-sdk`.
+    #[test]
+    fn subpath_import_resolves_to_the_declared_package() {
+        let rows = scan_fixture();
+        assert_eq!(
+            rows_for(&rows, "apps/api/src/subpath-import.ts"),
+            vec![(4, "publishEdge".to_string(), "courier-sdk".to_string())]
+        );
+    }
+
+    /// Relative imports, Node builtins (bare and `node:`-prefixed), and a
+    /// workspace-internal package all fail the structural rule.
+    #[test]
+    fn relative_builtin_and_workspace_imports_emit_nothing() {
+        let rows = scan_fixture();
+        assert_eq!(rows_for(&rows, "apps/api/src/no-rows.ts"), Vec::new());
+    }
+
+    /// carrick#510 is silent on dev dependencies, so they are excluded: a call
+    /// into a build or test tool is not service egress.
+    #[test]
+    fn dev_dependency_only_import_emits_nothing() {
+        let rows = scan_fixture();
+        assert_eq!(rows_for(&rows, "apps/api/src/dev-only.ts"), Vec::new());
+    }
+
+    /// A type-only declaration binds nothing, while the value specifier in a
+    /// mixed declaration still does.
+    #[test]
+    fn type_only_imports_emit_nothing() {
+        let rows = scan_fixture();
+        assert_eq!(rows_for(&rows, "apps/api/src/type-only.ts"), Vec::new());
+        assert!(
+            rows_for(&rows, "apps/api/src/member-call.ts").contains(&(
+                10,
+                "createInvoice".to_string(),
+                "ledger-client".to_string()
+            )),
+            "the value half of a mixed type/value import still resolves"
+        );
+    }
+
+    /// Direct guard on the type-only filter. A type binding in call position is
+    /// not valid TypeScript, but the parser accepts it, so the filter is
+    /// asserted rather than assumed.
+    #[test]
+    fn type_only_binding_is_never_callable() {
+        let dependencies: HashSet<String> = ["ledger-client".to_string()].into_iter().collect();
+        assert_eq!(
+            scan_content(
+                "src/t.ts",
+                Path::new("t.ts"),
+                "import type { createInvoice } from \"ledger-client\";\ncreateInvoice();\n",
+                &dependencies,
+            ),
+            Vec::new()
+        );
+        assert_eq!(
+            scan_content(
+                "src/t.ts",
+                Path::new("t.ts"),
+                "import { type createInvoice } from \"ledger-client\";\ncreateInvoice();\n",
+                &dependencies,
+            ),
+            Vec::new()
+        );
+    }
+
+    /// Test trees and build-artifact directories are excluded by the scanner's
+    /// existing walk rules, not by anything this module defines.
+    #[test]
+    fn test_and_artifact_files_are_never_scanned() {
+        let rows = scan_fixture();
+        assert!(
+            rows.iter().all(|row| !row.file.contains("__tests__")
+                && !row.file.contains("/dist/")
+                && !row.file.ends_with(".test.ts")),
+            "excluded trees leaked into the rows: {:?}",
+            rows
+        );
+    }
+
+    /// A local declaration shadowing an import must not inherit its package.
+    #[test]
+    fn shadowed_binding_does_not_resolve() {
+        let dependencies: HashSet<String> = ["courier-sdk".to_string()].into_iter().collect();
+        let rows = scan_content(
+            "src/shadow.ts",
+            Path::new("shadow.ts"),
+            r#"import { sendNotice } from "courier-sdk";
+
+export function local() {
+  const sendNotice = (m: string) => m;
+  return sendNotice("hi");
+}
+
+export function real() {
+  return sendNotice("hi");
+}
+"#,
+            &dependencies,
+        );
+        assert_eq!(
+            rows.iter().map(|r| r.line).collect::<Vec<_>>(),
+            vec![9],
+            "only the unshadowed call resolves: {:?}",
+            rows
+        );
+    }
+
+    /// Two scans of the same tree produce byte-identical rows.
+    #[test]
+    fn scan_is_deterministic() {
+        assert_eq!(scan_fixture(), scan_fixture());
+    }
+
+    #[test]
+    fn empty_dependency_set_emits_nothing() {
+        let root = fixture_root();
+        let root_str = root.to_string_lossy().to_string();
+        let (files, _) = find_service_files(&root_str, &fixture_service(), IGNORE_PATTERNS);
+        assert_eq!(
+            scan_files(&files, &root, &Packages::default()),
+            Vec::new(),
+            "no declared dependencies means no candidates"
+        );
+    }
+
+    #[test]
+    fn mechanism_serializes_as_snake_case() {
+        let row = ExternalCallCandidate {
+            file: "src/a.ts".to_string(),
+            line: 3,
+            callee: "client.send".to_string(),
+            package: "courier-sdk".to_string(),
+            mechanism: CallMechanism::Sdk,
+        };
+        assert_eq!(
+            serde_json::to_value(&row).unwrap(),
+            serde_json::json!({
+                "file": "src/a.ts",
+                "line": 3,
+                "callee": "client.send",
+                "package": "courier-sdk",
+                "mechanism": "sdk"
+            })
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod engine;
 pub mod env_alias;
 pub mod eval_output;
+pub mod external_call_candidates;
 pub mod extractor;
 pub mod file_based_router;
 pub mod file_finder;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod config;
 mod engine;
 mod env_alias;
 mod eval_output;
+mod external_call_candidates;
 mod extractor;
 mod file_based_router;
 mod file_finder;

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -978,6 +978,7 @@ mod tests {
             type_extraction_status: None,
             compat_verdicts: None,
             capture_stub: None,
+            external_call_candidates: None,
         }
     }
 

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -18,6 +18,15 @@ pub struct PackageJson {
     #[serde(default)]
     #[serde(rename = "peerDependencies")]
     pub peer_dependencies: HashMap<String, String>,
+    /// npm `optionalDependencies`. Deliberately NOT folded into
+    /// [`Packages::resolve_dependencies`]: `merged_dependencies` drives the
+    /// cloud dependency list and the synthetic type-check install, and an
+    /// optional dependency is by definition allowed to be absent there. It is
+    /// read only where "could this package be present at runtime?" is the
+    /// question — see `crate::external_call_candidates`.
+    #[serde(default)]
+    #[serde(rename = "optionalDependencies")]
+    pub optional_dependencies: HashMap<String, String>,
     /// yarn/pnpm `resolutions` (version-override map). Keys may be plain names
     /// or `name@range` selectors; values may be `npm:<real-name>@<range>`
     /// aliases that remap a locally-invented dependency name (e.g. MetaMask's

--- a/tests/dependency_analysis_test.rs
+++ b/tests/dependency_analysis_test.rs
@@ -21,6 +21,7 @@ async fn test_dependency_conflict_detection() {
         dependencies: deps_a,
         dev_dependencies: HashMap::new(),
         peer_dependencies: HashMap::new(),
+        optional_dependencies: HashMap::new(),
         resolutions: HashMap::new(),
     };
 
@@ -42,6 +43,7 @@ async fn test_dependency_conflict_detection() {
         dependencies: deps_b,
         dev_dependencies: HashMap::new(),
         peer_dependencies: HashMap::new(),
+        optional_dependencies: HashMap::new(),
         resolutions: HashMap::new(),
     };
 
@@ -96,6 +98,7 @@ async fn test_no_dependency_conflicts_when_versions_match() {
         dependencies: deps_a,
         dev_dependencies: HashMap::new(),
         peer_dependencies: HashMap::new(),
+        optional_dependencies: HashMap::new(),
         resolutions: HashMap::new(),
     };
 
@@ -116,6 +119,7 @@ async fn test_no_dependency_conflicts_when_versions_match() {
         dependencies: deps_b,
         dev_dependencies: HashMap::new(),
         peer_dependencies: HashMap::new(),
+        optional_dependencies: HashMap::new(),
         resolutions: HashMap::new(),
     };
 
@@ -153,6 +157,7 @@ async fn test_no_conflicts_for_unique_packages() {
         dependencies: deps_a,
         dev_dependencies: HashMap::new(),
         peer_dependencies: HashMap::new(),
+        optional_dependencies: HashMap::new(),
         resolutions: HashMap::new(),
     };
 
@@ -173,6 +178,7 @@ async fn test_no_conflicts_for_unique_packages() {
         dependencies: deps_b,
         dev_dependencies: HashMap::new(),
         peer_dependencies: HashMap::new(),
+        optional_dependencies: HashMap::new(),
         resolutions: HashMap::new(),
     };
 
@@ -216,6 +222,7 @@ async fn test_only_major_incompatible_conflicts_reported() {
         dependencies: deps_a,
         dev_dependencies: HashMap::new(),
         peer_dependencies: HashMap::new(),
+        optional_dependencies: HashMap::new(),
         resolutions: HashMap::new(),
     };
 
@@ -237,6 +244,7 @@ async fn test_only_major_incompatible_conflicts_reported() {
         dependencies: deps_b,
         dev_dependencies: HashMap::new(),
         peer_dependencies: HashMap::new(),
+        optional_dependencies: HashMap::new(),
         resolutions: HashMap::new(),
     };
 

--- a/tests/fixtures/external-call-candidates/apps/api/dist/bundle.ts
+++ b/tests/fixtures/external-call-candidates/apps/api/dist/bundle.ts
@@ -1,0 +1,5 @@
+import { sendNotice } from "courier-sdk";
+
+export function bundled(): void {
+  sendNotice({ userId: "generated" });
+}

--- a/tests/fixtures/external-call-candidates/apps/api/package.json
+++ b/tests/fixtures/external-call-candidates/apps/api/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@fixture/api",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@fixture/internal-lib": "workspace:*",
+    "courier-sdk": "^1.0.0",
+    "ledger-client": "^2.0.0"
+  },
+  "devDependencies": {
+    "bench-harness": "^1.0.0"
+  },
+  "peerDependencies": {
+    "telemetry-sink": "^3.0.0"
+  },
+  "optionalDependencies": {
+    "storage-uplink": "^4.0.0"
+  }
+}

--- a/tests/fixtures/external-call-candidates/apps/api/src/__tests__/notify.test.ts
+++ b/tests/fixtures/external-call-candidates/apps/api/src/__tests__/notify.test.ts
@@ -1,0 +1,5 @@
+import { sendNotice } from "courier-sdk";
+
+it("notifies", async () => {
+  await sendNotice({ userId: "u1" });
+});

--- a/tests/fixtures/external-call-candidates/apps/api/src/dev-only.ts
+++ b/tests/fixtures/external-call-candidates/apps/api/src/dev-only.ts
@@ -1,0 +1,5 @@
+import { runBench } from "bench-harness";
+
+export function bench(): void {
+  runBench();
+}

--- a/tests/fixtures/external-call-candidates/apps/api/src/direct-call.ts
+++ b/tests/fixtures/external-call-candidates/apps/api/src/direct-call.ts
@@ -1,0 +1,5 @@
+import { sendNotice } from "courier-sdk";
+
+export async function notify(userId: string): Promise<void> {
+  await sendNotice({ userId });
+}

--- a/tests/fixtures/external-call-candidates/apps/api/src/helper.ts
+++ b/tests/fixtures/external-call-candidates/apps/api/src/helper.ts
@@ -1,0 +1,3 @@
+export function helper(value: string): string {
+  return value.trim();
+}

--- a/tests/fixtures/external-call-candidates/apps/api/src/member-call.ts
+++ b/tests/fixtures/external-call-candidates/apps/api/src/member-call.ts
@@ -1,0 +1,11 @@
+import { LedgerClient, type Invoice, createInvoice } from "ledger-client";
+
+const ledger = new LedgerClient({ region: "eu-west-1" });
+
+export async function charge(amount: number): Promise<void> {
+  await ledger.payments.create({ amount });
+}
+
+export function draft(): Invoice {
+  return createInvoice({ total: 0 });
+}

--- a/tests/fixtures/external-call-candidates/apps/api/src/namespace-call.ts
+++ b/tests/fixtures/external-call-candidates/apps/api/src/namespace-call.ts
@@ -1,0 +1,8 @@
+import * as telemetry from "telemetry-sink";
+
+const sink = telemetry.createSink({ app: "api" });
+
+export function record(name: string): void {
+  telemetry.emit(name);
+  sink.flush();
+}

--- a/tests/fixtures/external-call-candidates/apps/api/src/no-rows.ts
+++ b/tests/fixtures/external-call-candidates/apps/api/src/no-rows.ts
@@ -1,0 +1,10 @@
+import { readFile } from "node:fs/promises";
+import { createHash } from "crypto";
+import { shared } from "@fixture/internal-lib";
+import { helper } from "./helper";
+
+export async function load(path: string): Promise<string> {
+  const raw = await readFile(path, "utf8");
+  createHash("sha256");
+  return helper(shared(raw));
+}

--- a/tests/fixtures/external-call-candidates/apps/api/src/optional-dep.ts
+++ b/tests/fixtures/external-call-candidates/apps/api/src/optional-dep.ts
@@ -1,0 +1,7 @@
+import { StorageUplink } from "storage-uplink";
+
+const uplink = new StorageUplink();
+
+export async function store(key: string, body: string): Promise<void> {
+  await uplink.put(key, body);
+}

--- a/tests/fixtures/external-call-candidates/apps/api/src/subpath-import.ts
+++ b/tests/fixtures/external-call-candidates/apps/api/src/subpath-import.ts
@@ -1,0 +1,5 @@
+import { publishEdge } from "courier-sdk/edge";
+
+export function ping(id: string): Promise<void> {
+  return publishEdge(id);
+}

--- a/tests/fixtures/external-call-candidates/apps/api/src/type-only.ts
+++ b/tests/fixtures/external-call-candidates/apps/api/src/type-only.ts
@@ -1,0 +1,5 @@
+import type { LedgerClient } from "ledger-client";
+
+export function describe(client: LedgerClient): string {
+  return client.describe();
+}

--- a/tests/fixtures/external-call-candidates/package.json
+++ b/tests/fixtures/external-call-candidates/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@fixture/egress-root",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"]
+}

--- a/tests/fixtures/external-call-candidates/packages/internal-lib/package.json
+++ b/tests/fixtures/external-call-candidates/packages/internal-lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/internal-lib",
+  "version": "0.0.0",
+  "private": true
+}

--- a/tests/fixtures/external-call-candidates/packages/internal-lib/src/index.ts
+++ b/tests/fixtures/external-call-candidates/packages/internal-lib/src/index.ts
@@ -1,0 +1,3 @@
+export function shared(value: string): string {
+  return value;
+}

--- a/tests/mock_storage_test.rs
+++ b/tests/mock_storage_test.rs
@@ -15,6 +15,7 @@ fn create_test_repo_data(repo_name: &str, commit_hash: &str) -> CloudRepoData {
         dependencies: deps,
         dev_dependencies: HashMap::new(),
         peer_dependencies: HashMap::new(),
+        optional_dependencies: HashMap::new(),
         resolutions: HashMap::new(),
     };
 
@@ -49,6 +50,7 @@ fn create_test_repo_data(repo_name: &str, commit_hash: &str) -> CloudRepoData {
         type_extraction_status: None,
         compat_verdicts: None,
         capture_stub: None,
+        external_call_candidates: None,
     }
 }
 


### PR DESCRIPTION
Refs #510.

## What this adds

A deterministic, AST-only pass that detects call expressions whose callee resolves, through the file's own imports, to a package the service declares as a runtime dependency. The rows land in a new field on the upload payload.

```
external_call_candidates: Option<Vec<ExternalCallCandidate>>

{
  "file": "apps/api/src/member-call.ts",   // repo-relative
  "line": 6,                               // 1-based
  "callee": "ledger.payments.create",      // dotted callee text, from the AST
  "package": "ledger-client",              // as the package.json names it
  "mechanism": "sdk"
}
```

The field is additive and optional, so a blob scanned before it existed carries `None`, which reads as "scanned before this channel existed" rather than as "this service makes no external calls".

## The resolution rule

The rule is structural, with no allowlist and no denylist of SDK or vendor names anywhere in the module. The dependency set is read off the service's own `package.json`, and workspace-internal packages are subtracted using the existing repo-wide `package.json` name sweep, so a call into a sibling monorepo member is an internal call rather than egress.

`dependencies`, `peerDependencies` and `optionalDependencies` count, while `devDependencies` do not, because #510 is silent on them and a call from a build or test tool is not service egress. `optionalDependencies` is a new field on `PackageJson`, read only here and deliberately not folded into `resolve_dependencies`, which drives the cloud dependency list and the synthetic type-check install.

Resolution goes as far as the AST proves and no further, so there is no type checker in this module. An import binding resolves, and a variable initialised from one resolves, which covers `const c = new Client()` and `const c = createClient()`. A receiver obtained any other way is left unresolved and emits nothing.

Node builtins, relative imports and workspace-internal packages produce no rows because none of them appears in the dependency set. Test trees and build-artefact directories are excluded by the scanner's existing walk rules rather than by anything new.

The dependency set comes from the one `package.json` `find_service_files` returns for the service, which is pre-existing behaviour shared with framework detection. A monorepo scanned with no declared `directory` therefore reads whichever manifest the unsorted walk reaches last, so the rows for that configuration are only as stable as the walk order. A service with a declared `directory` has exactly one manifest under its root and is unaffected. Filed as #512 rather than changed here, since the same resolution feeds detection and the type-check install.

## What it deliberately does not do

There is no matching integration. Endpoint extraction, cross-repo matching and type compatibility are untouched, and the rows are never projected into `endpoints` or `calls`. SDK traffic folded into HTTP endpoint matching is a known false-positive class (carrick-cloud#148), so this is a parallel channel by construction, with a test asserting that the payload's endpoint and call lists stay empty when candidates are attached.

The rows are candidates rather than verified egress. Any declared dependency qualifies, so a web framework, a local crypto library and a validation library all produce rows alongside genuine service clients, which is the intended trade of recall in the scanner against classification downstream.

The module doc comment records the limitations. The pass reads ESM `import` declarations only, so `require()` and `import =` bindings produce nothing; type-only imports are excluded at both the declaration and the specifier level; destructuring off a resolved binding is not followed; and constructor calls resolve the receiver without becoming rows themselves.

## Consumer

The rows feed an MCP egress-inventory surface that enumerates where a service talks to something it does not own. That work lands in the cloud repo, and nothing in this PR serves them.

## Tests

Sixteen new tests, fifteen of them in the module and one in the engine. The module tests cover a direct imported-function call, a member call on a constructed client, a namespace import call, a handle returned from a namespace call, a subpath import, peer and optional dependencies, a relative import, bare and `node:`-prefixed builtins, a workspace-internal package, a dev-dependency-only import, type-only imports at both levels, a shadowed binding, exclusion of test and artefact trees, run-to-run determinism, and the serialised row shape. They run over a fixture workspace through `find_service_files`, so the exclusions under test are the real pipeline's. The engine test asserts that the wiring populates only the new field.

Every test lives in a `#[cfg(test)]` module, so the existing `cargo test --lib` CI step covers them without a new workflow entry.

Everything below ran locally and passed: every `cargo test --test <name>` step in `ci.yml`, `cargo test --lib`, `cargo test -p carrick-match`, the sidecar's `npm test`, `cargo fmt --all -- --check`, and `cargo clippy --all-targets --all-features -- -D warnings`.

The wiring was also checked end to end on both analysis paths. A mocked offline scan of an existing corpus fixture persisted ten rows with every path repo-relative, and a second scan against the same cache, which took the incremental path, produced the same ten rows.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)