### PR TITLE
feat(scanner): retain egress domains, call lines, and env-var call sites

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -4254,6 +4254,12 @@ impl FileOrchestrator {
                         call_kind: data_call.call_kind,
                         repo_name: None,
                         service_name: None,
+                        // Retention only. Normalisation computes the host and
+                        // the extractor reports the line; both were previously
+                        // thrown away (the line survived as packed text inside
+                        // `file_location`). Neither field is read by matching.
+                        host: normalizer.absolute_host(&data_call.target),
+                        line: u32::try_from(data_call.line_number).ok().filter(|l| *l > 0),
                     },
                     data_call.call_expression_span_start.is_some(),
                 ));
@@ -5792,6 +5798,66 @@ export * from "./aFetch.js";"#,
             "https://api.example.com/data"
         );
         assert_eq!(graph.data_calls[0].method, "POST");
+    }
+
+    /// The host normalisation computes and the line extraction reports are both
+    /// retained on the call, and `file_location` keeps the exact text it
+    /// always had.
+    ///
+    /// The host is retained WITHOUT classification: `api.vendor.test` is
+    /// declared external here and `orders.internal.test` internal, and both
+    /// keep their host. What the declarations decide is matching, which this
+    /// retention does not touch.
+    #[test]
+    fn data_calls_retain_the_host_and_a_typed_line() {
+        let orchestrator = FileOrchestrator::new(AgentService::new());
+        let config = crate::config::Config {
+            internal_domains: ["orders.internal.test".to_string()].into_iter().collect(),
+            external_domains: ["api.vendor.test".to_string()].into_iter().collect(),
+            external_env_vars: ["BILLING_API".to_string()].into_iter().collect(),
+            ..Default::default()
+        };
+
+        let mut file_results = HashMap::new();
+        file_results.insert(
+            "src/service.ts".to_string(),
+            FileAnalysisResult {
+                graphql_consumer_locates: vec![],
+                mounts: vec![],
+                endpoints: vec![],
+                data_calls: vec![
+                    call_with_span(12, "https://api.vendor.test/v1/charges", Some(200)),
+                    call_with_span(18, "https://orders.internal.test/orders", Some(210)),
+                    call_with_span(24, "${process.env.BILLING_API}/invoices", Some(220)),
+                    call_with_span(31, "/api/local", Some(230)),
+                ],
+                graphql_operations: vec![],
+                pubsub_operations: vec![],
+            },
+        );
+
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::new(&config),
+            Path::new(""),
+        );
+
+        let mut retained: Vec<(Option<&str>, Option<u32>, &str)> = graph
+            .data_calls
+            .iter()
+            .map(|call| (call.host.as_deref(), call.line, call.file_location.as_str()))
+            .collect();
+        retained.sort();
+        assert_eq!(
+            retained,
+            vec![
+                (None, Some(24), "src/service.ts:24"),
+                (None, Some(31), "src/service.ts:31"),
+                (Some("api.vendor.test"), Some(12), "src/service.ts:12"),
+                (Some("orders.internal.test"), Some(18), "src/service.ts:18"),
+            ],
+            "an env-var base and a relative path have no literal host to retain"
+        );
     }
 
     /// A data call as the fifth pass sees it. `span` carries the

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1175,7 +1175,7 @@ impl Analyzer {
     /// - "${process.env.SERVICE_URL}/orders" -> "SERVICE_URL"
     /// - "${API_BASE}/users" -> "API_BASE"
     /// - "unknown" -> "UNKNOWN_API"
-    fn extract_env_var_name(route: &str) -> String {
+    pub(crate) fn extract_env_var_name(route: &str) -> String {
         // Handle ENV_VAR:NAME:/path format
         if route.starts_with("ENV_VAR:") {
             let parts: Vec<&str> = route.splitn(3, ':').collect();
@@ -1234,7 +1234,7 @@ impl Analyzer {
     /// - "/users/${userId}" (path parameter, not base URL)
     /// - "/api/${version}/data" (path parameter in middle)
     /// - "${userId}" (whole-URL opaque variable — no path to classify)
-    fn is_env_var_base_url(route: &str) -> bool {
+    pub(crate) fn is_env_var_base_url(route: &str) -> bool {
         // Check for explicit ENV_VAR: prefix format
         if route.starts_with("ENV_VAR:") {
             return true;
@@ -3532,6 +3532,71 @@ mod tests {
         )));
     }
 
+    /// Pin on the classification the egress channel reads (carrick#510).
+    ///
+    /// A call through a base declared in `externalEnvVars` is excluded from
+    /// matching and reported as nothing at all: no missing endpoint, no
+    /// env-var finding. An undeclared base still becomes an `EnvVarCall`.
+    /// The channel records the excluded call elsewhere; if that recording ever
+    /// starts changing this behaviour, this test is what fails.
+    #[test]
+    fn external_env_var_calls_stay_excluded_and_silent() {
+        let config = Config {
+            external_env_vars: ["BILLING_API".to_string()].into_iter().collect(),
+            ..Config::default()
+        };
+        let mut analyzer = Analyzer::new(config);
+        for route in [
+            "ENV_VAR:BILLING_API:/invoices",
+            "ENV_VAR:UNKNOWN_API:/posts",
+        ] {
+            analyzer.calls.push(ApiEndpointDetails {
+                owner: None,
+                key: OperationKey::http("GET", route),
+                params: vec![],
+                request_body: None,
+                response_body: None,
+                handler_name: None,
+                request_type: None,
+                response_type: None,
+                file_path: PathBuf::from("src/client.ts"),
+                repo_name: None,
+                service_name: None,
+                provenance: Default::default(),
+            });
+        }
+
+        let (findings, verified, cross_repo_matches) =
+            analyzer.analyze_matches_with_mount_graph(&MountGraph::new());
+
+        assert!(
+            !findings.iter().any(|f| matches!(
+                f,
+                Finding::EnvVarCall { env_var, .. } if env_var == "BILLING_API"
+            )),
+            "a declared-external base is not an env-var finding: {:?}",
+            findings
+        );
+        assert!(
+            !findings.iter().any(|f| matches!(
+                f,
+                Finding::MissingEndpoint { path, .. } if path == "/invoices"
+            )),
+            "a declared-external base is not a missing endpoint: {:?}",
+            findings
+        );
+        assert!(
+            findings.iter().any(|f| matches!(
+                f,
+                Finding::EnvVarCall { env_var, .. } if env_var == "UNKNOWN_API"
+            )),
+            "an undeclared base still reports: {:?}",
+            findings
+        );
+        assert!(verified.is_empty());
+        assert!(cross_repo_matches.is_empty());
+    }
+
     /// A consumer call whose path exists in the index under a different verb
     /// must surface exactly once, as a method-mismatch risk — not as a
     /// missing-endpoint + orphaned-endpoint pair.
@@ -3700,6 +3765,8 @@ mod tests {
             call_kind: None,
             repo_name: Some("consumer-repo".to_string()),
             service_name: None,
+            host: None,
+            line: None,
         });
 
         let (findings, verified, edges) = analyzer.analyze_matches_with_mount_graph(&mount_graph);
@@ -3803,6 +3870,8 @@ mod tests {
             call_kind: None,
             repo_name: Some("repo-beta".to_string()),
             service_name: None,
+            host: None,
+            line: None,
         });
         analyzer
             .calls
@@ -3875,6 +3944,8 @@ mod tests {
             call_kind: None,
             repo_name: Some("repo-beta".to_string()),
             service_name: None,
+            host: None,
+            line: None,
         });
         analyzer
             .calls
@@ -3930,6 +4001,8 @@ mod tests {
             call_kind: None,
             repo_name: Some("repo-alpha".to_string()),
             service_name: None,
+            host: None,
+            line: None,
         });
         analyzer.calls.push(http_call(
             "POST",
@@ -5010,6 +5083,8 @@ mod tests {
             call_kind: None,
             repo_name: Some(repo.to_string()),
             service_name: None,
+            host: None,
+            line: None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,13 +124,24 @@ impl Config {
             .any(|domain| route.starts_with(domain))
     }
 
+    /// True when `env_var` is declared in `externalEnvVars`.
+    ///
+    /// The same set [`Self::is_external_call`] consults for an
+    /// `ENV_VAR:<name>:<path>` route, exposed by name so a caller already
+    /// holding the variable name does not rebuild the route to ask. Keeping one
+    /// implementation matters: a second copy of the membership test is how the
+    /// egress channel would come to name a variable the matcher classifies
+    /// differently.
+    pub fn is_external_env_var(&self, env_var: &str) -> bool {
+        self.external_env_vars.contains(env_var)
+    }
+
     pub fn is_external_call(&self, route: &str) -> bool {
         // Check if route starts with any external env var
         if route.starts_with("ENV_VAR:") {
             let parts: Vec<&str> = route.split(':').collect();
             if parts.len() >= 2 {
-                let env_var = parts[1];
-                return self.external_env_vars.iter().any(|var| var == env_var);
+                return self.is_external_env_var(parts[1]);
             }
         }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1154,7 +1154,7 @@ async fn analyze_current_repo_incremental(
                 &protocol_extractions,
                 &merged_results,
             );
-            attach_external_call_candidates(&mut cloud_data, repo_path, &files, packages);
+            attach_external_call_candidates(&mut cloud_data, repo_path, &files, packages, config);
 
             // Populate cache fields
             let mut cached_file_results = merged_results.clone();
@@ -2172,13 +2172,18 @@ fn relativize_function_definition_paths(
     }
 }
 
-/// Run the deterministic external-call candidate scan and attach its rows to
-/// the payload (carrick#510).
+/// Attach the service's outbound-call candidates to the payload (carrick#510).
+///
+/// Two sources, one list: the deterministic SDK scan over the service's files,
+/// and the declared-external HTTP calls projected out of the mount graph the
+/// payload already carries. Reading the graph back off `cloud_data` rather than
+/// taking it as an argument keeps the rows and the uploaded graph provably the
+/// same set of calls.
 ///
 /// Called on both analysis paths and deliberately outside the incremental
-/// cache: the scan is pure AST over the service's already-discovered file list,
-/// costs nothing, and `files` is always the full set on both paths, so a cached
-/// run and a full run produce the same rows.
+/// cache: the SDK scan is pure AST over the service's already-discovered file
+/// list, costs nothing, and `files` is always the full set on both paths, so a
+/// cached run and a full run produce the same rows.
 ///
 /// `None` rather than an empty vector when there is nothing to report, so the
 /// cloud can tell "no candidates" apart from "scanned before this channel
@@ -2188,17 +2193,30 @@ fn attach_external_call_candidates(
     repo_path: &str,
     files: &[PathBuf],
     packages: &Packages,
+    config: &Config,
 ) {
-    let candidates = crate::external_call_candidates::scan_files(
-        files,
-        std::path::Path::new(repo_path),
-        packages,
-    );
+    let repo_root = std::path::Path::new(repo_path);
+    let sdk_rows = crate::external_call_candidates::scan_files(files, repo_root, packages);
+    let normalizer = UrlNormalizer::new(config);
+    let http_rows = cloud_data
+        .mount_graph
+        .as_ref()
+        .map(|graph| {
+            crate::external_call_candidates::from_data_calls(
+                &graph.data_calls,
+                repo_root,
+                config,
+                &normalizer,
+            )
+        })
+        .unwrap_or_default();
     debug!(
-        "External call candidates: {} row(s) for {}",
-        candidates.len(),
+        "External call candidates: {} sdk + {} http row(s) for {}",
+        sdk_rows.len(),
+        http_rows.len(),
         cloud_data.repo_name
     );
+    let candidates = crate::external_call_candidates::merge(sdk_rows, http_rows);
     if !candidates.is_empty() {
         cloud_data.external_call_candidates = Some(candidates);
     }
@@ -3212,7 +3230,7 @@ async fn analyze_current_repo(
         &protocol_extractions,
         &analysis_result.file_results,
     );
-    attach_external_call_candidates(&mut cloud_data, repo_path, &files, packages);
+    attach_external_call_candidates(&mut cloud_data, repo_path, &files, packages, config);
 
     let mut manifest_entries =
         build_type_manifest_entries(&analysis_result.mount_graph, config, repo_path);
@@ -3819,6 +3837,8 @@ mod tests {
                 call_kind: None,
                 repo_name: None,
                 service_name: None,
+                host: None,
+                line: None,
             }
         };
         let mut mount_graph = MountGraph::new();
@@ -3953,6 +3973,8 @@ mod tests {
             call_kind: None,
             repo_name: None,
             service_name: None,
+            host: None,
+            line: None,
         }];
 
         let entries = build_type_manifest_entries(&mount_graph, &config, ".");
@@ -4686,7 +4708,7 @@ mod tests {
             external_call_candidates: None,
         };
 
-        attach_external_call_candidates(&mut data, &fixture_str, &files, &packages);
+        attach_external_call_candidates(&mut data, &fixture_str, &files, &packages, &service);
 
         let rows = data
             .external_call_candidates
@@ -4699,6 +4721,132 @@ mod tests {
         );
         assert!(data.endpoints.is_empty(), "endpoints must not be touched");
         assert!(data.calls.is_empty(), "calls must not be touched");
+    }
+
+    /// Both sources reach the payload as one list, and the HTTP rows come from
+    /// the mount graph the payload itself carries — the same calls the index
+    /// records, not a second traversal that could disagree with it.
+    #[test]
+    fn attach_external_call_candidates_merges_sdk_and_http_rows() {
+        use crate::external_call_candidates::CallMechanism;
+
+        let fixture =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/external-call-candidates");
+        let fixture_str = fixture.to_string_lossy().to_string();
+        let service = Config {
+            directory: Some("apps/api".to_string()),
+            external_domains: ["api.vendor.test".to_string()].into_iter().collect(),
+            external_env_vars: ["BILLING_API".to_string()].into_iter().collect(),
+            ..Default::default()
+        };
+        let ignore_patterns = service_ignore_patterns(&service);
+        let (files, package_json) =
+            crate::file_finder::find_service_files(&fixture_str, &service, &ignore_patterns);
+        let mut packages = Packages::new(package_json.into_iter().collect()).expect("packages");
+        packages.internal_names = crate::packages::collect_internal_package_names(&fixture);
+
+        let mut graph = crate::mount_graph::MountGraph::new();
+        graph.data_calls = vec![
+            crate::mount_graph::DataFetchingCall {
+                method: "POST".to_string(),
+                target_url: "https://api.vendor.test/v1/charges".to_string(),
+                canonical_path: "/v1/charges".to_string(),
+                client: "fetch(".to_string(),
+                file_location: format!("{}/apps/api/src/pay.ts:12", fixture_str),
+                call_kind: None,
+                repo_name: None,
+                service_name: None,
+                host: Some("api.vendor.test".to_string()),
+                line: Some(12),
+            },
+            crate::mount_graph::DataFetchingCall {
+                method: "GET".to_string(),
+                target_url: "${process.env.BILLING_API}/invoices".to_string(),
+                canonical_path: "${process.env.BILLING_API}/invoices".to_string(),
+                client: "axios.".to_string(),
+                file_location: "apps/api/src/billing.ts:7".to_string(),
+                call_kind: None,
+                repo_name: None,
+                service_name: None,
+                host: None,
+                line: Some(7),
+            },
+        ];
+
+        let mut data = CloudRepoData {
+            repo_name: "svc".to_string(),
+            service_name: None,
+            endpoints: vec![],
+            calls: vec![],
+            mounts: vec![],
+            apps: HashMap::new(),
+            imported_handlers: vec![],
+            function_definitions: HashMap::new(),
+            config_json: None,
+            package_json: None,
+            packages: None,
+            last_updated: chrono::Utc::now(),
+            commit_hash: "abc123".to_string(),
+            mount_graph: Some(graph),
+            bundled_types: None,
+            type_manifest: None,
+            file_results: None,
+            cached_detection: None,
+            cached_guidance: None,
+            cached_extraction_config: None,
+            package_json_hash: None,
+            cache_version: None,
+            type_extraction_status: None,
+            compat_verdicts: None,
+            capture_stub: None,
+            external_call_candidates: None,
+        };
+
+        attach_external_call_candidates(&mut data, &fixture_str, &files, &packages, &service);
+
+        let rows = data.external_call_candidates.expect("rows");
+        assert!(
+            rows.iter().any(|row| row.mechanism == CallMechanism::Sdk),
+            "SDK rows survive the merge: {:?}",
+            rows
+        );
+        let http: Vec<_> = rows
+            .iter()
+            .filter(|row| row.mechanism != CallMechanism::Sdk)
+            .map(|row| {
+                (
+                    row.file.as_str(),
+                    row.line,
+                    row.callee.as_str(),
+                    row.package.as_str(),
+                    row.mechanism,
+                )
+            })
+            .collect();
+        assert_eq!(
+            http,
+            vec![
+                (
+                    "apps/api/src/billing.ts",
+                    7,
+                    "GET",
+                    "BILLING_API",
+                    CallMechanism::EnvVarUrl
+                ),
+                (
+                    "apps/api/src/pay.ts",
+                    12,
+                    "POST",
+                    "api.vendor.test",
+                    CallMechanism::ExternalHttp
+                ),
+            ],
+            "an absolute scan-root prefix is stripped, so both paths key the same way"
+        );
+        // The whole list is sorted as one set, whatever produced each row.
+        let mut sorted = rows.clone();
+        sorted.sort();
+        assert_eq!(rows, sorted);
     }
 
     #[test]
@@ -5224,6 +5372,8 @@ mod tests {
             call_kind: None,
             repo_name: None,
             service_name: None,
+            host: None,
+            line: None,
         }
     }
 
@@ -5275,6 +5425,8 @@ mod tests {
             call_kind: None,
             repo_name: None,
             service_name: None,
+            host: None,
+            line: None,
         }];
         let graphql = crate::graphql::GraphqlExtraction {
             producers: vec![],

--- a/src/external_call_candidates.rs
+++ b/src/external_call_candidates.rs
@@ -1,12 +1,24 @@
-//! Deterministic, AST-only detection of SDK-mediated outbound call candidates.
+//! Outbound call candidates: the scanner's egress channel.
 //!
-//! The scanner's existing outbound-call candidates are HTTP-shaped: `fetch` /
-//! axios-style calls, env-var-anchored URLs, absolute URLs. A call made through
-//! a service client imported from an npm package never looks like that, so it
-//! is invisible to candidate generation and to every surface downstream of it.
+//! Two sources feed one row shape.
 //!
-//! This module adds a parallel data channel for that class. It is intentionally
-//! narrow:
+//! **SDK-mediated calls** ([`scan_files`]) are detected here, deterministically
+//! and AST-only. The scanner's existing outbound-call candidates are
+//! HTTP-shaped: `fetch` / axios-style calls, env-var-anchored URLs, absolute
+//! URLs. A call made through a service client imported from an npm package
+//! never looks like that, so it is invisible to candidate generation and to
+//! every surface downstream of it.
+//!
+//! **HTTP-shaped calls** ([`from_data_calls`]) are already extracted and
+//! already classified; they are projected into this channel rather than
+//! detected again. A call to a host the repo declares in `externalDomains`, or
+//! through a base declared in `externalEnvVars`, is excluded from endpoint
+//! matching by design — which is correct, and which used to mean the fact of
+//! the call was recorded nowhere an egress inventory could read. Projecting the
+//! row changes no classification and no matching; it records what the
+//! classification already decided.
+//!
+//! The SDK detection is intentionally narrow:
 //!
 //! - **Structural, not name-based.** A call becomes a candidate when its callee
 //!   traces, through this file's own imports, to a package that the service's
@@ -41,7 +53,12 @@
 //! - Constructor calls (`new Client(...)`) resolve the receiver without becoming
 //!   rows themselves, because constructing a client is not egress.
 
+use crate::analyzer::Analyzer;
+use crate::config::Config;
+use crate::mount_graph::DataFetchingCall;
 use crate::packages::Packages;
+use crate::type_manifest::parse_file_location;
+use crate::url_normalizer::UrlNormalizer;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -60,37 +77,51 @@ use tracing::warn;
 pub const MAX_CANDIDATES_PER_SERVICE: usize = 5000;
 
 /// How the scanner established that a call site leaves the service.
-///
-/// Only [`CallMechanism::Sdk`] is produced today. The env-var-URL and
-/// external-domain HTTP classes are detected elsewhere in the scanner and are
-/// not yet projected into this channel; the enum is shaped so they join without
-/// changing the row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CallMechanism {
     /// The callee resolves, through an import, to a declared runtime dependency.
     Sdk,
+    /// An extracted HTTP call whose target names a host the repo declares in
+    /// `externalDomains`.
+    ExternalHttp,
+    /// An extracted HTTP call whose base URL is an environment variable the
+    /// repo declares in `externalEnvVars`.
+    EnvVarUrl,
 }
 
 /// One outbound call candidate.
 ///
