### PR TITLE
fix(scanner): bound intent-generation concurrency and jitter the retry backoff

### DIFF
--- a/docs/evals.md
+++ b/docs/evals.md
@@ -111,6 +111,7 @@ Label conventions the scorer normalizes for you:
 | `CARRICK_EVAL_CAPTURE=1` | Tier-A: dump raw file-analyzer input/output per run |
 | `CARRICK_EVAL_DUMP_DIR=<dir>` | Persist raw analyzer I/O for prompt diagnosis |
 | `CARRICK_SKIP_INTENTS=1` | Skip intent generation (dominant cost term; no eval dimension consumes intents) |
+| `CARRICK_INTENT_CONCURRENCY=N` | Concurrent `/generate-intent` calls per dependency level (default 8, capped by `CARRICK_CONCURRENCY_LIMIT`) |
 | `CARRICK_XREPO_CORPUS=<path>` | Offline harness corpus override |
 | `CARRICK_MOCK_ALL=1` | Fully offline scanner run (mocked LLM responses) |
 | `CARRICK_LOCAL_STORAGE_DIR` | Local upload cache dir — eval runs never write the real cloud index |

--- a/src/agent_service.rs
+++ b/src/agent_service.rs
@@ -48,14 +48,137 @@ fn is_quota_error(err: &AgentError) -> bool {
     err.code == "rate_limited"
 }
 
+/// Pseudo-code for the call-level failure raised once the quota breaker is
+/// open. Not a cloud code: the cloud never sends it, the scanner synthesises it
+/// so callers can tell "the backend is out of quota, everything downstream is
+/// doomed" apart from a genuine per-call failure.
+pub const QUOTA_ABORT_CODE: &str = "quota_exhausted";
+
 /// The error returned for an individual call once the breaker is open. Scoped
 /// to what's true at the call level (this call fails fast); the engine turns a
 /// tripped breaker into a fatal, no-upload abort via [`rate_limit_tripped`].
