### PR TITLE
fix(scanner): resolve mounted plugins by module, not by bare name

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -20,7 +20,8 @@ use crate::{
     agent_service::AgentService,
     agents::{
         file_analyzer_agent::{
-            EmissionStyle, EndpointResult, FileAnalysisResult, FileAnalyzerAgent, PubsubOperation,
+            EmissionStyle, EndpointResult, FileAnalysisResult, FileAnalyzerAgent, MountResult,
+            PubsubOperation,
         },
         framework_guidance_agent::ProtocolGuidance,
     },
@@ -32,6 +33,7 @@ use crate::{
     },
     file_based_router::{MethodSource, RoutingConvention, builtin_conventions, derive_route},
     framework_detector::DetectionResult,
+    import_bindings::BindingResolver,
     mount_graph::{DataFetchingCall, GraphNode, MountEdge, MountGraph, NodeType, ResolvedEndpoint},
     operation::{OperationKey, Protocol},
     parser::parse_file,
@@ -48,7 +50,7 @@ use crate::{
     visitor::{ImportSymbolExtractor, ImportedSymbol, SymbolKind, TypeSymbolExtractor},
 };
 use futures::stream::StreamExt;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use swc_common::{
     SourceMap,
@@ -534,6 +536,17 @@ fn template_pattern_matches(quasis: &[String], topic: &str) -> bool {
         }
     }
     remaining.ends_with(last.as_str())
+}
+
+/// A mount-site binding, resolved back to the file that defines it.
+///
+/// `child_node` is the name the MOUNTING file registered (`sessionsRoutes`);
+/// `local_name` is what the defining module calls it (`routes`), when its
+/// export table names it at all.
+#[derive(Debug, Clone)]
+struct MountBinding {
+    child_node: String,
+    local_name: Option<String>,
 }
 
 /// Orchestrates file-centric analysis using the FileAnalyzerAgent.
