### PR TITLE
fix(sidecar): resolve route contracts declared in handler params and route schemas

### DIFF
--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -28,6 +28,7 @@ import {
   type FunctionExpression,
   type MethodDeclaration,
   type CallExpression,
+  type ObjectLiteralExpression,
   type ParameterDeclaration,
   type PropertyAssignment,
   type Type,
@@ -591,14 +592,21 @@ export class TypeInferrer {
       // away from the registration line. Follow the handler at that line before
       // the generic function-return fallback, which can't reach a handler more
       // than a couple of lines from the registration.
-      const lineHandler = this.handlerAtLine(sourceFile, request.line_number);
-      if (lineHandler) {
+      const atLine = this.registrationAtLine(sourceFile, request.line_number);
+      if (atLine) {
+        const declared = this.declaredResponseInferredType(
+          request,
+          atLine.registration
+        );
+        if (declared) {
+          return declared;
+        }
         this.log(
           `Line ${request.line_number} is a route registration; following handler return`
         );
         return this.buildFunctionReturnInferredType(
           request,
-          lineHandler,
+          atLine.handler,
           extractionConfig,
           true
         );
@@ -619,6 +627,10 @@ export class TypeInferrer {
     if (!Node.isCallExpression(node)) {
       const registryHandler = this.resolveRegisteredHandler(node);
       if (registryHandler) {
+        const declared = this.declaredResponseInferredType(request, node);
+        if (declared) {
+          return declared;
+        }
         this.log(
           `Span resolves to a route-registry object literal at ${request.file_path}:${request.line_number}; following handler return`
         );
@@ -646,6 +658,14 @@ export class TypeInferrer {
         (arg) => Node.isArrowFunction(arg) || Node.isFunctionExpression(arg)
       );
       if (registersCallback) {
+        // A registration that DECLARES its response contract in a schema needs
+        // no indirection: the declaration is the contract the framework
+        // serializes against, so it wins over whatever the handler happens to
+        // return.
+        const declared = this.declaredResponseInferredType(request, node);
+        if (declared) {
+          return declared;
+        }
         // The locator lands on a route registration whose handler carries the
         // response contract in its RETURN type — one indirection away. Follow
         // the handler and infer its return instead of dropping the payload.
@@ -922,17 +942,21 @@ export class TypeInferrer {
     if (!located) {
       // Line-only anchor: the scanner points a request infer at the route
       // registration line with no span/text. Follow the handler at that line and
-      // read its first typed request expression (`c.req.json<T>()`, `req.body as
-      // T`) — one indirection into the handler body.
-      const lineHandler = this.handlerAtLine(sourceFile, request.line_number);
-      if (lineHandler) {
-        const requestType = this.inferRequestReadFromHandler(lineHandler);
+      // read the route's declared request contract — the handler's parameter
+      // annotation, the registration's schema, or the first typed request
+      // expression in the body (`c.req.json<T>()`, `req.body as T`).
+      const atLine = this.registrationAtLine(sourceFile, request.line_number);
+      if (atLine) {
+        const requestType = this.requestContractFromRegistration(
+          atLine.registration,
+          atLine.handler
+        );
         if (requestType) {
           return this.createInferredType(
             request,
             requestType,
             true,
-            this.getNodeLocation(lineHandler),
+            this.getNodeLocation(atLine.handler),
             undefined,
             undefined
           );
@@ -952,7 +976,10 @@ export class TypeInferrer {
     // consumer `JSON.stringify(payload)` / `req.body as T` paths are untouched.
     const registrationHandler = this.registrationHandlerAt(located);
     if (registrationHandler) {
-      const requestType = this.inferRequestReadFromHandler(registrationHandler);
+      const requestType = this.requestContractFromRegistration(
+        this.unwrapExpressionNode(located),
+        registrationHandler
+      );
       if (requestType) {
         return this.createInferredType(
           request,
@@ -2245,6 +2272,20 @@ export class TypeInferrer {
     sourceFile: SourceFile,
     line: number
   ): FunctionLike | undefined {
+    return this.registrationAtLine(sourceFile, line)?.handler;
+  }
+
+  /**
+   * The route registration on `line` together with the handler it references.
+   *
+   * `handlerAtLine` returns only the handler, but the route's DECLARED contract
+   * (a validation-schema object passed alongside the handler) lives on the
+   * registration node itself, so the schema anchors need both halves.
+   */
+  private registrationAtLine(
+    sourceFile: SourceFile,
+    line: number
+  ): { registration: Node; handler: FunctionLike } | undefined {
     for (const node of sourceFile.getDescendants()) {
       if (
         (Node.isCallExpression(node) ||
@@ -2253,7 +2294,7 @@ export class TypeInferrer {
       ) {
         const handler = this.resolveRegisteredHandler(node);
         if (handler) {
-          return handler;
+          return { registration: node, handler };
         }
       }
     }
@@ -2525,6 +2566,378 @@ export class TypeInferrer {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Same reduction as `structuralTextFromTypeNode`, but starting from a resolved
+   * `Type` rather than a syntax node. `at` only supplies the scope the type is
+   * rendered in.
+   */
+  private structuralTextFromType(type: Type, at: Node): string | null {
+    try {
+      const resolved = this.unwrapPromiseType(type);
+      const bare = typeText(resolved, at);
+      if (this.isUselessType(bare)) {
+        return null;
+      }
+      const expanded = this.expandResolvedTypeStructural(resolved, bare);
+      return this.isUselessType(expanded) ? null : expanded;
+    } catch {
+      return null;
+    }
+  }
+
+  // ===========================================================================
+  // Route-contract anchors (carrick#528)
+  // ===========================================================================
+  //
+  // A route registration can DECLARE its request/response contract in two
+  // places the payload locators never reach, because neither is an expression
+  // the handler evaluates:
+  //
+  //  (a) the handler's own parameter annotation — a request parameter typed
+  //      `T<{ Body: CreateWidget }>` exposes the contract as the `body` member
+  //      of that parameter's type;
+  //  (b) a validation-schema object passed alongside the handler — `{ schema:
+  //      { body: ref('CreateWidget'), response: { 200: ref('Widget') } } }` —
+  //      whose entries reference schema VALUES that carry their parsed output
+  //      type.
+  //
+  // Both are read structurally: (a) is "the `body` member of a parameter's
+  // type", (b) is "a `schema` property on a registration argument, whose
+  // entries resolve to a value whose `parse` returns the contract". No
+  // framework, library, or method-name list is involved — a framework whose
+  // request object exposes `body` and whose route options carry `schema` is
+  // read the same way regardless of which one it is.
+
+  /**
+   * Anchor (b) on the response side: the success-status contract declared in the
+   * registration's schema, as an `InferredType` ready to return. Null when the
+   * registration declares no resolvable response schema, so the caller falls
+   * back to following the handler's return.
+   */
+  private declaredResponseInferredType(
+    request: InferRequestItem,
+    registration: Node
+  ): InferredType | null {
+    const declared = this.routeSchemaContractText(registration, 'response');
+    if (!declared) {
+      return null;
+    }
+    this.log(
+      `Route registration at ${request.file_path}:${request.line_number} declares its ` +
+        'response schema; using the declared contract'
+    );
+    return this.createInferredType(
+      request,
+      declared,
+      true,
+      this.getNodeLocation(registration),
+      undefined,
+      undefined
+    );
+  }
+
+  /**
+   * The request contract of a route registration, in anchor order: the
+   * handler's parameter annotation (a), the registration's declared schema (b),
+   * then the first typed request read in the handler body (the pre-existing
+   * behaviour). The first anchor yielding a non-useless type wins; null means
+   * the route declares its request nowhere we can read.
+   */
+  private requestContractFromRegistration(
+    registration: Node,
+    handler: FunctionLike
+  ): string | null {
+    return (
+      this.requestBodyFromHandlerParams(handler) ??
+      this.routeSchemaContractText(registration, 'body') ??
+      this.inferRequestReadFromHandler(handler)
+    );
+  }
+
+  /**
+   * Anchor (a): the request contract declared on the handler's own signature.
+   *
+   * A typed request parameter (`request: CreateWidgetRequest` where that alias
+   * resolves to a request type parameterised with the body shape) exposes the
+   * contract as the `body` member of the parameter's type. Parameters are
+   * scanned in order and the first one carrying a non-useless `body` member
+   * wins; a reply/response parameter has no `body` member, and an unparameterised
+   * request type resolves `body` to `unknown`/`any`, which the useless-type
+   * guard rejects. So a handler that declares nothing yields null and the next
+   * anchor runs.
+   */
+  private requestBodyFromHandlerParams(func: FunctionLike): string | null {
+    for (const param of func.getParameters()) {
+      let paramType: Type;
+      try {
+        paramType = param.getType();
+      } catch {
+        continue;
+      }
+      const bodySymbol = paramType.getProperty('body');
+      if (!bodySymbol) {
+        continue;
+      }
+      let bodyType: Type;
+      try {
+        bodyType = bodySymbol.getTypeAtLocation(param);
+      } catch {
+        continue;
+      }
+      const text = this.structuralTextFromType(bodyType, param);
+      if (text) {
+        return text;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Anchor (b): the contract declared in the route's validation schema.
+   *
+   * `part` is `'body'` for the request contract and `'response'` for the
+   * response contract; a `response` entry keyed by status code resolves to its
+   * success entry. Returns null when the registration carries no schema, when
+   * the entry references something whose parsed output cannot be resolved, or
+   * when the schema is a plain JSON-schema literal (whose own object type is
+   * the JSON-Schema document, not the payload — emitting that would be worse
+   * than abstaining).
+   */
+  private routeSchemaContractText(
+    registration: Node,
+    part: 'body' | 'response'
+  ): string | null {
+    const schemaObject = this.routeSchemaObject(registration);
+    if (!schemaObject) {
+      return null;
+    }
+    const entry = schemaObject.getProperty(part);
+    if (!entry || !Node.isPropertyAssignment(entry)) {
+      return null;
+    }
+    const initializer = entry.getInitializer();
+    if (!initializer) {
+      return null;
+    }
+    const value: Node =
+      part === 'response'
+        ? (this.successStatusEntry(initializer) ?? initializer)
+        : initializer;
+    return this.schemaOutputTypeText(value);
+  }
+
+  /**
+   * The `schema` object literal carried by a route registration: scan the
+   * registration call's arguments (or the registry object literal itself) for a
+   * `schema` property whose value is an object literal.
+   */
+  private routeSchemaObject(
+    registration: Node
+  ): ObjectLiteralExpression | undefined {
+    const candidates: Node[] = [];
+    if (Node.isCallExpression(registration)) {
+      candidates.push(...registration.getArguments());
+    } else if (Node.isObjectLiteralExpression(registration)) {
+      candidates.push(registration);
+    }
+    for (const candidate of candidates) {
+      if (!Node.isObjectLiteralExpression(candidate)) {
+        continue;
+      }
+      const schemaProp = candidate.getProperty('schema');
+      if (!schemaProp || !Node.isPropertyAssignment(schemaProp)) {
+        continue;
+      }
+      const schemaValue = schemaProp.getInitializer();
+      if (schemaValue && Node.isObjectLiteralExpression(schemaValue)) {
+        return schemaValue;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * The success entry of a status-keyed response map (`{ 200: …, 4xx: … }`):
+   * exact `200` when present, else the lowest 2xx key. Returns undefined when
+   * the value is not a status-keyed map, so the caller reads it as the schema
+   * itself.
+   */
+  private successStatusEntry(value: Node): Node | undefined {
+    if (!Node.isObjectLiteralExpression(value)) {
+      return undefined;
+    }
+    let best: { code: number; node: Node } | undefined;
+    for (const prop of value.getProperties()) {
+      if (!Node.isPropertyAssignment(prop)) {
+        continue;
+      }
+      const name = prop.getName().replace(/['"`]/g, '').toLowerCase();
+      // `2xx` is a status RANGE key; treat it as the bottom of its range.
+      const code = /^\d{3}$/.test(name)
+        ? Number(name)
+        : /^\dxx$/.test(name)
+          ? Number(name[0]) * 100
+          : NaN;
+      if (!Number.isFinite(code) || code < 200 || code > 299) {
+        continue;
+      }
+      const initializer = prop.getInitializer();
+      if (!initializer) {
+        continue;
+      }
+      if (!best || code < best.code) {
+        best = { code, node: initializer };
+      }
+    }
+    return best?.node;
+  }
+
+  /**
+   * The payload type a schema entry declares.
+   *
+   * The entry is either a REFERENCE call — `ref('CreateWidget')`, a
+   * name-to-schema indirection whose registry is the argument the ref function
+   * was built from — or the schema value itself. Either way the payload is the
+   * schema's parsed output: the return type of its `parse` method (the shape
+   * every schema value exposes as its public validate-and-return API), falling
+   * back to a declared `_output` member. A value with neither is not a schema
+   * and yields null.
+   */
+  private schemaOutputTypeText(value: Node): string | null {
+    const node = this.unwrapExpressionNode(value);
+
+    let schemaType: Type | undefined;
+    if (Node.isCallExpression(node)) {
+      schemaType = this.registrySchemaType(node);
+    }
+    if (!schemaType) {
+      try {
+        schemaType = node.getType();
+      } catch {
+        return null;
+      }
+    }
+
+    const output = this.schemaOutputType(schemaType, node);
+    if (!output) {
+      this.log(
+        `Route schema entry at ${this.getNodeLocation(node).file_path}:${
+          this.getNodeLocation(node).start_line
+        } declares no resolvable parsed output (schema library types unavailable, ` +
+          'or a plain JSON-Schema literal); leaving unresolved'
+      );
+      return null;
+    }
+    return this.structuralTextFromType(output, node);
+  }
+
+  /**
+   * Follow a schema REFERENCE call (`ref('CreateWidget')`) to the schema value
+   * it names.
+   *
+   * The ref function is produced by a registry-building call — `const { $ref } =
+   * build({ CreateWidget, Widget })` — so the registry is that call's first
+   * argument, and the referenced key is a property of it. Resolve the callee to
+   * its declaration, walk to the variable declaration it is bound in, and read
+   * the key off the builder argument's type. Returns undefined for anything
+   * that is not this shape.
+   */
+  private registrySchemaType(call: CallExpression): Type | undefined {
+    const args = call.getArguments();
+    if (args.length === 0) {
+      return undefined;
+    }
+    const keyArg = this.unwrapExpressionNode(args[0]);
+    if (!Node.isStringLiteral(keyArg)) {
+      return undefined;
+    }
+    const key = keyArg.getLiteralValue();
+
+    const callee = call.getExpression();
+    const identifier = Node.isIdentifier(callee)
+      ? callee
+      : Node.isPropertyAccessExpression(callee)
+        ? callee.getNameNode()
+        : undefined;
+    if (!identifier || !Node.isIdentifier(identifier)) {
+      return undefined;
+    }
+
+    for (const def of identifier.getDefinitionNodes()) {
+      const varDecl = Node.isVariableDeclaration(def)
+        ? def
+        : def.getFirstAncestorByKind(SyntaxKind.VariableDeclaration);
+      const initializer = varDecl?.getInitializer();
+      if (!initializer) {
+        continue;
+      }
+      const builderCall = this.unwrapExpressionNode(initializer);
+      if (!Node.isCallExpression(builderCall)) {
+        continue;
+      }
+      const registryArg = builderCall.getArguments()[0];
+      if (!registryArg) {
+        continue;
+      }
+      let registryType: Type;
+      try {
+        registryType = registryArg.getType();
+      } catch {
+        continue;
+      }
+      const schemaSymbol = registryType.getProperty(key);
+      if (!schemaSymbol) {
+        continue;
+      }
+      try {
+        return schemaSymbol.getTypeAtLocation(registryArg);
+      } catch {
+        continue;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * The parsed output type of a schema value: the return type of its `parse`
+   * method, else a declared `_output` member. Returns undefined when neither
+   * carries a usable type — including when the schema library's own types are
+   * unavailable (an uninstalled dependency resolves the schema to `any`), which
+   * must abstain rather than publish `any` as a contract.
+   */
+  private schemaOutputType(schemaType: Type, at: Node): Type | undefined {
+    const usable = (type: Type | undefined): Type | undefined => {
+      if (!type) {
+        return undefined;
+      }
+      return this.isUselessType(typeText(type, at)) ? undefined : type;
+    };
+
+    const parseSymbol = schemaType.getProperty('parse');
+    if (parseSymbol) {
+      try {
+        const signatures = parseSymbol.getTypeAtLocation(at).getCallSignatures();
+        const returned = usable(signatures[0]?.getReturnType());
+        if (returned) {
+          return returned;
+        }
+      } catch {
+        // fall through to the declared-output member
+      }
+    }
+
+    const outputSymbol = schemaType.getProperty('_output');
+    if (outputSymbol) {
+      try {
+        return usable(outputSymbol.getTypeAtLocation(at));
+      } catch {
+        return undefined;
+      }
+    }
+
+    return undefined;
   }
 
   /**

--- a/src/sidecar/src/type-inferrer.ts
+++ b/src/sidecar/src/type-inferrer.ts
@@ -341,6 +341,19 @@ export class TypeInferrer {
     request: InferRequestItem,
     extractionConfig?: ExtractionConfig
   ): InferredType | null {
+    // A `function_return` request can point at a route REGISTRATION: that is
+    // the shape the scanner sends for a route whose handler RETURNS its
+    // payload. The containing-function walk below then resolves the function
+    // that registers the route, not the handler — so a registration declaring
+    // its response contract is read from that declaration first.
+    const registration = this.routeRegistrationForRequest(sourceFile, request);
+    if (registration) {
+      const declared = this.declaredResponseInferredType(request, registration);
+      if (declared) {
+        return declared;
+      }
+    }
+
     const func = this.resolveContainingFunction(sourceFile, request);
 
     if (!func) {
@@ -2609,6 +2622,28 @@ export class TypeInferrer {
   // framework, library, or method-name list is involved — a framework whose
   // request object exposes `body` and whose route options carry `schema` is
   // read the same way regardless of which one it is.
+
+  /**
+   * The route registration a request's locator points AT, or undefined when it
+   * points at anything else.
+   *
+   * Deliberately strict: the located node must itself be the registration (a
+   * call registering a handler, or a route-registry object literal), never an
+   * ancestor of it, so an expression inside a handler is not mistaken for the
+   * route it belongs to. A locator that resolves nothing falls back to the
+   * registration on the request's line.
+   */
+  private routeRegistrationForRequest(
+    sourceFile: SourceFile,
+    request: InferRequestItem
+  ): Node | undefined {
+    const located = this.resolveTargetNode(sourceFile, request);
+    if (located) {
+      const node = this.unwrapExpressionNode(located);
+      return this.registrationHandlerAt(node) ? node : undefined;
+    }
+    return this.registrationAtLine(sourceFile, request.line_number)?.registration;
+  }
 
   /**
    * Anchor (b) on the response side: the success-status contract declared in the

--- a/src/sidecar/test/fixtures/sample-repo/src/route-schema-anchors.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/route-schema-anchors.ts
@@ -1,0 +1,71 @@
+/**
+ * Schema-first route registrations (carrick#528).
+ *
+ * Every handler here is a thin arrow that forwards to a controller function, so
+ * the route file contains NO request read and NO payload expression — the only
+ * places the contract is written down are the handler's parameter annotation
+ * and the registration's `schema` object.
+ *
+ *  - `POST /widgets` declares both: a typed request parameter AND a schema.
+ *  - `POST /widgets/import` declares only the schema (its request parameter is
+ *    the unparameterised request type, whose `body` is `unknown`).
+ *  - `POST /widgets/legacy` declares neither, and casts inside the handler —
+ *    the pre-existing typed-request-read anchor must still win there.
+ */
+
+import type { Reply, RouteRequest, Server } from './route-schema-lib';
+import { $ref, type CreateWidgetRequest } from './route-schema-registry';
+
+export interface LegacyWidget {
+  legacyId: number;
+  label: string;
+}
+
+export function registerWidgetRoutes(server: Server): void {
+  server.post(
+    '/widgets',
+    {
+      schema: {
+        body: $ref('CreateWidget'),
+        response: {
+          200: $ref('WidgetView'),
+        },
+      },
+    },
+    async (request: CreateWidgetRequest, reply: Reply) =>
+      createWidget(request, reply)
+  );
+
+  server.post(
+    '/widgets/import',
+    {
+      schema: {
+        body: $ref('ImportWidgets'),
+      },
+    },
+    async (request: RouteRequest, reply: Reply) => importWidgets(request, reply)
+  );
+
+  server.post(
+    '/widgets/legacy',
+    {},
+    async (request: RouteRequest, reply: Reply) => {
+      const widget = request.body as LegacyWidget;
+      return reply.send(widget.label);
+    }
+  );
+}
+
+async function createWidget(
+  request: CreateWidgetRequest,
+  reply: Reply
+): Promise<unknown> {
+  return reply.send({ id: 'w-1', ...request.body });
+}
+
+async function importWidgets(
+  request: RouteRequest,
+  reply: Reply
+): Promise<unknown> {
+  return reply.send({ imported: 0, source: request.body });
+}

--- a/src/sidecar/test/fixtures/sample-repo/src/route-schema-lib.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/route-schema-lib.ts
@@ -1,0 +1,75 @@
+/**
+ * Minimal stand-ins for the two library shapes a schema-first route stack is
+ * built from, declared locally so the fixture needs no installed packages
+ * (same approach as `framework-handlers.ts`).
+ *
+ * Both mirror the real declarations the anchors read on a live service:
+ *
+ *  - a request object parameterised by a route generic, exposing the request
+ *    body as its `body` member (`body: RouteGeneric['Body']`, defaulting to
+ *    `unknown` when the route declares nothing);
+ *  - a schema value that carries its parsed output type, reachable through the
+ *    `parse` method every such value exposes, and a registry builder that maps
+ *    names to schema values and hands back a `$ref`-style lookup function.
+ */
+
+export interface RouteGeneric {
+  Body?: unknown;
+  Params?: unknown;
+  Query?: unknown;
+}
+
+export interface RouteRequest<Generic extends RouteGeneric = RouteGeneric> {
+  body: Generic['Body'];
+  params: Generic['Params'];
+  query: Generic['Query'];
+}
+
+export interface Reply {
+  status(code: number): Reply;
+  send(payload?: unknown): Reply;
+}
+
+export interface RouteOptions {
+  schema?: unknown;
+}
+
+export interface Server {
+  post<Request extends RouteRequest = RouteRequest>(
+    path: string,
+    options: RouteOptions,
+    handler: (request: Request, reply: Reply) => unknown
+  ): void;
+  get<Request extends RouteRequest = RouteRequest>(
+    path: string,
+    options: RouteOptions,
+    handler: (request: Request, reply: Reply) => unknown
+  ): void;
+}
+
+export interface Schema<Output> {
+  readonly _output: Output;
+  parse(data: unknown): Output;
+}
+
+/** The declared output type of a schema value (the `z.infer` of this stack). */
+export type Infer<S> = S extends Schema<infer Output> ? Output : never;
+
+export function defineSchema<Output>(): Schema<Output> {
+  return {
+    _output: undefined as unknown as Output,
+    parse: (data: unknown) => data as Output,
+  };
+}
+
+export function buildSchemaRefs<Models extends Record<string, Schema<unknown>>>(
+  models: Models
+): {
+  names: string[];
+  $ref: (key: keyof Models & string) => { $ref: string };
+} {
+  return {
+    names: Object.keys(models),
+    $ref: (key) => ({ $ref: `${key}#` }),
+  };
+}

--- a/src/sidecar/test/fixtures/sample-repo/src/route-schema-registry.ts
+++ b/src/sidecar/test/fixtures/sample-repo/src/route-schema-registry.ts
@@ -1,0 +1,39 @@
+/**
+ * Schema module for the schema-first route fixture: schema values, the alias
+ * a route handler annotates its request with, and the name-to-schema registry
+ * the `$ref` lookup is built from — the layout a schema-first service uses,
+ * with the schemas in a sibling module to the routes.
+ */
+
+import {
+  buildSchemaRefs,
+  defineSchema,
+  type Infer,
+  type RouteRequest,
+} from './route-schema-lib';
+
+export const CreateWidget = defineSchema<{
+  name: string;
+  sizeCm: number;
+  tags?: string[];
+}>();
+
+export const WidgetView = defineSchema<{
+  id: string;
+  name: string;
+  sizeCm: number;
+}>();
+
+export const ImportWidgets = defineSchema<{
+  sourceUrl: string;
+  overwrite: boolean;
+}>();
+
+export type CreateWidgetBody = Infer<typeof CreateWidget>;
+export type CreateWidgetRequest = RouteRequest<{ Body: CreateWidgetBody }>;
+
+export const { $ref } = buildSchemaRefs({
+  CreateWidget,
+  WidgetView,
+  ImportWidgets,
+});

--- a/src/sidecar/test/route-schema-anchors.test.ts
+++ b/src/sidecar/test/route-schema-anchors.test.ts
@@ -82,7 +82,7 @@ function registrationSpan(route: string): {
 async function infer(
   client: SidecarClient,
   route: string,
-  kind: 'request_body' | 'response_body',
+  kind: 'request_body' | 'response_body' | 'function_return',
   alias: string
 ): Promise<string | undefined> {
   const span = registrationSpan(route);
@@ -138,6 +138,24 @@ describe('schema-first route contract anchors', () => {
     assert.match(type, /sizeCm: number/);
     // The declared response schema, not the request schema.
     assert.doesNotMatch(type, /tags/);
+  });
+
+  it('anchor (b): the declared response also answers a function_return locator on the registration', async () => {
+    // The scanner sends `function_return` for a route whose handler returns its
+    // payload. Its containing-function walk resolves the function REGISTERING
+    // the route, so without the anchor this reports that function's return
+    // (`void` here), not the route's contract.
+    const type = await infer(
+      client,
+      '/widgets',
+      'function_return',
+      'WidgetsRet'
+    );
+
+    assert.ok(type, 'expected a resolved response type, got none');
+    assert.notStrictEqual(type, 'void', 'must not report the registering function return');
+    assert.match(type, /id: string/);
+    assert.match(type, /sizeCm: number/);
   });
 
   it('anchor (b): a POST with no typed request parameter falls through to the declared body schema', async () => {

--- a/src/sidecar/test/route-schema-anchors.test.ts
+++ b/src/sidecar/test/route-schema-anchors.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Route-contract anchors for schema-first services (carrick#528).
+ *
+ * A route registered as
+ *
+ *   server.post(path, { schema: { body: $ref('X'), response: { 200: $ref('Y') } } },
+ *               async (request: TypedRequest, reply) => controller(request, reply))
+ *
+ * writes its contract down in two places, and evaluates NEITHER: the handler's
+ * parameter annotation and the registration's schema object. The pre-existing
+ * request path followed the handler and looked for a typed request READ in its
+ * body; a forwarding arrow has none, so it returned null and the endpoint's
+ * request type stayed `any`. The response path followed the handler's RETURN
+ * type, which for a `reply.send(...)` forwarder is framework machinery, so the
+ * response stayed `any` too.
+ *
+ * These lock the two anchors in, in order, and lock in that the pre-existing
+ * typed-read anchor still wins on a route that declares neither.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { SidecarClient, FIXTURES_PATH } from './helpers.js';
+
+const FIXTURE = path.join(FIXTURES_PATH, 'src/route-schema-anchors.ts');
+const FIXTURE_SOURCE = fs.readFileSync(FIXTURE, 'utf-8');
+
+interface InferResponseShape {
+  request_id: string;
+  status: string;
+  inferred_types?: Array<{
+    alias: string;
+    type_string: string;
+    infer_kind: string;
+    is_explicit: boolean;
+  }>;
+  errors?: string[];
+}
+
+/**
+ * Byte span of one route registration, from `server.post(\n    '<route>'` to the
+ * matching close paren — the same whole-registration span the scanner sends
+ * from its SWC candidate. The fixture is ASCII-only, so byte == char offsets.
+ */
+function registrationSpan(route: string): {
+  start: number;
+  end: number;
+  line: number;
+} {
+  const marker = `server.post(\n    '${route}',`;
+  const start = FIXTURE_SOURCE.indexOf(marker);
+  assert.ok(start >= 0, `fixture must register: ${route}`);
+  assert.strictEqual(
+    FIXTURE_SOURCE.indexOf(marker, start + 1),
+    -1,
+    `fixture must register ${route} exactly once`
+  );
+
+  let depth = 0;
+  let end = -1;
+  for (let i = start; i < FIXTURE_SOURCE.length; i += 1) {
+    const char = FIXTURE_SOURCE[i];
+    if (char === '(') depth += 1;
+    if (char === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  assert.ok(end > start, `unbalanced registration for ${route}`);
+  return {
+    start,
+    end,
+    line: FIXTURE_SOURCE.slice(0, start).split('\n').length,
+  };
+}
+
+async function infer(
+  client: SidecarClient,
+  route: string,
+  kind: 'request_body' | 'response_body',
+  alias: string
+): Promise<string | undefined> {
+  const span = registrationSpan(route);
+  const response = await client.send<InferResponseShape>({
+    action: 'infer',
+    request_id: `route-schema-${alias}`,
+    requests: [
+      {
+        file_path: FIXTURE,
+        line_number: span.line,
+        span_start: span.start,
+        span_end: span.end,
+        infer_kind: kind,
+        alias,
+      },
+    ],
+  });
+  return response.inferred_types?.find((t) => t.alias === alias)?.type_string;
+}
+
+describe('schema-first route contract anchors', () => {
+  let client: SidecarClient;
+
+  before(async () => {
+    client = new SidecarClient();
+    await client.start();
+    await client.send({
+      action: 'init',
+      request_id: 'route-schema-init',
+      repo_root: FIXTURES_PATH,
+    });
+  });
+
+  after(async () => {
+    await client.stop();
+  });
+
+  it('anchor (a): a POST whose handler annotates its request parameter resolves the request body from that annotation', async () => {
+    const type = await infer(client, '/widgets', 'request_body', 'WidgetsReq');
+
+    assert.ok(type, 'expected a resolved request type, got none');
+    assert.notStrictEqual(type, 'any', 'request must not resolve to any');
+    assert.match(type, /name: string/);
+    assert.match(type, /sizeCm: number/);
+  });
+
+  it('anchor (b): the same POST resolves its response from the declared 200 schema', async () => {
+    const type = await infer(client, '/widgets', 'response_body', 'WidgetsRes');
+
+    assert.ok(type, 'expected a resolved response type, got none');
+    assert.notStrictEqual(type, 'any', 'response must not resolve to any');
+    assert.match(type, /id: string/);
+    assert.match(type, /sizeCm: number/);
+    // The declared response schema, not the request schema.
+    assert.doesNotMatch(type, /tags/);
+  });
+
+  it('anchor (b): a POST with no typed request parameter falls through to the declared body schema', async () => {
+    const type = await infer(
+      client,
+      '/widgets/import',
+      'request_body',
+      'ImportReq'
+    );
+
+    assert.ok(type, 'expected a resolved request type, got none');
+    assert.notStrictEqual(type, 'any', 'request must not resolve to any');
+    assert.match(type, /sourceUrl: string/);
+    assert.match(type, /overwrite: boolean/);
+  });
+
+  it('a route declaring no schema and no typed parameter still resolves from the typed request read in its handler', async () => {
+    const type = await infer(
+      client,
+      '/widgets/legacy',
+      'request_body',
+      'LegacyReq'
+    );
+
+    assert.ok(type, 'expected a resolved request type, got none');
+    assert.match(type, /legacyId: number/);
+    assert.match(type, /label: string/);
+  });
+});


### PR DESCRIPTION
Closes #528.

## The problem

A schema-first route declares its contract without ever evaluating it. Registered like

```ts
server.post("/widgets", {
  schema: { body: $ref("CreateWidget"), response: { 200: $ref("WidgetView") } },
}, async (request: CreateWidgetRequest, reply) => createWidget(server, request, reply));
```

the route file contains no request read and no payload expression, so both locators land on the registration call and bottom out there:

- request: the sidecar followed the handler and scanned its body for a typed request read (`c.req.json<T>()`, `req.body as T`). A forwarding arrow has none, so it returned null and the request type stayed `any`.
- response: the sidecar followed the handler's return type, which for a `reply.send(...)` forwarder is framework machinery, so the response stayed `any` too.

Neither locator read either of the two places where the contract is written down.

## The change

Two anchors in `type-inferrer.ts` carry this, and both are read structurally:

**(a) the handler's parameter annotation.** A parameter whose type carries a non-useless `body` member is the request object, and that member is the contract. An unparameterised request type resolves `body` to `unknown` and a reply parameter has no `body` at all, so a handler that declares nothing falls through.

**(b) the registration's schema object.** `schema.body` for the request, and the success entry of `schema.response` (exact `200`, else the lowest 2xx or `2xx` key) for the response. An entry is either a reference call such as `$ref("CreateWidget")` or the schema value itself. A reference call resolves by walking the ref function to the registry-builder call it was destructured from and looking the key up on the builder's argument. Either way the payload is the schema's parsed output, which is the return type of its `parse` method, falling back to a declared `_output` member.

Request-side order is (a), then (b), then the pre-existing typed request read. Response-side, the declared success schema wins over following the handler's return, since the declaration is what the framework serialises against, and it is consulted on both response locator kinds the scanner emits.

No framework, library or method-name list is involved. A stack whose request object exposes `body` and whose route options carry `schema` reads the same way whichever one it is. Where nothing resolves, whether from a schema declared as `any`, a plain JSON-Schema literal or an uninstalled schema library, the sidecar logs why and abstains rather than publishing `any` as a contract.

## Measured

The numbers come from a run through the real sidecar against a 29-route service using this shape (dependencies installed), counting endpoints whose request or response resolves to a non-empty type:

| | before | after |
|---|---|---|
| request | 0 / 16 | 10 / 16 |
| response, response-body locator | 4 / 29 | 16 / 29 |
| response, function-return locator | 0 / 29 | 13 / 29 |

Both response rows matter because the scanner picks the locator from the analyzer's emission-style classification, and a forwarding handler can land on either. The declared-schema anchor runs on both paths, so the route's contract does not depend on which one the classifier chose.

The `POST /sessions` endpoint from the issue now resolves both sides on either locator. The request resolves to the created-session body shape and the response to the session-details shape including `sessionViewerUrl`.

The endpoints still unresolved are abstentions: routes declaring their response schema as `any`, health checks, streams, and deletes with no body.

## Tests

The new coverage is `src/sidecar/test/route-schema-anchors.test.ts`, with a fixture under `src/sidecar/test/fixtures/sample-repo/` (sidecar tests and their fixtures live together, per AGENTS.md). It covers a POST declaring both a typed parameter and a schema, the same POST read through a function-return locator, a POST declaring only the schema, and a POST declaring neither, which guards the pre-existing typed-read anchor. Reverting the source change fails the first four and leaves the last one green.

- `cd src/sidecar && npm test` (326 pass, 0 fail; 321 before)
- `cargo test` (1833 pass, 0 fail)
- `cargo fmt --check`, `cargo clippy --all-targets` (clean)

## Worth knowing

The dominant cause on a bare checkout is upstream of this change: without the scanned repo's `node_modules`, the schema library's own types are unavailable, so `z.infer<typeof X>` is `any` and every library-typed contract resolves to `any` no matter which anchor fires. Every eval and CI workflow in this repo installs fixture dependencies before scanning, and `eval-oss.yml` warns that type metrics degrade without it, so deps-installed is the designed contract, and a scan workflow that checks out and scans without an install step will see this. Every number above was measured with dependencies installed.

Two residuals stay open:

- endpoints the analyzer classifies `NoPayload` get no response infer request at all, so no sidecar-side anchor can reach them.
- the request locator tries the model's payload expression text before the span. A route with no payload expression falls through to the span and lands on the registration, which is where these anchors run; a model that emits text resolving elsewhere would not reach them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
