### PR TITLE
fix: gate cache drop on staging, cap write retries, send payload digest

### DIFF
--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -3,6 +3,7 @@ use crate::oidc::OidcProvider;
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::time::Duration;
 use tracing::{debug, warn};
@@ -18,6 +19,50 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// one Lambda cold start or load-balancer blip must not discard the run.
 const MAX_TRANSIENT_RETRIES: u32 = 3;
 
+/// Retries after the first attempt for the actions that write the cloud index.
+/// A 5xx on a write is ambiguous: the gateway cuts the connection at its
+/// integration timeout while the handler keeps running, so the write may
+/// already have landed (carrick#536 — a `store-metadata` answered 200 after
+/// 118s, long past the 30s gateway cut, and each blind retry re-ran the whole
+/// embed). The cloud recognises a duplicate arriving after the row is durable
+/// and answers it cheaply, so one retry is worth making. A storm of them is
+/// not: on the measured incident four attempts did the same expensive work
+/// four times and the scan was still reported as failed.
+const MAX_WRITE_RETRIES: u32 = 1;
+
+/// The actions that write the cloud index. Everything else is a read (or a
+/// mint) and is safely repeatable, so it keeps the full retry budget.
+const WRITE_ACTIONS: [&str; 2] = ["complete-upload", "store-metadata"];
+
+fn is_write_action(action: &str) -> bool {
+    WRITE_ACTIONS.contains(&action)
+}
+
+/// Retry budget for an action. Unknown actions are treated as reads.
+fn max_retries_for_action(action: &str) -> u32 {
+    if is_write_action(action) {
+        MAX_WRITE_RETRIES
+    } else {
+        MAX_TRANSIENT_RETRIES
+    }
+}
+
+/// The error a caller sees once the retry budget is spent. On a write action
+/// the failure is ambiguous rather than final, and saying so is what stops the
+/// next reader from assuming the index is stale and forcing a re-scan.
+fn retry_exhausted_message(action: &str, transient_error: &str, attempts: u32) -> String {
+    if is_write_action(action) {
+        format!(
+            "{} (after {} attempts on '{}'). This action writes the index, and a response \
+             lost to a gateway timeout does not mean the write was lost — the index may \
+             already be current at this commit. Check it before re-running the scan.",
+            transient_error, attempts, action
+        )
+    } else {
+        format!("{} (after {} attempts)", transient_error, attempts)
+    }
+}
+
 /// Above this serialized size, CloudRepoData is PUT to a presigned S3
 /// staging URL instead of being inlined in the request body (carrick#486).
 /// The inline path dies at two walls: API Gateway rejects bodies over 10 MB
@@ -25,7 +70,7 @@ const MAX_TRANSIENT_RETRIES: u32 = 3;
 /// envelope escaping, so ~5.8 MB effective) surfaces as an unattributable
 /// 500. 4 MB leaves margin under the lower wall; one class-heavy service in
 /// a large monorepo measured past 10 MB after #483.