@@ -1276,7 +1289,8 @@ impl FileOrchestrator {
         debug!("  - Total data calls: {}", stats.total_data_calls);
 
         // STEP 5: Build aggregated mount graph from all file results
-        let mount_graph = self.build_mount_graph(&file_results, normalizer, service_root);
+        let mount_graph =
+            self.build_mount_graph(&file_results, normalizer, service_root, Path::new(""));
 
         Ok(FileCentricAnalysisResult {
             file_results,
@@ -2453,7 +2467,7 @@ impl FileOrchestrator {
     /// specifiers (packages, tsconfig aliases) return `None` — alias
     /// resolution needs the sidecar's tsconfig knowledge and is out of scope
     /// here.
-    fn resolve_relative_import(importer: &Path, spec: &str) -> Option<PathBuf> {
+    pub(crate) fn resolve_relative_import(importer: &Path, spec: &str) -> Option<PathBuf> {
         if !(spec.starts_with("./") || spec.starts_with("../")) {
             return None;
         }
@@ -4079,11 +4093,29 @@ impl FileOrchestrator {
         // the keys are already repo-relative (the engine normalizes them
         // before rebuilding the graph).
         scan_root: &Path,
+        // Directory the `file_results` keys are relative to ON DISK, so an
+        // imported binding can be resolved back to the module that defines
+        // it. `Path::new("")` when the keys already resolve as written
+        // (absolute, or relative to the working directory); the repo root
+        // when the engine has normalized them to repo-relative paths.
+        file_root: &Path,
     ) -> MountGraph {
         let mut graph = MountGraph::new();
 
-        // Track import mappings: import_source -> (file_path, local_name)
-        let mut import_map: HashMap<String, String> = HashMap::new();
+        // Which mount-site binding stands for which analysed file, resolved
+        // through the module graph — (file, exported name), never a bare name.
+        // This is what attributes a mounted plugin's routes to the binding it
+        // was registered under; everything below it is fallback.
+        let owner_bindings = Self::resolve_mount_bindings(file_results, file_root);
+
+        // Fallback name map for mounts the module graph cannot reach (tsconfig
+        // path aliases, workspace packages, files not on disk): normalized
+        // import source -> every child node mounted from it. A specifier that
+        // fronts SEVERAL distinct children is a barrel, and the name alone
+        // cannot say which module an endpoint belongs to, so the set is kept
+        // whole and the ambiguity refused rather than silently resolved to
+        // whichever mount was seen last.
+        let mut import_map: HashMap<String, BTreeSet<String>> = HashMap::new();
 
         // First pass: collect all nodes and build import mappings
         for (file_path, result) in file_results {
@@ -4135,7 +4167,10 @@ impl FileOrchestrator {
                 if let Some(import_source) = &mount.import_source {
                     // Normalize the import source
                     let normalized = Self::normalize_import_source(import_source);
-                    import_map.insert(normalized, mount.child_node.clone());
+                    import_map
+                        .entry(normalized)
+                        .or_default()
+                        .insert(mount.child_node.clone());
                 }
             }
         }
@@ -4178,8 +4213,12 @@ impl FileOrchestrator {
                 }
 
                 // Try to resolve the owner using import information
-                let resolved_owner =
-                    self.resolve_endpoint_owner(&graph, &endpoint.owner_node, file_path);
+                let resolved_owner = Self::resolve_endpoint_owner(
+                    &owner_bindings,
+                    &import_map,
+                    &endpoint.owner_node,
+                    file_path,
+                );
 
                 graph.endpoints.push(ResolvedEndpoint {
                     method,
@@ -4428,32 +4467,158 @@ impl FileOrchestrator {
         }
     }
 
-    /// Resolve endpoint owner using import information.
+    /// Resolve every mount's imported child back to the file that DEFINES it,
+    /// keyed by the `file_results` key of that file.
+    ///
+    /// This is the identity the old name-based resolution lost. A barrel gives
+    /// four mounts the same import specifier (`./routes.js`) and each module
+    /// typically names its own plugin identically (`const routes = ...; export
+    /// default routes`), so neither the specifier nor the local symbol
+    /// distinguishes them — only the module a binding was re-exported FROM
+    /// does. `BindingResolver` walks `export { default as X } from`,
+    /// `export { a as b } from`, and `export * from` hops to find it, with no
+    /// framework knowledge involved: an Express router, a Fastify plugin, and
+    /// anything else the mount graph follows resolve through the same path.
+    ///
+    /// Bindings are deduped by `child_node` so the same module mounted under
+    /// several prefixes stays ONE binding (the alias fan-out in
+    /// `resolve_endpoint_paths` handles the prefixes, #373).
+    ///
+    /// Keys are resolved against `file_root`, which is `Path::new("")` when
+    /// they already resolve as written and the repo root when the engine has
+    /// normalized them to repo-relative paths.
+    ///
+    /// Returns an empty map when nothing resolves — non-relative specifiers,
+    /// or `file_results` keys that are not paths on disk (in-memory tests, a
+    /// graph rebuilt away from the checkout). Callers fall back to the name
+    /// map there.
+    fn resolve_mount_bindings(
+        file_results: &HashMap<String, FileAnalysisResult>,
+        file_root: &Path,
+    ) -> HashMap<String, Vec<MountBinding>> {
+        // Canonical path -> the `file_results` key naming that file. Both
+        // sides are canonicalized: the resolver returns canonical paths, and a
+        // key can reach the same file through a relative path or a symlinked
+        // parent (`/var` -> `/private/var` on macOS).
+        let mut key_by_canonical: HashMap<PathBuf, &str> = HashMap::new();
+        for key in file_results.keys() {
+            if let Ok(canonical) = file_root.join(key).canonicalize() {
+                key_by_canonical.insert(canonical, key.as_str());
+            }
+        }
+        if key_by_canonical.is_empty() {
+            return HashMap::new();
+        }
+
+        // `file_results` is a HashMap: sort the mount sites so the bindings
+        // (and any tie-break between them) are identical run to run.
+        let mut mount_sites: Vec<(&str, &MountResult)> = file_results
+            .iter()
+            .flat_map(|(file_path, result)| {
+                result
+                    .mounts
+                    .iter()
+                    .map(move |mount| (file_path.as_str(), mount))
+            })
+            .collect();
+        mount_sites.sort_by(|(a_file, a), (b_file, b)| {
+            a_file
+                .cmp(b_file)
+                .then(a.line_number.cmp(&b.line_number))
+                .then(a.child_node.cmp(&b.child_node))
+        });
+
+        let mut resolver = BindingResolver::new();
+        let mut bindings: HashMap<String, Vec<MountBinding>> = HashMap::new();
+        for (file_path, mount) in mount_sites {
+            let Some(import_source) = &mount.import_source else {
+                continue; // locally defined child: no module to resolve
+            };
+            let Ok(importer) = file_root.join(file_path).canonicalize() else {
+                continue;
+            };
+            let Some(resolved) = resolver.resolve(&importer, import_source, &mount.child_node)
+            else {
+                continue;
+            };
+            let Some(target_key) = key_by_canonical.get(&resolved.file) else {
+                continue; // defining module was not analysed (no endpoints in it)
+            };
+            let entry = bindings.entry((*target_key).to_string()).or_default();
+            if entry
+                .iter()
+                .any(|binding| binding.child_node == mount.child_node)
+            {
+                continue;
+            }
+            entry.push(MountBinding {
+                child_node: mount.child_node.clone(),
+                local_name: resolved.local_name,
+            });
+        }
+        bindings
+    }
+
+    /// Resolve the node an endpoint belongs to, so its path can be joined to
+    /// the prefix its module was mounted under.
+    ///
+    /// Identity is file-first: when exactly one mounted binding resolves to
+    /// the file an endpoint was extracted from, that binding owns it. The
+    /// endpoint's own `owner_node` cannot carry that decision — it is the
+    /// variable the route was attached to, which for a plugin is the
+    /// framework instance handed to it (`server`, `fastify`), a name every
+    /// module in a repo shares.
+    ///
+    /// `local_name` only breaks ties, in the rarer case where one file
+    /// defines several mounted routers. When it cannot break the tie, the
+    /// original owner is kept: an unmounted-looking endpoint is a visible
+    /// gap, a confidently wrong prefix is not.
     fn resolve_endpoint_owner(
-        &self,
-        graph: &MountGraph,
+        owner_bindings: &HashMap<String, Vec<MountBinding>>,
+        import_map: &HashMap<String, BTreeSet<String>>,
         owner_name: &str,
         file_path: &str,
     ) -> String {
-        // Extract just the filename parts for matching
-        let file_parts: Vec<&str> = file_path.split('/').collect();
-
-        // Try to find a matching import mapping
-        for (key, node) in &graph.nodes {
-            if key.starts_with("__import_map__::") {
-                let source_pattern = key.trim_start_matches("__import_map__::");
-
-                // Check if the current file matches this source pattern
-                if file_path.contains(source_pattern)
-                    || file_parts.iter().any(|part| part.contains(source_pattern))
-                {
-                    return node.name.clone();
-                }
+        if let Some(bindings) = owner_bindings.get(file_path) {
+            if let [only] = bindings.as_slice() {
+                return only.child_node.clone();
             }
+            if let Some(binding) = bindings
+                .iter()
+                .find(|binding| binding.local_name.as_deref() == Some(owner_name))
+            {
+                return binding.child_node.clone();
+            }
+            // Several bindings resolved to this file and none of them names
+            // this owner: refuse to guess.
+            return owner_name.to_string();
         }
 
-        // No mapping found, return original owner
-        owner_name.to_string()
+        // Fallback: match the file against the import specifiers seen at mount
+        // sites. Substring matching, so it is only ever a hint — `./routes.js`
+        // matches every path containing "routes". Take the most specific
+        // pattern that matches, and use it only when the mounts agree on a
+        // single child; a specifier fronting several children is a barrel this
+        // path cannot see through.
+        let file_parts: Vec<&str> = file_path.split('/').collect();
+        let mut best_len = 0usize;
+        let mut candidates: BTreeSet<&str> = BTreeSet::new();
+        for (pattern, children) in import_map {
+            let matches =
+                file_path.contains(pattern) || file_parts.iter().any(|part| part.contains(pattern));
+            if !matches || pattern.len() < best_len {
+                continue;
+            }
+            if pattern.len() > best_len {
+                best_len = pattern.len();
+                candidates.clear();
+            }
+            candidates.extend(children.iter().map(String::as_str));
+        }
+        match candidates.iter().copied().collect::<Vec<_>>().as_slice() {
+            [only] => (*only).to_string(),
+            _ => owner_name.to_string(),
+        }
     }
 
     /// Resolve full paths for endpoints by traversing the mount graph.
@@ -5551,6 +5716,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new(""),
+            Path::new(""),
         );
 
         assert_eq!(graph.mounts.len(), 1);
@@ -5616,6 +5782,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new(""),
+            Path::new(""),
         );
 
         let mut full_paths: Vec<&str> = graph
@@ -5673,6 +5840,7 @@ export * from "./aFetch.js";"#,
         let graph = orchestrator.build_mount_graph(
             &file_results,
             &UrlNormalizer::default_permissive(),
+            Path::new(""),
             Path::new(""),
         );
 
@@ -5735,6 +5903,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new("tests/fixtures/mocks/service-a"),
+            Path::new(""),
         );
 
         assert_eq!(graph.endpoints.len(), 1);
@@ -5790,6 +5959,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new(""),
+            Path::new(""),
         );
 
         assert_eq!(graph.data_calls.len(), 1);
@@ -5839,6 +6009,7 @@ export * from "./aFetch.js";"#,
         let graph = orchestrator.build_mount_graph(
             &file_results,
             &UrlNormalizer::new(&config),
+            Path::new(""),
             Path::new(""),
         );
 
@@ -5922,6 +6093,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new(""),
+            Path::new(""),
         );
 
         assert_eq!(
@@ -5964,6 +6136,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new(""),
+            Path::new(""),
         );
 
         assert_eq!(graph.data_calls.len(), 1);
@@ -5996,6 +6169,7 @@ export * from "./aFetch.js";"#,
         let graph = orchestrator.build_mount_graph(
             &file_results,
             &UrlNormalizer::default_permissive(),
+            Path::new(""),
             Path::new(""),
         );
 
@@ -6045,7 +6219,7 @@ export * from "./aFetch.js";"#,
         let build = |result: FileAnalysisResult| {
             let mut file_results = HashMap::new();
             file_results.insert("lib/audit.ts".to_string(), result);
-            orchestrator.build_mount_graph(&file_results, &normalizer, Path::new(""))
+            orchestrator.build_mount_graph(&file_results, &normalizer, Path::new(""), Path::new(""))
         };
 
         // The verbatim rendering, run through the fold-time normalization the
@@ -6158,6 +6332,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new(""),
+            Path::new(""),
         );
 
         let call_paths: Vec<&str> = graph
@@ -6248,6 +6423,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new(""),
+            Path::new(""),
         );
 
         let evidence_of = |method: &str| {
@@ -6329,6 +6505,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new(""),
+            Path::new(""),
         );
 
         let targets: Vec<&str> = graph
@@ -6398,6 +6575,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new(""),
+            Path::new(""),
         );
         let config = Config::default();
         let (_explicit, infer, _inline) =
@@ -6442,6 +6620,7 @@ export * from "./aFetch.js";"#,
         let graph = orchestrator.build_mount_graph(
             &file_results,
             &UrlNormalizer::default_permissive(),
+            Path::new(""),
             Path::new(""),
         );
         let config = Config::default();
@@ -6508,6 +6687,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new(""),
+            Path::new(""),
         );
         let config = Config::default();
         let (_explicit, infer, _inline) =
@@ -6566,6 +6746,7 @@ export * from "./aFetch.js";"#,
         let graph = orchestrator.build_mount_graph(
             &file_results,
             &UrlNormalizer::default_permissive(),
+            Path::new(""),
             Path::new(""),
         );
         let config = Config::default();
@@ -6638,6 +6819,7 @@ export * from "./aFetch.js";"#,
         let graph = orchestrator.build_mount_graph(
             &file_results,
             &UrlNormalizer::default_permissive(),
+            Path::new(""),
             Path::new(""),
         );
         let config = Config::default();
@@ -7388,6 +7570,7 @@ export * from "./aFetch.js";"#,
             &file_results,
             &UrlNormalizer::default_permissive(),
             Path::new(""),
+            Path::new(""),
         );
 
         // Should have the mount and both endpoints