-fn rate_limit_abort_error() -> Box<dyn std::error::Error> {
-    "Carrick Cloud LLM quota exhausted; failing fast. This is a rate/quota \
-     limit on the analysis backend, not a problem with the scanned code. The \
-     scan will stop before uploading; re-run after the quota resets."
-        .into()
+fn rate_limit_abort_error() -> AgentCallError {
+    AgentCallError {
+        code: QUOTA_ABORT_CODE.to_string(),
+        message: "Carrick Cloud LLM quota exhausted; failing fast. This is a rate/quota \
+                  limit on the analysis backend, not a problem with the scanned code. The \
+                  scan will stop before uploading; re-run after the quota resets."
+            .to_string(),
+        retriable: false,
+    }
+}
+
+/// A failed lambda call, carrying the cloud's own transient/permanent verdict
+/// so callers can classify a failure without pattern-matching on message text.
+///
+/// `retriable` is the envelope's `error.retriable` verbatim when the call
+/// reached the lambda (the 429-wrapped 503 `model_error` the backend raises
+/// under Vertex pressure is `retriable: true`); for failures that never
+/// produced an envelope — bare network errors, unparseable gateway bodies —
+/// the scanner fills in the equivalent verdict. An `Err` with `retriable: true`
+/// therefore means "transient, and the backoff chain was already spent on it",
+/// which is what lets a caller report failed-after-retry honestly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentCallError {
+    /// Cloud error code (`model_error`, `rate_limited`, `internal_error`), or a
+    /// scanner-side pseudo-code for a failure that never reached the envelope.
+    pub code: String,
+    pub message: String,
+    /// Whether the failure class is transient. See the type doc.
+    pub retriable: bool,
+}
+
+impl AgentCallError {
+    /// A permanent, non-retriable failure (server-side bug, malformed response).
+    fn permanent(code: &str, message: String) -> Self {
+        Self {
+            code: code.to_string(),
+            message,
+            retriable: false,
+        }
+    }
+
+    /// A transient failure whose backoff chain has been spent.
+    fn transient(code: &str, message: String) -> Self {
+        Self {
+            code: code.to_string(),
+            message,
+            retriable: true,
+        }
+    }
+
+    /// Whether this call failed because the process-global quota breaker is
+    /// open rather than on its own merits. Such a call was never attempted, so
+    /// counting it as a retry failure overstates the loss.
+    pub fn is_quota_abort(&self) -> bool {
+        self.code == QUOTA_ABORT_CODE
+    }
+}
+
+impl std::fmt::Display for AgentCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Agent error '{}' (retriable={}): {}",
+            self.code, self.retriable, self.message
+        )
+    }
+}
+
+impl std::error::Error for AgentCallError {}
+
+/// Attempts per call: the initial try plus six backed-off retries.
+const MAX_RETRIES: u32 = 7;
+/// First backoff sleep; doubles each attempt.
+const RETRY_BASE_DELAY: Duration = Duration::from_secs(2);
+/// Ceiling on a single backoff sleep (reached at attempt 6: 2→4→8→16→32→64s).
+const RETRY_MAX_DELAY: Duration = Duration::from_secs(64);
+
+/// Whether a failed call should consume a backoff attempt.
+///
+/// The cloud's `retriable` flag is the single source of truth for the
+/// transient class — the scanner does not re-derive it from status codes or
+/// message text. A quota abort is excluded even though quota errors are
+/// nominally transient: quota does not clear inside one scan, and the breaker
+/// has already decided that every remaining call fails fast.
+fn should_retry(err: &AgentCallError, attempt: u32, max_retries: u32) -> bool {
+    err.retriable && !err.is_quota_abort() && attempt < max_retries
+}
+
+/// Equal-jitter exponential backoff: half the exponential delay, plus a random
+/// share of the other half.
+///
+/// Jitter is not cosmetic here. Up to `CARRICK_CONCURRENCY_LIMIT` workers hit
+/// the same overloaded backend within milliseconds of each other, and an
+/// unjittered `2^attempt` sleep makes them all wake in lockstep and re-fire as
+/// one burst — the exact pattern that keeps a rate-limited backend rate
+/// limited. Spreading each waker across half a window decorrelates them.
+///
+/// This is the standard equal-jitter formulation, so the previous unjittered
+/// schedule (2, 4, 8, 16, 32, 64s) is now the *ceiling* of each window rather
+/// than its midpoint: the worst-case chain is unchanged at ~126s, the mean
+/// sleep is three quarters of what it was. Decorrelating the wakers is worth
+/// more than the quarter-window of extra patience.
+///
+/// Pure so it can be tested: `jitter` is any value in `0..=u32::MAX`, supplied
+/// by [`jitter_seed`] at the call site.
+fn backoff_delay(attempt: u32, jitter: u32) -> Duration {
+    let exponential = RETRY_BASE_DELAY
+        .saturating_mul(2u32.saturating_pow(attempt.saturating_sub(1)))
+        .min(RETRY_MAX_DELAY);
+    let half = exponential / 2;
+    let spread = half.mul_f64(f64::from(jitter) / f64::from(u32::MAX));
+    half + spread
+}
+
+/// Jitter source: the sub-second component of the wall clock. Enough entropy
+/// to decorrelate wakers that are milliseconds apart, and avoids taking a
+/// direct dependency on `rand` for a sleep length.
+fn jitter_seed() -> u32 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0)
 }
 
 /// Reusable service for making Agent API calls