-/// Ordering is `(file, line, callee, package)`, which is also the sort key the
-/// scan emits in, so the row list is byte-identical across runs of the same
-/// tree.
+/// Ordering is `(file, line, callee, package, mechanism)`, which is also the
+/// sort key rows are emitted in. SDK rows are byte-identical across runs of the
+/// same tree because they are pure AST; the HTTP-shaped rows are projected from
+/// LLM extraction and inherit its stability, so the ORDER is fixed but the row
+/// set is only as reproducible as the extraction behind it.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ExternalCallCandidate {
     /// Repo-relative path of the file containing the call.
     pub file: String,
     /// 1-based line number of the call expression.
     pub line: usize,
-    /// The callee as written, dotted (`ledger.payments.create`). Computed from
-    /// the AST, so it carries no whitespace or comments from the source.
+    /// What was called, in the terms the mechanism knows.
+    ///
+    /// For [`CallMechanism::Sdk`], the callee as written, dotted
+    /// (`ledger.payments.create`), computed from the AST so it carries no
+    /// whitespace or comments from the source. For the two HTTP-shaped
+    /// mechanisms there is no callee to name — the client is `fetch` or an
+    /// axios-alike in every case — so the field carries the HTTP method, which
+    /// is the operation the row records.
     pub callee: String,