@@ -7400,6 +7583,218 @@ export * from "./aFetch.js";"#,
             .keys()
             .any(|k| k.starts_with("__import_map__::"));
         assert!(has_import_map, "Should have import mapping node");
+    }
+
+    /// Root of the on-disk module graph both barrel tests resolve through.
+    /// Endpoint extraction is LLM-side, so the `FileAnalysisResult`s below are
+    /// authored by hand to mirror what the analyzer emits for these files; the
+    /// FIXTURE is what the deterministic import/mount resolution reads.
+    fn barrel_fixture_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/barrel-reexport-mounts")
+    }
+
+    fn barrel_fixture(relative: &str) -> String {
+        barrel_fixture_root()
+            .join(relative)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// One route, attached to the plugin's own framework instance. Every
+    /// module in the fixture uses the SAME owner name (`server`) — that
+    /// collision is the point: the owner name cannot identify the module.
+    fn plugin_endpoint(method: &str, path: &str) -> EndpointResult {
+        EndpointResult {
+            candidate_id: format!("span:{method}:{path}"),
+            line_number: 4,
+            owner_node: "server".to_string(),
+            method: method.to_string(),
+            path: path.to_string(),
+            handler_name: "anonymous".to_string(),
+            pattern_matched: format!(".{}(", method.to_lowercase()),
+            call_expression_span_start: None,
+            call_expression_span_end: None,
+            payload_expression_text: None,
+            payload_expression_line: None,
+            response_expression_text: None,
+            response_expression_line: None,
+            emission_style: None,
+            primary_type_symbol: None,
+            type_import_source: None,
+        }
+    }
+
+    fn register_mount(line_number: i32, child: &str, prefix: &str, source: &str) -> MountResult {
+        MountResult {
+            line_number,
+            parent_node: "fastify".to_string(),
+            child_node: child.to_string(),
+            mount_path: prefix.to_string(),
+            import_source: Some(source.to_string()),
+            pattern_matched: ".register(".to_string(),
+        }
+    }
+
+    /// (method, full_path, owner) for every endpoint, sorted.
+    fn resolved_routes(graph: &MountGraph) -> Vec<(String, String, String)> {
+        let mut routes: Vec<(String, String, String)> = graph
+            .endpoints
+            .iter()
+            .map(|e| (e.method.clone(), e.full_path.clone(), e.owner.clone()))
+            .collect();
+        routes.sort();
+        routes
+    }
+
+    /// Four plugins registered through ONE barrel: same import specifier for
+    /// all four, and three of the four modules name their plugin `routes`.
+    /// Resolving by name collapsed every route onto the last binding
+    /// (`/v1/logs/<path>`, owner `logsRoutes`); resolving by (file, exported
+    /// name) keeps each module's identity.
+    #[test]
+    fn test_build_mount_graph_resolves_barrel_reexported_plugins_to_their_own_module() {
+        let agent_service = AgentService::new();
+        let orchestrator = FileOrchestrator::new(agent_service);
+
+        let mut file_results = HashMap::new();
+        file_results.insert(
+            "src/plugin.ts".to_string(),
+            FileAnalysisResult {
+                mounts: vec![
+                    register_mount(10, "actionsRoutes", "/v1", "./routes.js"),
+                    register_mount(11, "sessionsRoutes", "/v1", "./routes.js"),
+                    register_mount(12, "filesRoutes", "/v1", "./routes.js"),
+                    register_mount(13, "logsRoutes", "/v1/logs", "./routes.js"),
+                ],
+                ..Default::default()
+            },
+        );
+        for (module, path) in [
+            ("actions", "/actions"),
+            ("sessions", "/sessions"),
+            ("files", "/files"),
+        ] {
+            file_results.insert(
+                format!("src/modules/{module}/{module}.routes.ts"),
+                FileAnalysisResult {
+                    endpoints: vec![plugin_endpoint("POST", path)],
+                    ..Default::default()
+                },
+            );
+        }
+        file_results.insert(
+            "src/modules/logs/logs.routes.ts".to_string(),
+            FileAnalysisResult {
+                endpoints: vec![plugin_endpoint("POST", "/entries")],
+                ..Default::default()
+            },
+        );
+
+        // Repo-relative keys with the root passed separately: the shape the
+        // engine rebuilds a graph in, and the one that has to reach the
+        // module files on disk to resolve the barrel.
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            Path::new(""),
+            &barrel_fixture_root(),
+        );
+
+        assert_eq!(
+            resolved_routes(&graph),
+            vec![
+                (
+                    "POST".to_string(),
+                    "/v1/actions".to_string(),
+                    "actionsRoutes".to_string()
+                ),
+                (
+                    "POST".to_string(),
+                    "/v1/files".to_string(),
+                    "filesRoutes".to_string()
+                ),
+                (
+                    "POST".to_string(),
+                    "/v1/logs/entries".to_string(),
+                    "logsRoutes".to_string()
+                ),
+                (
+                    "POST".to_string(),
+                    "/v1/sessions".to_string(),
+                    "sessionsRoutes".to_string()
+                ),
+            ],
+            "each barrel-re-exported plugin must keep its own module's routes and prefix"
+        );
+    }
+
+    /// The same collision without a barrel: two modules, both `export default
+    /// routes`, imported directly and registered under different prefixes.
+    #[test]
+    fn test_build_mount_graph_resolves_direct_default_imports_to_their_own_module() {
+        let agent_service = AgentService::new();
+        let orchestrator = FileOrchestrator::new(agent_service);
+
+        let mut file_results = HashMap::new();
+        file_results.insert(
+            barrel_fixture("src/direct-plugin.ts"),
+            FileAnalysisResult {
+                mounts: vec![
+                    register_mount(
+                        8,
+                        "ordersRoutes",
+                        "/v1/orders",
+                        "./modules/orders/orders.routes.js",
+                    ),
+                    register_mount(
+                        9,
+                        "reportsRoutes",
+                        "/v1/reports",
+                        "./modules/reports/reports.routes.js",
+                    ),
+                ],
+                ..Default::default()
+            },
+        );
+        file_results.insert(
+            barrel_fixture("src/modules/orders/orders.routes.ts"),
+            FileAnalysisResult {
+                endpoints: vec![plugin_endpoint("GET", "/pending")],
+                ..Default::default()
+            },
+        );
+        file_results.insert(
+            barrel_fixture("src/modules/reports/reports.routes.ts"),
+            FileAnalysisResult {
+                endpoints: vec![plugin_endpoint("GET", "/daily")],
+                ..Default::default()
+            },
+        );
+
+        // As-scanned absolute keys, the shape `analyze_files` builds in.
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::default_permissive(),
+            &barrel_fixture_root(),
+            Path::new(""),
+        );
+
+        assert_eq!(
+            resolved_routes(&graph),
+            vec![
+                (
+                    "GET".to_string(),
+                    "/v1/orders/pending".to_string(),
+                    "ordersRoutes".to_string()
+                ),
+                (
+                    "GET".to_string(),
+                    "/v1/reports/daily".to_string(),
+                    "reportsRoutes".to_string()
+                ),
+            ],
+            "directly imported default exports must not collapse onto one module either"
+        );
     }
 
     #[test]
