### PR TITLE
feat(scanner): resolve external-call candidates through workspace wrappers

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1154,7 +1154,7 @@ async fn analyze_current_repo_incremental(
                 &protocol_extractions,
                 &merged_results,
             );
-            attach_external_call_candidates(&mut cloud_data, repo_path, &files, packages, config);
+            attach_external_call_candidates(&mut cloud_data, repo_path, &files, config);
 
             // Populate cache fields
             let mut cached_file_results = merged_results.clone();
@@ -2181,9 +2181,15 @@ fn relativize_function_definition_paths(
 /// same set of calls.
 ///
 /// Called on both analysis paths and deliberately outside the incremental
-/// cache: the SDK scan is pure AST over the service's already-discovered file
-/// list, costs nothing, and `files` is always the full set on both paths, so a
-/// cached run and a full run produce the same rows.
+/// cache: the SDK scan is pure AST over the tree on disk, and `files` is always
+/// the full service file list on both paths, so a cached run and a full run
+/// produce the same rows.
+///
+/// The dependency set the SDK scan resolves against comes from every manifest
+/// in the repo rather than from `packages`, which is scoped to this service's
+/// own `package.json` — in a monorepo the manifest declaring a vendor client is
+/// usually the shared package holding the wrapper, not the service shipping the
+/// call.
 ///
 /// `None` rather than an empty vector when there is nothing to report, so the
 /// cloud can tell "no candidates" apart from "scanned before this channel
@@ -2192,11 +2198,10 @@ fn attach_external_call_candidates(
     cloud_data: &mut CloudRepoData,
     repo_path: &str,
     files: &[PathBuf],
-    packages: &Packages,
     config: &Config,
 ) {
     let repo_root = std::path::Path::new(repo_path);
-    let sdk_rows = crate::external_call_candidates::scan_files(files, repo_root, packages);
+    let sdk_rows = crate::external_call_candidates::scan_workspace(files, repo_root);
     let normalizer = UrlNormalizer::new(config);
     let http_rows = cloud_data
         .mount_graph
@@ -3230,7 +3235,7 @@ async fn analyze_current_repo(
         &protocol_extractions,
         &analysis_result.file_results,
     );
-    attach_external_call_candidates(&mut cloud_data, repo_path, &files, packages, config);
+    attach_external_call_candidates(&mut cloud_data, repo_path, &files, config);
 
     let mut manifest_entries =
         build_type_manifest_entries(&analysis_result.mount_graph, config, repo_path);
@@ -4708,7 +4713,7 @@ mod tests {
             external_call_candidates: None,
         };
 
-        attach_external_call_candidates(&mut data, &fixture_str, &files, &packages, &service);
+        attach_external_call_candidates(&mut data, &fixture_str, &files, &service);
 
         let rows = data
             .external_call_candidates
@@ -4802,7 +4807,7 @@ mod tests {
             external_call_candidates: None,
         };
 
-        attach_external_call_candidates(&mut data, &fixture_str, &files, &packages, &service);
+        attach_external_call_candidates(&mut data, &fixture_str, &files, &service);
 
         let rows = data.external_call_candidates.expect("rows");
         assert!(

--- a/src/external_call_candidates.rs
+++ b/src/external_call_candidates.rs
@@ -2,12 +2,12 @@
 //!
 //! Two sources feed one row shape.
 //!
-//! **SDK-mediated calls** ([`scan_files`]) are detected here, deterministically
-//! and AST-only. The scanner's existing outbound-call candidates are
-//! HTTP-shaped: `fetch` / axios-style calls, env-var-anchored URLs, absolute
-//! URLs. A call made through a service client imported from an npm package
-//! never looks like that, so it is invisible to candidate generation and to
-//! every surface downstream of it.
+//! **SDK-mediated calls** ([`scan_workspace`]) are detected here,
+//! deterministically and AST-only. The scanner's existing outbound-call
+//! candidates are HTTP-shaped: `fetch` / axios-style calls, env-var-anchored
+//! URLs, absolute URLs. A call made through a service client imported from an
+//! npm package never looks like that, so it is invisible to candidate
+//! generation and to every surface downstream of it.
 //!
 //! **HTTP-shaped calls** ([`from_data_calls`]) are already extracted and
 //! already classified; they are projected into this channel rather than
@@ -18,18 +18,49 @@
 //! row changes no classification and no matching; it records what the
 //! classification already decided.
 //!
-//! The SDK detection is intentionally narrow:
+//! # How the SDK detection works
 //!
-//! - **Structural, not name-based.** A call becomes a candidate when its callee
-//!   traces, through this file's own imports, to a package that the service's
-//!   `package.json` declares as a runtime dependency. There is no allowlist and
-//!   no denylist of SDK or vendor names anywhere in this module — the
-//!   dependency set comes from the repo's own manifests.
-//! - **No type checking.** Resolution is limited to what the AST proves:
-//!   an import binding, and a variable whose initializer is rooted at one. A
-//!   receiver obtained any other way (returned from a helper, read off a DI
-//!   container, a class field) is not resolved and emits nothing. Recording
-//!   less than the truth is the deliberate choice over guessing.
+//! In a monorepo the file that calls a vendor client is rarely the file that
+//! imports it. A shared package wraps the client, exports a handle, and dozens
+//! of modules elsewhere in the tree call through the handle. Resolving only a
+//! file's own imports therefore sees the wrapper and misses every caller.
+//!
+//! So the scan runs over the whole workspace and answers one question per
+//! binding: which external package, if any, does the value in it come from?
+//!
+//! 1. **Facts.** Every source file in the repo is parsed once and reduced to
+//!    plain data — imports, re-exports, exports, aliases, function return
+//!    shapes, class field maps, and call sites. Every value expression the scan
+//!    cares about reduces to the same shape: a root (a binding, or `this`) plus
+//!    a list of steps, each either a property access or a call.
+//! 2. **Ownership.** A monotone fixpoint over those facts assigns each binding
+//!    and each export an owner: an external package, a record of properties
+//!    that are owned, a namespace standing for another file's exports, or a
+//!    function whose calls yield an owner. Two different packages reaching the
+//!    same slot is a conflict, and a conflict is terminal: the slot owns
+//!    nothing rather than owning a guess.
+//! 3. **Rows.** A call site becomes a row when its own root-and-steps chain
+//!    evaluates to a package.
+//! 4. **Attribution.** Each service takes the rows of the files reachable from
+//!    its own file list by following internal import edges. A file shared by
+//!    two services appears in both, which is the intended reading: this
+//!    service's deployment contains this call site.
+//!
+//! The detection is intentionally narrow:
+//!
+//! - **Structural, not name-based.** The external universe is the union of the
+//!   runtime dependencies every `package.json` in the tree declares, minus the
+//!   workspace's own package names. There is no allowlist and no denylist of
+//!   SDK or vendor names anywhere in this module.
+//! - **No type checking.** Resolution is limited to what the AST proves about
+//!   values. A receiver whose only anchor is a type annotation — a parameter
+//!   typed by an imported class, a value read off a DI container — is not
+//!   resolved and emits nothing.
+//! - **Unknown never blocks, disagreement does.** An unresolved contributor to
+//!   a slot leaves the slot's other contributors intact; two contributors that
+//!   name different packages drop it. That is the recall-leaning choice, taken
+//!   deliberately: a wrapper whose branches all reach one package is the common
+//!   shape, and a wrapper that reaches two is a genuine ambiguity.
 //! - **Never merged into HTTP matching.** These rows are their own mechanism
 //!   and their own payload field. They are not endpoints, they are not consumer
 //!   calls, and nothing here touches extraction, matching, or type
@@ -41,26 +72,56 @@
 //! library all produce rows alongside genuine service clients, which is the
 //! intended trade of recall in the scanner against classification downstream.
 //!
-//! Known limitations, all deliberate for this slice and all silent rather than
-//! guessed:
+//! # Known limitations
 //!
-//! - ESM `import` declarations only. `require()` and TypeScript `import =`
-//!   bindings produce no rows.
-//! - Type-only imports are excluded, both `import type ...` and per-specifier
-//!   `import { type Foo }`.
-//! - Destructuring off a resolved binding (`const { charges } = client`) is not
-//!   followed.
-//! - Constructor calls (`new Client(...)`) resolve the receiver without becoming
-//!   rows themselves, because constructing a client is not egress.
+//! All deliberate, and all silent rather than guessed:
+//!
+//! - **ESM only.** `import` declarations, re-exports, and `import()` with a
+//!   string literal. `require()`, TypeScript `import =`, and a dynamic import
+//!   whose specifier is computed produce no bindings and no reachability edge.
+//! - **Type-only imports carry nothing.** `import type ...`, per-specifier
+//!   `import { type Foo }`, and type-only re-exports bind nothing at runtime,
+//!   so a receiver whose only anchor is one of them is permanently out of
+//!   reach. That is the same line as "no type checking", seen from the import
+//!   side.
+//! - **Destructuring** is followed through object patterns with identifier
+//!   keys. Array patterns, rest elements, and computed keys are not.
+//! - **Transitivity has a shape, not a depth limit.** A handle reached through
+//!   wrapper modules, a factory's return value, a property of a returned object
+//!   literal, a class field, or a barrel re-export chain resolves however many
+//!   hops away it was written. A value that only exists at runtime — read from
+//!   a container, selected by configuration, passed in as a parameter — does
+//!   not.
+//! - **Unknown destinations emit nothing.** An internal wrapper around the
+//!   global `fetch` is real egress with no nameable target, so it produces no
+//!   row here.
+//! - **Constructor calls** (`new Client(...)`) resolve the receiver without
+//!   becoming rows themselves, because constructing a client is not egress.
+//! - **Class fields** resolve one level and without inheritance. A field
+//!   assigned from a constructor parameter is filled in from the construction
+//!   sites of that class in the same file, and every site contributes to one
+//!   field map, so two instances built with differently-owned arguments are not
+//!   told apart. A base class's fields do not reach a subclass, and a class
+//!   constructed through an imported binding carries no constructor facts.
+//!   `this` inside a class resolves against the innermost enclosing class
+//!   whatever function nests it.
+//!
+//! What a value's configuration comes from is not a limit on any of this. A
+//! factory reads its host and its credentials from the environment or from the
+//! database and still constructs the same client, so the binding owns the
+//! package the constructing expression names. Ownership is about which code
+//! the call goes through, not about which account it reaches.
 
 use crate::analyzer::Analyzer;
 use crate::config::Config;
+use crate::file_finder::find_files;
 use crate::mount_graph::DataFetchingCall;
-use crate::packages::Packages;
+use crate::packages::MANIFEST_SKIP_DIRS;
 use crate::type_manifest::parse_file_location;
 use crate::url_normalizer::UrlNormalizer;
+use crate::workspace_resolver::{Resolution, WorkspaceIndex};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::path::{Path, PathBuf};
 use swc_common::{FileName, GLOBALS, Globals, Mark, SourceMap, sync::Lrc};
 use swc_ecma_ast::*;
@@ -71,16 +132,33 @@ use tracing::warn;
 
 /// Upper bound on the rows one service contributes to the upload payload.
 /// Rows are sorted before truncation, so a repo over the cap yields a stable
-/// prefix rather than an arbitrary sample. The cap exists so a very large
-/// monorepo cannot push the payload towards the Lambda request limit; it is
-/// generous enough that no realistic service reaches it.
-pub const MAX_CANDIDATES_PER_SERVICE: usize = 5000;
+/// prefix rather than an arbitrary sample.
+///
+/// Measured rather than guessed. Once the scan became workspace-transitive, a
+/// service stopped contributing only its own directory and started contributing
+/// every shared package it reaches, which is a different order of magnitude: an
+/// offline probe over a large real-world monorepo produced roughly 15k, 7k, and
+/// 3.5k rows for its three services. The 5000 the channel shipped with would
+/// have silently truncated the largest of those, and truncation follows the sort
+/// order — file first — so what it drops is the tail of the alphabet, which in a
+/// monorepo is disproportionately the shared packages the widening was built to
+/// reach. 20000 leaves headroom above the measured peak while staying small:
+/// rows are around 100 bytes, so a service at the cap is about 2MB, far under
+/// the request limit the cap exists to protect.
+pub const MAX_CANDIDATES_PER_SERVICE: usize = 20000;
+
+/// Safety net on the ownership fixpoint. Each round can only move a slot up a
+/// finite lattice, so the loop terminates on its own; the bound turns a bug in
+/// that argument into a logged, truncated result rather than a scan that never
+/// returns on somebody's repo.
+const MAX_FIXPOINT_ROUNDS: usize = 64;
 
 /// How the scanner established that a call site leaves the service.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CallMechanism {
-    /// The callee resolves, through an import, to a declared runtime dependency.
+    /// The callee resolves, through the workspace, to a declared runtime
+    /// dependency.
     Sdk,
     /// An extracted HTTP call whose target names a host the repo declares in
     /// `externalDomains`.
@@ -107,7 +185,9 @@ pub struct ExternalCallCandidate {
     ///
     /// For [`CallMechanism::Sdk`], the callee as written, dotted
     /// (`ledger.payments.create`), computed from the AST so it carries no
-    /// whitespace or comments from the source. For the two HTTP-shaped
+    /// whitespace or comments from the source. A call inside the chain prints
+    /// as `()` (`getTransport().verify`), and a receiver held in a class field
+    /// prints as written (`this.client.upload`). For the two HTTP-shaped
     /// mechanisms there is no callee to name — the client is `fetch` or an
     /// axios-alike in every case — so the field carries the HTTP method, which
     /// is the operation the row records.
@@ -125,31 +205,40 @@ pub struct ExternalCallCandidate {
     pub mechanism: CallMechanism,
 }
 
-/// Scan `files` for SDK-mediated call candidates.
+/// Scan the whole workspace and return the SDK-mediated call candidates that
+/// belong to the service whose files are `service_files`.
 ///
-/// `files` is expected to be the service's already-filtered source list from
-/// [`crate::file_finder::find_service_files`], so test trees, story files, and
+/// The scan is workspace-wide because ownership is: the file that imports a
+/// vendor client and the file that calls through it are routinely in different
+/// packages. Attribution is per service: a row survives when its file is
+/// reachable from `service_files` by following internal import edges, which is
+/// the same question as "does this service's deployment contain that code?".
+///
+/// `service_files` is expected to be the service's already-filtered source list
+/// from [`crate::file_finder::find_service_files`], and the workspace pass uses
+/// the same walk over `repo_root`, so test trees, story files, and
 /// vendored/build directories are excluded by the scanner's existing rules
 /// rather than by anything invented here.
-pub fn scan_files(
-    files: &[PathBuf],
-    repo_root: &Path,
-    packages: &Packages,
-) -> Vec<ExternalCallCandidate> {
-    let dependencies = runtime_dependency_names(packages);
-    if dependencies.is_empty() {
+///
+/// Computed fresh per service. One extra parse pass per service costs less than
+/// threading a cache through the engine would, and keeps this entry point a
+/// pure function of the tree on disk.
+pub fn scan_workspace(service_files: &[PathBuf], repo_root: &Path) -> Vec<ExternalCallCandidate> {
+    let index = WorkspaceIndex::build(repo_root);
+    if !index.has_external_packages() {
         return Vec::new();
     }
 
-    let mut rows: BTreeSet<ExternalCallCandidate> = BTreeSet::new();
-    for file in files {
-        let Ok(content) = std::fs::read_to_string(file) else {
-            continue;
-        };
-        let relative = relative_path(file, repo_root);
-        rows.extend(scan_content(&relative, file, &content, &dependencies));
-    }
+    let workspace = Workspace::parse(repo_root, &index, service_files);
+    let ownership = workspace.resolve_ownership();
+    let rows_by_file = workspace.rows(&ownership);
 
+    let mut rows: BTreeSet<ExternalCallCandidate> = BTreeSet::new();
+    for file in workspace.reachable_from(service_files, repo_root) {
+        if let Some(file_rows) = rows_by_file.get(&file) {
+            rows.extend(file_rows.iter().cloned());
+        }
+    }
     cap(rows.into_iter().collect())
 }
 
@@ -265,55 +354,6 @@ pub fn merge(
     cap(merged.into_iter().collect())
 }
 
-/// Package names that count as external runtime dependencies of this service.
-///
-/// `dependencies`, `peerDependencies`, and `optionalDependencies` — the three
-/// maps whose contents can be present at runtime. `devDependencies` is excluded:
-/// carrick#510 asks for calls into "the repo's package.json dependency set" and
-/// says nothing about dev dependencies, and a test harness or build tool calling
-/// out is not service egress.
-///
-/// Workspace-internal packages are subtracted. A monorepo member is normally
-/// declared as a dependency of its siblings (`"workspace:*"`), and a call into
-/// one is an internal call, not egress. `Packages::internal_names` holds the
-/// name of every `package.json` in the repo tree, which is what makes this
-/// structural rather than a naming convention.
-fn runtime_dependency_names(packages: &Packages) -> HashSet<String> {
-    packages
-        .package_jsons
-        .iter()
-        .flat_map(|pkg| {
-            pkg.dependencies
-                .keys()
-                .chain(pkg.peer_dependencies.keys())
-                .chain(pkg.optional_dependencies.keys())
-        })
-        .filter(|name| !packages.internal_names.contains(*name))
-        .cloned()
-        .collect()
-}
-
-/// Rows are cloud-bound, so `file` must be repo-relative.
-///
-/// A file the scan root does not contain is reported verbatim rather than
-/// dropped, but loudly: an absolute path in the inventory means the walk root
-/// and the payload root have diverged, and that is a bug worth seeing rather
-/// than a row worth silently mangling.
-fn relative_path(file: &Path, repo_root: &Path) -> String {
-    match file.strip_prefix(repo_root) {
-        Ok(relative) => relative.to_string_lossy().to_string(),
-        Err(_) => {
-            warn!(
-                "External call candidate file {} is not under the scan root {}; \
-                 reporting the path as-is",
-                file.display(),
-                repo_root.display()
-            );
-            file.to_string_lossy().to_string()
-        }
-    }
-}
-
 /// Repo-relative file path for a projected HTTP row.
 ///
 /// The mount graph keys `file_location` as the analysis scanned it: already
@@ -331,26 +371,807 @@ fn relative_location(file: &str, repo_root: &Path) -> String {
         .to_string()
 }
 
-/// Which declared dependency does this module specifier import from?
+// ---------------------------------------------------------------------------
+// Reduced expressions
+// ---------------------------------------------------------------------------
+
+/// A binding, identified by name and by the syntax context the resolver
+/// stamped on it, so a local `const client = ...` inside a function does not
+/// collide with a module-level import of the same name.
 ///
-/// Exact match, or a subpath under it (`"pkg/edge"` resolves to `"pkg"`). This
-/// is the same matching convention the messaging-client and data-fetcher import
-/// gates use, kept identical so a package is recognized the same way
-/// everywhere. A relative specifier (`"./x"`), a bare Node builtin (`"fs"`,
-/// `"node:fs"`), and a workspace-internal package all fail it, because none of
-/// them appears in the dependency set.
-fn resolve_specifier<'a>(specifier: &str, dependencies: &'a HashSet<String>) -> Option<&'a String> {
-    if let Some(exact) = dependencies.get(specifier) {
-        return Some(exact);
-    }
-    dependencies
-        .iter()
-        .filter(|dep| specifier.starts_with(&format!("{}/", dep)))
-        // A specifier can only match one declared package by prefix in
-        // practice, but pick the longest deterministically rather than relying
-        // on HashSet order.
-        .max_by_key(|dep| dep.len())
+/// The context is kept as a plain integer rather than swc's `SyntaxContext` so
+/// that map ordering is a property of the source rather than of interning
+/// order, which matters because the row list must be byte-identical between
+/// runs.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct BindingId {
+    symbol: String,
+    context: u32,
 }
+
+impl BindingId {
+    fn of(ident: &Ident) -> Self {
+        BindingId {
+            symbol: ident.sym.to_string(),
+            context: ident.ctxt.as_u32(),
+        }
+    }
+
+    fn of_binding(ident: &BindingIdent) -> Self {
+        BindingId::of(&ident.id)
+    }
+
+    /// The slot an `export default <expression>` writes into. `*default*` is
+    /// not a legal identifier, so it can never collide with a real binding.
+    fn default_export() -> Self {
+        BindingId {
+            symbol: "*default*".to_string(),
+            context: 0,
+        }
+    }
+}
+
+/// Where a chain starts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Root {
+    Binding(BindingId),
+    /// `this` inside a class, carrying the index of the class whose field map
+    /// resolves it.
+    This(usize),
+}
+
+/// One hop along a chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Step {
+    Prop(String),
+    Call,
+}
+
+/// A value expression reduced to the only thing ownership can use: where it
+/// starts, and what was applied to it.
+///
+/// This one shape carries every resolvable form — a receiver, a factory result,
+/// a destructured property, a call in the middle of a callee — so the rules do
+/// not each need their own matcher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Chain {
+    root: Root,
+    steps: Vec<Step>,
+}
+
+impl Chain {
+    fn extended(&self, step: Step) -> Chain {
+        let mut steps = self.steps.clone();
+        steps.push(step);
+        Chain {
+            root: self.root.clone(),
+            steps,
+        }
+    }
+
+    /// The callee as written. A call inside the chain prints as `()`.
+    fn text(&self) -> String {
+        let mut text = match &self.root {
+            Root::Binding(id) => id.symbol.clone(),
+            Root::This(_) => "this".to_string(),
+        };
+        for step in &self.steps {
+            match step {
+                Step::Prop(name) => {
+                    text.push('.');
+                    text.push_str(name);
+                }
+                Step::Call => text.push_str("()"),
+            }
+        }
+        text
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ownership lattice
+// ---------------------------------------------------------------------------
+
+/// What one property of a record is known to own. Conflict is representable so
+/// that disagreement is sticky: a property two branches disagree about must
+/// stay dropped once it has been dropped, or the fixpoint could oscillate.
+///
+/// A record property carries a package and nothing richer, deliberately. That is
+/// what bounds the lattice: if a property could hold another record, a cyclic
+/// data structure would let records grow without limit and the fixpoint would
+/// never settle. Values that need to nest — a static field holding an instance,
+/// whose own field holds the client — live in slots of their own rather than
+/// inside a record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PropValue {
+    Pkg(String),
+    Conflict,
+}
+
+/// What a resolved slot holds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Owner {
+    /// A value that came out of an external package. Any property of it, and
+    /// any call on it, is still that package's.
+    Pkg(String),
+    /// An object whose named properties are owned — a function's returned
+    /// object literal, or a class instance's field map.
+    Record(BTreeMap<String, PropValue>),
+    /// A namespace standing for another file's exports; a property lookup goes
+    /// through that file's export table.
+    NamespaceOf(usize),
+    /// The class declared at `(file, class index)`, as a value. A property of it
+    /// is a static slot; constructing it yields the class's instance field map.
+    /// A marker rather than a record, so a static slot can hold anything a slot
+    /// can hold — an instance, a factory — which is what the singleton idiom
+    /// needs and what a record's package-only properties cannot express.
+    ClassOf(usize, usize),
+    /// A function whose calls yield the boxed owner. The binding itself carries
+    /// through assignment and export; only a call position unwraps it.
+    FnReturning(Box<Owner>),
+}
+
+/// A slot's value. Absent means unknown, which never blocks: it is the other
+/// contributors to the slot that decide. `Conflict` is the top of the lattice
+/// and is terminal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Value {
+    Owned(Owner),
+    Conflict,
+}
+
+fn join_owners(left: &Owner, right: &Owner) -> Value {
+    if left == right {
+        return Value::Owned(left.clone());
+    }
+    match (left, right) {
+        (Owner::Record(a), Owner::Record(b)) => {
+            let mut merged = a.clone();
+            for (key, value) in b {
+                match merged.get(key) {
+                    Some(existing) if existing == value => {}
+                    Some(_) => {
+                        merged.insert(key.clone(), PropValue::Conflict);
+                    }
+                    None => {
+                        merged.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+            Value::Owned(Owner::Record(merged))
+        }
+        (Owner::FnReturning(a), Owner::FnReturning(b)) => match join_owners(a, b) {
+            Value::Owned(owner) => Value::Owned(Owner::FnReturning(Box::new(owner))),
+            Value::Conflict => Value::Conflict,
+        },
+        _ => Value::Conflict,
+    }
+}
+
+/// The whole workspace's ownership state. Every map is a `BTreeMap` because
+/// the star-export rule iterates one of them, and iteration order there would
+/// otherwise reach the row list.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct Ownership {
+    bindings: BTreeMap<(usize, BindingId), Value>,
+    exports: BTreeMap<(usize, String), Value>,
+    /// A class's instance field map, keyed by file and class index. Separate
+    /// from the class's static slots: conflating the two would let a static read
+    /// resolve through an instance field.
+    class_instances: BTreeMap<(usize, usize), Value>,
+    /// One slot per static member, keyed by file, class index, and name. A slot
+    /// rather than a property of a record on the class binding, because the
+    /// singleton idiom stores an INSTANCE in a static field and reads a field of
+    /// it back out — two levels, which a record's package-only properties cannot
+    /// carry.
+    static_slots: BTreeMap<(usize, usize, String), Value>,
+}
+
+impl Ownership {
+    fn join_binding(&mut self, key: (usize, BindingId), value: Value) {
+        join_into(&mut self.bindings, key, value);
+    }
+
+    fn join_export(&mut self, key: (usize, String), value: Value) {
+        join_into(&mut self.exports, key, value);
+    }
+
+    fn join_class_instance(&mut self, key: (usize, usize), value: Value) {
+        join_into(&mut self.class_instances, key, value);
+    }
+
+    fn join_static_slot(&mut self, key: (usize, usize, String), value: Value) {
+        join_into(&mut self.static_slots, key, value);
+    }
+
+    fn binding(&self, file: usize, id: &BindingId) -> Option<&Owner> {
+        owner_of(self.bindings.get(&(file, id.clone())))
+    }
+
+    fn export(&self, file: usize, name: &str) -> Option<&Owner> {
+        owner_of(self.exports.get(&(file, name.to_string())))
+    }
+
+    fn class_instance(&self, file: usize, class: usize) -> Option<&Owner> {
+        owner_of(self.class_instances.get(&(file, class)))
+    }
+
+    fn static_slot(&self, file: usize, class: usize, name: &str) -> Option<&Owner> {
+        owner_of(self.static_slots.get(&(file, class, name.to_string())))
+    }
+
+    /// Evaluate a chain against this state: the root's owner, then one step at
+    /// a time. `None` is "not established", which covers both unknown and
+    /// conflicted.
+    fn eval(&self, file: usize, chain: &Chain) -> Option<Owner> {
+        let mut owner = match &chain.root {
+            Root::Binding(id) => self.binding(file, id)?.clone(),
+            Root::This(class) => self.class_instance(file, *class)?.clone(),
+        };
+        for step in &chain.steps {
+            owner = match (step, owner) {
+                // Anything reached off a package's value is still that
+                // package's: a sub-client, a namespace, a builder.
+                (_, Owner::Pkg(package)) => Owner::Pkg(package),
+                (Step::Prop(name), Owner::Record(fields)) => match fields.get(name) {
+                    Some(PropValue::Pkg(package)) => Owner::Pkg(package.clone()),
+                    _ => return None,
+                },
+                (Step::Prop(name), Owner::NamespaceOf(target)) => {
+                    self.export(target, name)?.clone()
+                }
+                (Step::Prop(name), Owner::ClassOf(target, class)) => {
+                    self.static_slot(target, class, name)?.clone()
+                }
+                // A class in call position is `new C(...)`: the chain reducer
+                // spells construction the same way it spells a call, and calling
+                // a class without `new` throws, so the two cannot be confused in
+                // code that runs.
+                (Step::Call, Owner::ClassOf(target, class)) => {
+                    self.class_instance(target, class)?.clone()
+                }
+                (Step::Call, Owner::FnReturning(returned)) => *returned,
+                _ => return None,
+            };
+        }
+        Some(owner)
+    }
+
+    /// The package a chain resolves to, if it resolves to one at all. Records,
+    /// namespaces, and uncalled functions are resolved values but not
+    /// destinations, so they yield no row.
+    fn resolve_package(&self, file: usize, chain: &Chain) -> Option<String> {
+        match self.eval(file, chain)? {
+            Owner::Pkg(package) => Some(package),
+            _ => None,
+        }
+    }
+}
+
+fn owner_of(value: Option<&Value>) -> Option<&Owner> {
+    match value {
+        Some(Value::Owned(owner)) => Some(owner),
+        _ => None,
+    }
+}
+
+fn join_into<K: Ord>(map: &mut BTreeMap<K, Value>, key: K, value: Value) {
+    let joined = match (map.get(&key), &value) {
+        (None, _) => value.clone(),
+        (Some(Value::Conflict), _) | (_, Value::Conflict) => Value::Conflict,
+        (Some(Value::Owned(existing)), Value::Owned(incoming)) => join_owners(existing, incoming),
+    };
+    map.insert(key, joined);
+}
+
+// ---------------------------------------------------------------------------
+// Per-file facts
+// ---------------------------------------------------------------------------
+
+/// Where a name imported or re-exported by a file comes from.
+#[derive(Debug, Clone)]
+enum Source {
+    ExternalPackage(String),
+    /// A named export of another workspace file.
+    InternalNamed(usize, String),
+    /// Another workspace file taken whole.
+    InternalNamespace(usize),
+}
+
+#[derive(Debug, Clone)]
+struct ImportFact {
+    local: BindingId,
+    source: Source,
+}
+
+#[derive(Debug, Clone)]
+struct ReExportFact {
+    name: String,
+    source: Source,
+}
+
+#[derive(Debug, Clone)]
+struct ExportFact {
+    name: String,
+    local: BindingId,
+}
+
+#[derive(Debug, Clone)]
+struct AliasFact {
+    local: BindingId,
+    value: Chain,
+}
+
+/// One argument at a construction site, reduced to what the constructor's field
+/// assignments can read out of it.
+#[derive(Debug, Clone)]
+enum Argument {
+    /// A chain: a binding, or something reached off one.
+    Value(Chain),
+    /// An object literal, which is how a constructor taking an options bag is
+    /// almost always called. Shorthand properties included.
+    Record(BTreeMap<String, Chain>),
+    /// A spread, or anything the chain reducer cannot name. Occupies the
+    /// position so later arguments keep their index.
+    Opaque,
+}
+
+/// `new LocalClass(args)`, wherever it appears. Collected from every `new`
+/// expression rather than only from variable declarators: the singleton idiom
+/// constructs into a static field, and a dependency-injected client reaches its
+/// class through exactly that assignment.
+#[derive(Debug, Clone)]
+struct ConstructionFact {
+    class_binding: BindingId,
+    arguments: Vec<Argument>,
+}
+
+/// The returns of one function, in the two shapes ownership can read.
+#[derive(Debug, Clone, Default)]
+struct ReturnShape {
+    /// Every `return <expr>` that reduces to a chain, and an arrow's expression
+    /// body.
+    returns: Vec<Chain>,
+    /// Properties of returned object literals: the property name and the chain
+    /// its value reduces to. Every branch of a ternary or of `??`/`||` in the
+    /// property's position contributes separately.
+    record_returns: Vec<(String, Chain)>,
+}
+
+impl ReturnShape {
+    fn is_empty(&self) -> bool {
+        self.returns.is_empty() && self.record_returns.is_empty()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FunctionFact {
+    local: BindingId,
+    shape: ReturnShape,
+}
+
+/// A static member that is a function: a factory, or a getter standing in for a
+/// field.
+#[derive(Debug, Clone)]
+struct StaticFunction {
+    name: String,
+    shape: ReturnShape,
+    /// A getter is read as a property, so its slot holds what it returns; a
+    /// method is called, so its slot holds a function.
+    is_getter: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ClassFact {
+    /// The binding the class is declared under, when it has one. That binding
+    /// resolves to the class itself, through which the static slots are reached.
+    binding: Option<BindingId>,
+    instance_fields: Vec<(String, Chain)>,
+    /// Static property initializers.
+    static_fields: Vec<(String, Chain)>,
+    static_functions: Vec<StaticFunction>,
+    /// `this.<field> = <constructor parameter>[.<property>...]`: the field, the
+    /// parameter's position, and the path read off it. The bare-parameter form
+    /// has an empty path. Filled in from the construction sites, one level, no
+    /// inheritance.
+    ctor_param_fields: Vec<(String, usize, Vec<String>)>,
+}
+
+#[derive(Debug, Clone)]
+struct CallSite {
+    line: usize,
+    callee: Chain,
+}
+
+#[derive(Debug, Default)]
+struct FileFacts {
+    imports: Vec<ImportFact>,
+    reexports: Vec<ReExportFact>,
+    /// `export * from <internal file>`.
+    star_exports: BTreeSet<usize>,
+    exports: Vec<ExportFact>,
+    aliases: Vec<AliasFact>,
+    constructions: Vec<ConstructionFact>,
+    /// `<identifier>.<field> = <expression>` at any depth. Folded against the
+    /// file's classes: the ones whose identifier names a class are static
+    /// assignments, the rest are dropped.
+    member_assignments: Vec<(BindingId, String, Chain)>,
+    functions: Vec<FunctionFact>,
+    classes: Vec<ClassFact>,
+    call_sites: Vec<CallSite>,
+    /// Files this one pulls in, however it pulls them in: static imports,
+    /// re-exports, stars, and literal dynamic imports all count, because all
+    /// four ship the target with the caller.
+    edges: BTreeSet<usize>,
+}
+
+/// Every source file in the repo, reduced to facts.
+struct Workspace {
+    files: Vec<PathBuf>,
+    facts: Vec<FileFacts>,
+}
+
+impl Workspace {
+    fn parse(repo_root: &Path, index: &WorkspaceIndex, service_files: &[PathBuf]) -> Workspace {
+        // The same walk the per-service scan uses, so the two see one file set
+        // and one set of exclusions.
+        let (mut absolute, _, _) = find_files(&repo_root.to_string_lossy(), &MANIFEST_SKIP_DIRS);
+
+        // Those exclusions are relative to the walk root, so a service rooted
+        // at a directory named after a build artifact (`packages/build`) is
+        // scanned by its own walk and skipped by the repo-wide one. Its files
+        // are added back rather than the exclusion being weakened: the
+        // directory is genuinely a service when it is the configured root and
+        // genuinely build output when it is not.
+        absolute.extend(service_files.iter().cloned());
+        absolute.sort();
+        absolute.dedup();
+
+        let files: Vec<PathBuf> = absolute
+            .iter()
+            .map(|path| path.strip_prefix(repo_root).unwrap_or(path).to_path_buf())
+            .collect();
+        let file_index: BTreeMap<PathBuf, usize> = files
+            .iter()
+            .enumerate()
+            .map(|(idx, path)| (path.clone(), idx))
+            .collect();
+
+        let facts = files
+            .iter()
+            .zip(absolute.iter())
+            .map(|(relative, path)| collect_facts(relative, path, index, &file_index))
+            .collect();
+
+        Workspace { files, facts }
+    }
+
+    /// Run the ownership rules to a fixpoint.
+    ///
+    /// Each round reads the previous round's state and writes a new one, so the
+    /// result cannot depend on the order facts are visited in. Every write is a
+    /// join, so a slot only ever moves up the lattice, and the lattice has
+    /// finite height per slot — that is what makes the loop terminate.
+    fn resolve_ownership(&self) -> Ownership {
+        let mut state = Ownership::default();
+        for round in 0..MAX_FIXPOINT_ROUNDS {
+            let previous = state.clone();
+            for (file, facts) in self.facts.iter().enumerate() {
+                self.apply_facts(file, facts, &previous, &mut state);
+            }
+            if state == previous {
+                return state;
+            }
+            if round + 1 == MAX_FIXPOINT_ROUNDS {
+                warn!(
+                    "External call candidate ownership did not settle in {} rounds; \
+                     reporting what resolved so far",
+                    MAX_FIXPOINT_ROUNDS
+                );
+            }
+        }
+        state
+    }
+
+    fn apply_facts(
+        &self,
+        file: usize,
+        facts: &FileFacts,
+        previous: &Ownership,
+        next: &mut Ownership,
+    ) {
+        for import in &facts.imports {
+            if let Some(value) = self.source_value(&import.source, previous) {
+                next.join_binding((file, import.local.clone()), value);
+            }
+        }
+
+        for (index, class) in facts.classes.iter().enumerate() {
+            let instance = record_of(file, &class.instance_fields, previous);
+            if !instance.is_empty() {
+                next.join_class_instance((file, index), record_value(instance));
+            }
+            if let Some(binding) = &class.binding {
+                next.join_binding(
+                    (file, binding.clone()),
+                    Value::Owned(Owner::ClassOf(file, index)),
+                );
+            }
+            for (name, chain) in &class.static_fields {
+                if let Some(owner) = previous.eval(file, chain) {
+                    next.join_static_slot((file, index, name.clone()), Value::Owned(owner));
+                }
+            }
+            for function in &class.static_functions {
+                let Some(owner) = return_owner(file, &function.shape, previous) else {
+                    continue;
+                };
+                let value = if function.is_getter {
+                    // A getter is read, never called, so its slot holds the
+                    // returned value rather than a function.
+                    Value::Owned(owner)
+                } else {
+                    Value::Owned(Owner::FnReturning(Box::new(owner)))
+                };
+                next.join_static_slot((file, index, function.name.clone()), value);
+            }
+        }
+
+        for function in &facts.functions {
+            if let Some(owner) = return_owner(file, &function.shape, previous) {
+                next.join_binding(
+                    (file, function.local.clone()),
+                    Value::Owned(Owner::FnReturning(Box::new(owner))),
+                );
+            }
+        }
+
+        for alias in &facts.aliases {
+            if let Some(owner) = previous.eval(file, &alias.value) {
+                next.join_binding((file, alias.local.clone()), Value::Owned(owner));
+            }
+        }
+
+        // The fields a constructor fills in from its arguments belong to the
+        // class, not to one construction site. Every site contributes to the one
+        // instance record, which over-approximates when a class is constructed
+        // twice with differently-owned arguments — two instances share one field
+        // map. For a candidates channel that is the right trade: the alternative
+        // is losing the shape entirely, and a disagreement between two sites
+        // still drops the field rather than picking one.
+        for construction in &facts.constructions {
+            let Some((index, fields)) =
+                self.construction_fields(file, facts, construction, previous)
+            else {
+                continue;
+            };
+            if !fields.is_empty() {
+                next.join_class_instance((file, index), record_value(fields));
+            }
+        }
+
+        for (target, field, chain) in &facts.member_assignments {
+            let Some(index) = facts
+                .classes
+                .iter()
+                .position(|class| class.binding.as_ref() == Some(target))
+            else {
+                continue;
+            };
+            if let Some(owner) = previous.eval(file, chain) {
+                next.join_static_slot((file, index, field.clone()), Value::Owned(owner));
+            }
+        }
+
+        for export in &facts.exports {
+            if let Some(value) = previous.bindings.get(&(file, export.local.clone())) {
+                next.join_export((file, export.name.clone()), value.clone());
+            }
+        }
+
+        for reexport in &facts.reexports {
+            if let Some(value) = self.source_value(&reexport.source, previous) {
+                next.join_export((file, reexport.name.clone()), value);
+            }
+        }
+
+        for star in &facts.star_exports {
+            for ((source_file, name), value) in &previous.exports {
+                if source_file == star {
+                    next.join_export((file, name.clone()), value.clone());
+                }
+            }
+        }
+    }
+
+    fn source_value(&self, source: &Source, state: &Ownership) -> Option<Value> {
+        match source {
+            Source::ExternalPackage(package) => Some(Value::Owned(Owner::Pkg(package.clone()))),
+            Source::InternalNamed(target, name) => {
+                state.exports.get(&(*target, name.clone())).cloned()
+            }
+            Source::InternalNamespace(target) => Some(Value::Owned(Owner::NamespaceOf(*target))),
+        }
+    }
+
+    /// What one construction site proves about the fields its constructor
+    /// assigns from its parameters, and which class those fields belong to.
+    ///
+    /// `None` when the identifier being constructed is not a class declared in
+    /// this file: an imported class carries no constructor facts here, one level
+    /// and no inheritance.
+    fn construction_fields(
+        &self,
+        file: usize,
+        facts: &FileFacts,
+        construction: &ConstructionFact,
+        state: &Ownership,
+    ) -> Option<(usize, BTreeMap<String, PropValue>)> {
+        let index = facts
+            .classes
+            .iter()
+            .position(|class| class.binding.as_ref() == Some(&construction.class_binding))?;
+        let class = &facts.classes[index];
+
+        let mut fields: BTreeMap<String, PropValue> = BTreeMap::new();
+        for (field, position, path) in &class.ctor_param_fields {
+            let Some(argument) = construction.arguments.get(*position) else {
+                continue;
+            };
+            let chain = match argument {
+                Argument::Value(chain) => {
+                    let mut chain = chain.clone();
+                    for property in path {
+                        chain = chain.extended(Step::Prop(property.clone()));
+                    }
+                    chain
+                }
+                // `new C({ client })` reading `options.client`: the property is
+                // in the literal, so the argument's own chain for it is what the
+                // field owns, with any deeper path appended.
+                Argument::Record(properties) => {
+                    let Some((first, rest)) = path.split_first() else {
+                        continue;
+                    };
+                    let Some(chain) = properties.get(first) else {
+                        continue;
+                    };
+                    let mut chain = chain.clone();
+                    for property in rest {
+                        chain = chain.extended(Step::Prop(property.clone()));
+                    }
+                    chain
+                }
+                Argument::Opaque => continue,
+            };
+            if let Some(package) = state.resolve_package(file, &chain) {
+                insert_prop(&mut fields, field.clone(), package);
+            }
+        }
+        Some((index, fields))
+    }
+
+    /// Rows for every workspace file, before any service takes its share.
+    fn rows(&self, state: &Ownership) -> BTreeMap<PathBuf, BTreeSet<ExternalCallCandidate>> {
+        let mut by_file: BTreeMap<PathBuf, BTreeSet<ExternalCallCandidate>> = BTreeMap::new();
+        for (file, facts) in self.facts.iter().enumerate() {
+            for site in &facts.call_sites {
+                let Some(package) = state.resolve_package(file, &site.callee) else {
+                    continue;
+                };
+                by_file.entry(self.files[file].clone()).or_default().insert(
+                    ExternalCallCandidate {
+                        file: self.files[file].to_string_lossy().to_string(),
+                        line: site.line,
+                        callee: site.callee.text(),
+                        package,
+                        mechanism: CallMechanism::Sdk,
+                    },
+                );
+            }
+        }
+        by_file
+    }
+
+    /// The files a service ships: its own, plus everything they pull in,
+    /// transitively.
+    ///
+    /// A service file the workspace walk did not produce — an `include` root
+    /// outside the scan root — seeds nothing, because a file outside the tree
+    /// has no facts to contribute.
+    fn reachable_from(&self, service_files: &[PathBuf], repo_root: &Path) -> BTreeSet<PathBuf> {
+        let file_index: BTreeMap<&Path, usize> = self
+            .files
+            .iter()
+            .enumerate()
+            .map(|(idx, path)| (path.as_path(), idx))
+            .collect();
+
+        let mut queue: VecDeque<usize> = VecDeque::new();
+        let mut seen: BTreeSet<usize> = BTreeSet::new();
+        for file in service_files {
+            let relative = file.strip_prefix(repo_root).unwrap_or(file);
+            if let Some(idx) = file_index.get(relative)
+                && seen.insert(*idx)
+            {
+                queue.push_back(*idx);
+            }
+        }
+        while let Some(idx) = queue.pop_front() {
+            for edge in &self.facts[idx].edges {
+                if seen.insert(*edge) {
+                    queue.push_back(*edge);
+                }
+            }
+        }
+        seen.into_iter()
+            .map(|idx| self.files[idx].clone())
+            .collect()
+    }
+}
+
+fn record_value(fields: BTreeMap<String, PropValue>) -> Value {
+    Value::Owned(Owner::Record(fields))
+}
+
+fn insert_prop(fields: &mut BTreeMap<String, PropValue>, name: String, package: String) {
+    match fields.get(&name) {
+        Some(PropValue::Pkg(existing)) if *existing == package => {}
+        Some(_) => {
+            fields.insert(name, PropValue::Conflict);
+        }
+        None => {
+            fields.insert(name, PropValue::Pkg(package));
+        }
+    }
+}
+
+fn record_of(
+    file: usize,
+    entries: &[(String, Chain)],
+    state: &Ownership,
+) -> BTreeMap<String, PropValue> {
+    let mut fields = BTreeMap::new();
+    for (name, chain) in entries {
+        if let Some(package) = state.resolve_package(file, chain) {
+            insert_prop(&mut fields, name.clone(), package);
+        }
+    }
+    fields
+}
+
+/// What calling this function yields.
+///
+/// Plain returns decide it when any of them resolve; otherwise the properties
+/// of returned object literals do. A function that has both is read as
+/// returning the value, not the record — a deliberate simplification, since a
+/// function that sometimes hands back a client and sometimes hands back a bag
+/// holding one is already telling the reader very little.
+///
+/// A function whose returns are themselves functions yields nothing: a second
+/// call level is out of scope, and wrapping would give the lattice unbounded
+/// height.
+fn return_owner(file: usize, shape: &ReturnShape, state: &Ownership) -> Option<Owner> {
+    let mut plain: Option<Value> = None;
+    for chain in &shape.returns {
+        if let Some(owner) = state.eval(file, chain) {
+            plain = Some(match plain {
+                None => Value::Owned(owner),
+                Some(Value::Owned(existing)) => join_owners(&existing, &owner),
+                Some(Value::Conflict) => Value::Conflict,
+            });
+        }
+    }
+    if let Some(Value::Owned(owner)) = plain {
+        return (!matches!(owner, Owner::FnReturning(_))).then_some(owner);
+    }
+    let record = record_of(file, &shape.record_returns, state);
+    (!record.is_empty()).then_some(Owner::Record(record))
+}
+
+// ---------------------------------------------------------------------------
+// Parsing and fact collection
+// ---------------------------------------------------------------------------
 
 fn syntax_for(file_path: &Path) -> (Syntax, bool) {
     match file_path.extension().and_then(|e| e.to_str()) {
@@ -380,21 +1201,22 @@ fn syntax_for(file_path: &Path) -> (Syntax, bool) {
     }
 }
 
-fn scan_content(
-    relative_file: &str,
-    file_path: &Path,
-    content: &str,
-    dependencies: &HashSet<String>,
-) -> Vec<ExternalCallCandidate> {
-    let (syntax, is_typescript) = syntax_for(file_path);
+fn collect_facts(
+    relative: &Path,
+    absolute: &Path,
+    index: &WorkspaceIndex,
+    file_index: &BTreeMap<PathBuf, usize>,
+) -> FileFacts {
+    let Ok(content) = std::fs::read_to_string(absolute) else {
+        return FileFacts::default();
+    };
+    let (syntax, is_typescript) = syntax_for(absolute);
 
     // A fresh SourceMap per file keeps byte offsets — and therefore the line
     // lookups below — file-local.
     let source_map: Lrc<SourceMap> = Default::default();
-    let source_file = source_map.new_source_file(
-        Lrc::new(FileName::Real(file_path.to_path_buf())),
-        content.to_string(),
-    );
+    let source_file =
+        source_map.new_source_file(Lrc::new(FileName::Real(absolute.to_path_buf())), content);
 
     let lexer = Lexer::new(
         syntax,
@@ -406,13 +1228,12 @@ fn scan_content(
     let Ok(mut module) = parser.parse_module() else {
         // An unparseable file contributes nothing. The scanner already reports
         // parse failures on its own path; this channel stays quiet.
-        return Vec::new();
+        return FileFacts::default();
     };
 
     // The resolver stamps syntax contexts, so bindings are compared by
-    // (symbol, context) rather than by name. A local `const stripe = ...`
-    // inside a function therefore does not collide with a module-level import
-    // of the same name.
+    // (symbol, context) rather than by name. Marks are per-file, which is why
+    // every slot is keyed by the file as well as the binding.
     GLOBALS.set(&Globals::new(), || {
         let unresolved_mark = Mark::new();
         let top_level_mark = Mark::new();
@@ -420,189 +1241,731 @@ fn scan_content(
         module.visit_mut_with(&mut pass);
     });
 
-    let mut bindings = import_bindings(&module, dependencies);
-    if bindings.is_empty() {
-        return Vec::new();
-    }
-    propagate_aliases(&module, &mut bindings);
-
-    let mut visitor = CandidateVisitor {
-        source_map: source_map.clone(),
-        file: relative_file.to_string(),
-        bindings: &bindings,
-        rows: Vec::new(),
+    let mut collector = FactCollector {
+        resolver: Resolver {
+            index,
+            file_index,
+            from: relative.to_path_buf(),
+        },
+        source_map,
+        facts: FileFacts::default(),
+        class_stack: Vec::new(),
+        ctor_params: Vec::new(),
     };
-    module.visit_with(&mut visitor);
-    visitor.rows
+    collector.collect_module_declarations(&module);
+    module.visit_with(&mut collector);
+    collector.facts
 }
 
-/// Local binding -> declared package, for every value import from a dependency.
-fn import_bindings(module: &Module, dependencies: &HashSet<String>) -> HashMap<Id, String> {
-    let mut bindings = HashMap::new();
-    for item in &module.body {
-        let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
-            continue;
-        };
+/// Specifier resolution bound to one file, folded down to the workspace's file
+/// indices.
+struct Resolver<'a> {
+    index: &'a WorkspaceIndex,
+    file_index: &'a BTreeMap<PathBuf, usize>,
+    from: PathBuf,
+}
+
+impl Resolver<'_> {
+    /// `None` when the specifier names nothing the scan can use: a builtin, an
+    /// asset, or a file the walk excluded (a test tree, build output).
+    fn resolve(&self, specifier: &str) -> Option<Target> {
+        match self.index.resolve(&self.from, specifier) {
+            Resolution::External(package) => Some(Target::External(package)),
+            Resolution::Internal(path) => self.file_index.get(&path).copied().map(Target::Internal),
+            Resolution::Unresolved => None,
+        }
+    }
+}
+
+enum Target {
+    External(String),
+    Internal(usize),
+}
+
+struct FactCollector<'a> {
+    resolver: Resolver<'a>,
+    source_map: Lrc<SourceMap>,
+    facts: FileFacts,
+    /// Indices of the classes currently being visited, innermost last.
+    class_stack: Vec<usize>,
+    /// Constructor parameter bindings of each class on the stack, by position.
+    ctor_params: Vec<Vec<Option<BindingId>>>,
+}
+
+impl FactCollector<'_> {
+    /// Imports, re-exports, and export declarations, which only ever appear at
+    /// the top level of a module.
+    fn collect_module_declarations(&mut self, module: &Module) {
+        for item in &module.body {
+            let ModuleItem::ModuleDecl(decl) = item else {
+                continue;
+            };
+            match decl {
+                ModuleDecl::Import(import) => self.collect_import(import),
+                ModuleDecl::ExportNamed(export) => self.collect_named_export(export),
+                ModuleDecl::ExportAll(export) => {
+                    if export.type_only {
+                        continue;
+                    }
+                    if let Some(Target::Internal(target)) =
+                        self.resolver.resolve(export.src.value.as_ref())
+                    {
+                        self.facts.edges.insert(target);
+                        self.facts.star_exports.insert(target);
+                    }
+                }
+                ModuleDecl::ExportDecl(export) => self.collect_exported_decl(&export.decl),
+                ModuleDecl::ExportDefaultDecl(export) => match &export.decl {
+                    DefaultDecl::Fn(function) => {
+                        if let Some(ident) = &function.ident {
+                            let local = BindingId::of(ident);
+                            // A default-exported function is a `FnExpr`, not a
+                            // `FnDecl`, so the declaration visitor never sees
+                            // it and its returns have to be read here.
+                            self.collect_function_body(
+                                local.clone(),
+                                function.function.body.as_ref(),
+                            );
+                            self.export_binding("default", local);
+                        }
+                    }
+                    DefaultDecl::Class(class) => {
+                        if let Some(ident) = &class.ident {
+                            self.export_binding("default", BindingId::of(ident));
+                        }
+                    }
+                    DefaultDecl::TsInterfaceDecl(_) => {}
+                },
+                ModuleDecl::ExportDefaultExpr(export) => {
+                    // A default export of an expression has no binding of its
+                    // own, so it gets a synthetic one and the expression is
+                    // recorded against it like any other alias.
+                    let local = match unwrap_value(&export.expr) {
+                        Expr::Ident(ident) => BindingId::of(ident),
+                        other => {
+                            let local = BindingId::default_export();
+                            if let Some(chain) = self.chain_of(other) {
+                                self.facts.aliases.push(AliasFact {
+                                    local: local.clone(),
+                                    value: chain,
+                                });
+                            }
+                            local
+                        }
+                    };
+                    self.export_binding("default", local);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn collect_import(&mut self, import: &ImportDecl) {
         // `import type { X } from 'pkg'` binds nothing at runtime.
         if import.type_only {
-            continue;
+            return;
         }
-        let Some(package) = resolve_specifier(import.src.value.as_ref(), dependencies) else {
-            continue;
+        let Some(target) = self.resolver.resolve(import.src.value.as_ref()) else {
+            return;
         };
+        if let Target::Internal(file) = target {
+            self.facts.edges.insert(file);
+        }
         for specifier in &import.specifiers {
-            let local = match specifier {
+            let (local, imported) = match specifier {
                 // `import { type X, y }` — the inline type specifier is erased.
                 ImportSpecifier::Named(named) if named.is_type_only => continue,
-                ImportSpecifier::Named(named) => named.local.to_id(),
-                ImportSpecifier::Default(default) => default.local.to_id(),
-                ImportSpecifier::Namespace(namespace) => namespace.local.to_id(),
+                ImportSpecifier::Named(named) => {
+                    let imported = match &named.imported {
+                        Some(ModuleExportName::Ident(ident)) => ident.sym.to_string(),
+                        Some(ModuleExportName::Str(name)) => name.value.to_string(),
+                        None => named.local.sym.to_string(),
+                    };
+                    (BindingId::of(&named.local), Some(imported))
+                }
+                ImportSpecifier::Default(default) => {
+                    (BindingId::of(&default.local), Some("default".to_string()))
+                }
+                ImportSpecifier::Namespace(namespace) => (BindingId::of(&namespace.local), None),
             };
-            bindings.insert(local, package.clone());
+            let source = match (&target, imported) {
+                (Target::External(package), _) => Source::ExternalPackage(package.clone()),
+                (Target::Internal(file), Some(name)) => Source::InternalNamed(*file, name),
+                (Target::Internal(file), None) => Source::InternalNamespace(*file),
+            };
+            self.facts.imports.push(ImportFact { local, source });
         }
     }
-    bindings
-}
 
-/// Extend `bindings` with variables whose initializer is rooted at an existing
-/// binding, so an instance held in a local resolves to the package that
-/// produced it.
-///
-/// Covers the shapes static resolution can actually prove:
-/// `const c = new Client()`, `const c = createClient()`,
-/// `const c = sdk.clients.build()`, `const c = sdk.storage`. The declarator
-/// name must be a plain identifier; destructuring is not followed.
-///
-/// Runs to a fixed point so a chain declared out of order resolves the same way
-/// as one declared in order, and so the result does not depend on traversal
-/// order. Each round can only add bindings, and the binding set is bounded by
-/// the number of declarators, so this terminates.
-fn propagate_aliases(module: &Module, bindings: &mut HashMap<Id, String>) {
-    let mut collector = AliasCollector {
-        aliases: Vec::new(),
-    };
-    module.visit_with(&mut collector);
-
-    loop {
-        let mut added = false;
-        for (local, init) in &collector.aliases {
-            if bindings.contains_key(local) {
-                continue;
-            }
-            if let Some((root, _)) = callee_chain(init)
-                && let Some(package) = bindings.get(&root).cloned()
-            {
-                bindings.insert(local.clone(), package);
-                added = true;
-            }
+    fn collect_named_export(&mut self, export: &NamedExport) {
+        if export.type_only {
+            return;
         }
-        if !added {
-            break;
+        let target = export
+            .src
+            .as_ref()
+            .and_then(|src| self.resolver.resolve(src.value.as_ref()));
+        if let Some(Target::Internal(file)) = &target {
+            self.facts.edges.insert(*file);
+        }
+        for specifier in &export.specifiers {
+            match specifier {
+                ExportSpecifier::Named(named) if named.is_type_only => {}
+                ExportSpecifier::Named(named) => {
+                    let ModuleExportName::Ident(local) = &named.orig else {
+                        continue;
+                    };
+                    let exported = match &named.exported {
+                        Some(ModuleExportName::Ident(ident)) => ident.sym.to_string(),
+                        Some(ModuleExportName::Str(name)) => name.value.to_string(),
+                        None => local.sym.to_string(),
+                    };
+                    match &target {
+                        Some(Target::External(package)) => {
+                            self.facts.reexports.push(ReExportFact {
+                                name: exported,
+                                source: Source::ExternalPackage(package.clone()),
+                            });
+                        }
+                        Some(Target::Internal(file)) => {
+                            self.facts.reexports.push(ReExportFact {
+                                name: exported,
+                                source: Source::InternalNamed(*file, local.sym.to_string()),
+                            });
+                        }
+                        // `export { x }` with no source re-exports a local
+                        // binding of this file.
+                        None => self.export_binding(&exported, BindingId::of(local)),
+                    }
+                }
+                ExportSpecifier::Namespace(namespace) => {
+                    let ModuleExportName::Ident(ident) = &namespace.name else {
+                        continue;
+                    };
+                    let source = match &target {
+                        Some(Target::External(package)) => Source::ExternalPackage(package.clone()),
+                        Some(Target::Internal(file)) => Source::InternalNamespace(*file),
+                        None => continue,
+                    };
+                    self.facts.reexports.push(ReExportFact {
+                        name: ident.sym.to_string(),
+                        source,
+                    });
+                }
+                ExportSpecifier::Default(_) => {}
+            }
         }
     }
-}
 
-struct AliasCollector {
-    /// `(bound identifier, expression it is initialized from)`, in source order.
-    aliases: Vec<(Id, Box<Expr>)>,
-}
-
-impl Visit for AliasCollector {
-    fn visit_var_declarator(&mut self, declarator: &VarDeclarator) {
-        if let (Pat::Ident(name), Some(init)) = (&declarator.name, &declarator.init) {
-            let source = match &**init {
-                // `new Client(...)` and `createClient(...)` both hand back an
-                // instance owned by whatever the callee resolves to.
-                Expr::New(new_expr) => Some(new_expr.callee.clone()),
-                Expr::Call(call) => match &call.callee {
-                    Callee::Expr(callee) => Some(callee.clone()),
-                    _ => None,
-                },
-                // `const storage = sdk.storage` — a handle reached off a
-                // resolved binding stays owned by the same package.
-                other @ (Expr::Member(_) | Expr::Ident(_)) => Some(Box::new(other.clone())),
-                _ => None,
-            };
-            if let Some(source) = source {
-                self.aliases.push((name.id.to_id(), source));
+    fn collect_exported_decl(&mut self, decl: &Decl) {
+        match decl {
+            Decl::Var(var) => {
+                for declarator in &var.decls {
+                    if let Pat::Ident(name) = &declarator.name {
+                        self.export_binding(name.id.sym.as_ref(), BindingId::of_binding(name));
+                    }
+                }
             }
+            Decl::Fn(function) => {
+                self.export_binding(function.ident.sym.as_ref(), BindingId::of(&function.ident));
+            }
+            Decl::Class(class) => {
+                self.export_binding(class.ident.sym.as_ref(), BindingId::of(&class.ident));
+            }
+            _ => {}
         }
-        declarator.visit_children_with(self);
     }
-}
 
-/// Split a callee expression into its root identifier and the property names
-/// applied to it, or `None` when any part is not statically nameable
-/// (computed access, a call in the middle of the chain, a literal receiver).
-fn callee_chain(expr: &Expr) -> Option<(Id, Vec<String>)> {
-    match expr {
-        Expr::Ident(ident) => Some((ident.to_id(), Vec::new())),
-        Expr::Paren(paren) => callee_chain(&paren.expr),
-        Expr::TsNonNull(non_null) => callee_chain(&non_null.expr),
-        Expr::TsAs(as_expr) => callee_chain(&as_expr.expr),
-        Expr::Member(member) => {
-            let MemberProp::Ident(prop) = &member.prop else {
-                return None;
-            };
-            let (root, mut props) = callee_chain(&member.obj)?;
-            props.push(prop.sym.to_string());
-            Some((root, props))
-        }
-        Expr::OptChain(opt_chain) => match &*opt_chain.base {
-            // `a?.b.c()` — the receiver chain is nameable even though it is
-            // guarded. A call inside the chain is not.
-            OptChainBase::Member(member) => {
+    fn export_binding(&mut self, name: &str, local: BindingId) {
+        self.facts.exports.push(ExportFact {
+            name: name.to_string(),
+            local,
+        });
+    }
+
+    /// Reduce an expression to a chain, or `None` when some part of it is not
+    /// statically nameable (computed access, a literal receiver, a spread).
+    ///
+    /// `await`, parentheses, and TypeScript's value-preserving casts are
+    /// transparent: they change the type of the expression, never where the
+    /// value came from.
+    fn chain_of(&self, expr: &Expr) -> Option<Chain> {
+        match unwrap_value(expr) {
+            Expr::Ident(ident) => Some(Chain {
+                root: Root::Binding(BindingId::of(ident)),
+                steps: Vec::new(),
+            }),
+            Expr::This(_) => self.class_stack.last().map(|class| Chain {
+                root: Root::This(*class),
+                steps: Vec::new(),
+            }),
+            Expr::Member(member) => {
                 let MemberProp::Ident(prop) = &member.prop else {
                     return None;
                 };
-                let (root, mut props) = callee_chain(&member.obj)?;
-                props.push(prop.sym.to_string());
-                Some((root, props))
+                Some(
+                    self.chain_of(&member.obj)?
+                        .extended(Step::Prop(prop.sym.to_string())),
+                )
             }
-            OptChainBase::Call(_) => None,
-        },
-        _ => None,
+            Expr::Call(call) => match &call.callee {
+                Callee::Expr(callee) => Some(self.chain_of(callee)?.extended(Step::Call)),
+                _ => None,
+            },
+            Expr::New(new_expr) => Some(self.chain_of(&new_expr.callee)?.extended(Step::Call)),
+            Expr::OptChain(opt_chain) => match &*opt_chain.base {
+                OptChainBase::Member(member) => {
+                    let MemberProp::Ident(prop) = &member.prop else {
+                        return None;
+                    };
+                    Some(
+                        self.chain_of(&member.obj)?
+                            .extended(Step::Prop(prop.sym.to_string())),
+                    )
+                }
+                OptChainBase::Call(call) => Some(self.chain_of(&call.callee)?.extended(Step::Call)),
+            },
+            _ => None,
+        }
     }
-}
 
-fn format_callee(root: &Id, props: &[String]) -> String {
-    let mut text = root.0.to_string();
-    for prop in props {
-        text.push('.');
-        text.push_str(prop);
+    fn record_call_site(&mut self, callee: &Expr, span: swc_common::Span) {
+        if let Some(chain) = self.chain_of(callee) {
+            self.facts.call_sites.push(CallSite {
+                line: self.source_map.lookup_char_pos(span.lo).line,
+                callee: chain,
+            });
+        }
     }
-    text
-}
 
-struct CandidateVisitor<'a> {
-    source_map: Lrc<SourceMap>,
-    file: String,
-    bindings: &'a HashMap<Id, String>,
-    rows: Vec<ExternalCallCandidate>,
-}
+    /// `import('<literal>')`, whatever position it appears in. Returns the
+    /// resolved target and records the reachability edge, because a dynamic
+    /// import ships its target with the importer exactly as a static one does.
+    fn dynamic_import_target(&mut self, expr: &Expr) -> Option<Target> {
+        let Expr::Call(call) = unwrap_value(expr) else {
+            return None;
+        };
+        self.dynamic_import_of(call)
+    }
 
-impl CandidateVisitor<'_> {
-    fn record(&mut self, callee: &Expr, span: swc_common::Span) {
-        let Some((root, props)) = callee_chain(callee) else {
+    fn dynamic_import_of(&mut self, call: &CallExpr) -> Option<Target> {
+        if !matches!(call.callee, Callee::Import(_)) {
+            return None;
+        }
+        let specifier = call.args.first().and_then(|arg| match &*arg.expr {
+            Expr::Lit(Lit::Str(literal)) => Some(literal.value.to_string()),
+            _ => None,
+        })?;
+        let target = self.resolver.resolve(&specifier)?;
+        if let Target::Internal(file) = &target {
+            self.facts.edges.insert(*file);
+        }
+        Some(target)
+    }
+
+    /// The bindings a variable declarator introduces, given the value it is
+    /// initialized from.
+    fn collect_declarator(&mut self, declarator: &VarDeclarator) {
+        let Some(init) = &declarator.init else {
             return;
         };
-        let Some(package) = self.bindings.get(&root) else {
+
+        // `const { x } = await import('spec')` / `const m = await import('spec')`
+        // bind names of another module, so they are import facts rather than
+        // aliases.
+        if let Some(target) = self.dynamic_import_target(init) {
+            self.collect_dynamic_import_binding(&declarator.name, &target);
+            return;
+        }
+
+        if let Pat::Ident(name) = &declarator.name {
+            let local = BindingId::of_binding(name);
+
+            // `const C = class { ... }` — the class's field maps belong to this
+            // binding.
+            if let Expr::Class(class) = unwrap_value(init) {
+                self.collect_class(&class.class, Some(local));
+                return;
+            }
+
+            // A function bound to a name: its returns decide what calling it
+            // yields.
+            match unwrap_value(init) {
+                Expr::Arrow(arrow) => self.collect_arrow(local.clone(), arrow),
+                Expr::Fn(function) => {
+                    self.collect_function_body(local.clone(), function.function.body.as_ref())
+                }
+                _ => {}
+            }
+
+            // `const c = new LocalClass(...)` needs no fact of its own: the
+            // alias below reduces it to the class binding plus a call, and a
+            // call on a class evaluates to that class's instance field map.
+
+            if let Some(chain) = self.chain_of(init) {
+                self.facts.aliases.push(AliasFact {
+                    local,
+                    value: chain,
+                });
+            }
+            return;
+        }
+
+        // `const { transport } = await getContext()` is the same chain as
+        // `getContext().transport`, one step longer.
+        if let Pat::Object(pattern) = &declarator.name
+            && let Some(chain) = self.chain_of(init)
+        {
+            for (property, local) in destructured_properties(pattern) {
+                self.facts.aliases.push(AliasFact {
+                    local,
+                    value: chain.extended(Step::Prop(property)),
+                });
+            }
+        }
+    }
+
+    fn collect_dynamic_import_binding(&mut self, pattern: &Pat, target: &Target) {
+        match pattern {
+            Pat::Ident(name) => {
+                let source = match target {
+                    Target::External(package) => Source::ExternalPackage(package.clone()),
+                    Target::Internal(file) => Source::InternalNamespace(*file),
+                };
+                self.facts.imports.push(ImportFact {
+                    local: BindingId::of_binding(name),
+                    source,
+                });
+            }
+            Pat::Object(object) => {
+                for (property, local) in destructured_properties(object) {
+                    let source = match target {
+                        Target::External(package) => Source::ExternalPackage(package.clone()),
+                        Target::Internal(file) => Source::InternalNamed(*file, property),
+                    };
+                    self.facts.imports.push(ImportFact { local, source });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn collect_arrow(&mut self, local: BindingId, arrow: &ArrowExpr) {
+        let shape = self.arrow_shape(arrow);
+        self.push_function(local, shape);
+    }
+
+    fn arrow_shape(&mut self, arrow: &ArrowExpr) -> ReturnShape {
+        let mut shape = ReturnShape::default();
+        match &*arrow.body {
+            BlockStmtOrExpr::BlockStmt(body) => self.collect_returns(Some(body), &mut shape),
+            BlockStmtOrExpr::Expr(expr) => self.collect_return_value(expr, &mut shape),
+        }
+        shape
+    }
+
+    fn collect_function_body(&mut self, local: BindingId, body: Option<&BlockStmt>) {
+        let shape = self.body_shape(body);
+        self.push_function(local, shape);
+    }
+
+    fn body_shape(&mut self, body: Option<&BlockStmt>) -> ReturnShape {
+        let mut shape = ReturnShape::default();
+        self.collect_returns(body, &mut shape);
+        shape
+    }
+
+    fn push_function(&mut self, local: BindingId, shape: ReturnShape) {
+        if shape.is_empty() {
+            return;
+        }
+        self.facts.functions.push(FunctionFact { local, shape });
+    }
+
+    fn collect_returns(&mut self, body: Option<&BlockStmt>, shape: &mut ReturnShape) {
+        let Some(body) = body else {
             return;
         };
-        self.rows.push(ExternalCallCandidate {
-            file: self.file.clone(),
-            line: self.source_map.lookup_char_pos(span.lo).line,
-            callee: format_callee(&root, &props),
-            package: package.clone(),
-            mechanism: CallMechanism::Sdk,
+        let mut collector = ReturnCollector {
+            returned: Vec::new(),
+        };
+        body.visit_with(&mut collector);
+        for expr in collector.returned {
+            self.collect_return_value(&expr, shape);
+        }
+    }
+
+    fn collect_return_value(&mut self, expr: &Expr, shape: &mut ReturnShape) {
+        // A function that picks between two object literals contributes both,
+        // so the branches are taken apart before the shape of any one of them
+        // is looked at.
+        for branch in value_branches(expr) {
+            let Expr::Object(object) = branch else {
+                if let Some(chain) = self.chain_of(branch) {
+                    shape.returns.push(chain);
+                }
+                continue;
+            };
+            for (name, chain) in self.object_properties(object) {
+                shape.record_returns.push((name, chain));
+            }
+        }
+    }
+
+    /// `{ a, b: c.d }` reduced to the property names and the chains behind them.
+    fn object_properties(&self, object: &ObjectLit) -> Vec<(String, Chain)> {
+        let mut properties = Vec::new();
+        for property in &object.props {
+            let PropOrSpread::Prop(prop) = property else {
+                continue;
+            };
+            match &**prop {
+                // `{ transport }` is `{ transport: transport }`, so the property
+                // is owned by whatever the binding is.
+                Prop::Shorthand(ident) => properties.push((
+                    ident.sym.to_string(),
+                    Chain {
+                        root: Root::Binding(BindingId::of(ident)),
+                        steps: Vec::new(),
+                    },
+                )),
+                Prop::KeyValue(entry) => {
+                    let Some(name) = property_name(&entry.key) else {
+                        continue;
+                    };
+                    for value in value_branches(&entry.value) {
+                        if let Some(chain) = self.chain_of(value) {
+                            properties.push((name.clone(), chain));
+                        }
+                    }
+                }
+                _ => continue,
+            }
+        }
+        properties
+    }
+
+    /// A class's field maps, its static members, and the constructor parameters
+    /// its body may assign from. Visits the body itself so nested classes and
+    /// `this` receivers see the right enclosing class.
+    fn collect_class(&mut self, class: &Class, binding: Option<BindingId>) {
+        let index = self.facts.classes.len();
+        self.facts.classes.push(ClassFact {
+            binding,
+            instance_fields: Vec::new(),
+            static_fields: Vec::new(),
+            static_functions: Vec::new(),
+            ctor_param_fields: Vec::new(),
+        });
+
+        let mut parameters: Vec<Option<BindingId>> = Vec::new();
+        for member in &class.body {
+            if let ClassMember::Constructor(constructor) = member {
+                parameters = constructor
+                    .params
+                    .iter()
+                    .map(|param| match param {
+                        ParamOrTsParamProp::Param(Param {
+                            pat: Pat::Ident(name),
+                            ..
+                        }) => Some(BindingId::of_binding(name)),
+                        _ => None,
+                    })
+                    .collect();
+            }
+        }
+
+        self.class_stack.push(index);
+        self.ctor_params.push(parameters);
+
+        for member in &class.body {
+            match member {
+                ClassMember::ClassProp(property) => {
+                    let (Some(name), Some(value)) = (property_name(&property.key), &property.value)
+                    else {
+                        continue;
+                    };
+                    let Some(chain) = self.chain_of(value) else {
+                        continue;
+                    };
+                    if property.is_static {
+                        self.facts.classes[index].static_fields.push((name, chain));
+                    } else {
+                        self.facts.classes[index]
+                            .instance_fields
+                            .push((name, chain));
+                    }
+                }
+                ClassMember::Method(method) if method.is_static => {
+                    let Some(name) = property_name(&method.key) else {
+                        continue;
+                    };
+                    let is_getter = match method.kind {
+                        MethodKind::Method => false,
+                        MethodKind::Getter => true,
+                        MethodKind::Setter => continue,
+                    };
+                    let shape = self.body_shape(method.function.body.as_ref());
+                    if shape.is_empty() {
+                        continue;
+                    }
+                    self.facts.classes[index]
+                        .static_functions
+                        .push(StaticFunction {
+                            name,
+                            shape,
+                            is_getter,
+                        });
+                }
+                _ => {}
+            }
+        }
+        class.visit_children_with(self);
+
+        self.class_stack.pop();
+        self.ctor_params.pop();
+    }
+
+    /// `<receiver>.<field> = <expression>`, in the two forms ownership reads:
+    /// `this.<field>` inside a class body, and `<identifier>.<field>` anywhere,
+    /// which is how a class's static field gets written.
+    fn collect_assignment(&mut self, assign: &AssignExpr) {
+        let AssignTarget::Simple(SimpleAssignTarget::Member(member)) = &assign.left else {
+            return;
+        };
+        let MemberProp::Ident(field) = &member.prop else {
+            return;
+        };
+        let field = field.sym.to_string();
+
+        if let Expr::Ident(receiver) = unwrap_value(&member.obj) {
+            // Kept whatever the receiver turns out to be; the fold drops every
+            // one whose identifier is not a class declared in this file.
+            if let Some(chain) = self.chain_of(&assign.right) {
+                self.facts
+                    .member_assignments
+                    .push((BindingId::of(receiver), field, chain));
+            }
+            return;
+        }
+
+        if !matches!(unwrap_value(&member.obj), Expr::This(_)) {
+            return;
+        }
+        let Some(class) = self.class_stack.last().copied() else {
+            return;
+        };
+
+        // A field assigned from a constructor parameter — the parameter itself,
+        // or a property read off it, which is how an options bag is unpacked —
+        // owns whatever the construction sites passed in.
+        if let Some(chain) = self.chain_of(&assign.right)
+            && let Root::Binding(assigned) = &chain.root
+            && let Some(position) = self
+                .ctor_params
+                .last()
+                .and_then(|params| params.iter().position(|p| p.as_ref() == Some(assigned)))
+        {
+            let mut path = Vec::new();
+            for step in &chain.steps {
+                match step {
+                    Step::Prop(name) => path.push(name.clone()),
+                    // A call on the parameter is a value the site cannot supply.
+                    Step::Call => return,
+                }
+            }
+            self.facts.classes[class]
+                .ctor_param_fields
+                .push((field, position, path));
+            return;
+        }
+
+        if let Some(chain) = self.chain_of(&assign.right) {
+            self.facts.classes[class]
+                .instance_fields
+                .push((field, chain));
+        }
+    }
+
+    /// Every `new <identifier>(...)`, wherever it sits. A construction inside an
+    /// assignment or an argument list is as good a witness of what the
+    /// constructor received as one in a declarator.
+    fn collect_construction(&mut self, new_expr: &NewExpr) {
+        let Expr::Ident(class) = unwrap_value(&new_expr.callee) else {
+            return;
+        };
+        let arguments = new_expr
+            .args
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|argument| {
+                if argument.spread.is_some() {
+                    // A spread shifts every later position, so nothing after it
+                    // can be matched to a parameter by index either.
+                    return Argument::Opaque;
+                }
+                if let Expr::Object(object) = unwrap_value(&argument.expr) {
+                    return Argument::Record(self.object_properties(object).into_iter().collect());
+                }
+                match self.chain_of(&argument.expr) {
+                    Some(chain) => Argument::Value(chain),
+                    None => Argument::Opaque,
+                }
+            })
+            .collect();
+        self.facts.constructions.push(ConstructionFact {
+            class_binding: BindingId::of(class),
+            arguments,
         });
     }
 }
 
-impl Visit for CandidateVisitor<'_> {
+impl Visit for FactCollector<'_> {
+    fn visit_var_declarator(&mut self, declarator: &VarDeclarator) {
+        self.collect_declarator(declarator);
+        // A class initializer has already been visited by `collect_class`.
+        if let Some(init) = &declarator.init
+            && matches!(unwrap_value(init), Expr::Class(_))
+        {
+            return;
+        }
+        declarator.visit_children_with(self);
+    }
+
+    fn visit_fn_decl(&mut self, function: &FnDecl) {
+        self.collect_function_body(
+            BindingId::of(&function.ident),
+            function.function.body.as_ref(),
+        );
+        function.visit_children_with(self);
+    }
+
+    fn visit_class_decl(&mut self, class: &ClassDecl) {
+        self.collect_class(&class.class, Some(BindingId::of(&class.ident)));
+    }
+
+    fn visit_class_expr(&mut self, class: &ClassExpr) {
+        self.collect_class(&class.class, class.ident.as_ref().map(BindingId::of));
+    }
+
+    fn visit_assign_expr(&mut self, assign: &AssignExpr) {
+        self.collect_assignment(assign);
+        assign.visit_children_with(self);
+    }
+
+    fn visit_new_expr(&mut self, new_expr: &NewExpr) {
+        self.collect_construction(new_expr);
+        new_expr.visit_children_with(self);
+    }
+
     fn visit_call_expr(&mut self, call: &CallExpr) {
         if let Callee::Expr(callee) = &call.callee {
-            self.record(callee, call.span);
+            self.record_call_site(callee, call.span);
+        } else {
+            // A dynamic import anywhere in the file is still an edge, whether
+            // or not anything is bound from it.
+            self.dynamic_import_of(call);
         }
         call.visit_children_with(self);
     }
@@ -612,9 +1975,95 @@ impl Visit for CandidateVisitor<'_> {
         // needs its own arm or the row is silently lost.
         if let OptChainBase::Call(call) = &*opt_chain.base {
             let callee = call.callee.clone();
-            self.record(&callee, opt_chain.span);
+            self.record_call_site(&callee, opt_chain.span);
         }
         opt_chain.visit_children_with(self);
+    }
+}
+
+/// Every `return <expr>` of one function body, stopping at nested function
+/// boundaries so an inner function's returns are not attributed to the outer
+/// one.
+struct ReturnCollector {
+    returned: Vec<Expr>,
+}
+
+impl Visit for ReturnCollector {
+    fn visit_return_stmt(&mut self, statement: &ReturnStmt) {
+        if let Some(argument) = &statement.arg {
+            self.returned.push((**argument).clone());
+        }
+        statement.visit_children_with(self);
+    }
+
+    fn visit_function(&mut self, _: &Function) {}
+    fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
+    fn visit_class(&mut self, _: &Class) {}
+}
+
+/// Strip the wrappers that change an expression's type without changing where
+/// its value came from.
+fn unwrap_value(expr: &Expr) -> &Expr {
+    match expr {
+        Expr::Await(inner) => unwrap_value(&inner.arg),
+        Expr::Paren(inner) => unwrap_value(&inner.expr),
+        Expr::TsNonNull(inner) => unwrap_value(&inner.expr),
+        Expr::TsAs(inner) => unwrap_value(&inner.expr),
+        Expr::TsSatisfies(inner) => unwrap_value(&inner.expr),
+        other => other,
+    }
+}
+
+/// The alternatives a value expression can take at runtime. A ternary and the
+/// short-circuiting operators each pick one branch, and any of them may be the
+/// one that carries the client.
+fn value_branches(expr: &Expr) -> Vec<&Expr> {
+    match unwrap_value(expr) {
+        Expr::Cond(cond) => {
+            let mut branches = value_branches(&cond.cons);
+            branches.extend(value_branches(&cond.alt));
+            branches
+        }
+        Expr::Bin(binary)
+            if matches!(binary.op, BinaryOp::NullishCoalescing | BinaryOp::LogicalOr) =>
+        {
+            let mut branches = value_branches(&binary.left);
+            branches.extend(value_branches(&binary.right));
+            branches
+        }
+        other => vec![other],
+    }
+}
+
+/// `{ a, b: c }` — the property read and the binding it lands in. Rest elements
+/// and computed keys carry nothing nameable and are skipped.
+fn destructured_properties(pattern: &ObjectPat) -> Vec<(String, BindingId)> {
+    let mut bound = Vec::new();
+    for property in &pattern.props {
+        match property {
+            ObjectPatProp::Assign(entry) => {
+                bound.push((
+                    entry.key.id.sym.to_string(),
+                    BindingId::of_binding(&entry.key),
+                ));
+            }
+            ObjectPatProp::KeyValue(entry) => {
+                if let (Some(name), Pat::Ident(local)) = (property_name(&entry.key), &*entry.value)
+                {
+                    bound.push((name, BindingId::of_binding(local)));
+                }
+            }
+            ObjectPatProp::Rest(_) => {}
+        }
+    }
+    bound
+}
+
+fn property_name(key: &PropName) -> Option<String> {
+    match key {
+        PropName::Ident(ident) => Some(ident.sym.to_string()),
+        PropName::Str(name) => Some(name.value.to_string()),
+        _ => None,
     }
 }
 
@@ -623,7 +2072,6 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::file_finder::find_service_files;
-    use crate::packages::{Packages, collect_internal_package_names};
 
     const IGNORE_PATTERNS: &[&str] = &["node_modules", "dist", "build", ".next"];
 
@@ -631,29 +2079,18 @@ mod tests {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/external-call-candidates")
     }
 
-    /// The fixture is a workspace whose scanned service is `apps/api`, matching
-    /// the monorepo shape `carrick.json` declares.
-    fn fixture_service() -> Config {
-        Config {
-            directory: Some("apps/api".to_string()),
-            ..Default::default()
-        }
-    }
-
     /// Run the scan exactly as the engine does: the service's file list comes
     /// from `find_service_files`, so the scanner's own test-file and
-    /// artifact-directory exclusions are what filter the input, and the
-    /// dependency set comes from the service's `package.json` plus the
-    /// repo-wide internal-name sweep.
-    fn scan_fixture() -> Vec<ExternalCallCandidate> {
+    /// artifact-directory exclusions are what filter the seeds, and the
+    /// external universe comes from the repo's own manifests.
+    fn scan(directory: &str) -> Vec<ExternalCallCandidate> {
         let root = fixture_root();
-        let root_str = root.to_string_lossy().to_string();
-        let (files, package_json) =
-            find_service_files(&root_str, &fixture_service(), IGNORE_PATTERNS);
-        let mut packages =
-            Packages::new(package_json.into_iter().collect()).expect("fixture package.json parses");
-        packages.internal_names = collect_internal_package_names(&root);
-        scan_files(&files, &root, &packages)
+        let service = Config {
+            directory: Some(directory.to_string()),
+            ..Default::default()
+        };
+        let (files, _) = find_service_files(&root.to_string_lossy(), &service, IGNORE_PATTERNS);
+        scan_workspace(&files, &root)
     }
 
     fn rows_for(rows: &[ExternalCallCandidate], file: &str) -> Vec<(usize, String, String)> {
@@ -663,11 +2100,8 @@ mod tests {
             .collect()
     }
 
-    #[test]
-    fn fixture_scan_matches_expected_rows() {
-        let rows = scan_fixture();
-        let actual: Vec<(String, usize, String, String)> = rows
-            .iter()
+    fn triples(rows: &[ExternalCallCandidate]) -> Vec<(String, usize, String, String)> {
+        rows.iter()
             .map(|row| {
                 (
                     row.file.clone(),
@@ -676,254 +2110,716 @@ mod tests {
                     row.package.clone(),
                 )
             })
-            .collect();
-
-        let expected: Vec<(String, usize, String, String)> = vec![
-            (
-                "apps/api/src/direct-call.ts",
-                4,
-                "sendNotice",
-                "courier-sdk",
-            ),
-            (
-                "apps/api/src/member-call.ts",
-                6,
-                "ledger.payments.create",
-                "ledger-client",
-            ),
-            (
-                "apps/api/src/member-call.ts",
-                10,
-                "createInvoice",
-                "ledger-client",
-            ),
-            (
-                "apps/api/src/namespace-call.ts",
-                3,
-                "telemetry.createSink",
-                "telemetry-sink",
-            ),
-            (
-                "apps/api/src/namespace-call.ts",
-                6,
-                "telemetry.emit",
-                "telemetry-sink",
-            ),
-            (
-                "apps/api/src/namespace-call.ts",
-                7,
-                "sink.flush",
-                "telemetry-sink",
-            ),
-            (
-                "apps/api/src/optional-dep.ts",
-                6,
-                "uplink.put",
-                "storage-uplink",
-            ),
-            (
-                "apps/api/src/subpath-import.ts",
-                4,
-                "publishEdge",
-                "courier-sdk",
-            ),
-        ]
-        .into_iter()
-        .map(|(file, line, callee, package)| {
-            (
-                file.to_string(),
-                line,
-                callee.to_string(),
-                package.to_string(),
-            )
-        })
-        .collect();
-
-        assert_eq!(actual, expected);
-        assert!(rows.iter().all(|row| row.mechanism == CallMechanism::Sdk));
+            .collect()
     }
 
-    #[test]
-    fn direct_imported_function_call_emits_a_row() {
-        let rows = scan_fixture();
-        assert_eq!(
-            rows_for(&rows, "apps/api/src/direct-call.ts"),
-            vec![(4, "sendNotice".to_string(), "courier-sdk".to_string())]
-        );
+    fn expected(rows: &[(&str, usize, &str, &str)]) -> Vec<(String, usize, String, String)> {
+        rows.iter()
+            .map(|(file, line, callee, package)| {
+                (
+                    file.to_string(),
+                    *line,
+                    callee.to_string(),
+                    package.to_string(),
+                )
+            })
+            .collect()
     }
 
-    /// The receiver is a local holding a client constructed from an imported
-    /// class, which is as far as static resolution reaches.
-    #[test]
-    fn member_call_on_constructed_client_emits_a_row() {
-        let rows = scan_fixture();
-        let member = rows_for(&rows, "apps/api/src/member-call.ts");
-        assert!(
-            member.contains(&(
-                6,
-                "ledger.payments.create".to_string(),
-                "ledger-client".to_string()
-            )),
-            "expected the instance member call, got {:?}",
-            member
-        );
+    /// The single-file service from carrick#511, unchanged. Widening the
+    /// dependency universe and the file set must not move a row that the
+    /// direct-import base case already produced.
+    mod direct_imports {
+        use super::*;
+
+        #[test]
+        fn fixture_scan_matches_expected_rows() {
+            let rows = scan("apps/api");
+            assert_eq!(
+                triples(&rows),
+                expected(&[
+                    (
+                        "apps/api/src/direct-call.ts",
+                        4,
+                        "sendNotice",
+                        "courier-sdk"
+                    ),
+                    (
+                        "apps/api/src/member-call.ts",
+                        6,
+                        "ledger.payments.create",
+                        "ledger-client"
+                    ),
+                    (
+                        "apps/api/src/member-call.ts",
+                        10,
+                        "createInvoice",
+                        "ledger-client"
+                    ),
+                    (
+                        "apps/api/src/namespace-call.ts",
+                        3,
+                        "telemetry.createSink",
+                        "telemetry-sink"
+                    ),
+                    (
+                        "apps/api/src/namespace-call.ts",
+                        6,
+                        "telemetry.emit",
+                        "telemetry-sink"
+                    ),
+                    (
+                        "apps/api/src/namespace-call.ts",
+                        7,
+                        "sink.flush",
+                        "telemetry-sink"
+                    ),
+                    (
+                        "apps/api/src/optional-dep.ts",
+                        6,
+                        "uplink.put",
+                        "storage-uplink"
+                    ),
+                    (
+                        "apps/api/src/subpath-import.ts",
+                        4,
+                        "publishEdge",
+                        "courier-sdk"
+                    ),
+                ])
+            );
+            assert!(rows.iter().all(|row| row.mechanism == CallMechanism::Sdk));
+        }
+
+        /// `peerDependencies` and `optionalDependencies` count as runtime
+        /// dependencies; `telemetry-sink` is a peer, `storage-uplink` optional.
+        #[test]
+        fn peer_and_optional_dependencies_resolve() {
+            let rows = scan("apps/api");
+            assert!(rows.iter().any(|row| row.package == "telemetry-sink"));
+            assert_eq!(
+                rows_for(&rows, "apps/api/src/optional-dep.ts"),
+                vec![(6, "uplink.put".to_string(), "storage-uplink".to_string())]
+            );
+        }
+
+        /// Relative imports, Node builtins (bare and `node:`-prefixed), and a
+        /// workspace-internal package all fail the structural rule.
+        #[test]
+        fn relative_builtin_and_workspace_imports_emit_nothing() {
+            assert_eq!(
+                rows_for(&scan("apps/api"), "apps/api/src/no-rows.ts"),
+                Vec::new()
+            );
+        }
+
+        /// A type-only declaration binds nothing, while the value specifier in
+        /// a mixed declaration still does.
+        #[test]
+        fn type_only_imports_emit_nothing() {
+            let rows = scan("apps/api");
+            assert_eq!(rows_for(&rows, "apps/api/src/type-only.ts"), Vec::new());
+            assert!(
+                rows_for(&rows, "apps/api/src/member-call.ts").contains(&(
+                    10,
+                    "createInvoice".to_string(),
+                    "ledger-client".to_string()
+                )),
+                "the value half of a mixed type/value import still resolves"
+            );
+        }
+
+        /// Test trees and build-artifact directories are excluded by the
+        /// scanner's existing walk rules, not by anything this module defines.
+        #[test]
+        fn test_and_artifact_files_are_never_scanned() {
+            let rows = scan("apps/api");
+            assert!(
+                rows.iter().all(|row| !row.file.contains("__tests__")
+                    && !row.file.contains("/dist/")
+                    && !row.file.ends_with(".test.ts")),
+                "excluded trees leaked into the rows: {:?}",
+                rows
+            );
+        }
     }
 
-    #[test]
-    fn namespace_import_call_emits_a_row() {
-        let rows = scan_fixture();
-        let namespace = rows_for(&rows, "apps/api/src/namespace-call.ts");
-        assert!(
-            namespace.contains(&(
-                6,
-                "telemetry.emit".to_string(),
-                "telemetry-sink".to_string()
-            )),
-            "expected the namespace call, got {:?}",
-            namespace
-        );
-        assert!(
-            namespace.contains(&(7, "sink.flush".to_string(), "telemetry-sink".to_string())),
-            "a handle returned from a namespace call keeps its package: {:?}",
-            namespace
-        );
-    }
+    /// The workspace service: every call site it ships is written in a package
+    /// that is not the service, and every wrapper shape in between is one the
+    /// ownership pass has to walk.
+    mod workspace_transitive {
+        use super::*;
 
-    /// `peerDependencies` and `optionalDependencies` count as runtime
-    /// dependencies; `telemetry-sink` is a peer, `storage-uplink` optional.
-    #[test]
-    fn peer_and_optional_dependencies_resolve() {
-        let rows = scan_fixture();
-        assert!(rows.iter().any(|row| row.package == "telemetry-sink"));
-        assert_eq!(
-            rows_for(&rows, "apps/api/src/optional-dep.ts"),
-            vec![(6, "uplink.put".to_string(), "storage-uplink".to_string())]
-        );
-    }
+        fn worker() -> Vec<ExternalCallCandidate> {
+            scan("apps/worker")
+        }
 
-    /// `courier-sdk/edge` resolves to the declared package `courier-sdk`.
-    #[test]
-    fn subpath_import_resolves_to_the_declared_package() {
-        let rows = scan_fixture();
-        assert_eq!(
-            rows_for(&rows, "apps/api/src/subpath-import.ts"),
-            vec![(4, "publishEdge".to_string(), "courier-sdk".to_string())]
-        );
-    }
+        #[test]
+        fn workspace_scan_matches_expected_rows() {
+            assert_eq!(
+                triples(&worker()),
+                expected(&[
+                    (
+                        "apps/worker/src/barrel-consumer.ts",
+                        3,
+                        "ledger.invoices.list",
+                        "ledger-client"
+                    ),
+                    (
+                        "apps/worker/src/billing.ts",
+                        4,
+                        "ledger.payments.create",
+                        "ledger-client"
+                    ),
+                    (
+                        "apps/worker/src/conflict.ts",
+                        5,
+                        "soloClient.upload",
+                        "vault-blob"
+                    ),
+                    (
+                        "apps/worker/src/destructured.ts",
+                        6,
+                        "transport.sendMail",
+                        "postbox-mailer"
+                    ),
+                    (
+                        "apps/worker/src/digest.ts",
+                        6,
+                        "transport.sendMail",
+                        "postbox-mailer"
+                    ),
+                    (
+                        "apps/worker/src/member-form.ts",
+                        6,
+                        "context.transport.sendMail",
+                        "postbox-mailer"
+                    ),
+                    (
+                        "apps/worker/src/namespace-internal.ts",
+                        4,
+                        "ledgerKit.ledger.payments.settle",
+                        "ledger-client"
+                    ),
+                    (
+                        "apps/worker/src/notify.ts",
+                        4,
+                        "mailer.sendMail",
+                        "postbox-mailer"
+                    ),
+                    (
+                        "apps/worker/src/shadow.ts",
+                        9,
+                        "mailer.sendMail",
+                        "postbox-mailer"
+                    ),
+                    (
+                        "apps/worker/src/split-context.ts",
+                        6,
+                        "transport.sendMail",
+                        "postbox-mailer"
+                    ),
+                    (
+                        "packages/crawl-kit/render.ts",
+                        3,
+                        "headless.launch",
+                        "crawler-kit"
+                    ),
+                    (
+                        "packages/crawl-kit/render.ts",
+                        6,
+                        "runtime.shutdown",
+                        "crawler-kit"
+                    ),
+                    ("packages/doc-kit/sign.ts", 4, "Pdf.load", "pdf-toolkit"),
+                    ("packages/doc-kit/sign.ts", 6, "doc.sign", "pdf-toolkit"),
+                    (
+                        "packages/job-kit/handler.ts",
+                        4,
+                        "mailer.sendMail",
+                        "postbox-mailer"
+                    ),
+                    (
+                        "packages/jobs-kit/provider.ts",
+                        19,
+                        "this._client.send",
+                        "relay-queue"
+                    ),
+                    (
+                        "packages/mail-kit/digest.ts",
+                        4,
+                        "createTransport",
+                        "postbox-mailer"
+                    ),
+                    (
+                        "packages/mail-kit/index.ts",
+                        9,
+                        "getTransport().verify",
+                        "postbox-mailer"
+                    ),
+                    (
+                        "packages/mail-kit/transport.ts",
+                        5,
+                        "createTransport",
+                        "postbox-mailer"
+                    ),
+                    (
+                        "packages/mail-kit/transport.ts",
+                        8,
+                        "createTransport",
+                        "postbox-mailer"
+                    ),
+                    (
+                        "packages/singleton-kit/index.ts",
+                        22,
+                        "reporter.client.shutdown",
+                        "pulse-analytics"
+                    ),
+                    (
+                        "packages/singleton-kit/index.ts",
+                        26,
+                        "PulseReporter.current.client.capture",
+                        "pulse-analytics"
+                    ),
+                    (
+                        "packages/storage-kit/beacon.ts",
+                        8,
+                        "Beacon.client.capture",
+                        "beacon-metrics"
+                    ),
+                    (
+                        "packages/storage-kit/blob-store.ts",
+                        11,
+                        "this.client.upload",
+                        "vault-blob"
+                    ),
+                    (
+                        "packages/storage-kit/queue-store.ts",
+                        13,
+                        "store.client.flush",
+                        "vault-blob"
+                    ),
+                ])
+            );
+        }
 
-    /// Relative imports, Node builtins (bare and `node:`-prefixed), and a
-    /// workspace-internal package all fail the structural rule.
-    #[test]
-    fn relative_builtin_and_workspace_imports_emit_nothing() {
-        let rows = scan_fixture();
-        assert_eq!(rows_for(&rows, "apps/api/src/no-rows.ts"), Vec::new());
-    }
+        /// A client constructed once in a shared package and consumed through a
+        /// subpath import of that package.
+        #[test]
+        fn exported_client_resolves_across_a_subpath_import() {
+            assert_eq!(
+                rows_for(&worker(), "apps/worker/src/billing.ts"),
+                vec![(
+                    4,
+                    "ledger.payments.create".to_string(),
+                    "ledger-client".to_string()
+                )]
+            );
+        }
 
-    /// carrick#510 is silent on dev dependencies, so they are excluded: a call
-    /// into a build or test tool is not service egress.
-    #[test]
-    fn dev_dependency_only_import_emits_nothing() {
-        let rows = scan_fixture();
-        assert_eq!(rows_for(&rows, "apps/api/src/dev-only.ts"), Vec::new());
-    }
+        /// A local factory whose every return constructs the client, consumed
+        /// through the module-level handle it produced.
+        #[test]
+        fn local_factory_result_is_owned_by_what_its_returns_construct() {
+            assert_eq!(
+                rows_for(&worker(), "apps/worker/src/notify.ts"),
+                vec![(
+                    4,
+                    "mailer.sendMail".to_string(),
+                    "postbox-mailer".to_string()
+                )]
+            );
+        }
 
-    /// A type-only declaration binds nothing, while the value specifier in a
-    /// mixed declaration still does.
-    #[test]
-    fn type_only_imports_emit_nothing() {
-        let rows = scan_fixture();
-        assert_eq!(rows_for(&rows, "apps/api/src/type-only.ts"), Vec::new());
-        assert!(
-            rows_for(&rows, "apps/api/src/member-call.ts").contains(&(
-                10,
-                "createInvoice".to_string(),
-                "ledger-client".to_string()
-            )),
-            "the value half of a mixed type/value import still resolves"
-        );
-    }
+        /// A call in the middle of the callee chain resolves through the
+        /// function it calls, and the row carries the outer call's line.
+        #[test]
+        fn a_call_inside_the_chain_resolves_and_prints_as_written() {
+            assert_eq!(
+                rows_for(&worker(), "packages/mail-kit/index.ts"),
+                vec![(
+                    9,
+                    "getTransport().verify".to_string(),
+                    "postbox-mailer".to_string()
+                )]
+            );
+        }
 
-    /// Direct guard on the type-only filter. A type binding in call position is
-    /// not valid TypeScript, but the parser accepts it, so the filter is
-    /// asserted rather than assumed.
-    #[test]
-    fn type_only_binding_is_never_callable() {
-        let dependencies: HashSet<String> = ["ledger-client".to_string()].into_iter().collect();
-        assert_eq!(
-            scan_content(
-                "src/t.ts",
-                Path::new("t.ts"),
-                "import type { createInvoice } from \"ledger-client\";\ncreateInvoice();\n",
-                &dependencies,
-            ),
-            Vec::new()
-        );
-        assert_eq!(
-            scan_content(
-                "src/t.ts",
-                Path::new("t.ts"),
-                "import { type createInvoice } from \"ledger-client\";\ncreateInvoice();\n",
-                &dependencies,
-            ),
-            Vec::new()
-        );
-    }
+        /// A property of a returned object literal, reached both by
+        /// destructuring the call and by a member access on its result. One
+        /// branch is plain, the other a ternary.
+        #[test]
+        fn returned_object_properties_resolve_both_ways() {
+            let rows = worker();
+            assert_eq!(
+                rows_for(&rows, "apps/worker/src/destructured.ts"),
+                vec![(
+                    6,
+                    "transport.sendMail".to_string(),
+                    "postbox-mailer".to_string()
+                )]
+            );
+            assert_eq!(
+                rows_for(&rows, "apps/worker/src/member-form.ts"),
+                vec![(
+                    6,
+                    "context.transport.sendMail".to_string(),
+                    "postbox-mailer".to_string()
+                )]
+            );
+        }
 
-    /// Test trees and build-artifact directories are excluded by the scanner's
-    /// existing walk rules, not by anything this module defines.
-    #[test]
-    fn test_and_artifact_files_are_never_scanned() {
-        let rows = scan_fixture();
-        assert!(
-            rows.iter().all(|row| !row.file.contains("__tests__")
-                && !row.file.contains("/dist/")
-                && !row.file.ends_with(".test.ts")),
-            "excluded trees leaked into the rows: {:?}",
-            rows
-        );
-    }
+        /// A default-exported function declaration is a function expression in
+        /// the AST, so its returns need reading where the export is read or the
+        /// factory shape is silently uncovered.
+        #[test]
+        fn a_default_exported_factory_resolves() {
+            assert_eq!(
+                rows_for(&worker(), "apps/worker/src/digest.ts"),
+                vec![(
+                    6,
+                    "transport.sendMail".to_string(),
+                    "postbox-mailer".to_string()
+                )]
+            );
+        }
 
-    /// A local declaration shadowing an import must not inherit its package.
-    #[test]
-    fn shadowed_binding_does_not_resolve() {
-        let dependencies: HashSet<String> = ["courier-sdk".to_string()].into_iter().collect();
-        let rows = scan_content(
-            "src/shadow.ts",
-            Path::new("shadow.ts"),
-            r#"import { sendNotice } from "courier-sdk";
+        /// A function that picks between two object literals owns the property
+        /// through both of them, so a return written as a ternary of records is
+        /// not a blind spot.
+        #[test]
+        fn a_ternary_of_returned_records_resolves() {
+            assert_eq!(
+                rows_for(&worker(), "apps/worker/src/split-context.ts"),
+                vec![(
+                    6,
+                    "transport.sendMail".to_string(),
+                    "postbox-mailer".to_string()
+                )]
+            );
+        }
 
-export function local() {
-  const sendNotice = (m: string) => m;
-  return sendNotice("hi");
-}
+        /// A field assigned in the constructor makes `this.<field>` a nameable
+        /// receiver.
+        #[test]
+        fn class_field_assigned_in_the_constructor_resolves() {
+            assert_eq!(
+                rows_for(&worker(), "packages/storage-kit/blob-store.ts"),
+                vec![(
+                    11,
+                    "this.client.upload".to_string(),
+                    "vault-blob".to_string()
+                )]
+            );
+        }
 
-export function real() {
-  return sendNotice("hi");
-}
-"#,
-            &dependencies,
-        );
-        assert_eq!(
-            rows.iter().map(|r| r.line).collect::<Vec<_>>(),
-            vec![9],
-            "only the unshadowed call resolves: {:?}",
-            rows
-        );
+        /// A field assigned straight from a constructor parameter owns whatever
+        /// the construction site passed in, so the instance the site produced
+        /// carries it.
+        #[test]
+        fn constructor_parameter_field_resolves_at_the_construction_site() {
+            assert_eq!(
+                rows_for(&worker(), "packages/storage-kit/queue-store.ts"),
+                vec![(
+                    13,
+                    "store.client.flush".to_string(),
+                    "vault-blob".to_string()
+                )]
+            );
+        }
+
+        /// A static field is the class's, not an instance's.
+        #[test]
+        fn static_field_resolves_through_the_class_binding() {
+            assert_eq!(
+                rows_for(&worker(), "packages/storage-kit/beacon.ts"),
+                vec![(
+                    8,
+                    "Beacon.client.capture".to_string(),
+                    "beacon-metrics".to_string()
+                )]
+            );
+        }
+
+        /// The singleton idiom: a static field is assigned an instance of the
+        /// class through the class name, and a field of that instance is read
+        /// back out. Two levels of value, which is why static members are slots
+        /// of their own rather than properties of a record on the class.
+        ///
+        /// Both ways in are covered — the field read directly, and the static
+        /// getter that usually wraps it.
+        #[test]
+        fn a_static_field_holding_an_instance_resolves_through_it() {
+            assert_eq!(
+                rows_for(&worker(), "packages/singleton-kit/index.ts"),
+                vec![
+                    (
+                        22,
+                        "reporter.client.shutdown".to_string(),
+                        "pulse-analytics".to_string()
+                    ),
+                    (
+                        26,
+                        "PulseReporter.current.client.capture".to_string(),
+                        "pulse-analytics".to_string()
+                    ),
+                ]
+            );
+        }
+
+        /// A constructor that unpacks an options object, called with an object
+        /// literal, at a construction site that is not a variable declarator.
+        /// The site is what proves the field's owner, and the row is inside the
+        /// class, on `this`.
+        #[test]
+        fn a_constructor_options_object_reaches_this_inside_the_class() {
+            assert_eq!(
+                rows_for(&worker(), "packages/jobs-kit/provider.ts"),
+                vec![(
+                    19,
+                    "this._client.send".to_string(),
+                    "relay-queue".to_string()
+                )]
+            );
+        }
+
+        /// A single `await` between the declaration and the factory call used
+        /// to defeat resolution outright.
+        #[test]
+        fn awaited_factory_result_resolves() {
+            assert_eq!(
+                rows_for(&worker(), "packages/doc-kit/sign.ts"),
+                vec![
+                    (4, "Pdf.load".to_string(), "pdf-toolkit".to_string()),
+                    (6, "doc.sign".to_string(), "pdf-toolkit".to_string()),
+                ]
+            );
+        }
+
+        /// Both binding forms of a literal dynamic import: destructured, and
+        /// taken whole.
+        #[test]
+        fn dynamic_import_bindings_resolve() {
+            assert_eq!(
+                rows_for(&worker(), "packages/crawl-kit/render.ts"),
+                vec![
+                    (3, "headless.launch".to_string(), "crawler-kit".to_string()),
+                    (6, "runtime.shutdown".to_string(), "crawler-kit".to_string()),
+                ]
+            );
+        }
+
+        /// Two re-export hops between the file that constructs the client and
+        /// the file that calls through it.
+        #[test]
+        fn a_barrel_re_export_chain_carries_ownership() {
+            assert_eq!(
+                rows_for(&worker(), "apps/worker/src/barrel-consumer.ts"),
+                vec![(
+                    3,
+                    "ledger.invoices.list".to_string(),
+                    "ledger-client".to_string()
+                )]
+            );
+        }
+
+        /// `export *` carries a name only one source owns. A name two sources
+        /// own differently is a genuine ambiguity and is dropped rather than
+        /// resolved to whichever star was written first.
+        #[test]
+        fn star_exports_carry_agreement_and_drop_disagreement() {
+            assert_eq!(
+                rows_for(&worker(), "apps/worker/src/conflict.ts"),
+                vec![(5, "soloClient.upload".to_string(), "vault-blob".to_string())]
+            );
+        }
+
+        /// A namespace import of an internal module resolves properties through
+        /// that module's exports.
+        #[test]
+        fn namespace_import_of_an_internal_module_resolves() {
+            assert_eq!(
+                rows_for(&worker(), "apps/worker/src/namespace-internal.ts"),
+                vec![(
+                    4,
+                    "ledgerKit.ledger.payments.settle".to_string(),
+                    "ledger-client".to_string()
+                )]
+            );
+        }
+
+        /// A handler no file imports statically still ships with the service
+        /// that loads it, so its call sites are the service's.
+        #[test]
+        fn a_file_reached_only_by_a_dynamic_import_is_in_scope() {
+            assert_eq!(
+                rows_for(&worker(), "packages/job-kit/handler.ts"),
+                vec![(
+                    4,
+                    "mailer.sendMail".to_string(),
+                    "postbox-mailer".to_string()
+                )]
+            );
+        }
+
+        /// A workspace file with resolvable call sites that no service reaches
+        /// is not that service's egress.
+        #[test]
+        fn an_unreachable_file_stays_out_of_the_service_rows() {
+            assert_eq!(
+                rows_for(&worker(), "packages/orphan-kit/orphan.ts"),
+                Vec::new()
+            );
+            assert_eq!(
+                rows_for(&scan("apps/api"), "packages/orphan-kit/orphan.ts"),
+                Vec::new()
+            );
+        }
+
+        /// Hoisting makes a root-declared dependency importable anywhere, and
+        /// the package that holds the wrapper declares nothing.
+        #[test]
+        fn a_dependency_only_the_root_manifest_declares_still_resolves() {
+            assert!(
+                worker().iter().any(|row| row.package == "pdf-toolkit"),
+                "the root-only dependency produced no rows"
+            );
+        }
+
+        /// carrick#510 is silent on dev dependencies, so they are excluded: a
+        /// call into a build or test tool is not service egress. The wrapper is
+        /// inside the service, so only the dependency map keeps it out.
+        #[test]
+        fn a_dev_dependency_wrapper_emits_nothing() {
+            assert_eq!(
+                rows_for(&worker(), "apps/worker/src/dev-wrapper.ts"),
+                Vec::new()
+            );
+            assert_eq!(
+                rows_for(&scan("apps/api"), "apps/api/src/dev-only.ts"),
+                Vec::new()
+            );
+        }
+
+        /// A type-only re-export binds nothing at runtime, so a name that
+        /// reaches the consumer only through one owns nothing.
+        #[test]
+        fn a_type_only_re_export_carries_nothing() {
+            assert_eq!(
+                rows_for(&worker(), "apps/worker/src/type-reexport.ts"),
+                Vec::new()
+            );
+        }
+
+        /// A local declaration shadowing an import must not inherit its
+        /// package.
+        #[test]
+        fn shadowed_binding_does_not_resolve() {
+            assert_eq!(
+                rows_for(&worker(), "apps/worker/src/shadow.ts"),
+                vec![(
+                    9,
+                    "mailer.sendMail".to_string(),
+                    "postbox-mailer".to_string()
+                )]
+            );
+        }
+
+        /// Calling an internal function is not egress, however much the
+        /// function itself owns.
+        #[test]
+        fn calling_an_internal_wrapper_is_not_a_row() {
+            let rows = worker();
+            for file in [
+                "apps/worker/src/documents.ts",
+                "apps/worker/src/crawl.ts",
+                "apps/worker/src/storage.ts",
+                "apps/worker/src/entry.ts",
+            ] {
+                assert_eq!(rows_for(&rows, file), Vec::new(), "{} emitted rows", file);
+            }
+        }
+
+        /// A file two services both reach belongs to both deployments, so its
+        /// rows appear in both payloads — and a service reaches nothing it does
+        /// not import.
+        #[test]
+        fn a_shared_file_contributes_to_every_service_that_reaches_it() {
+            let shared = (
+                8,
+                "createTransport".to_string(),
+                "postbox-mailer".to_string(),
+            );
+            assert!(
+                rows_for(&worker(), "packages/mail-kit/transport.ts").contains(&shared),
+                "the wrapper is missing from the worker payload"
+            );
+            assert!(
+                rows_for(&scan("apps/relay"), "packages/mail-kit/transport.ts").contains(&shared),
+                "the same wrapper is missing from the second service's payload"
+            );
+            let api_files: BTreeSet<String> =
+                scan("apps/api").into_iter().map(|row| row.file).collect();
+            assert!(
+                api_files.iter().all(|file| file.starts_with("apps/api/")),
+                "a service that imports no shared package reached one: {:?}",
+                api_files
+            );
+        }
+
+        /// `.catch()` on an owned call resolves through the inner call's root,
+        /// so the site yields a second row on the same line. Both rows are
+        /// true, and neither is special-cased away.
+        #[test]
+        fn a_catch_on_an_owned_call_yields_its_own_row() {
+            assert_eq!(
+                rows_for(&scan("apps/relay"), "apps/relay/src/index.ts"),
+                vec![
+                    (
+                        4,
+                        "mailer.sendMail".to_string(),
+                        "postbox-mailer".to_string()
+                    ),
+                    (
+                        4,
+                        "mailer.sendMail().catch".to_string(),
+                        "postbox-mailer".to_string()
+                    ),
+                ]
+            );
+        }
+
+        /// The repo-wide walk excludes directories named after build
+        /// artifacts, but a service configured to live in one is a service.
+        /// Its own files seed the scan whatever that walk thought of them.
+        #[test]
+        fn a_service_rooted_in_an_excluded_directory_still_scans() {
+            assert_eq!(
+                rows_for(&scan("apps/build"), "apps/build/src/index.ts"),
+                vec![(3, "sendNotice".to_string(), "courier-sdk".to_string())]
+            );
+        }
     }
 
     /// Two scans of the same tree produce byte-identical rows.
     #[test]
     fn scan_is_deterministic() {
-        assert_eq!(scan_fixture(), scan_fixture());
+        assert_eq!(scan("apps/worker"), scan("apps/worker"));
+        assert_eq!(scan("apps/api"), scan("apps/api"));
     }
 
     #[test]
-    fn empty_dependency_set_emits_nothing() {
-        let root = fixture_root();
-        let root_str = root.to_string_lossy().to_string();
-        let (files, _) = find_service_files(&root_str, &fixture_service(), IGNORE_PATTERNS);
+    fn a_repo_declaring_no_dependencies_emits_nothing() {
+        let repo = tempfile::tempdir().unwrap();
+        let root = repo.path();
+        std::fs::write(root.join("package.json"), r#"{"name":"bare"}"#).unwrap();
+        std::fs::write(
+            root.join("app.ts"),
+            "import { send } from \"courier-sdk\";\nsend();\n",
+        )
+        .unwrap();
         assert_eq!(
-            scan_files(&files, &root, &Packages::default()),
+            scan_workspace(&[root.join("app.ts")], root),
             Vec::new(),
             "no declared dependencies means no candidates"
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,4 @@ pub mod type_manifest;
 pub mod url_normalizer;
 pub mod utils;
 pub mod visitor;
+pub mod workspace_resolver;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod type_manifest;
 mod url_normalizer;
 mod utils;
 mod visitor;
+mod workspace_resolver;
 
 use crate::cloud_storage::{AwsStorage, LocalDirStorage, MockStorage};
 use crate::services::TypeSidecar;

--- a/src/workspace_resolver.rs
+++ b/src/workspace_resolver.rs
@@ -1,0 +1,478 @@
+//! Manifest index and module resolution for the outbound-call scan.
+//!
+//! Two questions the egress scan asks of a module specifier, and nothing else:
+//! is it an external package, and if it is workspace-internal, which file does
+//! it name? Both answers come from the repo's own manifests and its own file
+//! tree, so there is no vendor list and no naming convention anywhere in here.
+//!
+//! The external universe is deliberately repo-wide. npm hoisting makes any
+//! package declared by any manifest in the tree importable from any file in it,
+//! and in a monorepo the manifest that declares a service client is almost
+//! never the manifest of the service that ends up shipping the call — it is the
+//! manifest of the shared package holding the wrapper. Scoping the universe to
+//! one service's `package.json` therefore answers "external?" with "no" for
+//! most real wrappers.
+//!
+//! This is not a Node resolver. `exports` maps, conditions, `browser` fields,
+//! `paths` from tsconfig, and `node_modules` lookups are all out of scope: the
+//! scan needs to know which SOURCE file in this repo a specifier names, and the
+//! candidate list below is what the repo's own layout proves.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path, PathBuf};
+
+use crate::packages::MANIFEST_SKIP_DIRS;
+
+/// Source extensions a specifier may resolve to, in the order they are tried.
+/// TypeScript first: in a repo that has both, the `.ts` file is the source and
+/// the `.js` file is build output that the walk usually excludes anyway.
+const SOURCE_EXTENSIONS: [&str; 4] = ["ts", "tsx", "js", "jsx"];
+
+/// What a module specifier names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// A package the repo's manifests declare as an external dependency. Carries
+    /// the declared name, so a subpath specifier reports the package.
+    External(String),
+    /// A file inside this repo, repo-relative.
+    Internal(PathBuf),
+    /// Node builtins, absolute paths, assets, and anything the repo's own
+    /// manifests and file tree do not account for.
+    Unresolved,
+}
+
+/// One workspace member: where it lives and what its manifest says its entry
+/// point is.
+#[derive(Debug, Clone)]
+struct InternalPackage {
+    /// Repo-relative directory holding the `package.json`.
+    dir: PathBuf,
+    /// The manifest's `main`, when it has one. Used only for a bare import of
+    /// the package with no subpath.
+    main: Option<String>,
+}
+
+/// The repo's manifests, reduced to what specifier resolution needs.
+#[derive(Debug, Clone)]
+pub struct WorkspaceIndex {
+    repo_root: PathBuf,
+    /// Every package name any manifest declares as a runtime dependency, minus
+    /// the workspace's own package names.
+    external_packages: BTreeSet<String>,
+    /// Workspace package name -> its directory.
+    internal_packages: BTreeMap<String, InternalPackage>,
+}
+
+impl WorkspaceIndex {
+    /// Read every `package.json` in the tree once, and derive both halves from
+    /// the same walk so the two can never disagree about which names are
+    /// internal.
+    ///
+    /// `dependencies`, `peerDependencies`, and `optionalDependencies` are the
+    /// three maps whose contents can be present at runtime.
+    /// `devDependencies` stays out: a build or test tool calling out is not
+    /// service egress, and a package a wrapper genuinely uses at runtime is
+    /// declared as a runtime dependency by the package that holds the wrapper,
+    /// even when the root manifest also lists it as a dev dependency.
+    pub fn build(repo_root: &Path) -> Self {
+        let mut declared: BTreeSet<String> = BTreeSet::new();
+        let mut internal_names: BTreeSet<String> = BTreeSet::new();
+        let mut internal_packages: BTreeMap<String, InternalPackage> = BTreeMap::new();
+
+        for manifest in manifest_paths(repo_root) {
+            let Ok(text) = std::fs::read_to_string(&manifest) else {
+                continue;
+            };
+            let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+                continue;
+            };
+            for field in ["dependencies", "peerDependencies", "optionalDependencies"] {
+                if let Some(map) = json.get(field).and_then(|v| v.as_object()) {
+                    declared.extend(map.keys().cloned());
+                }
+            }
+            let Some(name) = json.get("name").and_then(|n| n.as_str()) else {
+                continue;
+            };
+            internal_names.insert(name.to_string());
+            let Some(dir) = manifest
+                .parent()
+                .and_then(|d| d.strip_prefix(repo_root).ok())
+                .map(Path::to_path_buf)
+            else {
+                continue;
+            };
+            let main = json
+                .get("main")
+                .and_then(|m| m.as_str())
+                .map(str::to_string);
+            // Two directories can declare the same package name — a vendored
+            // copy, a fork kept alongside the original. Keeping the
+            // lexicographically smallest directory makes the choice a property
+            // of the tree rather than of walk order, which is the same
+            // determinism requirement carrick#512 tracks for the manifest walk.
+            match internal_packages.get(name) {
+                Some(existing) if existing.dir <= dir => {}
+                _ => {
+                    internal_packages.insert(name.to_string(), InternalPackage { dir, main });
+                }
+            }
+        }
+
+        // A workspace member declared as a sibling's dependency (`workspace:*`)
+        // is an internal call, not egress.
+        for name in &internal_names {
+            declared.remove(name);
+        }
+
+        WorkspaceIndex {
+            repo_root: repo_root.to_path_buf(),
+            external_packages: declared,
+            internal_packages,
+        }
+    }
+
+    /// Whether any external package is declared at all. An empty universe means
+    /// no specifier can resolve external, so the caller can skip the scan.
+    pub fn has_external_packages(&self) -> bool {
+        !self.external_packages.is_empty()
+    }
+
+    /// Resolve `specifier` as written in `from_file` (repo-relative).
+    ///
+    /// Relative first, then workspace members, then the external universe:
+    /// a workspace member shadows an external package of the same name, which
+    /// is what the `internal_names` subtraction in [`WorkspaceIndex::build`]
+    /// already decided.
+    pub fn resolve(&self, from_file: &Path, specifier: &str) -> Resolution {
+        if specifier.starts_with("./") || specifier.starts_with("../") {
+            let base = match from_file.parent() {
+                Some(dir) => normalize(&dir.join(specifier)),
+                None => normalize(Path::new(specifier)),
+            };
+            return match self.resolve_file(&base) {
+                Some(file) => Resolution::Internal(file),
+                None => Resolution::Unresolved,
+            };
+        }
+
+        if let Some(name) = longest_match(specifier, self.internal_packages.keys()) {
+            let package = &self.internal_packages[&name];
+            let subpath = specifier[name.len()..].trim_start_matches('/');
+            let resolved = if subpath.is_empty() {
+                self.resolve_package_entry(package)
+            } else {
+                self.resolve_file(&normalize(&package.dir.join(subpath)))
+            };
+            return match resolved {
+                Some(file) => Resolution::Internal(file),
+                None => Resolution::Unresolved,
+            };
+        }
+
+        match longest_match(specifier, self.external_packages.iter()) {
+            Some(package) => Resolution::External(package),
+            None => Resolution::Unresolved,
+        }
+    }
+
+    /// A bare import of a workspace member: its declared `main` if it has one,
+    /// then the two index conventions. `main` is run through the same candidate
+    /// list because it habitually points at build output (`dist/index.js`) that
+    /// the source tree spells `.ts`.
+    fn resolve_package_entry(&self, package: &InternalPackage) -> Option<PathBuf> {
+        if let Some(main) = &package.main
+            && let Some(file) = self.resolve_file(&normalize(&package.dir.join(main)))
+        {
+            return Some(file);
+        }
+        self.resolve_file(&package.dir.join("index"))
+            .or_else(|| self.resolve_file(&package.dir.join("src/index")))
+    }
+
+    /// The candidate list, first hit wins: the path as written when it already
+    /// names an existing source file; the path with each source extension
+    /// appended; a written `.js`/`.jsx` swapped for its TypeScript counterpart
+    /// (the ESM-import-specifier convention, where the specifier names the
+    /// emitted file); and finally the directory's index file.
+    fn resolve_file(&self, base: &Path) -> Option<PathBuf> {
+        let has_source_extension = base
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| SOURCE_EXTENSIONS.contains(&e));
+        if has_source_extension && self.exists(base) {
+            return Some(base.to_path_buf());
+        }
+
+        let name = base.file_name().and_then(|n| n.to_str())?.to_string();
+        let parent = base.parent().map(Path::to_path_buf).unwrap_or_default();
+
+        for extension in SOURCE_EXTENSIONS {
+            let candidate = parent.join(format!("{}.{}", name, extension));
+            if self.exists(&candidate) {
+                return Some(candidate);
+            }
+        }
+
+        for (written, source) in [("js", "ts"), ("js", "tsx"), ("jsx", "tsx"), ("jsx", "ts")] {
+            if let Some(stem) = name.strip_suffix(&format!(".{}", written)) {
+                let candidate = parent.join(format!("{}.{}", stem, source));
+                if self.exists(&candidate) {
+                    return Some(candidate);
+                }
+            }
+        }
+
+        for extension in SOURCE_EXTENSIONS {
+            let candidate = base.join(format!("index.{}", extension));
+            if self.exists(&candidate) {
+                return Some(candidate);
+            }
+        }
+
+        None
+    }
+
+    fn exists(&self, relative: &Path) -> bool {
+        self.repo_root.join(relative).is_file()
+    }
+}
+
+/// Every `package.json` under `repo_root`, sorted, skipping dependency installs
+/// and build output. Sorted so the duplicate-name tiebreak in
+/// [`WorkspaceIndex::build`] sees a stable sequence whatever the filesystem
+/// hands back.
+fn manifest_paths(repo_root: &Path) -> Vec<PathBuf> {
+    let walker = walkdir::WalkDir::new(repo_root)
+        .follow_links(true)
+        .into_iter()
+        .filter_entry(|e| {
+            e.depth() == 0
+                || !(e.file_type().is_dir()
+                    && e.file_name()
+                        .to_str()
+                        .is_some_and(|n| MANIFEST_SKIP_DIRS.contains(&n)))
+        });
+    let mut manifests: Vec<PathBuf> = walker
+        .flatten()
+        .filter(|e| e.file_type().is_file() && e.file_name() == "package.json")
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    manifests.sort();
+    manifests
+}
+
+/// The longest name in `names` that `specifier` either equals or sits under as
+/// a subpath. Ties break on the name itself so the result is a property of the
+/// inputs rather than of iteration order.
+fn longest_match<'a>(specifier: &str, names: impl Iterator<Item = &'a String>) -> Option<String> {
+    names
+        .filter(|name| specifier == name.as_str() || specifier.starts_with(&format!("{}/", name)))
+        .max_by_key(|name| (name.len(), name.as_str()))
+        .cloned()
+}
+
+/// Collapse `.` and `..` lexically. Paths here are repo-relative and may not
+/// exist yet (the candidate list is about to test several spellings), so this
+/// cannot go through `canonicalize`.
+fn normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !out.pop() {
+                    out.push("..");
+                }
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/external-call-candidates")
+    }
+
+    fn index() -> WorkspaceIndex {
+        WorkspaceIndex::build(&fixture_root())
+    }
+
+    fn resolve(from: &str, specifier: &str) -> Resolution {
+        index().resolve(Path::new(from), specifier)
+    }
+
+    #[test]
+    fn relative_specifier_resolves_to_a_sibling_file() {
+        assert_eq!(
+            resolve("apps/api/src/no-rows.ts", "./helper"),
+            Resolution::Internal(PathBuf::from("apps/api/src/helper.ts"))
+        );
+    }
+
+    #[test]
+    fn parent_segments_are_collapsed() {
+        assert_eq!(
+            resolve("apps/api/src/nested/deep.ts", "../helper"),
+            Resolution::Internal(PathBuf::from("apps/api/src/helper.ts"))
+        );
+    }
+
+    #[test]
+    fn internal_package_name_resolves_through_its_manifest_main() {
+        // `@fixture/internal-lib` declares `src/index.ts` as its main.
+        assert_eq!(
+            resolve("apps/api/src/no-rows.ts", "@fixture/internal-lib"),
+            Resolution::Internal(PathBuf::from("packages/internal-lib/src/index.ts"))
+        );
+    }
+
+    #[test]
+    fn internal_package_subpath_resolves_under_the_package_dir() {
+        assert_eq!(
+            resolve("apps/api/src/no-rows.ts", "@fixture/mail-kit/transport"),
+            Resolution::Internal(PathBuf::from("packages/mail-kit/transport.ts"))
+        );
+    }
+
+    /// A specifier written as the emitted `.js` file resolves to the TypeScript
+    /// source it is emitted from.
+    #[test]
+    fn written_js_extension_swaps_to_the_typescript_source() {
+        assert_eq!(
+            resolve("apps/api/src/no-rows.ts", "./helper.js"),
+            Resolution::Internal(PathBuf::from("apps/api/src/helper.ts"))
+        );
+    }
+
+    #[test]
+    fn directory_specifier_resolves_to_its_index_file() {
+        assert_eq!(
+            resolve("apps/worker/src/entry.ts", "./barrel"),
+            Resolution::Internal(PathBuf::from("apps/worker/src/barrel/index.ts"))
+        );
+    }
+
+    /// A package with no `main` falls back to `index.*` beside the manifest,
+    /// then `src/index.*`.
+    #[test]
+    fn package_without_main_falls_back_to_index() {
+        assert_eq!(
+            resolve("apps/worker/src/entry.ts", "@fixture/mail-kit"),
+            Resolution::Internal(PathBuf::from("packages/mail-kit/index.ts"))
+        );
+    }
+
+    #[test]
+    fn declared_dependency_resolves_external_by_name_and_by_subpath() {
+        assert_eq!(
+            resolve("apps/api/src/direct-call.ts", "courier-sdk"),
+            Resolution::External("courier-sdk".to_string())
+        );
+        assert_eq!(
+            resolve("apps/api/src/direct-call.ts", "courier-sdk/edge"),
+            Resolution::External("courier-sdk".to_string())
+        );
+    }
+
+    /// A dependency only the root manifest declares is still external
+    /// everywhere: hoisting makes it importable from any file in the tree.
+    #[test]
+    fn root_only_dependency_is_in_the_external_universe() {
+        assert_eq!(
+            resolve("packages/doc-kit/sign.ts", "pdf-toolkit"),
+            Resolution::External("pdf-toolkit".to_string())
+        );
+    }
+
+    #[test]
+    fn dev_dependency_is_not_external() {
+        assert_eq!(
+            resolve("apps/api/src/dev-only.ts", "bench-harness"),
+            Resolution::Unresolved
+        );
+    }
+
+    #[test]
+    fn builtins_and_absolute_paths_are_unresolved() {
+        for specifier in ["fs", "node:fs/promises", "/etc/config", "crypto"] {
+            assert_eq!(
+                resolve("apps/api/src/no-rows.ts", specifier),
+                Resolution::Unresolved,
+                "{} should not resolve",
+                specifier
+            );
+        }
+    }
+
+    #[test]
+    fn a_relative_specifier_naming_no_file_is_unresolved() {
+        assert_eq!(
+            resolve("apps/api/src/no-rows.ts", "./nowhere"),
+            Resolution::Unresolved
+        );
+    }
+
+    /// Duplicate package names keep the lexicographically smallest directory,
+    /// so the choice does not depend on walk order.
+    #[test]
+    fn duplicate_package_name_keeps_the_smallest_directory() {
+        let repo = tempfile::tempdir().unwrap();
+        let root = repo.path();
+        std::fs::write(root.join("package.json"), r#"{"name":"root-app"}"#).unwrap();
+        for dir in ["zeta-copy", "alpha-copy"] {
+            std::fs::create_dir_all(root.join(dir)).unwrap();
+            std::fs::write(
+                root.join(dir).join("package.json"),
+                r#"{"name":"@dup/shared"}"#,
+            )
+            .unwrap();
+            std::fs::write(root.join(dir).join("index.ts"), "export const x = 1;\n").unwrap();
+        }
+        let index = WorkspaceIndex::build(root);
+        assert_eq!(
+            index.resolve(Path::new("app.ts"), "@dup/shared"),
+            Resolution::Internal(PathBuf::from("alpha-copy/index.ts"))
+        );
+    }
+
+    /// Installed packages are not workspace members, and their manifests must
+    /// not contribute to either half of the index.
+    #[test]
+    fn installed_manifests_are_skipped() {
+        let repo = tempfile::tempdir().unwrap();
+        let root = repo.path();
+        std::fs::write(
+            root.join("package.json"),
+            r#"{"name":"root-app","dependencies":{"courier-sdk":"^1.0.0"}}"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("node_modules/courier-sdk")).unwrap();
+        std::fs::write(
+            root.join("node_modules/courier-sdk/package.json"),
+            r#"{"name":"courier-sdk","dependencies":{"hoisted-only":"^1.0.0"}}"#,
+        )
+        .unwrap();
+        let index = WorkspaceIndex::build(root);
+        assert_eq!(
+            index.resolve(Path::new("app.ts"), "courier-sdk"),
+            Resolution::External("courier-sdk".to_string())
+        );
+        assert_eq!(
+            index.resolve(Path::new("app.ts"), "hoisted-only"),
+            Resolution::Unresolved
+        );
+    }
+
+    #[test]
+    fn a_repo_declaring_nothing_has_no_external_packages() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join("package.json"), r#"{"name":"bare"}"#).unwrap();
+        assert!(!WorkspaceIndex::build(repo.path()).has_external_packages());
+    }
+}

--- a/tests/fixtures/external-call-candidates/apps/build/package.json
+++ b/tests/fixtures/external-call-candidates/apps/build/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/build-service",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "courier-sdk": "^1.0.0"
+  }
+}

--- a/tests/fixtures/external-call-candidates/apps/build/src/index.ts
+++ b/tests/fixtures/external-call-candidates/apps/build/src/index.ts
@@ -1,0 +1,3 @@
+import { sendNotice } from "courier-sdk";
+
+export const announce = (userId: string): Promise<void> => sendNotice({ userId });

--- a/tests/fixtures/external-call-candidates/apps/relay/package.json
+++ b/tests/fixtures/external-call-candidates/apps/relay/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/relay",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@fixture/mail-kit": "workspace:*"
+  }
+}

--- a/tests/fixtures/external-call-candidates/apps/relay/src/index.ts
+++ b/tests/fixtures/external-call-candidates/apps/relay/src/index.ts
@@ -1,0 +1,5 @@
+import { mailer } from "@fixture/mail-kit";
+
+export const relay = async (to: string): Promise<void> => {
+  await mailer.sendMail({ to }).catch(() => undefined);
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/package.json
+++ b/tests/fixtures/external-call-candidates/apps/worker/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@fixture/worker",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@fixture/context-kit": "workspace:*",
+    "@fixture/conflict-kit": "workspace:*",
+    "@fixture/crawl-kit": "workspace:*",
+    "@fixture/doc-kit": "workspace:*",
+    "@fixture/job-kit": "workspace:*",
+    "@fixture/ledger-kit": "workspace:*",
+    "@fixture/mail-kit": "workspace:*",
+    "@fixture/storage-kit": "workspace:*"
+  },
+  "devDependencies": {
+    "bench-harness": "^1.0.0"
+  }
+}

--- a/tests/fixtures/external-call-candidates/apps/worker/src/barrel-consumer.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/barrel-consumer.ts
@@ -1,0 +1,3 @@
+import { ledger } from "./barrel";
+
+export const listInvoices = (): Promise<unknown> => ledger.invoices.list();

--- a/tests/fixtures/external-call-candidates/apps/worker/src/barrel/index.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/barrel/index.ts
@@ -1,0 +1,1 @@
+export { ledger } from "@fixture/ledger-kit";

--- a/tests/fixtures/external-call-candidates/apps/worker/src/billing.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/billing.ts
@@ -1,0 +1,5 @@
+import { ledger } from "@fixture/ledger-kit/client";
+
+export const charge = async (amount: number): Promise<void> => {
+  await ledger.payments.create({ amount });
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/conflict.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/conflict.ts
@@ -1,0 +1,6 @@
+import { shared, soloClient } from "@fixture/conflict-kit";
+
+export const attempt = async (): Promise<void> => {
+  await shared.send({ kind: "ambiguous" });
+  await soloClient.upload("key", "body");
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/crawl.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/crawl.ts
@@ -1,0 +1,3 @@
+import { render } from "@fixture/crawl-kit/render";
+
+export const snapshot = (url: string): Promise<string> => render(url);

--- a/tests/fixtures/external-call-candidates/apps/worker/src/destructured.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/destructured.ts
@@ -1,0 +1,7 @@
+import { getContext } from "@fixture/context-kit";
+
+export const sendPrimary = async (to: string): Promise<void> => {
+  const { transport } = await getContext(true);
+
+  await transport.sendMail({ to });
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/dev-wrapper.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/dev-wrapper.ts
@@ -1,0 +1,5 @@
+import { runBench } from "bench-harness";
+
+export const bench = (): void => {
+  runBench();
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/digest.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/digest.ts
@@ -1,0 +1,7 @@
+import digestTransport from "@fixture/mail-kit/digest";
+
+export const sendDigest = async (to: string): Promise<void> => {
+  const transport = digestTransport();
+
+  await transport.sendMail({ to });
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/documents.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/documents.ts
@@ -1,0 +1,3 @@
+import { sealDocument } from "@fixture/doc-kit/sign";
+
+export const seal = (bytes: Uint8Array): Promise<unknown> => sealDocument(bytes);

--- a/tests/fixtures/external-call-candidates/apps/worker/src/entry.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/entry.ts
@@ -1,0 +1,7 @@
+import { loadHandler } from "@fixture/job-kit";
+
+export const start = async (): Promise<void> => {
+  const run = await loadHandler();
+
+  await run();
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/jobs.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/jobs.ts
@@ -1,0 +1,5 @@
+import { QueueProvider } from "@fixture/jobs-kit/provider";
+
+export const enqueue = (): void => {
+  QueueProvider.getInstance();
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/member-form.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/member-form.ts
@@ -1,0 +1,7 @@
+import { getContext } from "@fixture/context-kit";
+
+export const sendFallback = async (to: string): Promise<void> => {
+  const context = await getContext(false);
+
+  await context.transport.sendMail({ to });
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/namespace-internal.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/namespace-internal.ts
@@ -1,0 +1,5 @@
+import * as ledgerKit from "@fixture/ledger-kit";
+
+export const settle = async (id: string): Promise<void> => {
+  await ledgerKit.ledger.payments.settle(id);
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/notify.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/notify.ts
@@ -1,0 +1,6 @@
+import { mailer, verifyTransport } from "@fixture/mail-kit";
+
+export const notify = async (to: string): Promise<void> => {
+  await mailer.sendMail({ to });
+  verifyTransport();
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/shadow.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/shadow.ts
@@ -1,0 +1,9 @@
+import { mailer } from "@fixture/mail-kit";
+
+export const local = (): string => {
+  const mailer = { sendMail: (to: string) => to };
+
+  return mailer.sendMail("nobody");
+};
+
+export const real = (to: string): Promise<void> => mailer.sendMail({ to });

--- a/tests/fixtures/external-call-candidates/apps/worker/src/singleton.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/singleton.ts
@@ -1,0 +1,7 @@
+import { capture, flush, PulseReporter } from "@fixture/singleton-kit";
+
+export const report = async (name: string): Promise<void> => {
+  PulseReporter.start();
+  capture(name);
+  await flush();
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/split-context.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/split-context.ts
@@ -1,0 +1,7 @@
+import { getSplitContext } from "@fixture/context-kit/split";
+
+export const sendSplit = async (to: string): Promise<void> => {
+  const { transport } = getSplitContext(true);
+
+  await transport.sendMail({ to });
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/storage.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/storage.ts
@@ -1,0 +1,11 @@
+import { record } from "@fixture/storage-kit/beacon";
+import { BlobStore } from "@fixture/storage-kit/blob-store";
+import { drain } from "@fixture/storage-kit/queue-store";
+
+export const archive = async (key: string, body: string): Promise<void> => {
+  const store = new BlobStore("eu-west-1");
+
+  await store.put(key, body);
+  await drain();
+  record("archived");
+};

--- a/tests/fixtures/external-call-candidates/apps/worker/src/type-reexport.ts
+++ b/tests/fixtures/external-call-candidates/apps/worker/src/type-reexport.ts
@@ -1,0 +1,6 @@
+import { Transporter } from "@fixture/mail-kit";
+
+// A type-only re-export binds nothing at runtime. Calling the name is not
+// valid TypeScript, but the parser accepts it, so the absence of a row here is
+// asserted rather than assumed.
+export const describe = (): string => Transporter.describe();

--- a/tests/fixtures/external-call-candidates/package.json
+++ b/tests/fixtures/external-call-candidates/package.json
@@ -2,5 +2,11 @@
   "name": "@fixture/egress-root",
   "version": "0.0.0",
   "private": true,
-  "workspaces": ["apps/*", "packages/*"]
+  "workspaces": ["apps/*", "packages/*"],
+  "dependencies": {
+    "pdf-toolkit": "^0.4.1"
+  },
+  "devDependencies": {
+    "bench-harness": "^1.0.0"
+  }
 }

--- a/tests/fixtures/external-call-candidates/packages/conflict-kit/index.ts
+++ b/tests/fixtures/external-call-candidates/packages/conflict-kit/index.ts
@@ -1,0 +1,3 @@
+export * from "./left";
+export * from "./right";
+export * from "./solo";

--- a/tests/fixtures/external-call-candidates/packages/conflict-kit/left.ts
+++ b/tests/fixtures/external-call-candidates/packages/conflict-kit/left.ts
@@ -1,0 +1,3 @@
+import { LedgerClient } from "ledger-client";
+
+export const shared = new LedgerClient({ region: "eu-west-1" });

--- a/tests/fixtures/external-call-candidates/packages/conflict-kit/package.json
+++ b/tests/fixtures/external-call-candidates/packages/conflict-kit/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixture/conflict-kit",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "ledger-client": "^2.0.0",
+    "vault-blob": "^1.0.0"
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/conflict-kit/right.ts
+++ b/tests/fixtures/external-call-candidates/packages/conflict-kit/right.ts
@@ -1,0 +1,3 @@
+import { VaultClient } from "vault-blob";
+
+export const shared = new VaultClient({ region: "eu-west-1" });

--- a/tests/fixtures/external-call-candidates/packages/conflict-kit/solo.ts
+++ b/tests/fixtures/external-call-candidates/packages/conflict-kit/solo.ts
@@ -1,0 +1,3 @@
+import { VaultClient } from "vault-blob";
+
+export const soloClient = new VaultClient({ region: "us-east-1" });

--- a/tests/fixtures/external-call-candidates/packages/context-kit/index.ts
+++ b/tests/fixtures/external-call-candidates/packages/context-kit/index.ts
@@ -1,0 +1,9 @@
+import { backupMailer, mailer } from "@fixture/mail-kit";
+
+export const getContext = async (primary: boolean) => {
+  if (primary) {
+    return { transport: mailer, region: "eu-west" };
+  }
+
+  return { transport: primary ? mailer : backupMailer, region: "us-east" };
+};

--- a/tests/fixtures/external-call-candidates/packages/context-kit/package.json
+++ b/tests/fixtures/external-call-candidates/packages/context-kit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/context-kit",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@fixture/mail-kit": "workspace:*"
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/context-kit/split.ts
+++ b/tests/fixtures/external-call-candidates/packages/context-kit/split.ts
@@ -1,0 +1,6 @@
+import { backupMailer, mailer } from "@fixture/mail-kit";
+
+export const getSplitContext = (primary: boolean) =>
+  primary
+    ? { transport: mailer, region: "eu-central" }
+    : { transport: backupMailer, region: "us-west" };

--- a/tests/fixtures/external-call-candidates/packages/crawl-kit/package.json
+++ b/tests/fixtures/external-call-candidates/packages/crawl-kit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/crawl-kit",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "crawler-kit": "^2.0.0"
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/crawl-kit/render.ts
+++ b/tests/fixtures/external-call-candidates/packages/crawl-kit/render.ts
@@ -1,0 +1,9 @@
+export const render = async (url: string): Promise<string> => {
+  const { headless } = await import("crawler-kit");
+  const page = await headless.launch(url);
+
+  const runtime = await import("crawler-kit");
+  await runtime.shutdown();
+
+  return page;
+};

--- a/tests/fixtures/external-call-candidates/packages/doc-kit/package.json
+++ b/tests/fixtures/external-call-candidates/packages/doc-kit/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/doc-kit",
+  "version": "0.0.0",
+  "private": true
+}

--- a/tests/fixtures/external-call-candidates/packages/doc-kit/sign.ts
+++ b/tests/fixtures/external-call-candidates/packages/doc-kit/sign.ts
@@ -1,0 +1,7 @@
+import { Pdf } from "pdf-toolkit";
+
+export const sealDocument = async (bytes: Uint8Array) => {
+  const doc = await Pdf.load(bytes);
+
+  return doc.sign({ reason: "archive" });
+};

--- a/tests/fixtures/external-call-candidates/packages/internal-lib/package.json
+++ b/tests/fixtures/external-call-candidates/packages/internal-lib/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@fixture/internal-lib",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "main": "src/index.ts"
 }

--- a/tests/fixtures/external-call-candidates/packages/job-kit/handler.ts
+++ b/tests/fixtures/external-call-candidates/packages/job-kit/handler.ts
@@ -1,0 +1,5 @@
+import { mailer } from "@fixture/mail-kit";
+
+export const run = async (): Promise<void> => {
+  await mailer.sendMail({ subject: "job finished" });
+};

--- a/tests/fixtures/external-call-candidates/packages/job-kit/index.ts
+++ b/tests/fixtures/external-call-candidates/packages/job-kit/index.ts
@@ -1,0 +1,5 @@
+export const loadHandler = async () => {
+  const { run } = await import("./handler");
+
+  return run;
+};

--- a/tests/fixtures/external-call-candidates/packages/job-kit/package.json
+++ b/tests/fixtures/external-call-candidates/packages/job-kit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/job-kit",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@fixture/mail-kit": "workspace:*"
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/jobs-kit/package.json
+++ b/tests/fixtures/external-call-candidates/packages/jobs-kit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/jobs-kit",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "relay-queue": "^1.0.0"
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/jobs-kit/provider.ts
+++ b/tests/fixtures/external-call-candidates/packages/jobs-kit/provider.ts
@@ -1,0 +1,21 @@
+import { QueueClient } from "relay-queue";
+
+export class QueueProvider {
+  private static _instance: QueueProvider;
+
+  private _client: QueueClient;
+
+  private constructor(options: { client: QueueClient }) {
+    this._client = options.client;
+  }
+
+  static getInstance(): void {
+    const client = new QueueClient({ region: "eu-west-1" });
+
+    QueueProvider._instance = new QueueProvider({ client });
+  }
+
+  async trigger(name: string): Promise<void> {
+    await this._client.send({ name });
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/ledger-kit/client.ts
+++ b/tests/fixtures/external-call-candidates/packages/ledger-kit/client.ts
@@ -1,0 +1,3 @@
+import { LedgerClient } from "ledger-client";
+
+export const ledger = new LedgerClient({ region: "eu-west-1" });

--- a/tests/fixtures/external-call-candidates/packages/ledger-kit/index.ts
+++ b/tests/fixtures/external-call-candidates/packages/ledger-kit/index.ts
@@ -1,0 +1,1 @@
+export { ledger } from "./client";

--- a/tests/fixtures/external-call-candidates/packages/ledger-kit/package.json
+++ b/tests/fixtures/external-call-candidates/packages/ledger-kit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/ledger-kit",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "ledger-client": "^2.0.0"
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/mail-kit/digest.ts
+++ b/tests/fixtures/external-call-candidates/packages/mail-kit/digest.ts
@@ -1,0 +1,5 @@
+import { createTransport } from "postbox-mailer";
+
+export default function digestTransport() {
+  return createTransport({ jsonTransport: true });
+}

--- a/tests/fixtures/external-call-candidates/packages/mail-kit/index.ts
+++ b/tests/fixtures/external-call-candidates/packages/mail-kit/index.ts
@@ -1,0 +1,11 @@
+import { buildTransport } from "./transport";
+
+const getTransport = () => buildTransport(process.env.MAIL_HOST ?? "");
+
+export const mailer = getTransport();
+
+export const backupMailer = buildTransport("backup.invalid");
+
+export const verifyTransport = () => getTransport().verify();
+
+export type { Transporter } from "postbox-mailer";

--- a/tests/fixtures/external-call-candidates/packages/mail-kit/package.json
+++ b/tests/fixtures/external-call-candidates/packages/mail-kit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/mail-kit",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "postbox-mailer": "^5.0.0"
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/mail-kit/transport.ts
+++ b/tests/fixtures/external-call-candidates/packages/mail-kit/transport.ts
@@ -1,0 +1,9 @@
+import { createTransport } from "postbox-mailer";
+
+export const buildTransport = (host: string) => {
+  if (host.length === 0) {
+    return createTransport({ jsonTransport: true });
+  }
+
+  return createTransport({ host, port: 587 });
+};

--- a/tests/fixtures/external-call-candidates/packages/orphan-kit/orphan.ts
+++ b/tests/fixtures/external-call-candidates/packages/orphan-kit/orphan.ts
@@ -1,0 +1,3 @@
+import { sendNotice } from "courier-sdk";
+
+export const shout = (): Promise<void> => sendNotice({ userId: "orphan" });

--- a/tests/fixtures/external-call-candidates/packages/orphan-kit/package.json
+++ b/tests/fixtures/external-call-candidates/packages/orphan-kit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/orphan-kit",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "courier-sdk": "^1.0.0"
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/singleton-kit/index.ts
+++ b/tests/fixtures/external-call-candidates/packages/singleton-kit/index.ts
@@ -1,0 +1,27 @@
+import { PulseClient } from "pulse-analytics";
+
+export class PulseReporter {
+  private static _instance: PulseReporter;
+
+  private client = new PulseClient({ app: "worker" });
+
+  static start(): void {
+    const started = new PulseReporter();
+
+    PulseReporter._instance = started;
+  }
+
+  static get current(): PulseReporter {
+    return PulseReporter._instance;
+  }
+}
+
+export const flush = async (): Promise<void> => {
+  const reporter = PulseReporter._instance;
+
+  await reporter.client.shutdown();
+};
+
+export const capture = (name: string): void => {
+  PulseReporter.current.client.capture(name);
+};

--- a/tests/fixtures/external-call-candidates/packages/singleton-kit/package.json
+++ b/tests/fixtures/external-call-candidates/packages/singleton-kit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@fixture/singleton-kit",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "pulse-analytics": "^2.0.0"
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/storage-kit/beacon.ts
+++ b/tests/fixtures/external-call-candidates/packages/storage-kit/beacon.ts
@@ -1,0 +1,9 @@
+import { MetricsClient } from "beacon-metrics";
+
+export class Beacon {
+  static client = new MetricsClient({ app: "worker" });
+}
+
+export const record = (name: string): void => {
+  Beacon.client.capture(name);
+};

--- a/tests/fixtures/external-call-candidates/packages/storage-kit/blob-store.ts
+++ b/tests/fixtures/external-call-candidates/packages/storage-kit/blob-store.ts
@@ -1,0 +1,13 @@
+import { VaultClient } from "vault-blob";
+
+export class BlobStore {
+  private client: VaultClient;
+
+  constructor(region: string) {
+    this.client = new VaultClient({ region });
+  }
+
+  async put(key: string, body: string): Promise<void> {
+    await this.client.upload(key, body);
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/storage-kit/package.json
+++ b/tests/fixtures/external-call-candidates/packages/storage-kit/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fixture/storage-kit",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "beacon-metrics": "^3.0.0",
+    "vault-blob": "^1.0.0"
+  }
+}

--- a/tests/fixtures/external-call-candidates/packages/storage-kit/queue-store.ts
+++ b/tests/fixtures/external-call-candidates/packages/storage-kit/queue-store.ts
@@ -1,0 +1,13 @@
+import { VaultClient } from "vault-blob";
+
+export class QueueStore {
+  readonly client: VaultClient;
+
+  constructor(client: VaultClient) {
+    this.client = client;
+  }
+}
+
+const store = new QueueStore(new VaultClient({ region: "eu-west-1" }));
+
+export const drain = (): Promise<void> => store.client.flush();


### PR DESCRIPTION
Closes the wrapper-resolution gap in the outbound-call candidate channel (#510 follow-up to #511/#514).

## Problem

Single-file resolution answered "which external package does this callee come from?" using only a file's own direct imports and the service's own package.json. On real monorepos both assumptions fail: genuine egress sites import workspace-internal wrappers (a mailer module, a payments singleton, a storage provider), and the manifest declaring the SDK is the shared package's, not the service's. The result on a large real-world monorepo benchmark was an inventory with thousands of direct-import UI rows and zero of the repo's actual egress sites.

## What this does

- **Transitive ownership.** Every source file in the workspace is parsed once into plain facts: imports (including literal `import()`), re-exports, exports, aliases (await-unwrapped, object destructuring), function return shapes (including returned object-literal properties), class field maps (instance, static, constructor-parameter with property paths), and call sites reduced to one root-plus-steps chain shape. A monotone fixpoint assigns each binding, export, and static slot an owner: an external package, a record of owned properties, a namespace, a class, or a function whose calls yield an owner. Two different packages reaching one slot is a conflict and drops it.
- **Workspace scope with per-service attribution.** Rows are computed for every workspace file; each service takes the rows of the files reachable from its own file list over internal import edges (static, re-export, star, literal dynamic). A shared package's rows appear in every service that ships it.
- **Repo-wide dependency universe.** Union of dependencies/peerDependencies/optionalDependencies across every manifest in the tree minus workspace-internal names. devDependencies stay excluded.
- **Cap raised to 20000, measured.** The widened scan produced ~15k rows on the benchmark's largest service; 5000 truncated in sorted-by-file order, which drops shared-package rows first.

Deterministic throughout: BTree maps everywhere ownership can reach the output, Jacobi-style fixpoint (order-independent), lexicographic tiebreak for duplicate package names, and a double-scan byte-equality test. No LLM, no network, no vendor name lists, no type checking, and still no rows for destinations the AST cannot name (internal fetch wrappers stay out by design).

Unchanged: the HTTP-shaped projection (`from_data_calls`), row shape and serde, matching, extraction, and everything downstream.

## Verification

- Full suite green (fmt, clippy --all-targets --all-features -D warnings, 1600+ tests); 30+ new unit tests over an extended fixture workspace covering barrels, star-export conflicts, namespace imports, dynamic-import-only reachability, dead-file exclusion, root-only dependencies, dev-dependency exclusion, static singletons, and options-object constructor injection.
- Offline probe against a frozen 99-site egress ground truth on a real-world monorepo mirror: 0/99 before, **68/99 after**, which is every site reachable by deterministic ownership (the remainder needs domain/env-var declarations, is dead code no service imports, or is anchored only by type annotations or runtime values, which this channel deliberately does not guess).

Scan cost: the workspace pass parses the whole repo once per service on both analysis paths (~0.5s per service on a ~1000-file monorepo, release build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)