@@ -97,7 +220,7 @@ impl AgentService {
         task_path: &str,
         user_message: &str,
         response_schema: Option<serde_json::Value>,
-    ) -> Result<String, Box<dyn std::error::Error>> {
+    ) -> Result<String, AgentCallError> {
         let request = LambdaRequest {
             user_message: user_message.to_string(),
             response_schema,
@@ -113,12 +236,13 @@ impl AgentService {
         task_path: &str,
         body: &B,
         mock_seed: &str,
-    ) -> Result<String, Box<dyn std::error::Error>> {
-        let _permit = self
-            .semaphore
-            .acquire()
-            .await
-            .map_err(|e| format!("Failed to acquire semaphore permit: {}", e))?;
+    ) -> Result<String, AgentCallError> {
+        let _permit = self.semaphore.acquire().await.map_err(|e| {
+            AgentCallError::permanent(
+                "semaphore_closed",
+                format!("Failed to acquire semaphore permit: {}", e),
+            )
+        })?;
 
         if env::var("CARRICK_MOCK_ALL").is_ok() {
             return Ok(generate_mock_for_task(task_path, body, mock_seed));
@@ -131,11 +255,7 @@ impl AgentService {
     /// the version header, parses the structured error envelope, and
     /// only consumes a backoff attempt when the error is marked
     /// retriable=true (or on bare network failures).
-    async fn post_with_retry<B>(
-        &self,
-        path: &str,
-        body: &B,
-    ) -> Result<String, Box<dyn std::error::Error>>
+    async fn post_with_retry<B>(&self, path: &str, body: &B) -> Result<String, AgentCallError>
     where
         B: Serialize + ?Sized,
     {
@@ -145,18 +265,23 @@ impl AgentService {
         // Mint the OIDC token once up front; the cloud derives identity from
         // its signed claims. Tokens are short-lived, so on a 401 we re-mint
         // once mid-loop (long scans can outlive a token).
-        let provider = OidcProvider::global()?;
-        let mut token = provider.token().await?;
+        let provider = OidcProvider::global()
+            .map_err(|e| AgentCallError::permanent("oidc_unavailable", e.to_string()))?;
+        let mut token = provider
+            .token()
+            .await
+            .map_err(|e| AgentCallError::permanent("oidc_unavailable", e.to_string()))?;
         let mut reminted = false;
 
-        // Retry logic for transient failures with exponential backoff.
-        // 7 attempts: 2s, 4s, 8s, 16s, 32s, 64s. The lambda's structured
-        // error envelope (`error.retriable`) is the source of truth for
+        // Retry logic for transient failures with jittered exponential
+        // backoff. 7 attempts, sleeps halving-jittered around 2s, 4s, 8s, 16s,
+        // 32s, 64s (see `backoff_delay`). The lambda's structured error
+        // envelope (`error.retriable`) is the source of truth for
         // application-level errors. We additionally retry on transient
         // *gateway* errors (429/502/503/504) where the body may not
         // even be a parseable JSON envelope (API Gateway timeouts return
         // non-envelope responses).
-        let max_retries = 7;
+        let max_retries = MAX_RETRIES;
         for attempt in 1..=max_retries {
             // A sibling call (any phase, any `AgentService`) may have already
             // hit the backend quota wall. Re-checked each attempt so a worker
@@ -184,7 +309,9 @@ impl AgentService {
                     // consuming a backoff sleep.
                     if status.as_u16() == 401 && !reminted {
                         warn!("Agent proxy returned 401; re-minting OIDC token and retrying once");
-                        token = provider.remint().await?;
+                        token = provider.remint().await.map_err(|e| {
+                            AgentCallError::permanent("oidc_unavailable", e.to_string())
+                        })?;
                         reminted = true;
                         continue;
                     }
@@ -199,7 +326,7 @@ impl AgentService {
                             // is a known transient gateway code, retry —
                             // otherwise fail fast (server-side bug).
                             if is_transient_gateway_status && attempt < max_retries {
-                                let wait_time = Duration::from_secs(2u64.pow(attempt as u32));
+                                let wait_time = backoff_delay(attempt, jitter_seed());
                                 warn!(
                                     "Gateway status {} with non-envelope body: {}. Retrying in {:?} (attempt {}/{})",
                                     status, e, wait_time, attempt, max_retries
@@ -207,11 +334,15 @@ impl AgentService {
                                 sleep(wait_time).await;
                                 continue;
                             }
-                            return Err(format!(
+                            let message = format!(
                                 "Agent proxy returned status {} with unparseable body: {}",
                                 status, e
-                            )
-                            .into());
+                            );
+                            return Err(if is_transient_gateway_status {
+                                AgentCallError::transient("gateway_error", message)
+                            } else {
+                                AgentCallError::permanent("bad_response", message)
+                            });
                         }
                     };
 
@@ -222,11 +353,13 @@ impl AgentService {
                     let err = match body.error {
                         Some(err) => err,
                         None => {
-                            return Err(format!(
-                                "Agent proxy status {} success={} but no error envelope",
-                                status, body.success
-                            )
-                            .into());
+                            return Err(AgentCallError::permanent(
+                                "bad_response",
+                                format!(
+                                    "Agent proxy status {} success={} but no error envelope",
+                                    status, body.success
+                                ),
+                            ));
                         }
                     };
 
@@ -244,26 +377,28 @@ impl AgentService {
                         return Err(rate_limit_abort_error());
                     }
 
-                    if err.retriable && attempt < max_retries {
-                        let wait_time = Duration::from_secs(2u64.pow(attempt as u32));
+                    let call_err = AgentCallError {
+                        code: err.code,
+                        message: err.message,
+                        retriable: err.retriable,
+                    };
+
+                    if should_retry(&call_err, attempt, max_retries) {
+                        let wait_time = backoff_delay(attempt, jitter_seed());
                         warn!(
                             "Agent error '{}' is retriable, retrying in {:?} (attempt {}/{}): {}",
-                            err.code, wait_time, attempt, max_retries, err.message
+                            call_err.code, wait_time, attempt, max_retries, call_err.message
                         );
                         sleep(wait_time).await;
                         continue;
                     }
 
-                    return Err(format!(
-                        "Agent error '{}' (retriable={}): {}",
-                        err.code, err.retriable, err.message
-                    )
-                    .into());
+                    return Err(call_err);
                 }
                 Err(e) => {
                     // Bare network failure (no response received) — retriable by definition.
                     if attempt < max_retries {
-                        let wait_time = Duration::from_secs(2u64.pow(attempt as u32));
+                        let wait_time = backoff_delay(attempt, jitter_seed());
                         warn!(
                             "Agent proxy network error: {}, retrying in {:?} (attempt {}/{})",
                             e, wait_time, attempt, max_retries
@@ -272,12 +407,18 @@ impl AgentService {
                         continue;
                     }
 
-                    return Err(format!("Agent proxy call failed: {}", e).into());
+                    return Err(AgentCallError::transient(
+                        "network_error",
+                        format!("Agent proxy call failed: {}", e),
+                    ));
                 }
             }
         }
 
-        Err("Maximum retry attempts exceeded".into())
+        Err(AgentCallError::transient(
+            "retries_exhausted",
+            "Maximum retry attempts exceeded".to_string(),
+        ))
     }
 }
 
@@ -1475,5 +1616,55 @@ mod tests {
         // The message must read as a backend capacity limit, not a code fault.
         let msg = rate_limit_abort_error().to_string().to_lowercase();
         assert!(msg.contains("quota"));
+    }
+
+    #[test]
+    fn transient_errors_retry_and_permanent_ones_do_not() {
+        // The cloud's own `retriable` flag decides — the scanner never
+        // re-derives the class from message text. The 429-wrapped 503 the
+        // backend raises under Vertex pressure (#460) arrives as
+        // `model_error, retriable: true` and must consume a backoff attempt.
+        let transient = AgentCallError::transient("model_error", "Gemini overloaded".to_string());
+        assert!(should_retry(&transient, 1, MAX_RETRIES));
+        assert!(should_retry(&transient, MAX_RETRIES - 1, MAX_RETRIES));
+        // ...but only while attempts remain.
+        assert!(!should_retry(&transient, MAX_RETRIES, MAX_RETRIES));
+
+        // A permanent failure is never retried, at any attempt.
+        let permanent = AgentCallError::permanent("internal_error", "boom".to_string());
+        assert!(!should_retry(&permanent, 1, MAX_RETRIES));
+
+        // A quota abort is not a per-call failure: the breaker is open, so
+        // retrying only burns more of an exhausted budget.
+        assert!(rate_limit_abort_error().is_quota_abort());
+        assert!(!should_retry(&rate_limit_abort_error(), 1, MAX_RETRIES));
+        assert!(!transient.is_quota_abort());
+    }
+
+    #[test]
+    fn backoff_is_jittered_exponential_under_a_cap() {
+        // Zero jitter is the floor (half the exponential), max jitter the
+        // ceiling (the full exponential) — so every waker lands somewhere in
+        // the back half of its window instead of all on the same instant.
+        for attempt in 1..=MAX_RETRIES {
+            let low = backoff_delay(attempt, 0);
+            let high = backoff_delay(attempt, u32::MAX);
+            assert!(low <= high, "attempt {attempt}: jitter inverted the range");
+            assert!(
+                high <= RETRY_MAX_DELAY,
+                "attempt {attempt}: {high:?} exceeded the {RETRY_MAX_DELAY:?} cap"
+            );
+            assert!(low >= RETRY_BASE_DELAY / 2);
+        }
+
+        // Unjittered schedule: 2, 4, 8, 16, 32, 64 seconds, then held at the cap.
+        assert_eq!(backoff_delay(1, u32::MAX), Duration::from_secs(2));
+        assert_eq!(backoff_delay(2, u32::MAX), Duration::from_secs(4));
+        assert_eq!(backoff_delay(6, u32::MAX), RETRY_MAX_DELAY);
+        assert_eq!(backoff_delay(7, u32::MAX), RETRY_MAX_DELAY);
+        // Doubling is real, not an artefact of the cap.
+        assert!(backoff_delay(3, 0) > backoff_delay(2, 0));
+        // A large attempt number cannot overflow into a tiny (or huge) sleep.
+        assert_eq!(backoff_delay(64, u32::MAX), RETRY_MAX_DELAY);
     }
 }

--- a/src/intent_generator.rs
+++ b/src/intent_generator.rs
@@ -10,8 +10,9 @@
 //! definitions so that source code is not uploaded to AWS. The intent
 //! serves as the index; GitHub is the source of truth for code.
 
-use crate::agent_service::AgentService;
+use crate::agent_service::{AgentCallError, AgentService, rate_limit_tripped};
 use crate::visitor::{FunctionCallRef, FunctionDefinition, ImportedSymbol};
+use futures::StreamExt;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use tracing::{debug, warn};
@@ -142,6 +143,76 @@ fn is_local_callee(caller_key: &str, body: &str, candidate_key: &str) -> bool {
         }
 }
 
+/// A cache-miss function awaiting its `/generate-intent` call: everything the
+/// payload needs, plus the content hash to persist if the call succeeds.
+struct Pending {
+    name: String,
+    body: String,
+    called_intents: Vec<String>,
+    hash: String,
+}
+
+/// Concurrent `/generate-intent` calls in flight per dependency level when
+/// `CARRICK_INTENT_CONCURRENCY` is unset.
+///
+/// Deliberately below the shared `CARRICK_CONCURRENCY_LIMIT` (20) that file
+/// analysis runs at. Intent calls outnumber file-analysis calls by an order of
+/// magnitude on a function-dense repo — roughly one per function rather than
+/// one per file — so the same in-flight count is a far higher sustained
+/// request rate against the same backend quota, which is what produced the
+/// 429-wrapped 503s in #460.
+const DEFAULT_INTENT_CONCURRENCY: usize = 8;
+
+/// In-flight `/generate-intent` calls allowed per level.
+///
+/// `CARRICK_INTENT_CONCURRENCY` overrides the default. Raising it above
+/// `CARRICK_CONCURRENCY_LIMIT` has no effect: `AgentService` holds a semaphore
+/// at that count, so it is the hard ceiling for every lambda call.
+fn intent_concurrency() -> usize {
+    std::env::var("CARRICK_INTENT_CONCURRENCY")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_INTENT_CONCURRENCY)
+        .max(1)
+}
+
+/// Dispatch one dependency level's calls at most `concurrency` at a time,
+/// returning each `Pending` paired with its own result **in input order**.
+///
+/// Completion order under `buffer_unordered` is arbitrary — a slow call
+/// finishes after ones queued behind it. Results are therefore carried
+/// alongside the `Pending` that produced them and re-sorted by input position,
+/// so neither the fold nor any future caller can associate an intent with the
+/// wrong function, and a re-run over the same level produces the same sequence
+/// regardless of backend timing.
+async fn generate_level<F, Fut>(
+    pending: Vec<Pending>,
+    concurrency: usize,
+    call: F,
+) -> Vec<(Pending, Result<String, AgentCallError>)>
+where
+    F: Fn(Pending) -> Fut,
+    Fut: std::future::Future<Output = (Pending, Result<String, AgentCallError>)>,
+{
+    let mut results: Vec<(usize, Pending, Result<String, AgentCallError>)> =
+        futures::stream::iter(pending.into_iter().enumerate().map(|(idx, item)| {
+            let fut = call(item);
+            async move {
+                let (item, result) = fut.await;
+                (idx, item, result)
+            }
+        }))
+        .buffer_unordered(concurrency)
+        .collect()
+        .await;
+
+    results.sort_by_key(|(idx, _, _)| *idx);
+    results
+        .into_iter()
+        .map(|(_, item, result)| (item, result))
+        .collect()
+}
+
 /// Generate intents for every function with a non-trivial body source,
 /// regardless of export status. The only exclusion is a trivial body
 /// (single line, at most [`TRIVIAL_BODY_MAX_CHARS`] chars), which keeps
@@ -269,15 +340,9 @@ pub async fn generate_function_intents(
     let mut reused = 0usize;
     let mut generated = 0usize;
 
-    for level in &levels {
+    for (level_idx, level) in levels.iter().enumerate() {
         // Compute each function's called_intents context and content hash, then
         // split into cache hits (reuse) and misses (call the lambda).
-        struct Pending {
-            name: String,
-            body: String,
-            called_intents: Vec<String>,
-            hash: String,
-        }
         let mut to_generate: Vec<Pending> = Vec::new();
 
         for name in level {
@@ -319,25 +384,36 @@ pub async fn generate_function_intents(
             }
         }
 
-        // Run all cache-miss lambda calls for this level in parallel.
-        let futures: Vec<_> = to_generate
-            .iter()
-            .map(|pending| async move {
-                let payload = serde_json::json!({
-                    "name": pending.name,
-                    "body": pending.body,
-                    "called_intents": pending.called_intents,
-                });
-                let result = agent_service
-                    .post_to_lambda("/generate-intent", &payload, &pending.name)
-                    .await;
-                (pending.name.clone(), pending.hash.clone(), result)
-            })
-            .collect();
+        if to_generate.is_empty() {
+            continue;
+        }
 
-        let results = futures::future::join_all(futures).await;
+        // Run this level's cache-miss lambda calls with bounded concurrency
+        // (#460). Every call in a level is independent, so the old unbounded
+        // `join_all` queued the whole level at once; on a function-dense repo
+        // that is thousands of simultaneous requests, and the backend answers
+        // the overflow with a 429-wrapped 503 that costs those functions their
+        // intents.
+        let attempted = to_generate.len();
+        let outcomes = generate_level(to_generate, intent_concurrency(), |pending| async move {
+            let payload = serde_json::json!({
+                "name": pending.name,
+                "body": pending.body,
+                "called_intents": pending.called_intents,
+            });
+            let result = agent_service
+                .post_to_lambda("/generate-intent", &payload, &pending.name)
+                .await;
+            (pending, result)
+        })
+        .await;
 
-        for (name, hash, result) in results {
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+        let mut aborted = 0usize;
+
+        for (pending, result) in outcomes {
+            let Pending { name, hash, .. } = pending;
             match result {
                 Ok(intent) => {
                     let intent = intent.trim().to_string();
@@ -345,6 +421,7 @@ pub async fn generate_function_intents(
                         hashes.insert(name.clone(), hash);
                         intents.insert(name, intent);
                         generated += 1;
+                        succeeded += 1;
                     } else {
                         // Empty or over-long response: drop it. The function
                         // keeps `intent = None`, so it (and its callers) retry
@@ -355,12 +432,56 @@ pub async fn generate_function_intents(
                             name,
                             intent.len()
                         );
+                        failed += 1;
                     }
                 }
                 Err(e) => {
-                    warn!("Failed to generate intent for {}: {}", name, e);
+                    // Degrade gracefully: no intent and no content hash is
+                    // written, so the next scan retries exactly this function
+                    // and replays the rest from cache.
+                    if e.is_quota_abort() {
+                        aborted += 1;
+                    } else {
+                        warn!("Failed to generate intent for {}: {}", name, e);
+                        failed += 1;
+                    }
                 }
             }
+        }
+
+        // One line per level that actually called out, so a degraded scan is
+        // visible as a number rather than as N scattered warnings.
+        // Aborts are named only when they happened, but they must be named:
+        // without them `attempted` would not equal succeeded + failed and the
+        // line would read as unexplained loss.
+        let summary = format!(
+            "Intent level {}/{}: attempted {}, succeeded {}, failed after retry {}{}",
+            level_idx + 1,
+            levels.len(),
+            attempted,
+            succeeded,
+            failed,
+            if aborted > 0 {
+                format!(", aborted on backend quota {}", aborted)
+            } else {
+                String::new()
+            }
+        );
+        if failed > 0 || aborted > 0 {
+            warn!("{}", summary);
+        } else {
+            debug!("{}", summary);
+        }
+
+        // The quota breaker is process-global and does not clear inside a
+        // scan: every remaining call would fail instantly without reaching the
+        // model, so stop here rather than logging a level's worth of aborts.
+        if rate_limit_tripped() {
+            warn!(
+                "Backend LLM quota exhausted; stopping intent generation ({} call(s) in this level aborted unattempted)",
+                aborted
+            );
+            break;
         }
     }
 
@@ -972,5 +1093,158 @@ mod tests {
         assert!(!is_local_callee("helper", "return helper();", "helper"));
         // A method body referencing a module-level function links normally.
         assert!(is_local_callee("Svc.run", "return helper();", "helper"));
+    }
+
+    fn pending(name: &str) -> Pending {
+        Pending {
+            name: name.to_string(),
+            body: format!("return {}();", name),
+            called_intents: vec![],
+            hash: format!("hash-of-{}", name),
+        }
+    }
+
+    #[tokio::test]
+    async fn level_results_stay_associated_when_calls_finish_out_of_order() {
+        // Under `buffer_unordered` completion order is arbitrary. Force the
+        // worst case: the first call finishes last, the last finishes first.
+        let names = ["alpha", "beta", "gamma", "delta"];
+        let level: Vec<Pending> = names.iter().map(|n| pending(n)).collect();
+        let total = level.len() as u64;
+        let completion_order = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let observed = completion_order.clone();
+        let outcomes = generate_level(level, 4, move |p| {
+            let observed = observed.clone();
+            async move {
+                let position = names.iter().position(|n| *n == p.name).unwrap() as u64;
+                tokio::time::sleep(std::time::Duration::from_millis((total - position) * 20)).await;
+                observed.lock().unwrap().push(p.name.clone());
+                let intent = format!("intent for {}", p.name);
+                (p, Ok(intent))
+            }
+        })
+        .await;
+
+        // The hazard is real: they did NOT complete in input order.
+        assert_eq!(
+            *completion_order.lock().unwrap(),
+            vec!["delta", "gamma", "beta", "alpha"],
+            "test did not actually exercise out-of-order completion"
+        );
+
+        // Output order is input order regardless, and every result is paired
+        // with the function that produced it.
+        let returned: Vec<&str> = outcomes.iter().map(|(p, _)| p.name.as_str()).collect();
+        assert_eq!(returned, names);
+        for (p, result) in &outcomes {
+            assert_eq!(
+                result.as_ref().unwrap(),
+                &format!("intent for {}", p.name),
+                "result was paired with the wrong function"
+            );
+            assert_eq!(p.hash, format!("hash-of-{}", p.name));
+        }
+    }
+
+    #[tokio::test]
+    async fn level_failures_are_isolated_to_their_own_function() {
+        // One failing call must not cost its siblings their intents, and the
+        // failure must arrive attached to the function that failed — that is
+        // what leaves exactly that function with `intent = None` and no
+        // content hash, so a rescan retries it alone.
+        let level = vec![pending("ok_one"), pending("boom"), pending("ok_two")];
+
+        let outcomes = generate_level(level, 2, |p| async move {
+            if p.name == "boom" {
+                let err = AgentCallError {
+                    code: "model_error".to_string(),
+                    message: "Gemini overloaded; retries exhausted".to_string(),
+                    retriable: true,
+                };
+                return (p, Err(err));
+            }
+            let intent = format!("intent for {}", p.name);
+            (p, Ok(intent))
+        })
+        .await;
+
+        assert_eq!(outcomes.len(), 3);
+        assert!(outcomes[0].1.is_ok());
+        assert_eq!(outcomes[1].0.name, "boom");
+        let err = outcomes[1].1.as_ref().unwrap_err();
+        // Transient class, so the summary counts it as failed-after-retry
+        // rather than as a doomed-from-the-start quota abort.
+        assert!(err.retriable);
+        assert!(!err.is_quota_abort());
+        assert!(outcomes[2].1.is_ok());
+    }
+
+    #[tokio::test]
+    async fn intent_concurrency_knob_overrides_the_default() {
+        let _env = ENV_LOCK.lock().await;
+        let prev = std::env::var("CARRICK_INTENT_CONCURRENCY").ok();
+
+        // SAFETY: env vars are process-global; ENV_LOCK serializes this
+        // module's env-touching tests, and the var is restored before the
+        // guard drops.
+        unsafe {
+            std::env::remove_var("CARRICK_INTENT_CONCURRENCY");
+        }
+        assert_eq!(intent_concurrency(), DEFAULT_INTENT_CONCURRENCY);
+
+        unsafe {
+            std::env::set_var("CARRICK_INTENT_CONCURRENCY", "3");
+        }
+        assert_eq!(intent_concurrency(), 3);
+
+        // Zero would stall `buffer_unordered` forever; garbage falls back to
+        // the default rather than failing the scan.
+        unsafe {
+            std::env::set_var("CARRICK_INTENT_CONCURRENCY", "0");
+        }
+        assert_eq!(intent_concurrency(), 1);
+        unsafe {
+            std::env::set_var("CARRICK_INTENT_CONCURRENCY", "lots");
+        }
+        assert_eq!(intent_concurrency(), DEFAULT_INTENT_CONCURRENCY);
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("CARRICK_INTENT_CONCURRENCY", v),
+                None => std::env::remove_var("CARRICK_INTENT_CONCURRENCY"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn bounded_concurrency_caps_calls_in_flight() {
+        // The point of the fix: a level of 12 must never put more than the
+        // configured number of requests on the backend at once.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let level: Vec<Pending> = (0..12).map(|i| pending(&format!("fn{}", i))).collect();
+        let in_flight = std::sync::Arc::new(AtomicUsize::new(0));
+        let peak = std::sync::Arc::new(AtomicUsize::new(0));
+
+        let (in_flight_c, peak_c) = (in_flight.clone(), peak.clone());
+        let outcomes = generate_level(level, 3, move |p| {
+            let (in_flight, peak) = (in_flight_c.clone(), peak_c.clone());
+            async move {
+                let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(now, Ordering::SeqCst);
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+                (p, Ok("intent".to_string()))
+            }
+        })
+        .await;
+
+        assert_eq!(outcomes.len(), 12);
+        assert!(
+            peak.load(Ordering::SeqCst) <= 3,
+            "peak in-flight was {}, expected at most 3",
+            peak.load(Ordering::SeqCst)
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,10 @@ ENVIRONMENT VARIABLES:
     ACTIONS_ID_TOKEN_REQUEST_TOKEN  Bearer token for the OIDC endpoint (auto-set)
     CARRICK_MOCK_ALL                Use mock storage instead of Carrick Cloud
     CARRICK_API_ENDPOINT            API endpoint for the carrick service (build-time)
+    CARRICK_INTENT_CONCURRENCY      Concurrent function-intent requests (default 8).
+                                    Lower it if a large repo loses intents to
+                                    backend overload; capped by
+                                    CARRICK_CONCURRENCY_LIMIT
 "#
         );
     }


### PR DESCRIPTION
Fixes #460.

## What

- Intent generation dispatched every cache-miss function of a dependency level through an unbounded `join_all`; at scale the cloud answered with the 429-wrapped 503 and those functions lost their intents (~18% measured on a function-dense repo). Replaced with bounded dispatch, knob `CARRICK_INTENT_CONCURRENCY` (default 8, clamped ≥1). `AgentService`'s semaphore (`CARRICK_CONCURRENCY_LIMIT`, 20) stays the hard ceiling, so the intent knob only ever lowers the rate; documented in `--help` and docs/evals.md.
- Retry already existed and was already typed on the cloud envelope's `retriable` flag (7 attempts), so no second loop was added. What was missing was jitter: up to 20 workers slept exactly `2^attempt` and woke as one burst. Backoff is now equal-jitter exponential (`half + rand(0..half)`, cap 64s); the old schedule is the ceiling of each window, worst-case chain unchanged.
- `AgentCallError { code, message, retriable }` is the public error type from `post_to_lambda`/`analyze_with_lambda`; call sites unchanged (they `?` into `Box<dyn Error>`). A tripped quota breaker now stops the level instead of grinding through doomed calls.
- Output order is input order regardless of completion order; one summary line per level (attempted / succeeded / failed after retry / aborted on quota). Degrade semantics unchanged: failure keeps `intent = None` and writes no hash, so a rescan retries exactly the missing functions.

## Tests

`level_results_stay_associated_when_calls_finish_out_of_order`, `level_failures_are_isolated_to_their_own_function`, `bounded_concurrency_caps_calls_in_flight`, `intent_concurrency_knob_overrides_the_default`, `transient_errors_retry_and_permanent_ones_do_not`, `backoff_is_jittered_exponential_under_a_cap`. fmt/clippy/test green; cassette gate byte-identical.

Not verified live: the default of 8 is a judgement from the issue's numbers, not a measured optimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)