-    /// The declared dependency the callee resolves to, exactly as the
-    /// `package.json` names it (a subpath import such as `pkg/edge` resolves to
-    /// `pkg`).
+    /// Where the call goes, in the terms the mechanism knows: the declared
+    /// dependency for [`CallMechanism::Sdk`], exactly as the `package.json`
+    /// names it (a subpath import such as `pkg/edge` resolves to `pkg`); the
+    /// hostname for [`CallMechanism::ExternalHttp`]; the environment variable
+    /// name for [`CallMechanism::EnvVarUrl`].
+    ///
+    /// The field keeps the name it shipped with in carrick#511, when `sdk` was
+    /// the only mechanism. cloud#350 calls the same column `target`.
     pub package: String,
-    /// Always [`CallMechanism::Sdk`] for now.
+    /// Which of the three detections produced this row.
     pub mechanism: CallMechanism,
 }
 
@@ -119,7 +150,98 @@ pub fn scan_files(
         rows.extend(scan_content(&relative, file, &content, &dependencies));
     }
 
-    let mut rows: Vec<ExternalCallCandidate> = rows.into_iter().collect();
+    cap(rows.into_iter().collect())
+}
+
+/// Project the already-classified HTTP-shaped calls of a service into channel
+/// rows.
+///
+/// `data_calls` are the consumer calls of the built mount graph, so every row
+/// here corresponds to a call the scanner already extracted, already keyed, and
+/// already classified. Nothing is re-detected and nothing is re-classified:
+/// this reads `host` (retained by the mount-graph builder from normalisation)
+/// and the same `externalDomains` / `externalEnvVars` declarations the matcher
+/// consults, and writes down what they already say.
+///
+/// Which calls become rows, and the reason in each case:
+///
+/// - **Declared-external host** → [`CallMechanism::ExternalHttp`]. The repo has
+///   said this host is somebody else's.
+/// - **Declared-external env-var base** → [`CallMechanism::EnvVarUrl`]. Same
+///   statement, made about a base URL the source does not spell out.
+/// - **Declared-internal, either shape** → no row. An in-org destination is
+///   already carried by the endpoint index, and calling it is not egress.
+/// - **Undeclared, either shape** → no row. Where the call goes is exactly what
+///   is unknown; the scanner already reports the undeclared env-var bases as
+///   `EnvVarCall` findings, and inventing an egress row from a host nobody
+///   classified would be a guess. The retained `host` on the call itself is
+///   what a later surface would widen from, without another scan.
+///
+/// A call whose extracted line is not a positive integer is skipped: a row
+/// without a location cannot be audited.
+pub fn from_data_calls(
+    data_calls: &[DataFetchingCall],
+    repo_root: &Path,
+    config: &Config,
+    normalizer: &UrlNormalizer,
+) -> Vec<ExternalCallCandidate> {
+    let mut rows: BTreeSet<ExternalCallCandidate> = BTreeSet::new();
+    for call in data_calls {
+        let Some((target, mechanism)) = classify_data_call(call, config, normalizer) else {
+            continue;
+        };
+        let Some(line) = call.line else {
+            continue;
+        };
+        // `file_location` packs the file and the line as `"{file}:{line}"`;
+        // only the file half is wanted here, because the line is carried
+        // typed. `parse_file_location` is the repo's existing unpacker, and is
+        // used rather than a second string split so this file half is the same
+        // one every other consumer of the location sees.
+        let (file, _) = parse_file_location(&call.file_location);
+        rows.insert(ExternalCallCandidate {
+            file: relative_location(&file, repo_root),
+            line: line as usize,
+            // No callee to name on an HTTP call; the method is the operation.
+            callee: call.method.to_uppercase(),
+            package: target,
+            mechanism,
+        });
+    }
+    cap(rows.into_iter().collect())
+}
+
+/// The mechanism and target for one already-classified consumer call, or `None`
+/// when the call is not declared external.
+fn classify_data_call(
+    call: &DataFetchingCall,
+    config: &Config,
+    normalizer: &UrlNormalizer,
+) -> Option<(String, CallMechanism)> {
+    // Host first: a literal absolute origin is never an env-var base, and the
+    // host is only retained for that shape.
+    if let Some(host) = &call.host {
+        return normalizer
+            .is_external_host(host)
+            .then(|| (host.clone(), CallMechanism::ExternalHttp));
+    }
+    // The env-var check runs on `canonical_path` — the key the matcher itself
+    // classifies on — so this row names the variable the matcher excluded the
+    // call for, not a differently-derived one.
+    if !Analyzer::is_env_var_base_url(&call.canonical_path) {
+        return None;
+    }
+    let env_var = Analyzer::extract_env_var_name(&call.canonical_path);
+    config
+        .is_external_env_var(&env_var)
+        .then_some((env_var, CallMechanism::EnvVarUrl))
+}
+
+/// Sort order is already fixed by the `BTreeSet` the rows arrive in; this
+/// applies the per-service cap, so a service over it yields a stable prefix
+/// rather than an arbitrary sample. The cap spans mechanisms, because the cap
+/// exists to bound the payload and the payload carries one list.
+fn cap(mut rows: Vec<ExternalCallCandidate>) -> Vec<ExternalCallCandidate> {
     if rows.len() > MAX_CANDIDATES_PER_SERVICE {
         warn!(
             "External call candidates truncated to {} of {} rows for this service",
@@ -129,6 +251,18 @@ pub fn scan_files(
         rows.truncate(MAX_CANDIDATES_PER_SERVICE);
     }
     rows
+}
+
+/// Merge the rows of both sources into the single list the payload carries.
+///
+/// Sorted and deduplicated as one set, then capped once, so the channel has one
+/// order and one bound whatever produced a given row.
+pub fn merge(
+    sdk_rows: Vec<ExternalCallCandidate>,
+    http_rows: Vec<ExternalCallCandidate>,
+) -> Vec<ExternalCallCandidate> {
+    let merged: BTreeSet<ExternalCallCandidate> = sdk_rows.into_iter().chain(http_rows).collect();
+    cap(merged.into_iter().collect())
 }
 
 /// Package names that count as external runtime dependencies of this service.
@@ -178,6 +312,23 @@ fn relative_path(file: &Path, repo_root: &Path) -> String {
             file.to_string_lossy().to_string()
         }
     }
+}
+
+/// Repo-relative file path for a projected HTTP row.
+///
+/// The mount graph keys `file_location` as the analysis scanned it: already
+/// repo-relative on the incremental path (the engine normalises the keys before
+/// rebuilding the graph) and as-scanned on the full path. Strip the scan root
+/// when it is present, and a leading `./` either way, so the two paths produce
+/// the same row for the same file — and so an HTTP row is comparable with an
+/// SDK row, which is relative by construction.
+fn relative_location(file: &str, repo_root: &Path) -> String {
+    let path = Path::new(file);
+    path.strip_prefix(repo_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .trim_start_matches("./")
+        .to_string()
 }
 
 /// Which declared dependency does this module specifier import from?
@@ -797,5 +948,251 @@ export function real() {
                 "mechanism": "sdk"
             })
         );