@@ -7948,6 +8343,7 @@ export { routes };
         let graph = orchestrator.build_mount_graph(
             &file_results,
             &UrlNormalizer::default_permissive(),
+            Path::new(""),
             Path::new(""),
         );
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1100,6 +1100,9 @@ async fn analyze_current_repo_incremental(
                 &merged_results,
                 &normalizer,
                 std::path::Path::new(""),
+                // Keys are repo-relative here, so the import/mount resolution
+                // needs the repo root to reach the modules on disk.
+                std::path::Path::new(repo_path),
             );
 
             // Deterministic protocol scans run BEFORE the graph is projected:

--- a/src/import_bindings.rs
+++ b/src/import_bindings.rs
@@ -1,0 +1,501 @@
+//! Resolve an imported binding to the module that actually defines it.
+//!
+//! A mount site names its child by whatever local binding the importing file
+//! happens to use (`fastify.register(sessionsRoutes)`, `app.use(userRouter)`).
+//! Attributing the mounted routes to that binding needs the module the binding
+//! came FROM, and a barrel breaks the naive answer:
+//!
+//! ```text
+//! routes.ts:   export { default as sessionsRoutes } from "./modules/sessions/sessions.routes.js";
+//!              export { default as logsRoutes }     from "./modules/logs/logs.routes.js";
+//! plugin.ts:   import { sessionsRoutes, logsRoutes } from "./routes.js";
+//! ```
+//!
+//! Every one of those bindings has the SAME import specifier, and each module
+//! usually names its own plugin identically (`const routes = ...; export
+//! default routes`). Anything that keys on the specifier, on the local symbol
+//! name, or on a substring of the file path collapses all of them onto one
+//! module — last write wins.
+//!
+//! This module resolves the pair that is actually unique: **(file, exported
+//! name)**. It reads each module's export table with SWC and follows
+//! re-export hops — `export { default as X } from`, `export { a as b } from`,
+//! and `export * from` — until it reaches the module that declares the
+//! binding. Purely structural: no framework knowledge, no naming heuristics.
+//! Non-relative specifiers (packages, tsconfig path aliases) are out of scope
+//! and resolve to `None`, because reaching them needs the sidecar's tsconfig
+//! knowledge; the caller falls back to its previous behaviour there.
+
+use crate::agents::file_orchestrator::FileOrchestrator;
+use crate::parser::parse_file;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use swc_common::{
+    SourceMap,
+    errors::{ColorConfig, Handler},
+    sync::Lrc,
+};
+use swc_ecma_ast::{
+    Decl, DefaultDecl, ExportSpecifier, Expr, ModuleDecl, ModuleExportName, ModuleItem, Pat,
+};
+
+/// The export name a default export is published under. Not a valid
+/// identifier, so it can never collide with a named export in the same table.
+const DEFAULT_EXPORT: &str = "default";
+
+/// How many re-export hops a single binding may be followed through. A barrel
+/// in front of a barrel is two; a deeper chain is indistinguishable from a
+/// mis-resolution and each hop costs a file parse.
+const MAX_HOPS: usize = 8;
+
+/// Hard cap on modules parsed while resolving one binding, so a wide
+/// `export *` fan-out cannot turn one import into an unbounded parse storm.
+const MAX_VISITS: usize = 64;
+
+/// Where an imported binding is defined.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedBinding {
+    /// Canonical path of the module that declares the binding.
+    pub file: PathBuf,
+    /// The local symbol the module declares it as (`export default routes` →
+    /// `routes`). `None` when the export has no nameable local binding —
+    /// `export default async (server) => {}` — which is common enough that
+    /// callers must treat identity as file-level and use this only to break
+    /// ties between two bindings resolved to the same file.
+    pub local_name: Option<String>,
+}
+
+/// One module's export table, as written in its source.
+#[derive(Debug, Default, Clone)]
+struct ModuleExports {
+    /// Exported name → the local binding it names in THIS module.
+    local: HashMap<String, Option<String>>,
+    /// Exported name → (module specifier, name inside that module).
+    forwarded: HashMap<String, (String, String)>,
+    /// `export * from "./x"` specifiers, in source order.
+    stars: Vec<String>,
+}
+
+/// Resolver with a per-file export-table cache. Parsing is the expensive part
+/// and barrels are re-read by every importer, so one resolver should be built
+/// per pass and reused across every binding it resolves.
+pub struct BindingResolver {
+    source_map: Lrc<SourceMap>,
+    handler: Handler,
+    exports: HashMap<PathBuf, ModuleExports>,
+}
+
+impl Default for BindingResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BindingResolver {
+    pub fn new() -> Self {
+        let source_map: Lrc<SourceMap> = Default::default();
+        // Quiet, non-colour diagnostics: a barrel that fails to parse is a
+        // resolution miss, not something to shout about mid-scan.
+        let handler =
+            Handler::with_tty_emitter(ColorConfig::Never, false, false, Some(source_map.clone()));
+        Self {
+            source_map,
+            handler,
+            exports: HashMap::new(),
+        }
+    }
+
+    /// Resolve the binding `local_binding` that `importer` imports from
+    /// `specifier` to the module that declares it.
+    ///
+    /// `local_binding` is the name the IMPORTING file uses. Two export names
+    /// are tried against the target module, in order: the binding name itself
+    /// (`import { sessionsRoutes } from "./routes.js"` — the usual named
+    /// import, where local and exported names agree) and then `default`
+    /// (`import sessionsRoutes from "./sessions.routes.js"`). A renaming
+    /// import (`import { a as b }`) is not recoverable from a mount site
+    /// alone and resolves to `None` rather than to a guess.
+    pub fn resolve(
+        &mut self,
+        importer: &Path,
+        specifier: &str,
+        local_binding: &str,
+    ) -> Option<ResolvedBinding> {
+        let target = FileOrchestrator::resolve_relative_import(importer, specifier)?;
+        if local_binding != DEFAULT_EXPORT
+            && let Some(found) = self.follow(&target, local_binding)
+        {
+            return Some(found);
+        }
+        self.follow(&target, DEFAULT_EXPORT)
+    }
+
+    /// Follow `export_name` out of `file` through re-export hops to the
+    /// module that declares it.
+    fn follow(&mut self, file: &Path, export_name: &str) -> Option<ResolvedBinding> {
+        let mut visited: HashSet<PathBuf> = HashSet::new();
+        visited.insert(file.to_path_buf());
+        self.follow_inner(file.to_path_buf(), export_name.to_string(), 0, &mut visited)
+    }
+
+    fn follow_inner(
+        &mut self,
+        file: PathBuf,
+        export_name: String,
+        hops: usize,
+        visited: &mut HashSet<PathBuf>,
+    ) -> Option<ResolvedBinding> {
+        if hops > MAX_HOPS || visited.len() > MAX_VISITS {
+            return None;
+        }
+
+        let exports = self.exports_of(&file)?;
+
+        // `export { x as y } from "./m"` — the binding lives one hop away.
+        if let Some((specifier, upstream_name)) = exports.forwarded.get(&export_name).cloned() {
+            let next = FileOrchestrator::resolve_relative_import(&file, &specifier)?;
+            if !visited.insert(next.clone()) {
+                return None; // circular re-export
+            }
+            return self.follow_inner(next, upstream_name, hops + 1, visited);
+        }
+
+        // Declared here.
+        if let Some(local_name) = exports.local.get(&export_name).cloned() {
+            return Some(ResolvedBinding { file, local_name });
+        }
+
+        // `export * from "./m"` re-publishes every NAMED export of the target
+        // but never its default, so a default lookup stops here.
+        if export_name != DEFAULT_EXPORT {
+            for specifier in exports.stars.clone() {
+                let Some(next) = FileOrchestrator::resolve_relative_import(&file, &specifier)
+                else {
+                    continue;
+                };
+                if !visited.insert(next.clone()) {
+                    continue;
+                }
+                if let Some(found) = self.follow_inner(next, export_name.clone(), hops + 1, visited)
+                {
+                    return Some(found);
+                }
+            }
+        }
+
+        None
+    }
+
+    fn exports_of(&mut self, file: &Path) -> Option<&ModuleExports> {
+        if !self.exports.contains_key(file) {
+            let module = parse_file(file, &self.source_map, &self.handler)?;
+            self.exports
+                .insert(file.to_path_buf(), collect_exports(&module));
+        }
+        self.exports.get(file)
+    }
+}
+
+/// Read a module's export table from its AST.
+///
+/// Type-only exports are skipped throughout: they bind nothing at runtime, so
+/// they can never be the plugin or router a mount site registers.
+fn collect_exports(module: &swc_ecma_ast::Module) -> ModuleExports {
+    let mut exports = ModuleExports::default();
+
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(decl) = item else {
+            continue;
+        };
+        match decl {
+            // `export const routes = ...`, `export function f() {}`, `export class C {}`
+            ModuleDecl::ExportDecl(export) => match &export.decl {
+                Decl::Fn(f) => {
+                    let name = f.ident.sym.to_string();
+                    exports.local.insert(name.clone(), Some(name));
+                }
+                Decl::Class(c) => {
+                    let name = c.ident.sym.to_string();
+                    exports.local.insert(name.clone(), Some(name));
+                }
+                Decl::Var(var) => {
+                    for declarator in &var.decls {
+                        if let Pat::Ident(ident) = &declarator.name {
+                            let name = ident.id.sym.to_string();
+                            exports.local.insert(name.clone(), Some(name));
+                        }
+                    }
+                }
+                _ => {}
+            },
+            // `export default function routes() {}`, `export default class C {}`
+            ModuleDecl::ExportDefaultDecl(export) => match &export.decl {
+                DefaultDecl::Fn(f) => {
+                    exports.local.insert(
+                        DEFAULT_EXPORT.to_string(),
+                        f.ident.as_ref().map(|i| i.sym.to_string()),
+                    );
+                }
+                DefaultDecl::Class(c) => {
+                    exports.local.insert(
+                        DEFAULT_EXPORT.to_string(),
+                        c.ident.as_ref().map(|i| i.sym.to_string()),
+                    );
+                }
+                DefaultDecl::TsInterfaceDecl(_) => {}
+            },
+            // `export default routes;`, `export default async (s) => {};`
+            ModuleDecl::ExportDefaultExpr(export) => {
+                let local = match &*export.expr {
+                    Expr::Ident(ident) => Some(ident.sym.to_string()),
+                    _ => None,
+                };
+                exports.local.insert(DEFAULT_EXPORT.to_string(), local);
+            }
+            ModuleDecl::ExportNamed(named) => {
+                if named.type_only {
+                    continue;
+                }
+                match &named.src {
+                    // `export { a as b } from "./m"`, `export { default as X } from "./m"`
+                    Some(src) => {
+                        let specifier = src.value.to_string();
+                        for spec in &named.specifiers {
+                            match spec {
+                                ExportSpecifier::Named(spec) if !spec.is_type_only => {
+                                    let upstream = export_name_string(&spec.orig);
+                                    let exported = spec
+                                        .exported
+                                        .as_ref()
+                                        .map(export_name_string)
+                                        .unwrap_or_else(|| upstream.clone());
+                                    exports
+                                        .forwarded
+                                        .insert(exported, (specifier.clone(), upstream));
+                                }
+                                // `export v from "./m"` — the default under a new name.
+                                ExportSpecifier::Default(spec) => {
+                                    exports.forwarded.insert(
+                                        spec.exported.sym.to_string(),
+                                        (specifier.clone(), DEFAULT_EXPORT.to_string()),
+                                    );
+                                }
+                                // `export * as ns from "./m"` binds a namespace
+                                // OBJECT, not a mountable value; nothing to follow.
+                                _ => {}
+                            }
+                        }
+                    }
+                    // `export { routes as default }`, `export { router }` — local.
+                    None => {
+                        for spec in &named.specifiers {
+                            if let ExportSpecifier::Named(spec) = spec
+                                && !spec.is_type_only
+                            {
+                                let local = export_name_string(&spec.orig);
+                                let exported = spec
+                                    .exported
+                                    .as_ref()
+                                    .map(export_name_string)
+                                    .unwrap_or_else(|| local.clone());
+                                exports.local.insert(exported, Some(local));
+                            }
+                        }
+                    }
+                }
+            }
+            ModuleDecl::ExportAll(export) if !export.type_only => {
+                exports.stars.push(export.src.value.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    exports
+}
+
+fn export_name_string(name: &ModuleExportName) -> String {
+    match name {
+        ModuleExportName::Ident(ident) => ident.sym.to_string(),
+        ModuleExportName::Str(s) => s.value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Write a small module tree and return its canonicalized root.
+    fn workspace(files: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for (relative, content) in files {
+            let path = dir.path().join(relative);
+            fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+            fs::write(&path, content).expect("write");
+        }
+        let root = dir.path().canonicalize().expect("canonicalize root");
+        (dir, root)
+    }
+
+    #[test]
+    fn resolves_default_reexport_through_a_barrel_to_its_own_module() {
+        let (_dir, root) = workspace(&[
+            (
+                "src/routes.ts",
+                r#"
+export { default as sessionsRoutes } from "./modules/sessions/sessions.routes.js";
+export { default as logsRoutes } from "./modules/logs/logs.routes.js";
+"#,
+            ),
+            (
+                "src/modules/sessions/sessions.routes.ts",
+                "const routes = async (server) => {};\nexport default routes;\n",
+            ),
+            (
+                "src/modules/logs/logs.routes.ts",
+                "const logsRoutes = async (server) => {};\nexport default logsRoutes;\n",
+            ),
+            (
+                "src/plugin.ts",
+                "import { sessionsRoutes } from './routes.js';\n",
+            ),
+        ]);
+
+        let mut resolver = BindingResolver::new();
+        let importer = root.join("src/plugin.ts");
+
+        let sessions = resolver
+            .resolve(&importer, "./routes.js", "sessionsRoutes")
+            .expect("sessionsRoutes resolves");
+        assert_eq!(
+            sessions.file,
+            root.join("src/modules/sessions/sessions.routes.ts")
+        );
+        assert_eq!(sessions.local_name.as_deref(), Some("routes"));
+
+        let logs = resolver
+            .resolve(&importer, "./routes.js", "logsRoutes")
+            .expect("logsRoutes resolves");
+        assert_eq!(logs.file, root.join("src/modules/logs/logs.routes.ts"));
+        assert_eq!(logs.local_name.as_deref(), Some("logsRoutes"));
+    }
+
+    #[test]
+    fn resolves_renaming_reexport_and_star_barrel() {
+        let (_dir, root) = workspace(&[
+            (
+                "src/index.ts",
+                r#"
+export { router as userRouter } from "./users.js";
+export * from "./health.js";
+"#,
+            ),
+            ("src/users.ts", "export const router = 1;\n"),
+            ("src/health.ts", "export const healthRouter = 1;\n"),
+            ("src/app.ts", "import { userRouter } from './index.js';\n"),
+        ]);
+
+        let mut resolver = BindingResolver::new();
+        let importer = root.join("src/app.ts");
+
+        let user = resolver
+            .resolve(&importer, "./index.js", "userRouter")
+            .expect("renamed re-export resolves");
+        assert_eq!(user.file, root.join("src/users.ts"));
+        assert_eq!(user.local_name.as_deref(), Some("router"));
+
+        let health = resolver
+            .resolve(&importer, "./index.js", "healthRouter")
+            .expect("star re-export resolves");
+        assert_eq!(health.file, root.join("src/health.ts"));
+        assert_eq!(health.local_name.as_deref(), Some("healthRouter"));
+    }
+
+    #[test]
+    fn resolves_direct_default_import_without_a_barrel() {
+        let (_dir, root) = workspace(&[
+            (
+                "src/modules/a.routes.ts",
+                "const routes = async (server) => {};\nexport default routes;\n",
+            ),
+            (
+                "src/plugin.ts",
+                "import aRoutes from './modules/a.routes.js';\n",
+            ),
+        ]);
+
+        let mut resolver = BindingResolver::new();
+        let binding = resolver
+            .resolve(
+                &root.join("src/plugin.ts"),
+                "./modules/a.routes.js",
+                "aRoutes",
+            )
+            .expect("default import resolves");
+        assert_eq!(binding.file, root.join("src/modules/a.routes.ts"));
+        assert_eq!(binding.local_name.as_deref(), Some("routes"));
+    }
+
+    #[test]
+    fn anonymous_default_export_resolves_to_the_file_with_no_local_name() {
+        let (_dir, root) = workspace(&[
+            ("src/a.routes.ts", "export default async (server) => {};\n"),
+            ("src/plugin.ts", "import aRoutes from './a.routes.js';\n"),
+        ]);
+
+        let mut resolver = BindingResolver::new();
+        let binding = resolver
+            .resolve(&root.join("src/plugin.ts"), "./a.routes.js", "aRoutes")
+            .expect("anonymous default resolves to its file");
+        assert_eq!(binding.file, root.join("src/a.routes.ts"));
+        assert_eq!(binding.local_name, None);
+    }
+
+    #[test]
+    fn star_reexport_does_not_carry_default_and_cycles_terminate() {
+        let (_dir, root) = workspace(&[
+            ("src/a.ts", "export * from \"./b.js\";\n"),
+            (
+                "src/b.ts",
+                "export * from \"./a.js\";\nconst r = 1;\nexport default r;\n",
+            ),
+            ("src/app.ts", "import x from './a.js';\n"),
+        ]);
+
+        let mut resolver = BindingResolver::new();
+        assert_eq!(
+            resolver.resolve(&root.join("src/app.ts"), "./a.js", "x"),
+            None,
+            "`export *` must not republish a default, and the cycle must terminate"
+        );
+    }
+
+    #[test]
+    fn non_relative_specifier_is_out_of_scope() {
+        let (_dir, root) = workspace(&[("src/app.ts", "import x from '@acme/routes';\n")]);
+        let mut resolver = BindingResolver::new();
+        assert_eq!(
+            resolver.resolve(&root.join("src/app.ts"), "@acme/routes", "x"),
+            None
+        );
+    }
+
+    #[test]
+    fn type_only_reexport_binds_nothing() {
+        let (_dir, root) = workspace(&[
+            (
+                "src/index.ts",
+                "export type { Routes } from \"./types.js\";\n",
+            ),
+            ("src/types.ts", "export type Routes = string;\n"),
+            ("src/app.ts", "import { Routes } from './index.js';\n"),
+        ]);
+
+        let mut resolver = BindingResolver::new();
+        assert_eq!(
+            resolver.resolve(&root.join("src/app.ts"), "./index.js", "Routes"),
+            None
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod findings;
 pub mod formatter;
 pub mod framework_detector;
 pub mod graphql;
+pub mod import_bindings;
 pub mod intent_generator;
 pub mod logging;
 pub mod mount_graph;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod findings;
 mod formatter;
 mod framework_detector;
 mod graphql;
+mod import_bindings;
 mod intent_generator;
 mod logging;
 mod mount_graph;

--- a/tests/fixtures/barrel-reexport-mounts/package.json
+++ b/tests/fixtures/barrel-reexport-mounts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "barrel-reexport-mounts",
+  "version": "1.0.0",
+  "description": "Plugins registered through a barrel that re-exports each module's default export",
+  "main": "src/plugin.ts",
+  "dependencies": {
+    "fastify": "^5.0.0"
+  }
+}

--- a/tests/fixtures/barrel-reexport-mounts/src/direct-plugin.ts
+++ b/tests/fixtures/barrel-reexport-mounts/src/direct-plugin.ts
@@ -1,0 +1,10 @@
+import { FastifyInstance } from "fastify";
+// No barrel: both modules are imported directly, and both export a default
+// named `routes`.
+import ordersRoutes from "./modules/orders/orders.routes.js";
+import reportsRoutes from "./modules/reports/reports.routes.js";
+
+export async function registerDirectRoutes(fastify: FastifyInstance) {
+  await fastify.register(ordersRoutes, { prefix: "/v1/orders" });
+  await fastify.register(reportsRoutes, { prefix: "/v1/reports" });
+}

--- a/tests/fixtures/barrel-reexport-mounts/src/modules/actions/actions.routes.ts
+++ b/tests/fixtures/barrel-reexport-mounts/src/modules/actions/actions.routes.ts
@@ -1,0 +1,9 @@
+import { FastifyPluginAsync } from "fastify";
+
+const routes: FastifyPluginAsync = async (server) => {
+  server.post("/actions", async (request, reply) => {
+    return { ok: true };
+  });
+};
+
+export default routes;

--- a/tests/fixtures/barrel-reexport-mounts/src/modules/files/files.routes.ts
+++ b/tests/fixtures/barrel-reexport-mounts/src/modules/files/files.routes.ts
@@ -1,0 +1,9 @@
+import { FastifyPluginAsync } from "fastify";
+
+const routes: FastifyPluginAsync = async (server) => {
+  server.post("/files", async (request, reply) => {
+    return { ok: true };
+  });
+};
+
+export default routes;

--- a/tests/fixtures/barrel-reexport-mounts/src/modules/logs/logs.routes.ts
+++ b/tests/fixtures/barrel-reexport-mounts/src/modules/logs/logs.routes.ts
@@ -1,0 +1,11 @@
+import { FastifyPluginAsync } from "fastify";
+
+// Named differently from its siblings on purpose: the local symbol name must
+// not be what decides which module a route belongs to.
+const logsRoutes: FastifyPluginAsync = async (server) => {
+  server.post("/entries", async (request, reply) => {
+    return { ok: true };
+  });
+};
+
+export default logsRoutes;

--- a/tests/fixtures/barrel-reexport-mounts/src/modules/orders/orders.routes.ts
+++ b/tests/fixtures/barrel-reexport-mounts/src/modules/orders/orders.routes.ts
@@ -1,0 +1,9 @@
+import { FastifyPluginAsync } from "fastify";
+
+const routes: FastifyPluginAsync = async (server) => {
+  server.get("/pending", async (request, reply) => {
+    return [];
+  });
+};
+
+export default routes;

--- a/tests/fixtures/barrel-reexport-mounts/src/modules/reports/reports.routes.ts
+++ b/tests/fixtures/barrel-reexport-mounts/src/modules/reports/reports.routes.ts
@@ -1,0 +1,9 @@
+import { FastifyPluginAsync } from "fastify";
+
+const routes: FastifyPluginAsync = async (server) => {
+  server.get("/daily", async (request, reply) => {
+    return [];
+  });
+};
+
+export default routes;

--- a/tests/fixtures/barrel-reexport-mounts/src/modules/sessions/sessions.routes.ts
+++ b/tests/fixtures/barrel-reexport-mounts/src/modules/sessions/sessions.routes.ts
@@ -1,0 +1,9 @@
+import { FastifyPluginAsync } from "fastify";
+
+const routes: FastifyPluginAsync = async (server) => {
+  server.post("/sessions", async (request, reply) => {
+    return { ok: true };
+  });
+};
+
+export default routes;

--- a/tests/fixtures/barrel-reexport-mounts/src/plugin.ts
+++ b/tests/fixtures/barrel-reexport-mounts/src/plugin.ts
@@ -1,0 +1,14 @@
+import { FastifyInstance } from "fastify";
+import {
+  actionsRoutes,
+  sessionsRoutes,
+  filesRoutes,
+  logsRoutes,
+} from "./routes.js";
+
+export async function registerRoutes(fastify: FastifyInstance) {
+  await fastify.register(actionsRoutes, { prefix: "/v1" });
+  await fastify.register(sessionsRoutes, { prefix: "/v1" });
+  await fastify.register(filesRoutes, { prefix: "/v1" });
+  await fastify.register(logsRoutes, { prefix: "/v1/logs" });
+}

--- a/tests/fixtures/barrel-reexport-mounts/src/routes.ts
+++ b/tests/fixtures/barrel-reexport-mounts/src/routes.ts
@@ -1,0 +1,8 @@
+// Barrel: every module's default export, re-exported under a distinct name.
+// The import specifier is identical for all four, and each module names its
+// own plugin `routes`, so nothing but the module a binding came FROM tells
+// them apart.
+export { default as actionsRoutes } from "./modules/actions/actions.routes.js";
+export { default as sessionsRoutes } from "./modules/sessions/sessions.routes.js";
+export { default as filesRoutes } from "./modules/files/files.routes.js";
+export { default as logsRoutes } from "./modules/logs/logs.routes.js";


### PR DESCRIPTION
## What

Endpoint ownership in the mount graph keyed on the import specifier's bare stem with last-write-wins. Through a barrel (`export { default as sessionsRoutes } from "./modules/sessions/sessions.routes.js"`) every mount shares the specifier `./routes.js`, every module names its plugin `routes`, and every module path contains "routes", so all of a repo's endpoints landed on the last-registered plugin and inherited its prefix. Observed on a real Fastify 5 codebase today: `server.post("/sessions")` in `sessions.routes.ts` indexed as `POST /v1/logs/sessions`, owner `logsRoutes`.

Root cause: `src/agents/file_orchestrator.rs` `resolve_endpoint_owner` (pre-change :4432-4453), substring match against a bare-name map filled at :4138.

## Fix

- New `src/import_bindings.rs`: `BindingResolver` reads module export tables with SWC and resolves an imported binding to (file, exported symbol) through `export { default as X } from`, `export { a as b } from`, `export * from`, cycle-guarded, per-file parse cache. Non-relative specifiers return `None` (aliases are out of scope here, as before).
- `build_mount_graph` now attributes endpoints by the file they were extracted from, via the binding that resolves to that file. The local symbol only breaks ties when one file defines several mounted routers; ambiguity is refused rather than guessed. Dedup by `child_node` keeps the multi-prefix alias fan-out (#373).
- `build_mount_graph` takes a `file_root` so the engine's repo-relative rebuild resolves on disk; the old name map stays as fallback only (aliases, workspace packages) and now keeps every child per specifier and refuses barrels.

No framework special-casing; Express routers go through the same path.

## Tests

- `test_build_mount_graph_resolves_barrel_reexported_plugins_to_their_own_module` (fails without the fix and if the `file_root` plumbing is reverted)
- `test_build_mount_graph_resolves_direct_default_imports_to_their_own_module`
- 7 resolver unit tests in `import_bindings.rs`
- Fixture uses `owner_node: "server"` in every module so the test cannot pass on owner-name luck. Cassette gate output byte-identical.

## Follow-ups (not in this PR)

Other bare-name identity lookups found while fixing this, same bug class, latent: `analyzer/mod.rs:1452` and `:1393` (global `function_definitions` by handler name, import source discarded), `file_orchestrator.rs:4117` (node key check vs bare insert), `mount_graph.rs:169`, `visitor.rs:716` (no re-export edges in the symbol table). `__import_map__::` nodes are now written but read by nothing in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)