-const INLINE_PAYLOAD_LIMIT_BYTES: usize = 4 * 1024 * 1024;
+pub(crate) const INLINE_PAYLOAD_LIMIT_BYTES: usize = 4 * 1024 * 1024;
 
 fn retry_backoff(retries_so_far: u32) -> Duration {
     // 2s, 4s, 8s
@@ -79,6 +124,37 @@ struct LambdaRequest {
     #[serde(rename = "payloadInS3")]
     #[serde(skip_serializing_if = "Option::is_none")]
     payload_in_s3: Option<bool>,
+    /// Payload staging integrity (carrick#536): lowercase-hex SHA-256 of the
+    /// exact bytes PUT to the staging object. The cloud verifies the object it
+    /// fetches against this before parsing it, so a truncated or swapped blob
+    /// is rejected instead of indexed. Only meaningful alongside
+    /// `payloadInS3`; when `cloudRepoData` rides inline the request body is
+    /// itself the authenticated payload and there is no second hop to verify.
+    #[serde(rename = "payloadSha256")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload_sha256: Option<String>,
+    /// Byte length of those same bytes. Checked off the cloud's HeadObject
+    /// before the download, so a truncated PUT costs one head request.
+    #[serde(rename = "payloadSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload_size: Option<u64>,
+}
+
+/// Integrity fields for a payload that was staged to S3 rather than inlined.
+/// Computed once, from the same serialized bytes that are PUT.
+#[derive(Clone)]
+struct StagedPayload {
+    sha256: String,
+    size: u64,
+}
+
+impl StagedPayload {
+    fn of(serialized: &str) -> Self {
+        Self {
+            sha256: format!("{:x}", Sha256::digest(serialized.as_bytes())),
+            size: serialized.len() as u64,
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -193,11 +269,14 @@ impl AwsStorage {
     /// returning the raw response body on success. OIDC tokens are short-lived,
     /// so on a 401 (token likely expired mid-run) we re-mint once and retry.
     /// Transient failures (network errors, 408/429/5xx) are retried with
-    /// exponential backoff up to [`MAX_TRANSIENT_RETRIES`] times.
-    async fn send_lambda<B>(&self, body: &B) -> Result<String, StorageError>
+    /// exponential backoff, up to [`max_retries_for_action`] times for the
+    /// named action — the full budget for reads, one retry for the actions
+    /// that write the index, where a lost response does not mean a lost write.
+    async fn send_lambda<B>(&self, action: &str, body: &B) -> Result<String, StorageError>
     where
         B: serde::Serialize + ?Sized,
     {
+        let max_retries = max_retries_for_action(action);
         let provider =
             OidcProvider::global().map_err(|e| StorageError::ConnectionError(e.to_string()))?;
         let mut token = provider
@@ -251,11 +330,11 @@ impl AwsStorage {
                 Err(e) => format!("Lambda request failed: {}", e),
             };
 
-            if retries >= MAX_TRANSIENT_RETRIES {
-                return Err(StorageError::ConnectionError(format!(
-                    "{} (after {} attempts)",
-                    transient_error,
-                    retries + 1
+            if retries >= max_retries {
+                return Err(StorageError::ConnectionError(retry_exhausted_message(
+                    action,
+                    &transient_error,
+                    retries + 1,
                 )));
             }
 
@@ -265,7 +344,7 @@ impl AwsStorage {
                 transient_error,
                 backoff.as_secs(),
                 retries + 1,
-                MAX_TRANSIENT_RETRIES
+                max_retries
             );
             tokio::time::sleep(backoff).await;
             retries += 1;
@@ -276,7 +355,7 @@ impl AwsStorage {
     where
         T: for<'de> serde::Deserialize<'de>,
     {
-        let response_text = self.send_lambda(request).await?;
+        let response_text = self.send_lambda(&request.action, request).await?;
         serde_json::from_str(&response_text).map_err(|e| {
             StorageError::SerializationError(format!(
                 "Failed to parse lambda response for action '{}': {}. Raw response: {}",
@@ -285,12 +364,16 @@ impl AwsStorage {
         })
     }
 
-    async fn call_lambda_generic<Req, Resp>(&self, request: &Req) -> Result<Resp, StorageError>
+    async fn call_lambda_generic<Req, Resp>(
+        &self,
+        action: &str,
+        request: &Req,
+    ) -> Result<Resp, StorageError>
     where
         Req: serde::Serialize,
         Resp: for<'de> serde::Deserialize<'de>,
     {
-        let response_text = self.send_lambda(request).await?;
+        let response_text = self.send_lambda(action, request).await?;
         serde_json::from_str(&response_text).map_err(|e| {
             StorageError::SerializationError(format!("Failed to parse lambda response: {}", e))
         })
@@ -363,7 +446,7 @@ impl AwsStorage {
         &self,
         data: &CloudRepoData,
         s3_url: &str,
-        payload_staged: bool,
+        staged: Option<&StagedPayload>,
     ) -> Result<(), StorageError> {
         let request = LambdaRequest {
             action: "store-metadata".to_string(),
@@ -371,10 +454,12 @@ impl AwsStorage {
             service_name: data.service_name.clone(),
             hash: data.commit_hash.clone(),
             filename: "types.d.ts".to_string(),
-            cloud_repo_data: (!payload_staged).then(|| data.clone()),
+            cloud_repo_data: staged.is_none().then(|| data.clone()),
             s3_url: Some(s3_url.to_string()),
             wants_payload_url: None,
-            payload_in_s3: payload_staged.then_some(true),
+            payload_in_s3: staged.is_some().then_some(true),
+            payload_sha256: staged.map(|s| s.sha256.clone()),
+            payload_size: staged.map(|s| s.size),
         };
 
         let _response: StoreMetadataResponse = self.call_lambda(&request).await?;
@@ -426,6 +511,11 @@ impl CloudStorage for AwsStorage {
         })?;
         let stage_payload = serialized.len() > INLINE_PAYLOAD_LIMIT_BYTES;
 
+        // Integrity fields for the staged object, digested once over exactly
+        // the bytes that get PUT (carrick#536). Not computed on the inline
+        // path, where the request body is itself the authenticated payload.
+        let staged = stage_payload.then(|| StagedPayload::of(&serialized));
+
         // Step 1: Check if we need to upload type file
         let check_request = LambdaRequest {
             action: "check-or-upload".to_string(),
@@ -437,6 +527,8 @@ impl CloudStorage for AwsStorage {
             s3_url: None,
             wants_payload_url: stage_payload.then_some(true),
             payload_in_s3: None,
+            payload_sha256: None,
+            payload_size: None,
         };
 
         let lambda_response: LambdaResponse = self.call_lambda(&check_request).await?;
@@ -467,6 +559,8 @@ impl CloudStorage for AwsStorage {
                     s3_url: Some(lambda_response.s3_url),
                     wants_payload_url: None,
                     payload_in_s3: stage_payload.then_some(true),
+                    payload_sha256: staged.as_ref().map(|s| s.sha256.clone()),
+                    payload_size: staged.as_ref().map(|s| s.size),
                 };
 
                 let _complete_response: serde_json::Value =
@@ -477,12 +571,12 @@ impl CloudStorage for AwsStorage {
                     "No bundled types available for {}; storing metadata only",
                     repo
                 );
-                self.store_repo_metadata(data, &lambda_response.s3_url, stage_payload)
+                self.store_repo_metadata(data, &lambda_response.s3_url, staged.as_ref())
                     .await?;
             }
         } else {
             debug!("Type file already exists, just updating metadata");
-            self.store_repo_metadata(data, &lambda_response.s3_url, stage_payload)
+            self.store_repo_metadata(data, &lambda_response.s3_url, staged.as_ref())
                 .await?;
         }
 
@@ -509,6 +603,8 @@ impl CloudStorage for AwsStorage {
             s3_url: None,
             wants_payload_url: None,
             payload_in_s3: None,
+            payload_sha256: None,
+            payload_size: None,
         };
 
         let lambda_response: LambdaResponse = self.call_lambda(&request).await?;
@@ -527,7 +623,8 @@ impl CloudStorage for AwsStorage {
             action: "get-cross-repo-data".to_string(),
         };
 
-        let response: CrossRepoResponse = self.call_lambda_generic(&request).await?;
+        let response: CrossRepoResponse =
+            self.call_lambda_generic(&request.action, &request).await?;
 
         let mut all_repo_data = Vec::new();
         let mut repo_s3_urls = HashMap::new();
@@ -600,7 +697,7 @@ impl CloudStorage for AwsStorage {
             timestamp,
         };
 
-        let resp: UploadLogsResponse = self.call_lambda_generic(&request).await?;
+        let resp: UploadLogsResponse = self.call_lambda_generic(&request.action, &request).await?;
         self.upload_to_s3(&resp.upload_url, log_content).await?;
 
         Ok(())
@@ -623,7 +720,7 @@ impl CloudStorage for AwsStorage {
 
         // Best-effort by contract (caller logs and swallows), but surface the
         // transport error so the caller can log a useful message.
-        self.send_lambda(&request).await?;
+        self.send_lambda(request.action, &request).await?;
         debug!(
             "Posted PR result for {} (PR #{})",
             payload.repo, payload.pr_number
@@ -642,6 +739,8 @@ impl CloudStorage for AwsStorage {
             s3_url: None,
             wants_payload_url: None,
             payload_in_s3: None,
+            payload_sha256: None,
+            payload_size: None,
         };
 
         match self.call_lambda::<LambdaResponse>(&request).await {
@@ -665,6 +764,16 @@ impl CloudStorage for AwsStorage {
     fn supports_multi_service(&self) -> bool {
         self.multi_service
             .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    // Oversized payloads go to the presigned staging object rather than the
+    // request body. Unconditionally true, and honest because it is: this is a
+    // property of the upload path, not a cloud capability to be discovered. A
+    // cloud that has not shipped staging returns no `payloadUploadUrl`, and
+    // `stage_payload` fails the upload with that named as the cause instead of
+    // silently truncating the payload.
+    fn stages_oversized_payloads(&self) -> bool {
+        true
     }
 }
 
@@ -715,6 +824,8 @@ mod tests {
             s3_url: None,
             wants_payload_url: None,
             payload_in_s3: None,
+            payload_sha256: None,
+            payload_size: None,
         };
         let json = serde_json::to_string(&bare).unwrap();
         assert!(!json.contains("wantsPayloadUrl"));
@@ -728,6 +839,123 @@ mod tests {
         let json = serde_json::to_string(&staged).unwrap();
         assert!(json.contains("\"wantsPayloadUrl\":true"));
         assert!(json.contains("\"payloadInS3\":true"));
+    }
+
+    /// Staged-payload integrity (carrick#536): the digest is lowercase hex of
+    /// the raw serialized bytes, and the size is their byte length — not the
+    /// character count of some re-encoding of the same data.
+    #[test]
+    fn staged_payload_digest_is_lowercase_hex_of_the_raw_bytes() {
+        // Known SHA-256 vector.
+        let staged = StagedPayload::of("abc");
+        assert_eq!(
+            staged.sha256,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(staged.size, 3);
+        assert_eq!(staged.sha256.len(), 64);
+        assert!(
+            staged
+                .sha256
+                .chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+        );
+
+        // Multi-byte characters count as bytes, matching what S3 stores.
+        let multibyte = StagedPayload::of("{\"note\":\"café\"}");
+        assert_eq!(multibyte.size, 16);
+    }
+
+    /// The integrity fields ride the write actions under the camelCase names
+    /// the cloud reads, and are omitted on every request that does not stage —
+    /// the inline body is itself the authenticated payload, so there is no
+    /// second hop to verify.
+    #[test]
+    fn integrity_fields_serialize_by_name_and_omit_when_none() {
+        let inline = LambdaRequest {
+            action: "store-metadata".to_string(),
+            repo: "r".to_string(),
+            service_name: None,
+            hash: "h".to_string(),
+            filename: "types.d.ts".to_string(),
+            cloud_repo_data: None,
+            s3_url: None,
+            wants_payload_url: None,
+            payload_in_s3: None,
+            payload_sha256: None,
+            payload_size: None,
+        };
+        let json = serde_json::to_string(&inline).unwrap();
+        assert!(!json.contains("payloadSha256"));
+        assert!(!json.contains("payloadSize"));
+
+        let digest = StagedPayload::of("{}");
+        let staged = LambdaRequest {
+            payload_in_s3: Some(true),
+            payload_sha256: Some(digest.sha256.clone()),
+            payload_size: Some(digest.size),
+            ..inline
+        };
+        let v = serde_json::to_value(&staged).unwrap();
+        assert_eq!(v["payloadSha256"], digest.sha256);
+        assert_eq!(v["payloadSize"], 2);
+    }
+
+    /// carrick#536: `complete-upload` and `store-metadata` write the index, so
+    /// a 5xx on them is ambiguous rather than final — the gateway can cut the
+    /// connection while the handler runs on and commits. One retry is enough
+    /// to catch the duplicate-recognition path; more just repeats the work.
+    /// Reads keep the full budget.
+    #[test]
+    fn write_actions_get_one_retry_and_reads_keep_the_full_budget() {
+        assert_eq!(max_retries_for_action("complete-upload"), 1);
+        assert_eq!(max_retries_for_action("store-metadata"), 1);
+
+        assert_eq!(
+            max_retries_for_action("check-or-upload"),
+            MAX_TRANSIENT_RETRIES
+        );
+        assert_eq!(
+            max_retries_for_action("get-cross-repo-data"),
+            MAX_TRANSIENT_RETRIES
+        );
+        assert_eq!(max_retries_for_action("upload-logs"), MAX_TRANSIENT_RETRIES);
+        assert_eq!(
+            max_retries_for_action("post-pr-result"),
+            MAX_TRANSIENT_RETRIES
+        );
+        // An action this file does not know is treated as a read.
+        assert_eq!(max_retries_for_action("some-new-action"), 3);
+    }
+
+    /// 5xx stays retryable as a status — the write cap is what bounds it, not
+    /// a status reclassification. Reclassifying would give writes zero retries
+    /// and lose the one attempt that recovers a cold start.
+    #[test]
+    fn write_cap_bounds_retries_without_reclassifying_5xx() {
+        assert!(is_transient_status(StatusCode::GATEWAY_TIMEOUT));
+        assert!(is_transient_status(StatusCode::INTERNAL_SERVER_ERROR));
+        let write = max_retries_for_action("store-metadata");
+        let read = max_retries_for_action("check-or-upload");
+        assert_eq!(write, MAX_WRITE_RETRIES);
+        assert!(write >= 1, "one retry is still made");
+        assert!(write < read, "writes are capped below the read budget");
+    }
+
+    /// Exhausting the budget on a write must not read as "the scan is lost".
+    /// The write may have landed before the gateway cut the response, which is
+    /// exactly what happened on the incident behind carrick#536.
+    #[test]
+    fn write_exhaustion_message_says_the_index_may_already_be_current() {
+        let msg = retry_exhausted_message("store-metadata", "Lambda returned 504: timeout", 2);
+        assert!(msg.contains("Lambda returned 504: timeout"));
+        assert!(msg.contains("after 2 attempts"));
+        assert!(msg.contains("store-metadata"));
+        assert!(msg.contains("may already be current"));
+
+        // Reads are unambiguous — no such caveat.
+        let read = retry_exhausted_message("get-cross-repo-data", "boom", 4);
+        assert_eq!(read, "boom (after 4 attempts)");
     }
 
     /// A pre-staging cloud omits `payloadUploadUrl` entirely; a staging cloud

--- a/src/cloud_storage/local_dir_storage.rs
+++ b/src/cloud_storage/local_dir_storage.rs
@@ -96,6 +96,12 @@ impl CloudStorage for LocalDirStorage {
         true
     }
 
+    // Writes to a local file, so no request-size wall applies and the caches
+    // are kept whatever the payload weighs.
+    fn stages_oversized_payloads(&self) -> bool {
+        true
+    }
+
     async fn download_all_repo_data(
         &self,
     ) -> Result<(Vec<CloudRepoData>, HashMap<String, String>), StorageError> {

--- a/src/cloud_storage/mock_storage.rs
+++ b/src/cloud_storage/mock_storage.rs
@@ -44,6 +44,12 @@ impl CloudStorage for MockStorage {
         true
     }
 
+    // Nothing crosses a wire, so no request-size wall applies and payloads are
+    // recorded whole — mock runs see the same caches a staged upload keeps.
+    fn stages_oversized_payloads(&self) -> bool {
+        true
+    }
+
     async fn post_pr_result(
         &self,
         payload: &crate::findings::PrResultPayload,

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -23,6 +23,7 @@ mod mock_storage;
 pub use mock_storage::MockStorage;
 mod aws_storage;
 pub use aws_storage::AwsStorage;
+pub(crate) use aws_storage::INLINE_PAYLOAD_LIMIT_BYTES;
 mod local_dir_storage;
 pub use local_dir_storage::{CACHE_DIR_ENV, LocalDirStorage};
 
@@ -569,6 +570,18 @@ pub trait CloudStorage {
     /// Mock storage records uploads in memory and is safe, so it overrides
     /// this. Gates multi-service index upload in the engine.
     fn supports_multi_service(&self) -> bool {
+        false
+    }
+
+    /// Whether this backend can carry a `CloudRepoData` that exceeds
+    /// [`INLINE_PAYLOAD_LIMIT_BYTES`] without dropping anything from it.
+    ///
+    /// `AwsStorage` PUTs oversized payloads to a presigned staging object
+    /// (carrick#486), which has no request-size wall, so the incremental
+    /// caches survive at any size. The engine's payload-size guard reads this:
+    /// when it is false the caches are dropped to fit the request under the
+    /// wall, and the next scan re-analyzes every file (carrick#536).
+    fn stages_oversized_payloads(&self) -> bool {
         false
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -3,8 +3,8 @@ use crate::agents::file_orchestrator::FileOrchestrator;
 use crate::agents::framework_guidance_agent::{FrameworkGuidanceAgent, ProtocolGuidance};
 use crate::analyzer::{Analyzer, ApiEndpointDetails, builder::AnalyzerBuilder};
 use crate::cloud_storage::{
-    CloudRepoData, CloudStorage, ManifestRole, ManifestTypeKind, ManifestTypeState,
-    TypeManifestEntry, get_current_commit_hash, mount_graph_to_api_details,
+    CloudRepoData, CloudStorage, INLINE_PAYLOAD_LIMIT_BYTES, ManifestRole, ManifestTypeKind,
+    ManifestTypeState, TypeManifestEntry, get_current_commit_hash, mount_graph_to_api_details,
 };
 use crate::config::Config;
 use crate::file_finder::find_service_files;
@@ -298,7 +298,7 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
             Some(
                 current_services_data
                     .iter()
-                    .map(|data| strip_ast_nodes(data.clone()))
+                    .map(|data| strip_ast_nodes(data.clone(), storage.stages_oversized_payloads()))
                     .collect(),
             )
         }
@@ -513,8 +513,9 @@ async fn run_analysis_engine_inner<T: CloudStorage>(
         // verdicts were appended after it — re-apply so a payload that was
         // near the cap can't be re-inflated past it and 413 the upload
         // (verdicts are tiny; the caches are what gets dropped).
+        let staging_available = storage.stages_oversized_payloads();
         for payload in &mut payloads {
-            enforce_payload_size_limit(payload);
+            enforce_payload_size_limit(payload, staging_available);
         }
         upload_service_payloads(storage, &payloads).await?;
     }
@@ -722,9 +723,11 @@ async fn upload_service_payloads<T: CloudStorage>(
     Ok(())
 }
 
-/// Remove AST nodes from CloudRepoData for serialization.
-/// Also enforces payload size limit for Lambda (6MB) — drops file_results if too large.
-fn strip_ast_nodes(mut data: CloudRepoData) -> CloudRepoData {
+/// Remove AST nodes from CloudRepoData for serialization, then run the payload
+/// size guard. `staging_available` comes from the storage backend and decides
+/// whether an oversized payload can keep its incremental caches — see
+/// [`enforce_payload_size_limit`].
+fn strip_ast_nodes(mut data: CloudRepoData, staging_available: bool) -> CloudRepoData {
     fn strip_endpoint_ast(endpoint: &mut ApiEndpointDetails) {
         endpoint.request_type = None;
         endpoint.response_type = None;
@@ -733,53 +736,78 @@ fn strip_ast_nodes(mut data: CloudRepoData) -> CloudRepoData {
     data.endpoints.iter_mut().for_each(strip_endpoint_ast);
     data.calls.iter_mut().for_each(strip_endpoint_ast);
 
-    enforce_payload_size_limit(&mut data);
+    enforce_payload_size_limit(&mut data, staging_available);
 
     data
 }
 
-/// Payload size guard: Lambda function URLs have a 6MB request payload limit.
-/// If serialized data exceeds ~5MB, drop the incremental caches (file_results
-/// being the bulk) to stay under the limit; warn loudly if it is still over
-/// Lambda's hard limit afterwards.
+/// Payload size guard for the request body.
+///
+/// A payload over [`INLINE_PAYLOAD_LIMIT_BYTES`] is not sent in the request
+/// body at all: `upload_repo_data` PUTs it to a presigned staging object and
+/// the write action carries only a pointer. The staged object has no
+/// request-size wall, so there is nothing to make room for and the incremental
+/// caches are kept whole. `staging_available` is the backend's answer to
+/// whether it does that (`CloudStorage::stages_oversized_payloads`); the
+/// threshold below is the same one `upload_repo_data` measures against, so the
+/// two decisions cannot drift.
+///
+/// Only when the backend does not stage does the request body have to fit, and
+/// then the incremental caches (`file_results` being the multi-MB bulk) are
+/// what gets dropped. Before carrick#536 the drop ran unconditionally, so every
+/// large repo lost its caches and re-analyzed every file on the next scan even
+/// though its payload had been staged.
 ///
 /// Called twice per upload payload: inside [`strip_ast_nodes`] when the payload
 /// is prepared, and again after [`crate::cloud_storage::attach_compat_verdicts`]
 /// adds the per-pair type verdicts (#351) — anything appended after the first
-/// pass could otherwise re-inflate the JSON past the cap and 413 the upload.
-/// Degradation order is deliberate: verdicts are tiny (a handful of short
-/// strings per cross-repo edge) while `file_results` is the multi-MB bulk, so
-/// the caches are always what gets dropped; verdicts are kept.
-fn enforce_payload_size_limit(data: &mut CloudRepoData) {
-    const MAX_PAYLOAD_BYTES: usize = 5 * 1024 * 1024; // 5MB safety margin
-    const LAMBDA_HARD_LIMIT_BYTES: usize = 6 * 1024 * 1024;
-    if let Ok(serialized) = serde_json::to_string(&data)
-        && serialized.len() > MAX_PAYLOAD_BYTES
+/// pass could otherwise re-inflate the JSON past the cap. Degradation order is
+/// deliberate: verdicts are tiny (a handful of short strings per cross-repo
+/// edge) while `file_results` is the bulk, so the caches are always what gets
+/// dropped; verdicts are kept.
+fn enforce_payload_size_limit(data: &mut CloudRepoData, staging_available: bool) {
+    // Sits above INLINE_PAYLOAD_LIMIT_BYTES, so any payload that reaches this
+    // threshold is one `upload_repo_data` stages rather than inlines.
+    const MAX_PAYLOAD_BYTES: usize = 5 * 1024 * 1024;
+    let Ok(serialized) = serde_json::to_string(&data) else {
+        return;
+    };
+    if serialized.len() <= MAX_PAYLOAD_BYTES {
+        return;
+    }
+
+    if staging_available && serialized.len() > INLINE_PAYLOAD_LIMIT_BYTES {
+        debug!(
+            "Payload size {}KB is over the {}KB inline limit, so it will be staged to S3 \
+             rather than sent in the request body; keeping the incremental caches",
+            serialized.len() / 1024,
+            INLINE_PAYLOAD_LIMIT_BYTES / 1024
+        );
+        return;
+    }
+
+    warn!(
+        "Payload size {}KB exceeds {}KB limit and this backend does not stage oversized \
+         payloads, so the file_results cache is dropped for this upload — the next scan \
+         cannot run incrementally and will re-analyze every file",
+        serialized.len() / 1024,
+        MAX_PAYLOAD_BYTES / 1024
+    );
+    data.file_results = None;
+    data.cached_detection = None;
+    data.cached_guidance = None;
+
+    // Re-check: if the body is still over the inline limit even without the
+    // caches, say so up front — the upload will be rejected.
+    if let Ok(reserialized) = serde_json::to_string(&data)
+        && reserialized.len() > INLINE_PAYLOAD_LIMIT_BYTES
     {
         warn!(
-            "Payload size {}KB exceeds {}KB limit, dropping file_results cache for this \
-             upload — the next scan cannot run incrementally and will re-analyze every file",
-            serialized.len() / 1024,
-            MAX_PAYLOAD_BYTES / 1024
+            "Payload is still {}KB after dropping caches, over the {}KB the request body \
+             can carry — the upload will be rejected.",
+            reserialized.len() / 1024,
+            INLINE_PAYLOAD_LIMIT_BYTES / 1024
         );
-        data.file_results = None;
-        data.cached_detection = None;
-        data.cached_guidance = None;
-
-        // Re-check: if the payload is still over Lambda's hard request limit
-        // even without the cache, say so up front — the upload will be
-        // rejected with an otherwise cryptic 413.
-        if let Ok(reserialized) = serde_json::to_string(&data)
-            && reserialized.len() > LAMBDA_HARD_LIMIT_BYTES
-        {
-            warn!(
-                "Payload is still {}KB after dropping caches, which exceeds the cloud's \
-                 {}KB request limit — the upload will likely be rejected. Consider splitting \
-                 the repo into services via carrick.json.",
-                reserialized.len() / 1024,
-                LAMBDA_HARD_LIMIT_BYTES / 1024
-            );
-        }
     }
 }
 
@@ -4156,7 +4184,7 @@ mod tests {
         };
 
         // Verify strip_ast_nodes removes AST nodes
-        let stripped = strip_ast_nodes(test_data);
+        let stripped = strip_ast_nodes(test_data, true);
 
         assert!(stripped.endpoints[0].request_type.is_none());
         assert!(stripped.endpoints[0].response_type.is_none());
@@ -4885,12 +4913,14 @@ mod tests {
             sdk_unresolved: None,
         };
 
-        let stripped = strip_ast_nodes(data);
+        // Staging unavailable: the request body has to carry the payload, so
+        // the caches are what gets dropped to fit it under the wall.
+        let stripped = strip_ast_nodes(data, false);
 
-        // file_results should be dropped because payload exceeds 5MB
         assert!(
             stripped.file_results.is_none(),
-            "file_results should be dropped when payload exceeds 5MB"
+            "file_results should be dropped when the payload exceeds 5MB and \
+             the backend cannot stage it"
         );
     }
 
@@ -4934,7 +4964,7 @@ mod tests {
             sdk_unresolved: None,
         };
 
-        let stripped = strip_ast_nodes(data);
+        let stripped = strip_ast_nodes(data, true);
 
         // file_results should be preserved (small payload)
         assert!(
@@ -4943,10 +4973,93 @@ mod tests {
         );
     }
 
+    /// carrick#536 regression: the guard used to drop the incremental caches
+    /// from every payload over 5MB, without asking whether that payload was
+    /// going to travel in the request body at all. It was not — anything over
+    /// the 5MB guard is also over [`INLINE_PAYLOAD_LIMIT_BYTES`], so
+    /// `upload_repo_data` stages it to S3 and the request carries a pointer.
+    /// Large repos lost their caches and re-analyzed every file on the next
+    /// scan for nothing. Same oversized payload, both answers from the backend.
+    #[test]
+    fn test_payload_size_guard_keeps_caches_when_the_payload_will_be_staged() {
+        const MAX_PAYLOAD_BYTES: usize = 5 * 1024 * 1024; // mirrors the guard
+
+        fn oversized() -> CloudRepoData {
+            let mut result = make_file_result(vec!["/api/orders"], vec![]);
+            result.endpoints[0].payload_expression_text = Some("x".repeat(MAX_PAYLOAD_BYTES));
+            let mut file_results = HashMap::new();
+            file_results.insert("src/big.ts".to_string(), result);
+            CloudRepoData {
+                repo_name: "orders-svc".to_string(),
+                service_name: None,
+                endpoints: vec![],
+                calls: vec![],
+                mounts: vec![],
+                apps: HashMap::new(),
+                imported_handlers: vec![],
+                function_definitions: HashMap::new(),
+                config_json: None,
+                package_json: None,
+                packages: None,
+                last_updated: chrono::Utc::now(),
+                commit_hash: "test-hash".to_string(),
+                mount_graph: None,
+                bundled_types: None,
+                type_manifest: None,
+                file_results: Some(file_results),
+                cached_detection: Some(crate::framework_detector::DetectionResult {
+                    frameworks: vec!["express".to_string()],
+                    data_fetchers: vec![],
+                    messaging_clients: vec![],
+                    notes: String::new(),
+                }),
+                cached_guidance: None,
+                cached_extraction_config: None,
+                package_json_hash: None,
+                cache_version: Some(CACHE_VERSION),
+                type_extraction_status: None,
+                compat_verdicts: None,
+                capture_stub: None,
+                external_call_candidates: None,
+                sdk_surface: None,
+                sdk_edges: None,
+                sdk_unresolved: None,
+            }
+        }
+
+        // Test setup: the payload is over the guard's threshold, and therefore
+        // also over the inline limit the staging decision measures against.
+        let len = serde_json::to_string(&oversized()).unwrap().len();
+        assert!(len > MAX_PAYLOAD_BYTES);
+        assert!(len > INLINE_PAYLOAD_LIMIT_BYTES);
+
+        let mut staged = oversized();
+        enforce_payload_size_limit(&mut staged, true);
+        assert!(
+            staged.file_results.is_some(),
+            "a payload the upload path will stage keeps its file_results cache"
+        );
+        assert!(
+            staged.cached_detection.is_some(),
+            "a payload the upload path will stage keeps its detection cache"
+        );
+
+        let mut inlined = oversized();
+        enforce_payload_size_limit(&mut inlined, false);
+        assert!(
+            inlined.file_results.is_none(),
+            "without staging the request body must fit, so the caches are dropped"
+        );
+        assert!(
+            inlined.cached_detection.is_none(),
+            "without staging the detection cache is dropped too"
+        );
+    }
+
     /// #351 regression: `attach_compat_verdicts` runs AFTER the strip_ast_nodes
     /// size-guard pass, so verdicts appended to a payload that squeaked under
-    /// the 5MB cap could re-inflate it past the Lambda limit and 413 the
-    /// upload. The engine re-applies `enforce_payload_size_limit` after
+    /// the 5MB cap could re-inflate it past what the request body can carry.
+    /// The engine re-applies `enforce_payload_size_limit` after
     /// attachment; this pins that a near-limit payload with verdicts attached
     /// still respects the cap, with the SAME degradation order as the first
     /// pass — the bulky caches are dropped, the tiny verdicts are kept.
@@ -5007,7 +5120,7 @@ mod tests {
 
         // First guard pass (as strip_ast_nodes runs it): under the cap, so the
         // caches survive.
-        let mut payloads = vec![strip_ast_nodes(data)];
+        let mut payloads = vec![strip_ast_nodes(data, false)];
         assert!(
             payloads[0].file_results.is_some(),
             "test setup: payload must start under the cap with caches intact"
@@ -5038,7 +5151,7 @@ mod tests {
 
         // The engine's post-attachment pass: back under the cap, caches
         // dropped, verdicts kept.
-        enforce_payload_size_limit(&mut payloads[0]);
+        enforce_payload_size_limit(&mut payloads[0], false);
         let after = serde_json::to_string(&payloads[0]).unwrap().len();
         assert!(
             after <= MAX_PAYLOAD_BYTES,


### PR DESCRIPTION
Closes #537.

Seven consumer calls in the reported case were recorded as `POST /*` / `GET /*` and matched to the producer's catch-all UI route. Two independent defects produced that, one on each side of the join.

## 1. Config-object request calls raised no candidate at all

`client({ method: "post", url: "/api/v1/auth/universal-auth/login" })` states its method and URL as data on one object-literal argument, and the scanner could not see it:

- no argument is a string, so the URL-scheme and stringish-argument signals never fire;
- the client is frequently a bare binding passed in as a parameter, so the callee-name heuristics never fire either;
- the object's first-line source snippet is `{`, so even when another signal did emit the span, the candidate carried nothing to anchor on.

A probe of that shape through `scan_content` returns zero candidates on `main`. The path was therefore whatever the model returned, and nothing in `src/` synthesises `/*`, so the wildcard came from the model guessing at a call it had been given no hint for.

`CandidateVisitor::call_request_spec` now reads the `{ method, url }` pair off the first argument structurally. Property names are the whole signal, and no client library is named anywhere. Three guards keep it off ordinary options bags: both values must be string literals, the method must be an HTTP verb, and the URL must be route-shaped (a leading `/` or an http(s) URL). It stays separate from `route_descriptor`, which owns the producer registry shape and keeps its #241 behaviour unchanged.

The spec does three things:

- it raises the candidate (signal 2b), so the file is no longer skipped before the analyzer sees it;
- it puts the URL literal in the candidate's `path_snippet`, where the existing endpoint re-anchor already reads it, so a route registered the same way (`server.route({ method, url, handler })`) anchors to its real path too;
- it rides on the candidate as a `#[serde(skip)]` field, so `reanchor_data_call` can overrule the model's `target` and `method` after it replies. The candidate JSON in the prompt stays byte-identical, which keeps the implicit prefix cache intact.

A target that already ends with the structural URL at a segment boundary is kept rather than replaced. A client built with a configured `baseURL` yields `${API_URL}/api/v1/login`, and that base is the one part of the answer the model may know better, since the normalizer needs it for internal and external classification. This is the same baked-prefix rule `reanchor_endpoint_path` applies on the producer side.

## 2. A path-less call could still match

`match_agreement("/*", "/*")` returns `Some(0)` through its exact-equality shortcut, and `Some(0)` reads as a match to any surface that only asks `paths_match`, so a producer's SPA fallback absorbs every call whose path never resolved.

**carrick-match changed, additively.** New public items:

- `is_unknown_call_path`, true for a consumer path with no literal segment (`/*`, `*`, `/`, empty, a wholly interpolated template). Such a path is not a call to every route, it is a call whose path the scanner failed to resolve;
- `MatchVerdict`, with variants `Matched`, `UnknownCallPath`, `CatchAllRoute`, `NoRouteMatch` and `NoLiteralAgreement`, ordered so the consumer's own failure is named first;
- `match_verdict` and `reportable_agreement`, which answer the question a reporting surface actually asks, in enum and `Option<u32>` form.

`paths_match` and `match_agreement` keep their exact current semantics and every existing test. `paths_match` still answers routing truth, which `classify_endpoint_evidence` depends on, and narrowing it would have re-opened the #379 fabricated-producer class.

The analyzer now calls `reportable_agreement` instead of re-deriving the rule, and it reports a call with an unresolved path as unmatched rather than letting a catch-all swallow it in silence. A catch-all absorbing a *known* path stays silent, as #381 pinned.

**The cloud pin must be bumped.** These are new wasm exports, so the cloud and the MCP server pick them up on the next release by hash, and until then they keep the old surface and the old behaviour. The wasm smoke tests in `ci.yml` and `wasm-artifact.yml` assert the new exports, and the `nodejs` glue was built locally against the pinned wasm-bindgen 0.2.126 to confirm the enum and the `Option<u32>` return cross the ABI.

## Tests

Twelve new tests, with `cargo test` fully green including the cassette hard gate. That gate needs `npm run build` in `src/sidecar` first; without it the diff is entirely type-resolution fields and it fails the same way on a clean tree.

- `crates/carrick-match`: the unknown-path definition, both halves of the rejection, prefixed catch-alls staying reportable, and the two rejections keeping distinct names.
- `src/swc_scanner.rs`: the reported shape yields method, URL and an anchored `path_snippet`; the shape is recognised whatever the callee is; five non-request config objects carry no spec; a config-object route registration anchors its own path literal.
- `src/agents/file_orchestrator.rs`: the spec overrules the model's target and method; a target already carrying the URL is kept; candidates without a spec are untouched.
- `src/analyzer/mod.rs`: a path-less call never pairs and surfaces as unmatched.

The two fixes compose, since once extraction lands those calls have real paths and stop being unknown-path, so each is tested independently of the other.

## Follow-up

`src/engine/type_compat_v2.rs:643` carries a private `paths_match` with its own scoring that does not delegate to carrick-match, against the never-fork rule in AGENTS.md. That is out of scope here and worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