+    }
+
+    /// The HTTP-shaped mechanisms ride the row shape `sdk` shipped with — same
+    /// five keys, same casing — so one reader handles all three.
+    #[test]
+    fn http_mechanisms_serialize_in_the_same_row_shape() {
+        let row = ExternalCallCandidate {
+            file: "src/pay.ts".to_string(),
+            line: 12,
+            callee: "POST".to_string(),
+            package: "api.vendor.test".to_string(),
+            mechanism: CallMechanism::ExternalHttp,
+        };
+        assert_eq!(
+            serde_json::to_value(&row).unwrap(),
+            serde_json::json!({
+                "file": "src/pay.ts",
+                "line": 12,
+                "callee": "POST",
+                "package": "api.vendor.test",
+                "mechanism": "external_http"
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(ExternalCallCandidate {
+                mechanism: CallMechanism::EnvVarUrl,
+                package: "BILLING_API".to_string(),
+                ..row
+            })
+            .unwrap()["mechanism"],
+            serde_json::json!("env_var_url")
+        );
+    }
+
+    mod http_rows {
+        use super::*;
+        use crate::mount_graph::DataFetchingCall;
+
+        fn config() -> Config {
+            Config {
+                internal_domains: ["orders.internal.test".to_string()].into_iter().collect(),
+                external_domains: ["api.vendor.test".to_string()].into_iter().collect(),
+                internal_env_vars: ["ORDERS_URL".to_string()].into_iter().collect(),
+                external_env_vars: ["BILLING_API".to_string()].into_iter().collect(),
+                ..Config::default()
+            }
+        }
+
+        /// A consumer call as the mount-graph builder records one: the host and
+        /// the typed line are the fields it now retains from normalisation and
+        /// extraction.
+        fn call(target: &str, host: Option<&str>, line: Option<u32>) -> DataFetchingCall {
+            DataFetchingCall {
+                method: "get".to_string(),
+                target_url: target.to_string(),
+                canonical_path: target.to_string(),
+                client: "fetch(".to_string(),
+                file_location: format!("src/client.ts:{}", line.unwrap_or(1)),
+                call_kind: None,
+                repo_name: None,
+                service_name: None,
+                host: host.map(str::to_string),
+                line,
+            }
+        }
+
+        fn rows(calls: &[DataFetchingCall]) -> Vec<ExternalCallCandidate> {
+            let config = config();
+            from_data_calls(
+                calls,
+                Path::new("/repo"),
+                &config,
+                &crate::url_normalizer::UrlNormalizer::new(&config),
+            )
+        }
+
+        /// The domain and the line the scanner used to discard both reach the
+        /// row, and the HTTP method stands in for the callee.
+        #[test]
+        fn declared_external_host_becomes_a_row() {
+            assert_eq!(
+                rows(&[call(
+                    "https://api.vendor.test/v1/charges",
+                    Some("api.vendor.test"),
+                    Some(12)
+                )]),
+                vec![ExternalCallCandidate {
+                    file: "src/client.ts".to_string(),
+                    line: 12,
+                    callee: "GET".to_string(),
+                    package: "api.vendor.test".to_string(),
+                    mechanism: CallMechanism::ExternalHttp,
+                }]
+            );
+        }
+
+        /// A subdomain of a declared external domain is classified external by
+        /// the normalizer, and the row names the host as written, not the
+        /// declaration that matched it.
+        #[test]
+        fn subdomain_of_a_declared_host_keeps_its_own_name() {
+            let rows = rows(&[call(
+                "https://eu.api.vendor.test/v1/charges",
+                Some("eu.api.vendor.test"),
+                Some(3),
+            )]);
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].package, "eu.api.vendor.test");
+        }
+
+        /// The env-var name reaches the row for a variable the repo declares
+        /// external — the pair the matcher drops on its way past the call.
+        #[test]
+        fn declared_external_env_var_becomes_a_row() {
+            assert_eq!(
+                rows(&[call("${process.env.BILLING_API}/invoices", None, Some(7))]),
+                vec![ExternalCallCandidate {
+                    file: "src/client.ts".to_string(),
+                    line: 7,
+                    callee: "GET".to_string(),
+                    package: "BILLING_API".to_string(),
+                    mechanism: CallMechanism::EnvVarUrl,
+                }]
+            );
+        }
+
+        /// The canonical `ENV_VAR:NAME:/path` shape resolves to the same row as
+        /// the raw interpolation.
+        #[test]
+        fn canonical_env_var_route_becomes_a_row() {
+            let rows = rows(&[call("ENV_VAR:BILLING_API:/invoices", None, Some(4))]);
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].package, "BILLING_API");
+            assert_eq!(rows[0].mechanism, CallMechanism::EnvVarUrl);
+        }
+
+        /// An undeclared destination is the one thing the scanner does not
+        /// know. It stays out of the inventory rather than being guessed into
+        /// it; the unclassified env-var case is already reported as an
+        /// `EnvVarCall` finding, which this channel does not touch.
+        #[test]
+        fn undeclared_destinations_emit_nothing() {
+            assert_eq!(
+                rows(&[
+                    call(
+                        "https://api.unlisted.test/v1/x",
+                        Some("api.unlisted.test"),
+                        Some(2)
+                    ),
+                    call("${process.env.UNKNOWN_API}/x", None, Some(3)),
+                ]),
+                Vec::new()
+            );
+        }
+
+        /// An in-org destination is not egress: it is already in the endpoint
+        /// index as a call, and the inventory would double-count it.
+        #[test]
+        fn declared_internal_destinations_emit_nothing() {
+            assert_eq!(
+                rows(&[
+                    call(
+                        "https://orders.internal.test/orders",
+                        Some("orders.internal.test"),
+                        Some(2)
+                    ),
+                    call("${process.env.ORDERS_URL}/orders", None, Some(3)),
+                ]),
+                Vec::new()
+            );
+        }
+
+        /// A relative call has no destination to name at all.
+        #[test]
+        fn relative_call_emits_nothing() {
+            assert_eq!(rows(&[call("/api/orders", None, Some(9))]), Vec::new());
+        }
+
+        /// A row with no line cannot be audited, so it is dropped rather than
+        /// carried with a guessed location.
+        #[test]
+        fn call_without_a_line_emits_nothing() {
+            assert_eq!(
+                rows(&[call(
+                    "https://api.vendor.test/v1/charges",
+                    Some("api.vendor.test"),
+                    None
+                )]),
+                Vec::new()
+            );
+        }
+
+        /// The file half of `file_location` is repo-relative in the row
+        /// whichever analysis path recorded it — the incremental path
+        /// normalises its keys, the full path does not.
+        #[test]
+        fn absolute_scan_paths_are_relativized() {
+            let mut absolute = call(
+                "https://api.vendor.test/v1/charges",
+                Some("api.vendor.test"),
+                Some(5),
+            );
+            absolute.file_location = "/repo/src/client.ts:5".to_string();
+            assert_eq!(rows(&[absolute])[0].file, "src/client.ts");
+        }
+
+        /// Two calls to the same host on the same line collapse; the same host
+        /// on different lines does not.
+        #[test]
+        fn rows_are_deduplicated_and_sorted() {
+            let hit = call(
+                "https://api.vendor.test/v1/charges",
+                Some("api.vendor.test"),
+                Some(12),
+            );
+            let mut earlier = hit.clone();
+            earlier.line = Some(4);
+            earlier.file_location = "src/client.ts:4".to_string();
+            let rows = rows(&[hit.clone(), earlier, hit]);
+            assert_eq!(
+                rows.iter().map(|row| row.line).collect::<Vec<_>>(),
+                vec![4, 12]
+            );
+        }
+
+        /// The merged list is one sorted, deduplicated set, so the payload has
+        /// a single order whatever produced a given row.
+        #[test]
+        fn merge_sorts_both_sources_as_one_set() {
+            let sdk = ExternalCallCandidate {
+                file: "src/client.ts".to_string(),
+                line: 20,
+                callee: "ledger.charge".to_string(),
+                package: "ledger-client".to_string(),
+                mechanism: CallMechanism::Sdk,
+            };
+            let http = ExternalCallCandidate {
+                file: "src/client.ts".to_string(),
+                line: 12,
+                callee: "GET".to_string(),
+                package: "api.vendor.test".to_string(),
+                mechanism: CallMechanism::ExternalHttp,
+            };
+            let merged = merge(vec![sdk.clone(), sdk.clone()], vec![http.clone()]);
+            assert_eq!(merged, vec![http, sdk]);
+        }
     }
 }

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -94,6 +94,24 @@ pub struct DataFetchingCall {
     /// producer by service but the consumer by repo (#368).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_name: Option<String>,
+    /// Hostname of an absolute-URL target, retained from normalisation.
+    ///
+    /// `UrlNormalizer` computes the host on its way to a comparable path and
+    /// then discards it, so the only record of WHERE a call goes used to be the
+    /// raw `target_url`. Retained verbatim and without judgement: the field
+    /// says a host was written at this call site, not that the host is external
+    /// (classification stays with `internalDomains`/`externalDomains` and is
+    /// unchanged by this field existing).
+    ///
+    /// `None` for relative paths, env-var bases, and template bases — those
+    /// have no literal hostname to retain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    /// 1-based line of the call site: the typed counterpart of the line packed
+    /// into `file_location` as `"{file}:{line}"` text. `None` when extraction
+    /// reported a line that is not a positive integer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
 }
 
 /// The complete mount and endpoint graph
