### PR TITLE
feat(sdk-edges): carry the SDK->producer type verdict onto each edge

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -475,6 +475,14 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
     results.sdk_edges = sdk_join.edges().to_vec();
     results.sdk_unresolved = sdk_join.unresolved();
 
+    // An SDK-mediated break is a contract risk like any other, so it joins the
+    // findings rather than living only in its own section (#525). The PR result
+    // payload the cloud renders the comment from carries `findings` and not
+    // `sdk_edges`, so this is what turns the consumer's PR red.
+    results
+        .findings
+        .extend(crate::sdk_edges::type_mismatch_findings(&results.sdk_edges));
+
     // Eval harness output mode: emit a machine-readable projection of the
     // results and skip the human Markdown report + PR-comment relay. Consumed
     // by the offline scorer (Slice 1 of the evals plan). Deliberately terminal —

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -480,14 +480,14 @@ fn format_sdk_section(
             let verdict = match edge.type_compatible {
                 Some(true) => "compatible".to_string(),
                 Some(false) => format!(
-                    "incompatible: {}",
+                    "**INCOMPATIBLE**: {}",
                     code_span(
                         edge.mismatch_reason
                             .as_deref()
                             .unwrap_or("no reason recorded")
                     )
                 ),
-                None => "not compared".to_string(),
+                None => "unverified".to_string(),
             };
             output.push_str(&format!(
                 "| `{}` | `{}` | `{}` → `{}` | {} (`{}`) | {} |\n",
@@ -501,6 +501,35 @@ fn format_sdk_section(
             ));
         }
         output.push('\n');
+
+        // "unverified" is a statement about where the verdict would have come
+        // from, not about the types (#525). The verdict for an SDK hop is the
+        // one the SDK repo's own scan stored for its call to the producer, so
+        // an edge without one says the SDK repo has not stored a verdict for
+        // that pair — silence would read as "compared and fine".
+        let unverified = edges
+            .iter()
+            .filter(|edge| edge.type_compatible.is_none())
+            .count();
+        if unverified > 0 {
+            let sdk_repos: BTreeSet<&str> = edges
+                .iter()
+                .filter(|edge| edge.type_compatible.is_none())
+                .map(|edge| edge.sdk_repo.as_str())
+                .collect();
+            output.push_str(&format!(
+                "{} edge{} unverified: no type verdict is stored in {}'s own scan for that call. \
+                 Re-scan it to produce one.\n\n",
+                unverified,
+                plural(unverified),
+                join_human(
+                    &sdk_repos
+                        .into_iter()
+                        .map(|name| format!("`{}`", code_span(name)))
+                        .collect::<Vec<_>>()
+                )
+            ));
+        }
     }
 
     if !unresolved.is_empty() {
@@ -1187,9 +1216,10 @@ mod tests {
         assert!(output.contains("| `checkout` | `src/checkout.ts:42` | `ledger.payments.create` \u{2192} `@fixture/ledger-sdk` | `POST /v1/payments` (`payments-api`) | compatible |"));
     }
 
-    /// A pair the compiler never compared must not read as compatible.
+    /// A pair with no stored verdict must not read as compatible, and the
+    /// section says where the missing verdict would have come from (#525).
     #[test]
-    fn sdk_section_reports_an_unevaluated_pair_as_not_compared() {
+    fn sdk_section_reports_an_unevaluated_pair_as_unverified() {
         let mut edge = sdk_edge("http|POST|/v1/payments");
         edge.type_compatible = None;
         let output = format_analysis_results(
@@ -1197,8 +1227,51 @@ mod tests {
             &topology_baseline(),
             None,
         );
-        assert!(output.contains("| not compared |"));
+        assert!(output.contains("| unverified |"));
         assert!(!output.contains("| compatible |"));
+        assert!(output.contains(
+            "1 edge unverified: no type verdict is stored in `ledger-sdk`'s own scan for that \
+             call. Re-scan it to produce one."
+        ));
+    }
+
+    /// An incompatible edge names the break in its row.
+    #[test]
+    fn sdk_section_reports_an_incompatible_pair_with_its_reason() {
+        let mut edge = sdk_edge("http|POST|/v1/payments");
+        edge.type_compatible = Some(false);
+        edge.mismatch_reason = Some("Property 'amountCents' is missing".to_string());
+        let output = format_analysis_results(
+            result_with_sdk(vec![edge], vec![]),
+            &topology_baseline(),
+            None,
+        );
+        assert!(output.contains("| **INCOMPATIBLE**: Property 'amountCents' is missing |"));
+        // Every edge carries a verdict, so the unverified footnote stays away.
+        assert!(!output.contains("unverified"));
+    }
+
+    /// The point of #525: an SDK-mediated break weighs the same as a direct
+    /// one. The finding the join emits is a contract risk, so it counts in the
+    /// headline and turns the callout red.
+    #[test]
+    fn an_incompatible_sdk_edge_counts_toward_the_pr_verdict() {
+        let mut edge = sdk_edge("http|POST|/v1/payments");
+        edge.type_compatible = Some(false);
+        edge.mismatch_reason = Some("Property 'amountCents' is missing".to_string());
+
+        let mut result = result_with_sdk(vec![edge.clone()], vec![]);
+        // The engine appends exactly this before rendering.
+        result.findings = crate::sdk_edges::type_mismatch_findings(&[edge]);
+
+        let output = format_analysis_results(result, &topology_baseline(), None);
+
+        assert!(output.contains("<!-- CARRICK_ISSUE_COUNT:1 -->"));
+        assert!(output.contains("[!CAUTION]"));
+        assert!(output.contains("**1 contract risk**"));
+        // The risk row cites the consumer's own call site and the hop.
+        assert!(output.contains("<summary><strong>Contract risks (1)</strong></summary>"));
+        assert!(output.contains("reached through `@fixture/ledger-sdk`"));
     }
 
     /// "There are no such calls" and "this package is called and nothing is

--- a/src/sdk_edges.rs
+++ b/src/sdk_edges.rs
@@ -486,7 +486,7 @@ pub fn type_mismatch_findings(edges: &[SdkEdge]) -> Vec<Finding> {
                 edge.producer_repo.clone(),
                 format!("{} ({})", edge.package, edge.sdk_member),
                 &format!(
-                    "reached through `{}` — `{}` at {}:{} — {}",
+                    "reached through `{}` (`{}` at {}:{}): {}",
                     edge.package, edge.sdk_member, edge.sdk_repo, edge.sdk_location, reason
                 ),
             )

--- a/src/sdk_edges.rs
+++ b/src/sdk_edges.rs
@@ -460,6 +460,13 @@ fn pair_verdict(peer: &SdkPeer, producer: &CrossRepoMatch) -> (Option<bool>, Opt
 /// the SDK repo's scan persists a verdict and a diagnostic but no type names,
 /// so naming a symbol would mean inventing one. The hop the break travels
 /// through is spelled out in `detail`, ahead of the stored diagnostic.
+///
+/// Nothing is deduped against the direct findings, and in one shape that shows:
+/// a `carrick.json` whose `services` array holds BOTH the SDK service and a
+/// service that consumes it. The SDK's own pair is then checked this run and
+/// emits its own risk row, alongside this one. Two rows for one broken field,
+/// deliberately — they cite different call sites, and in that layout both are
+/// the reader's to fix.
 pub fn type_mismatch_findings(edges: &[SdkEdge]) -> Vec<Finding> {
     edges
         .iter()

--- a/src/sdk_edges.rs
+++ b/src/sdk_edges.rs
@@ -18,6 +18,34 @@
 //! like the current repo's are — and the result is a relationship of its own,
 //! never folded back into `endpoints`/`calls`.
 //!
+//! # The type verdict (#525)
+//!
+//! An edge's `type_compatible` is the verdict for the SDK→producer pair, not
+//! for a comparison this run performs. Cross-repo type checking only evaluates
+//! pairs where a CURRENT service is the consumer, and in the consumer's run the
+//! SDK repo is a peer — so the `CrossRepoMatch` its call formed carries no
+//! verdict. Two sources are read, in order:
+//!
+//! 1. the verdict overlaid on the match this run (present only when the SDK
+//!    repo is itself one of the current services);
+//! 2. the verdict the SDK repo's OWN scan persisted on its blob
+//!    ([`CompatVerdict`]), looked up by the four canonical fields of that same
+//!    match: `(producer_repo, producer_key, consumer_repo, consumer_key)`.
+//!
+//! `sdk_location` is what selects WHICH match — the member's span is what the
+//! SDK's own call site has to fall inside — but it is not part of the lookup
+//! key, because `attach_compat_verdicts` stores one verdict per canonical pair
+//! and no location. Two members whose calls collapse onto the same canonical
+//! producer/consumer pair therefore share one verdict (incompatible-wins, as
+//! stored).
+//!
+//! Neither source is a fresh comparison against the producer as it stands
+//! today: a stored verdict was computed when the SDK repo last scanned, and
+//! nothing in [`CompatVerdict`] records which producer revision it judged. A
+//! producer that changed since then is not re-judged here (#530).
+//! Absent both sources the edge stays `None` — "no verdict stored", never
+//! "compatible" (#324).
+//!
 //! # Where it stops
 //!
 //! Each dead end is recorded as an [`SdkUnresolved`] reason rather than
@@ -51,8 +79,9 @@
 //! finds no member.
 
 use crate::analyzer::CrossRepoMatch;
-use crate::cloud_storage::{CloudRepoData, SdkEdge, SdkUnresolved};
+use crate::cloud_storage::{CloudRepoData, CompatVerdict, SdkEdge, SdkUnresolved};
 use crate::external_call_candidates::{CallMechanism, ExternalCallCandidate};
+use crate::findings::Finding;
 use crate::sdk_surface::SdkMember;
 use crate::type_manifest::parse_file_location;
 use std::collections::BTreeMap;
@@ -86,6 +115,11 @@ struct SdkPeer {
     surface: Option<Vec<SdkMember>>,
     /// `(file, line)` of every outbound call the SDK repo makes.
     data_calls: Vec<(String, u32)>,
+    /// The verdicts the SDK repo's own scan persisted for the pairs where it
+    /// is the consumer. Empty when it stored none — which includes every blob
+    /// written before the field existed, and every scan whose type check did
+    /// not evaluate the pair. Absent is never read as compatible (#324).
+    compat_verdicts: Vec<CompatVerdict>,
 }
 
 /// A current service whose SDK calls are being resolved.
@@ -180,6 +214,7 @@ impl SdkJoinInput {
                             .collect()
                     })
                     .unwrap_or_default(),
+                compat_verdicts: repo.compat_verdicts.clone().unwrap_or_default(),
             })
             .collect();
         let consumers = consumers
@@ -320,6 +355,7 @@ pub fn join(input: &SdkJoinInput, matches: &[CrossRepoMatch]) -> SdkJoin {
                 for producer in producers {
                     matched = true;
                     let consumer_location = format!("{}:{}", candidate.file, candidate.line);
+                    let (type_compatible, mismatch_reason) = pair_verdict(peer, producer);
                     edges.insert(
                         (
                             consumer.service_id.clone(),
@@ -337,8 +373,8 @@ pub fn join(input: &SdkJoinInput, matches: &[CrossRepoMatch]) -> SdkJoin {
                             sdk_location: format!("{}:{}", member.file, member.line),
                             producer_repo: producer.producer_repo.clone(),
                             producer_key: producer.producer_key.clone(),
-                            type_compatible: producer.type_compatible,
-                            mismatch_reason: producer.mismatch_reason.clone(),
+                            type_compatible,
+                            mismatch_reason,
                             scanner_version: scanner_version.to_string(),
                         },
                     );
@@ -365,6 +401,102 @@ pub fn join(input: &SdkJoinInput, matches: &[CrossRepoMatch]) -> SdkJoin {
                 )
             })
             .collect(),
+    }
+}
+
+/// The type verdict for one SDK→producer pair (#525).
+///
+/// Prefers the verdict this run overlaid on the match — present only when the
+/// SDK repo is itself a current service, because compat is evaluated for
+/// current-service consumers only — and otherwise reads the verdict the SDK
+/// repo's own scan persisted for the same canonical pair. Returns
+/// `(None, None)` when neither source has one, which downstream reads as "no
+/// verdict stored", never as compatible (#324).
+///
+/// The lookup key is the match's four canonical fields. `CompatVerdict` stores
+/// no location, so this cannot key on the SDK call site; see the module docs.
+fn pair_verdict(peer: &SdkPeer, producer: &CrossRepoMatch) -> (Option<bool>, Option<String>) {
+    if producer.type_compatible.is_some() {
+        return (producer.type_compatible, producer.mismatch_reason.clone());
+    }
+    let stored = peer.compat_verdicts.iter().find(|verdict| {
+        verdict.producer_repo == producer.producer_repo
+            && verdict.producer_key == producer.producer_key
+            && verdict.consumer_repo == producer.consumer_repo
+            && verdict.consumer_key == producer.consumer_key
+    });
+    match stored {
+        Some(verdict) => (
+            Some(verdict.compatible),
+            if verdict.compatible {
+                None
+            } else {
+                verdict.mismatch_reason.clone()
+            },
+        ),
+        None => {
+            debug!(
+                "No type verdict for {} → {} ({}): neither this run nor '{}'s own scan stored one",
+                producer.consumer_key,
+                producer.producer_key,
+                producer.producer_repo,
+                peer.service_id
+            );
+            (None, None)
+        }
+    }
+}
+
+/// Project every INCOMPATIBLE SDK edge into a [`Finding::TypeMismatch`], so a
+/// contract break reached through a published client counts toward the PR
+/// verdict exactly like a direct incompatible pair (#525).
+///
+/// This is the only route to the verdict: the PR result payload the cloud
+/// renders the comment from carries `findings`, not `sdk_edges`, so an edge
+/// that stayed inside the SDK section would render a red row under a green
+/// headline.
+///
+/// `producer_type` / `consumer_type` are SIDE LABELS here, not type symbols:
+/// the SDK repo's scan persists a verdict and a diagnostic but no type names,
+/// so naming a symbol would mean inventing one. The hop the break travels
+/// through is spelled out in `detail`, ahead of the stored diagnostic.
+pub fn type_mismatch_findings(edges: &[SdkEdge]) -> Vec<Finding> {
+    edges
+        .iter()
+        .filter(|edge| edge.type_compatible == Some(false))
+        .map(|edge| {
+            let (method, path) = key_labels(&edge.producer_key);
+            let reason = edge
+                .mismatch_reason
+                .as_deref()
+                .filter(|reason| !reason.is_empty())
+                .unwrap_or("producer and consumer types are incompatible");
+            Finding::type_mismatch(
+                method,
+                path,
+                None,
+                vec![edge.consumer_location.clone()],
+                edge.producer_repo.clone(),
+                format!("{} ({})", edge.package, edge.sdk_member),
+                &format!(
+                    "reached through `{}` — `{}` at {}:{} — {}",
+                    edge.package, edge.sdk_member, edge.sdk_repo, edge.sdk_location, reason
+                ),
+            )
+        })
+        .collect()
+}
+
+/// Split an `OperationKey::canonical()` into the `(method, path)` display
+/// labels a finding carries. Three-segment keys (`http|POST|/v1/payments`,
+/// `graphql|query|orders`, `socket|emit|tick`) name both; the two-segment
+/// pub/sub key names only a topic, so the protocol stands in for the method.
+fn key_labels(producer_key: &str) -> (String, String) {
+    let parts: Vec<&str> = producer_key.splitn(3, '|').collect();
+    match parts.as_slice() {
+        [_protocol, method, path] => (method.to_string(), path.to_string()),
+        [protocol, topic] => (protocol.to_string(), topic.to_string()),
+        _ => (String::new(), producer_key.to_string()),
     }
 }
 
@@ -761,6 +893,253 @@ mod tests {
             &[sdk_to_producer_match()],
         );
         assert_eq!(joined.edges().len(), 1);
+    }
+
+    // ---- #525: the type verdict on an SDK edge ----
+
+    /// The same match, with compat NOT overlaid — what the CONSUMER's run
+    /// actually sees, because the check only evaluates pairs whose consumer is
+    /// a current service and the SDK repo is a peer there.
+    fn unjudged_match() -> CrossRepoMatch {
+        let mut edge = sdk_to_producer_match();
+        edge.type_compatible = None;
+        edge.mismatch_reason = None;
+        edge
+    }
+
+    /// A verdict as the SDK repo's own scan persisted it, keyed by the four
+    /// canonical fields `attach_compat_verdicts` writes.
+    fn stored_verdict(compatible: bool) -> CompatVerdict {
+        CompatVerdict {
+            producer_repo: "payments-api".to_string(),
+            producer_key: PRODUCER_KEY.to_string(),
+            consumer_repo: "ledger-sdk".to_string(),
+            consumer_key: "http|POST|/v1/payments".to_string(),
+            compatible,
+            mismatch_reason: (!compatible)
+                .then(|| "Property 'amountCents' is missing in type 'Payment'".to_string()),
+            scanner_version: "0.0.0-test".to_string(),
+        }
+    }
+
+    fn sdk_repo_storing(verdicts: Vec<CompatVerdict>) -> CloudRepoData {
+        let mut data = sdk_repo();
+        data.compat_verdicts = Some(verdicts);
+        data
+    }
+
+    #[test]
+    fn an_incompatible_stored_verdict_reaches_the_edge() {
+        let joined = run(
+            &[producer(), sdk_repo_storing(vec![stored_verdict(false)])],
+            &[consumer_with(candidate("ledger.payments.create"))],
+            &[unjudged_match()],
+        );
+
+        let edge = &joined.edges()[0];
+        assert_eq!(edge.type_compatible, Some(false));
+        assert_eq!(
+            edge.mismatch_reason.as_deref(),
+            Some("Property 'amountCents' is missing in type 'Payment'")
+        );
+    }
+
+    #[test]
+    fn a_compatible_stored_verdict_reaches_the_edge_without_a_reason() {
+        let joined = run(
+            &[producer(), sdk_repo_storing(vec![stored_verdict(true)])],
+            &[consumer_with(candidate("ledger.payments.create"))],
+            &[unjudged_match()],
+        );
+
+        let edge = &joined.edges()[0];
+        assert_eq!(edge.type_compatible, Some(true));
+        assert!(edge.mismatch_reason.is_none());
+    }
+
+    /// This run's own overlay is the fresher fact, so it wins over anything the
+    /// SDK repo stored on a previous scan.
+    #[test]
+    fn this_runs_verdict_wins_over_the_stored_one() {
+        let mut judged = sdk_to_producer_match();
+        judged.type_compatible = Some(false);
+        judged.mismatch_reason = Some("checked this run".to_string());
+
+        let joined = run(
+            &[producer(), sdk_repo_storing(vec![stored_verdict(true)])],
+            &[consumer_with(candidate("ledger.payments.create"))],
+            &[judged],
+        );
+
+        let edge = &joined.edges()[0];
+        assert_eq!(edge.type_compatible, Some(false));
+        assert_eq!(edge.mismatch_reason.as_deref(), Some("checked this run"));
+    }
+
+    /// The whole reason the lookup key is a four-tuple: a verdict stored for a
+    /// DIFFERENT pair must never be carried onto this edge. Fabricating a
+    /// `true` here is the #324 fail-open trap.
+    #[test]
+    fn a_verdict_for_another_pair_is_never_borrowed() {
+        let other_consumer_key = {
+            let mut verdict = stored_verdict(true);
+            verdict.consumer_key = "http|POST|/v1/refunds".to_string();
+            verdict
+        };
+        let other_producer_repo = {
+            let mut verdict = stored_verdict(true);
+            verdict.producer_repo = "ledger-api".to_string();
+            verdict
+        };
+        let other_producer_key = {
+            let mut verdict = stored_verdict(true);
+            verdict.producer_key = "http|POST|/v1/refunds".to_string();
+            verdict
+        };
+        let other_consumer_repo = {
+            let mut verdict = stored_verdict(true);
+            verdict.consumer_repo = "billing-sdk".to_string();
+            verdict
+        };
+
+        for verdict in [
+            other_consumer_key,
+            other_producer_repo,
+            other_producer_key,
+            other_consumer_repo,
+        ] {
+            let joined = run(
+                &[producer(), sdk_repo_storing(vec![verdict.clone()])],
+                &[consumer_with(candidate("ledger.payments.create"))],
+                &[unjudged_match()],
+            );
+            assert_eq!(
+                joined.edges()[0].type_compatible,
+                None,
+                "borrowed a verdict from {verdict:?}"
+            );
+        }
+    }
+
+    /// No verdict anywhere: the edge stays `None` — "no verdict stored", never
+    /// "compatible".
+    #[test]
+    fn no_verdict_anywhere_leaves_the_edge_unverified() {
+        let joined = run(
+            &[producer(), sdk_repo()],
+            &[consumer_with(candidate("ledger.payments.create"))],
+            &[unjudged_match()],
+        );
+
+        let edge = &joined.edges()[0];
+        assert_eq!(edge.type_compatible, None);
+        assert!(edge.mismatch_reason.is_none());
+    }
+
+    /// A shared-external-contract match is two call sites encoding the same
+    /// externally-served contract; compat is never overlaid on one and the
+    /// stored verdicts are keyed by producer identity, so no verdict is
+    /// fabricated from it.
+    #[test]
+    fn a_shared_external_contract_edge_carries_no_verdict() {
+        let mut shared = unjudged_match();
+        shared.relationship = carrick_match::MatchRelationship::SharedExternalContract;
+        let joined = run(
+            &[producer(), sdk_repo()],
+            &[consumer_with(candidate("ledger.payments.create"))],
+            &[shared],
+        );
+        assert_eq!(joined.edges()[0].type_compatible, None);
+    }
+
+    #[test]
+    fn only_incompatible_edges_become_findings() {
+        let edge = |compatible: Option<bool>| SdkEdge {
+            consumer_repo: "checkout".to_string(),
+            consumer_location: "src/checkout.ts:42".to_string(),
+            package: SDK_PACKAGE.to_string(),
+            import_symbol: Some("default".to_string()),
+            callee: "ledger.payments.create".to_string(),
+            sdk_repo: "ledger-sdk".to_string(),
+            sdk_member: "payments.create".to_string(),
+            sdk_location: "src/resources/payments.ts:28".to_string(),
+            producer_repo: "payments-api".to_string(),
+            producer_key: PRODUCER_KEY.to_string(),
+            type_compatible: compatible,
+            mismatch_reason: (compatible == Some(false))
+                .then(|| "Property 'amountCents' is missing".to_string()),
+            scanner_version: "0.0.0-test".to_string(),
+        };
+
+        let findings = type_mismatch_findings(&[edge(Some(true)), edge(None), edge(Some(false))]);
+        assert_eq!(findings.len(), 1);
+        match &findings[0] {
+            Finding::TypeMismatch {
+                method,
+                path,
+                call_sites,
+                producer_type,
+                consumer_type,
+                detail,
+                ..
+            } => {
+                assert_eq!(method, "POST");
+                assert_eq!(path, "/v1/payments");
+                // The consumer's own call site is the actionable location.
+                assert_eq!(call_sites, &["src/checkout.ts:42".to_string()]);
+                assert_eq!(producer_type, "payments-api");
+                assert_eq!(consumer_type, "@fixture/ledger-sdk (payments.create)");
+                assert!(detail.contains("reached through"));
+                assert!(detail.contains("src/resources/payments.ts:28"));
+                assert!(detail.contains("Property 'amountCents' is missing"));
+            }
+            other => panic!("expected a type mismatch, got {other:?}"),
+        }
+    }
+
+    /// A finding is a contract risk, and risks are what the headline counts —
+    /// so an incompatible SDK edge reaches the PR verdict by the same route a
+    /// direct incompatible pair does.
+    #[test]
+    fn an_sdk_finding_is_a_contract_risk() {
+        let edge = SdkEdge {
+            consumer_repo: "checkout".to_string(),
+            consumer_location: "src/checkout.ts:42".to_string(),
+            package: SDK_PACKAGE.to_string(),
+            import_symbol: Some("default".to_string()),
+            callee: "ledger.payments.create".to_string(),
+            sdk_repo: "ledger-sdk".to_string(),
+            sdk_member: "payments.create".to_string(),
+            sdk_location: "src/resources/payments.ts:28".to_string(),
+            producer_repo: "payments-api".to_string(),
+            producer_key: PRODUCER_KEY.to_string(),
+            type_compatible: Some(false),
+            mismatch_reason: None,
+            scanner_version: "0.0.0-test".to_string(),
+        };
+        let findings = type_mismatch_findings(&[edge]);
+        assert_eq!(
+            findings[0].severity(),
+            crate::findings::Severity::Risk,
+            "an SDK break must weigh the same as a direct one"
+        );
+    }
+
+    #[test]
+    fn key_labels_split_every_protocol_key() {
+        assert_eq!(
+            key_labels("http|POST|/v1/payments"),
+            ("POST".to_string(), "/v1/payments".to_string())
+        );
+        assert_eq!(
+            key_labels("graphql|query|orders"),
+            ("query".to_string(), "orders".to_string())
+        );
+        // Pub/sub identity is the topic alone, so the protocol stands in.
+        assert_eq!(
+            key_labels("pubsub|orders.created"),
+            ("pubsub".to_string(), "orders.created".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #525.

## The problem

Every SDK-mediated edge in the first live run of #524 rendered "not
compared". The consumer's scan forms the SDK repo's `CrossRepoMatch`
against the producer, but cross-repo type checking only evaluates pairs
whose consumer is a CURRENT service. In the consumer's run the SDK repo
is a peer, so the match its own call formed carries no verdict and the
edge had nothing to copy.

## Where the verdict comes from

Option (b) from the issue. Two sources, in order:

1. the verdict this run overlaid on that match, present only when the SDK
   repo is itself one of the current services;
2. the verdict the SDK repo's own scan persisted on its blob
   (`compat_verdicts`, written by `attach_compat_verdicts`), looked up by
   the four canonical fields of the same match:
   `(producer_repo, producer_key, consumer_repo, consumer_key)`.

Absent both, the edge stays `None`. "No verdict stored" is never read as
compatible (#324).

One precision note on the key. The issue asked for a lookup keyed by the
SDK call site (`sdk_location`), but `CompatVerdict` stores no location:
`attach_compat_verdicts` already collapses every call site onto one
canonical pair, incompatible-wins. So `sdk_location` selects WHICH match
is read (the SDK's own call has to fall inside the member's span, which
is how #524 already works) but it is not part of the lookup key. Two
members whose calls land on the same canonical pair share one verdict.
That is a small precision loss, not a wrong answer.

`SdkEdge`'s field names are unchanged, so carrick-cloud#372 keeps
reading `type_compatible` and `mismatch_reason` as-is.

## How it reaches the PR verdict

An edge with `type_compatible == Some(false)` now becomes a
`Finding::TypeMismatch`, which is a contract risk, so it counts in
`CARRICK_ISSUE_COUNT` and turns the verdict callout to CAUTION exactly
like a direct incompatible pair.

This is the only route: the PR result payload the cloud renders the
comment from carries `findings`, not `sdk_edges`. An edge that stayed
inside its own section would have rendered a red row under a green
headline, and `format_no_issues` hardcodes `CARRICK_ISSUE_COUNT:0`.

`producer_type` / `consumer_type` on that finding are side labels (the
producer service, and `package (member)`), not type symbols: the SDK
repo's scan persists a verdict and a diagnostic but no type names, so
naming a symbol would mean inventing one. The hop and the stored
diagnostic go in `detail`.

## CI comment

The "Consumers via SDK" table now reads `compatible`, `**INCOMPATIBLE**:
<reason>`, or `unverified`, and an unverified edge adds a line naming the
SDK repo whose scan stored no verdict for that call, rather than leaving
the gap silent.

## Known gap: staleness

A stored verdict was computed when the SDK repo last scanned, and
`CompatVerdict` records `scanner_version` and nothing about which
producer revision it judged. So a producer that renames a field after the
SDK repo's last scan leaves a stored `compatible: true` that this change
faithfully carries onto the consumer's edge. That is fail-open, and it is
inherent to option (b). Filed as #530, with option (a) (re-derive the
pair in the consumer's run) as the real fix.

## Tests

`cargo test` green (864 + 879 unit, all integration suites). New unit
tests, neutral fixture names only:

- stored verdict reaches the edge, compatible and incompatible;
- this run's overlay wins over a stored verdict;
- a verdict stored for a different pair is never borrowed (each of the
  four key fields varied independently);
- no verdict anywhere leaves the edge unverified;
- a shared-external-contract match fabricates no verdict;
- only incompatible edges become findings, and the finding is a Risk;
- `key_labels` splits http / graphql / pubsub canonical keys;
- formatter: unverified row plus its footnote, INCOMPATIBLE row with its
  reason, and an incompatible edge counting into
  `CARRICK_ISSUE_COUNT:1` + CAUTION + the contract-risks section.

## Checked, not just assumed

- **An `any`-typed producer cannot fabricate a green edge.** #528 has every
  sbx-bench producer type resolving to `any`, which would be the obvious way
  for this change to turn twenty honest "unverified" rows into twenty
  meaningless "compatible" ones. It cannot: an alias that bakes to `any`
  fires the sidecar's IsAny probe gate, classifies as
  `gate_caught_baked_any`, and lands in `VerdictBucket::Unverifiable`, so
  `type_compatible` is `None` and `attach_compat_verdicts` persists nothing.
  Until #528 lands the sbx-bench table stays unverified, which is the honest
  answer.
- **The upload size guard cannot strip the verdicts.**
  `enforce_payload_size_limit` drops `file_results`, `cached_detection` and
  `cached_guidance` only, so a large SDK blob never uploads with
  `compat_verdicts` silently missing.
- **The eval projection does not read `findings`,** so the new risk rows
  cannot move corpus scores.
- **One monorepo shape yields two risk rows for one broken field:** a
  `carrick.json` `services` array holding both the SDK service and a service
  that consumes it. The SDK's own pair is checked that run and emits its own
  row alongside the via_sdk one. Left in deliberately (the rows cite
  different call sites, and in that layout both are the reader's to fix) and
  noted in the code.

## Not in scope

`SdkJoinInput::collect` still builds edges only where a CURRENT service
is the consumer, so a PR on the PRODUCER still does not name its
SDK-mediated consumers. This change turns the CONSUMER's PR red, which is
what #525 asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