@@ -457,6 +475,53 @@ mod tests {
     use super::*;
 
     use crate::config::Config;
+
+    /// The retained fields are additive on the wire: a call with nothing to
+    /// retain serialises to exactly the keys it always had, so a payload
+    /// written by this scanner is byte-identical to one written before the
+    /// fields existed, and an older payload still deserialises.
+    #[test]
+    fn retained_fields_are_absent_when_empty() {
+        let call = DataFetchingCall {
+            method: "GET".to_string(),
+            target_url: "/api/orders".to_string(),
+            canonical_path: "/api/orders".to_string(),
+            client: "fetch(".to_string(),
+            file_location: "src/orders.ts:4".to_string(),
+            call_kind: None,
+            repo_name: None,
+            service_name: None,
+            host: None,
+            line: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&call).unwrap(),
+            serde_json::json!({
+                "method": "GET",
+                "target_url": "/api/orders",
+                "canonical_path": "/api/orders",
+                "client": "fetch(",
+                "file_location": "src/orders.ts:4"
+            })
+        );
+
+        let older: DataFetchingCall = serde_json::from_str(
+            r#"{"method":"GET","target_url":"/api/orders","canonical_path":"/api/orders",
+                "client":"fetch(","file_location":"src/orders.ts:4"}"#,
+        )
+        .expect("a payload written before the fields existed still reads");
+        assert_eq!(older.host, None);
+        assert_eq!(older.line, None);
+
+        let retained = DataFetchingCall {
+            host: Some("api.vendor.test".to_string()),
+            line: Some(4),
+            ..call
+        };
+        let json = serde_json::to_value(&retained).unwrap();
+        assert_eq!(json["host"], serde_json::json!("api.vendor.test"));
+        assert_eq!(json["line"], serde_json::json!(4));
+    }
 
     #[test]
     fn test_url_normalized_matching_full_url() {
@@ -1043,6 +1108,8 @@ mod tests {
                 call_kind: None,
                 repo_name: None,
                 service_name: None,
+                host: None,
+                line: None,
             });
         let merged = MountGraph::merge_from_repos(&[repo]);
         assert_eq!(merged.data_calls.len(), 1);

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -420,8 +420,35 @@ impl UrlNormalizer {
     }
 
     /// Check if a host is configured as external
-    fn is_external_host(&self, host: &str) -> bool {
+    pub fn is_external_host(&self, host: &str) -> bool {
         Self::host_matches_domains(host, &self.external_domains)
+    }
+
+    /// The literal hostname a target carries when it is written as an absolute
+    /// URL, or `None` when it carries none.
+    ///
+    /// [`Self::normalize`] already computes this on its way to a comparable
+    /// path and drops it with the rest of the `NormalizedUrl`. This exposes it
+    /// so a caller can retain the host without re-implementing the parse.
+    ///
+    /// Only the absolute (`scheme://host`) and protocol-relative (`//host`)
+    /// shapes have a literal host. For an `ENV_VAR:`, `process.env`, or
+    /// template-literal base, `NormalizedUrl::stripped_host` holds the variable
+    /// expression that stood in for the origin (`${API_URL}`,
+    /// `process.env.API_URL`) rather than a hostname, so those return `None` —
+    /// an interpolated origin (`https://${host}/v1`) does too, for the same
+    /// reason.
+    pub fn absolute_host(&self, url: &str) -> Option<String> {
+        let trimmed = url.trim_matches(|c| c == '`' || c == '"' || c == '\'');
+        if !(trimmed.starts_with("http://")
+            || trimmed.starts_with("https://")
+            || trimmed.starts_with("//"))
+        {
+            return None;
+        }
+        self.normalize(url)
+            .stripped_host
+            .filter(|host| !host.is_empty() && !host.contains('$') && !host.contains('{'))
     }
 
     /// True if `host` exactly equals, or is a subdomain of, one of `domains`.
@@ -1282,5 +1309,65 @@ mod tests {
         let unknown_result = normalizer.normalize("https://unknown-service.local/api/data");
         assert!(!unknown_result.is_internal);
         assert!(!unknown_result.is_external);
+    }
+
+    /// `absolute_host` retains a hostname and nothing else. Every shape whose
+    /// `stripped_host` is a variable expression standing in for the origin
+    /// returns `None`, so a caller retaining the host never records
+    /// `${API_URL}` as a domain.
+    #[test]
+    fn absolute_host_retains_only_literal_hosts() {
+        let config = create_test_config();
+        let normalizer = UrlNormalizer::new(&config);
+
+        assert_eq!(
+            normalizer.absolute_host("https://api.stripe.com/v1/charges"),
+            Some("api.stripe.com".to_string())
+        );
+        assert_eq!(
+            normalizer.absolute_host("http://localhost:4002/orders"),
+            Some("localhost:4002".to_string()),
+            "the port is part of the host the normalizer strips"
+        );
+        assert_eq!(
+            normalizer.absolute_host("//cdn.example.com/asset.js"),
+            Some("cdn.example.com".to_string()),
+            "a protocol-relative origin is still a literal host"
+        );
+        assert_eq!(
+            normalizer.absolute_host("`https://api.github.com/repos`"),
+            Some("api.github.com".to_string()),
+            "extraction can hand back the source quoting"
+        );
+
+        for no_host in [
+            "/api/orders",
+            "ENV_VAR:STRIPE_API:/v1/charges",
+            "${process.env.STRIPE_API}/v1/charges",
+            "${API_URL}/users",
+            "https://${host}/v1/charges",
+        ] {
+            assert_eq!(
+                normalizer.absolute_host(no_host),
+                None,
+                "{} carries no literal host",
+                no_host
+            );
+        }
+    }
+
+    /// Retention is not classification: an undeclared host is retained exactly
+    /// like a declared one.
+    #[test]
+    fn absolute_host_ignores_domain_classification() {
+        let config = create_test_config();
+        let normalizer = UrlNormalizer::new(&config);
+
+        assert_eq!(
+            normalizer.absolute_host("https://unknown-service.local/api/data"),
+            Some("unknown-service.local".to_string())
+        );
+        assert!(!normalizer.is_external_host("unknown-service.local"));
+        assert!(normalizer.is_external_host("api.stripe.com"));
     }
 }


### PR DESCRIPTION
Slice 2a of the egress-inventory work. Refs carrick#510, cloud#350 (row shape), follows carrick#511 (the `sdk` channel).

Two facts the scanner already computed and then discarded now reach the upload payload. Everything here is additive. Matching, endpoint extraction, type compatibility and every existing payload field are untouched.

## What was being lost

1. An externally classified HTTP call kept no record of its domain. `UrlNormalizer` computes the host on its way to a comparable path and drops it, and `DataFetchingCall` had nowhere to put it. The call site's line survived only as packed `"{file}:{line}"` text inside `file_location`.
2. The env-var name and call site pair was recorded only for unclassified variables. For a variable listed in `externalEnvVars` the matcher's exclusion fires first, so the pair went nowhere.

## What landed

`DataFetchingCall` gains two optional fields:

```rust
/// Hostname of an absolute-URL target, retained from normalisation.
#[serde(default, skip_serializing_if = "Option::is_none")]
pub host: Option<String>,
/// 1-based line of the call site: the typed counterpart of the line packed
/// into `file_location` as `"{file}:{line}"` text.
#[serde(default, skip_serializing_if = "Option::is_none")]
pub line: Option<u32>,
```

`host` is retained without classification. A declared-internal host, a declared-external host and an undeclared host are all retained the same way, because the field records what the URL contained rather than a judgement about it. Only a literal origin (`https://host/…`, `//host/…`) yields a host; an env-var or template base returns `None`, since `NormalizedUrl::stripped_host` holds the variable expression rather than a hostname for those shapes.

`external_call_candidates` gains the two mechanisms the enum was shaped for in #511. The row shape is unchanged, with five keys for all three mechanisms:

```json
{"file": "src/pay.ts", "line": 12, "callee": "POST", "package": "api.vendor.test", "mechanism": "external_http"}
{"file": "src/billing.ts", "line": 7, "callee": "GET", "package": "BILLING_API", "mechanism": "env_var_url"}
{"file": "src/ship.ts", "line": 4, "callee": "ledger.charge", "package": "ledger-client", "mechanism": "sdk"}
```

`package` keeps the name it shipped with; cloud#350 calls the same column `target`. Renaming it would break the reader now being written against that field, so the doc comment carries the mapping instead: declared dependency for `sdk`, hostname for `external_http`, variable name for `env_var_url`. `callee` carries the HTTP method for the two new mechanisms. The method is the operation an HTTP row records, because the client is `fetch` or an axios-alike in every case.

## Design decisions

**One channel, not a parallel field.** The rows join `external_call_candidates`, sorted, deduplicated and capped as one set, so the cloud gets one list and one reader.

**Rows are projected, not detected.** `from_data_calls` reads the mount graph the payload already carries, so the inventory and the index describe the same calls. It reads the retained `host` and the same `externalDomains` / `externalEnvVars` declarations the matcher consults, and it classifies nothing itself.

**The env-var gap is closed upstream of the classification, not at the `continue`.** `analyzer/mod.rs` is not modified. The pair is retained where the call is built, which leaves the exclusion and the `Finding::EnvVarCall` path exactly as they were. A new analyzer test pins both cases: a declared-external base still produces no match and no finding, and an undeclared one still produces its finding.

**Undeclared destinations produce no row.** The destination of such a call is unknown, and an inventory row would be a guess. Undeclared env-var bases are already reported as `EnvVarCall` findings, which this change does not touch. Declared-internal destinations produce no row either, because an in-org call is already in the endpoint index and is not egress.

That keeps emission tied to what the repo has declared, which is narrow on a repo that declares little. The retained `host` is what allows that to widen later. It is present in the payload for every absolute-URL call regardless of classification, so a serving surface can broaden the inventory without another scan, and that decision belongs to slice 3.

**One call site can produce two rows.** An HTTP client that is itself a declared dependency, which covers `axios`, `node-fetch` and `got` on most repos, yields an `sdk` row naming the client and an `external_http` row naming the destination, at the same file and line. The rows are complementary rather than duplicated, and deduplicating on `(file, line)` is a serving-surface decision, alongside the framework-call filter already deferred there.

## Tests

The tests are in-module and fixture-driven, and none of them call an LLM.

- `data_calls_retain_the_host_and_a_typed_line`: an external-domain fetch retains its host and line, an internal host retains its host too, an env-var base and a relative path retain none, and `file_location` keeps its exact text.
- `http_rows::*`: declared-external host and declared-external env var each become one row with the domain or variable name and the line; subdomains keep their own name; undeclared, declared-internal, relative and line-less calls emit nothing; absolute scan paths are relativised; rows deduplicate and sort.
- `external_env_var_calls_stay_excluded_and_silent`: the matching exclusion and the unclassified finding are both unchanged.
- `retained_fields_are_absent_when_empty`: a call with nothing retained serialises to exactly its previous keys, and a payload written before the fields existed still deserialises.
- `absolute_host_retains_only_literal_hosts` and `absolute_host_ignores_domain_classification`.
- `attach_external_call_candidates_merges_sdk_and_http_rows`: both sources reach the payload as one sorted list.

## Verification

Everything ci.yml runs passed locally: the full `--lib` suite (761), every named integration test, `carrick-match`, the sidecar suite (321), `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and both release builds. The endpoint regression job was run by hand against the release binary: express-single indexes 3 endpoints, and imported-routers indexes 10 with no `Unique endpoint paths: 0`.

Release ordering from the slice-1 note still holds. Do not cut a scanner release carrying this until cloud ingest is deployed and verified with one real ingest.
