### PR TITLE
fix(sdk): resolve accessor-returned resources and layered SDK calls

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2364,6 +2364,9 @@ fn relativize_cloud_paths(cloud_data: &mut CloudRepoData, repo_path: &str) {
     if let Some(members) = cloud_data.sdk_surface.as_mut() {
         for member in members {
             member.file = repo_relative(&member.file, repo_path);
+            for span in member.delegates.iter_mut() {
+                span.file = repo_relative(&span.file, repo_path);
+            }
         }
     }
 }
@@ -4020,6 +4023,11 @@ mod tests {
                 file: abs("src/resources/payments.ts"),
                 line: 28,
                 end_line: 33,
+                delegates: vec![crate::sdk_surface::SdkSpan {
+                    file: abs("src/api/payments.ts"),
+                    line: 12,
+                    end_line: 18,
+                }],
             }]),
             sdk_edges: None,
             sdk_unresolved: None,

--- a/src/sdk_edges.rs
+++ b/src/sdk_edges.rs
@@ -10,7 +10,9 @@
 //! 2. the SDK repo's [`crate::sdk_surface`], which maps that export and member
 //!    chain to the source span implementing it;
 //! 3. the [`crate::analyzer::CrossRepoMatch`] the SDK repo's OWN outbound call
-//!    inside that span already formed with the producer endpoint.
+//!    inside that span — or inside one of the member's delegate spans, for a
+//!    client that layers its transport below the published method — already
+//!    formed with the producer endpoint.
 //!
 //! Nothing new is matched here. Step 3 reads the edges the cross-repo analyzer
 //! produced this run — it merges every repo's calls and endpoints into one
@@ -53,9 +55,11 @@
 //!
 //! - `no_sdk_repo_in_project` — no scanned repo declares that package name, or
 //!   several do (which one publishes it is then a guess).
-//! - `receiver_unresolved` — the receiver is a namespace import, or the callee
-//!   chain runs through a call (`getClient().payments.create`), so no single
-//!   member is named.
+//! - `receiver_unresolved` — the receiver is a namespace import, so there is no
+//!   export to anchor the chain to. An accessor call INSIDE the chain is not
+//!   this case: `client.transfers().send` names the member the surface
+//!   walks as `transfers.send`, and whether it exists is
+//!   `member_not_found`'s answer.
 //! - `member_not_found` — the SDK repo publishes no such member; also the
 //!   answer for a subpath import (`pkg/edge`), whose entry module is not the
 //!   root one the surface was walked from, and for a peer scanned before
@@ -344,7 +348,10 @@ pub fn join(input: &SdkJoinInput, matches: &[CrossRepoMatch]) -> SdkJoin {
             // 3. Which producer does the SDK's own call inside that member reach?
             let mut matched = false;
             for (file, line) in &peer.data_calls {
-                if file != &member.file || *line < member.line || *line > member.end_line {
+                let inside = member_spans(member).any(|(span_file, start, end)| {
+                    span_file == file && *line >= start && *line <= end
+                });
+                if !inside {
                     continue;
                 }
                 let Some(producers) =
@@ -516,12 +523,34 @@ fn key_labels(producer_key: &str) -> (String, String) {
 /// already answered by `import_symbol`.
 fn member_chain(callee: &str) -> Option<String> {
     let mut segments = callee.split('.');
+    // The root binding's own `()` is not read: what bound the receiver is
+    // already answered by `import_symbol`.
     segments.next()?;
-    let rest: Vec<&str> = segments.collect();
-    if rest.iter().any(|segment| segment.contains("()")) {
-        return None;
+    let mut chain = Vec::new();
+    for segment in segments {
+        // An accessor call inside the chain names a member exactly as a field
+        // does — `client.transfers().send` reaches what the published
+        // surface walks as `transfers.send`. Whether that member exists is
+        // the surface's answer, not a reason to stop here.
+        let name = segment.trim_end_matches("()");
+        if name.contains('(') || name.contains(')') {
+            return None;
+        }
+        chain.push(name);
     }
-    Some(rest.join("."))
+    Some(chain.join("."))
+}
+
+/// Every span the SDK's own outbound call for `member` may sit in: the member
+/// itself, and the same-repo methods it delegates to. A layered client writes
+/// its route one hop below the published method.
+fn member_spans(member: &SdkMember) -> impl Iterator<Item = (&str, u32, u32)> {
+    std::iter::once((member.file.as_str(), member.line, member.end_line)).chain(
+        member
+            .delegates
+            .iter()
+            .map(|span| (span.file.as_str(), span.line, span.end_line)),
+    )
 }
 
 /// Attach each service's SDK edges to its upload payload, mirroring
@@ -611,6 +640,7 @@ mod tests {
             file: "src/resources/payments.ts".to_string(),
             line: 28,
             end_line: 33,
+            delegates: vec![],
         }]);
         let mut graph = MountGraph::new();
         graph.data_calls = vec![DataFetchingCall {
@@ -712,6 +742,90 @@ mod tests {
         assert!(joined.unresolved().is_empty());
     }
 
+    /// A layered client: the member a consumer calls holds no route, and the
+    /// SDK's own outbound call sits in the api wrapper one hop below it. The
+    /// consumer writes the accessor call in the middle of the chain.
+    ///
+    /// Both halves of the join move here — `transfers().send` has to reduce to
+    /// the member `transfers.send`, and the producer has to be found through
+    /// the member's delegate span rather than its own.
+    fn layered_sdk_repo() -> CloudRepoData {
+        let mut data = sdk_repo();
+        data.sdk_surface = Some(vec![SdkMember {
+            export: "default".to_string(),
+            chain: "transfers.send".to_string(),
+            file: "src/resources/transfers.ts".to_string(),
+            line: 6,
+            end_line: 8,
+            delegates: vec![crate::sdk_surface::SdkSpan {
+                file: "src/api/transfers.ts".to_string(),
+                line: 2,
+                end_line: 7,
+            }],
+        }]);
+        let mut graph = MountGraph::new();
+        graph.data_calls = vec![DataFetchingCall {
+            method: "POST".to_string(),
+            target_url: "/v1/payments".to_string(),
+            canonical_path: "/v1/payments".to_string(),
+            client: "fetch(".to_string(),
+            file_location: "src/api/transfers.ts:3".to_string(),
+            call_kind: None,
+            repo_name: None,
+            service_name: None,
+            host: None,
+            line: Some(3),
+        }];
+        data.mount_graph = Some(graph);
+        data
+    }
+
+    fn layered_match() -> CrossRepoMatch {
+        let mut edge = sdk_to_producer_match();
+        edge.consumer_location = Some("src/api/transfers.ts:3".to_string());
+        edge
+    }
+
+    #[test]
+    fn an_accessor_call_in_the_chain_resolves_to_the_member_it_names() {
+        let joined = run(
+            &[producer(), layered_sdk_repo()],
+            &[consumer_with(candidate("ledger.transfers().send"))],
+            &[layered_match()],
+        );
+
+        assert_eq!(joined.edges().len(), 1, "{:?}", joined);
+        let edge = &joined.edges()[0];
+        assert_eq!(edge.sdk_member, "transfers.send");
+        assert_eq!(edge.callee, "ledger.transfers().send");
+        // The location stays the member's own: the delegate is where the call
+        // was found, not what the consumer reached.
+        assert_eq!(edge.sdk_location, "src/resources/transfers.ts:6");
+        assert_eq!(edge.producer_key, PRODUCER_KEY);
+        assert!(joined.unresolved().is_empty());
+    }
+
+    /// Without the delegate span the same call has nowhere to land: the
+    /// member's own body holds no route.
+    #[test]
+    fn a_layered_call_outside_every_known_span_is_unresolved() {
+        let mut sdk = layered_sdk_repo();
+        if let Some(members) = sdk.sdk_surface.as_mut() {
+            members[0].delegates.clear();
+        }
+        let joined = run(
+            &[producer(), sdk],
+            &[consumer_with(candidate("ledger.transfers().send"))],
+            &[layered_match()],
+        );
+
+        assert!(joined.edges().is_empty());
+        assert_eq!(
+            reasons(&joined),
+            vec![(SDK_PACKAGE.to_string(), NO_MATCHING_PRODUCER.to_string(), 1)]
+        );
+    }
+
     /// The edge lands on the CONSUMER's blob, the same storage convention the
     /// compat verdicts follow — never on the producer's or the SDK's.
     #[test]
@@ -779,10 +893,12 @@ mod tests {
         );
     }
 
-    /// A call in the middle of the chain means the value the chain continues
-    /// from only exists at runtime.
+    /// A call in the middle of the chain names a member the surface may or may
+    /// not publish. When it does not, that is `member_not_found` — the same
+    /// answer a field spelled the same way would get, and not a claim that the
+    /// receiver was unresolvable.
     #[test]
-    fn a_call_inside_the_chain_is_unresolved() {
+    fn an_accessor_the_sdk_does_not_publish_is_not_found() {
         let joined = run(
             &[producer(), sdk_repo()],
             &[consumer_with(candidate("ledger.transport().create"))],
@@ -791,7 +907,7 @@ mod tests {
         assert!(joined.edges().is_empty());
         assert_eq!(
             reasons(&joined),
-            vec![(SDK_PACKAGE.to_string(), RECEIVER_UNRESOLVED.to_string(), 1)]
+            vec![(SDK_PACKAGE.to_string(), MEMBER_NOT_FOUND.to_string(), 1)]
         );
     }
 
@@ -1162,6 +1278,17 @@ mod tests {
             member_chain("getLedger().scrape").as_deref(),
             Some("scrape")
         );
-        assert_eq!(member_chain("ledger.transport().send"), None);
+        // An accessor call inside the chain names a member exactly as a field
+        // does; whether that member exists is the surface's answer.
+        assert_eq!(
+            member_chain("ledger.transfers().send").as_deref(),
+            Some("transfers.send")
+        );
+        // `Step::Call` renders as a bare `()` whatever its arguments, so a
+        // curried factory repeats it rather than printing anything else.
+        assert_eq!(
+            member_chain("ledger.transfers()().send").as_deref(),
+            Some("transfers.send")
+        );
     }
 }

--- a/src/sdk_surface.rs
+++ b/src/sdk_surface.rs
@@ -24,12 +24,35 @@
 //!   into each field whose declared type or `new X(...)` initialiser names a
 //!   class declared in the repo (`payments: API.Payments = new
 //!   API.Payments(this)` → the `Payments` class, with `payments.` prefixed to
-//!   every member it contributes);
+//!   every member it contributes). A constructor **parameter property**
+//!   (`constructor(public payments: Payments) {}`) is a field like any other;
+//! - a method or function-valued field that **hands back** a sub-resource
+//!   (`transfers = () => this.transfersClient`, `transfers(): Transfers { ... }`)
+//!   is both a callable member and a hop: the class it returns contributes
+//!   `transfers.` — which is the chain a consumer writes as
+//!   `client.transfers().send(...)`;
 //! - an exported **object literal** contributes the same way over its
 //!   properties;
 //! - `export { default as Ledger } from './client'` and `export default
 //!   Ledger` both publish under the export name `default`, which is what a
 //!   consumer's default import binds.
+//!
+//! `private` and `protected` members are not surface: TypeScript forbids a
+//! consumer writing them, so publishing `transfersClient.send` for a
+//! `private transfersClient` names a chain nobody can call. They stay fully
+//! resolvable internally — a public accessor that returns `this.transfersClient`
+//! reaches the class through exactly that field.
+//!
+//! # Delegates
+//!
+//! A layered client puts the route one hop below the member: the published
+//! `send` calls `this.api.send(...)`, and only THAT method writes
+//! `/v1/transfers`. A member therefore carries the spans of the
+//! same-repo methods its body calls through a `this.<field>` receiver, up to
+//! [`MAX_DELEGATE_DEPTH`] hops, so the join in [`crate::sdk_edges`] can find
+//! the SDK's own outbound call wherever in that chain it sits. Only class
+//! hops are followed: a field holding an object literal names no declaration
+//! to resolve a method in.
 //!
 //! Resolution runs through [`crate::import_bindings::BindingResolver`], so a
 //! barrel in front of the real module is followed rather than guessed at.
@@ -69,10 +92,12 @@ use swc_common::{
     sync::Lrc,
 };
 use swc_ecma_ast::{
-    Class, ClassMember, Decl, DefaultDecl, Expr, ImportSpecifier, MethodKind, Module, ModuleDecl,
-    ModuleExportName, ModuleItem, ObjectLit, Pat, Prop, PropName, PropOrSpread, Stmt, TsEntityName,
-    TsType, TsTypeAnn,
+    Accessibility, ArrowExpr, BindingIdent, BlockStmt, BlockStmtOrExpr, CallExpr, Callee, Class,
+    ClassMember, Decl, DefaultDecl, Expr, Function, ImportSpecifier, MethodKind, Module,
+    ModuleDecl, ModuleExportName, ModuleItem, ObjectLit, ParamOrTsParamProp, Pat, Prop, PropName,
+    PropOrSpread, Stmt, TsEntityName, TsParamPropParam, TsType, TsTypeAnn,
 };
+use swc_ecma_visit::{Visit, VisitWith};
 use tracing::{debug, warn};
 
 /// The export name a default export is published under.
@@ -84,6 +109,15 @@ const MAX_DEPTH: usize = 4;
 /// Hard cap on emitted members. A surface this size is a resolution accident,
 /// not a client library; truncating keeps the payload bounded and logs loudly.
 const MAX_MEMBERS: usize = 20_000;
+
+/// How many same-repo method hops a member's delegate spans follow. Two covers
+/// the layered shape this exists for — published method → api wrapper → the
+/// transport that writes the URL — without walking a whole call graph.
+const MAX_DELEGATE_DEPTH: usize = 2;
+
+/// Cap on the delegate spans one member carries. A member that reaches more
+/// than this is a fan-out, not a delegation chain.
+const MAX_DELEGATES: usize = 32;
 
 /// Directories whose contents are build output or dependencies, never the
 /// package's own source.
@@ -105,7 +139,25 @@ pub struct SdkMember {
     /// 1-based first line of the method.
     pub line: u32,
     /// 1-based last line of the method. The span a consumer's call maps onto:
-    /// the SDK's own outbound call sits somewhere inside it.
+    /// the SDK's own outbound call sits somewhere inside it, or inside one of
+    /// the [`SdkMember::delegates`].
+    pub end_line: u32,
+    /// Spans of the same-repo methods this member's body calls through a
+    /// `this.<field>` receiver, and what those call in turn. A layered client
+    /// writes its route one hop below the published method, so the SDK's own
+    /// outbound call is not always inside the member's own span.
+    ///
+    /// `default` for surfaces written before the field existed: absent is an
+    /// unlayered member, which is what every such surface was read as.
+    #[serde(default)]
+    pub delegates: Vec<SdkSpan>,
+}
+
+/// A source range in the SDK repo, repo-relative and 1-based.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SdkSpan {
+    pub file: String,
+    pub line: u32,
     pub end_line: u32,
 }
 
@@ -252,6 +304,83 @@ impl Declared {
     }
 }
 
+/// The class a `this` refers to, with the module context that resolves its
+/// fields. Carried through the walk so an arrow written in a class body — as a
+/// field, or inside an object literal a field holds — resolves `this.<field>`
+/// against the class that lexically encloses it.
+#[derive(Clone)]
+struct ClassCtx {
+    file: PathBuf,
+    module: Rc<Module>,
+    class: Rc<Class>,
+}
+
+/// A function written as a value: `payments = () => ...` or `payments =
+/// function () { ... }`. The two shapes answer the same three questions, and
+/// every caller needs all three.
+enum FunctionValue<'a> {
+    Arrow(&'a ArrowExpr),
+    Fn(&'a Function),
+}
+
+impl FunctionValue<'_> {
+    fn this_calls(&self) -> Vec<Vec<String>> {
+        match self {
+            FunctionValue::Arrow(arrow) => this_calls_of_arrow(arrow),
+            FunctionValue::Fn(function) => this_calls_of_function(function),
+        }
+    }
+
+    fn return_type(&self) -> Option<&TsTypeAnn> {
+        match self {
+            FunctionValue::Arrow(arrow) => arrow.return_type.as_deref(),
+            FunctionValue::Fn(function) => function.return_type.as_deref(),
+        }
+    }
+
+    fn returned_expr(&self) -> Option<Expr> {
+        match self {
+            FunctionValue::Arrow(arrow) => arrow_returned_expr(arrow).cloned(),
+            FunctionValue::Fn(function) => function
+                .body
+                .as_ref()
+                .and_then(block_returned_expr)
+                .cloned(),
+        }
+    }
+}
+
+/// The function an initialiser expression IS, if any.
+fn function_value(expr: Option<&Expr>) -> Option<FunctionValue<'_>> {
+    match expr? {
+        Expr::Arrow(arrow) => Some(FunctionValue::Arrow(arrow)),
+        Expr::Fn(function) => Some(FunctionValue::Fn(&function.function)),
+        _ => None,
+    }
+}
+
+/// The binding a constructor parameter property declares, whether or not it
+/// carries a default (`public receipts: Refunds = new Refunds()`).
+fn param_prop_ident(param: &TsParamPropParam) -> Option<&BindingIdent> {
+    match param {
+        TsParamPropParam::Ident(ident) => Some(ident),
+        TsParamPropParam::Assign(assign) => match &*assign.left {
+            Pat::Ident(ident) => Some(ident),
+            _ => None,
+        },
+    }
+}
+
+/// Whether a class member is part of the surface a consumer can write.
+/// TypeScript forbids reaching a `private` or `protected` member from outside
+/// the class, so publishing one names a chain nobody can call.
+fn is_public(accessibility: Option<Accessibility>) -> bool {
+    !matches!(
+        accessibility,
+        Some(Accessibility::Private) | Some(Accessibility::Protected)
+    )
+}
+
 struct SurfaceScanner {
     repo_root: PathBuf,
     source_map: Lrc<SourceMap>,
@@ -290,7 +419,7 @@ impl SurfaceScanner {
                 continue;
             };
             let mut visited = HashSet::new();
-            self.walk(&export, "", declared, 0, &mut visited);
+            self.walk(&export, "", declared, None, 0, &mut visited);
         }
     }
 
@@ -424,11 +553,13 @@ impl SurfaceScanner {
         self.declaration_of(&binding.file, binding.local_name.as_deref())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn walk(
         &mut self,
         export: &str,
         prefix: &str,
         declared: Declared,
+        this_ctx: Option<&ClassCtx>,
         depth: usize,
         visited: &mut HashSet<(PathBuf, BytePos)>,
     ) {
@@ -441,12 +572,18 @@ impl SurfaceScanner {
         }
         match &declared {
             Declared::Class(file, module, class) => {
-                let (file, module, class) = (file.clone(), module.clone(), class.clone());
-                self.walk_class(export, prefix, &file, &module, &class, depth, visited);
+                let ctx = ClassCtx {
+                    file: file.clone(),
+                    module: module.clone(),
+                    class: class.clone(),
+                };
+                self.walk_class(export, prefix, &ctx, depth, visited);
             }
             Declared::Object(file, module, object) => {
                 let (file, module, object) = (file.clone(), module.clone(), object.clone());
-                self.walk_object(export, prefix, &file, &module, &object, depth, visited);
+                self.walk_object(
+                    export, prefix, &file, &module, &object, this_ctx, depth, visited,
+                );
             }
             // A bare exported function has no member chain under it: the
             // consumer calls the export itself, which `import_symbol` already
@@ -456,39 +593,76 @@ impl SurfaceScanner {
         visited.remove(&anchor);
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn walk_class(
         &mut self,
         export: &str,
         prefix: &str,
-        file: &Path,
-        module: &Rc<Module>,
-        class: &Class,
+        ctx: &ClassCtx,
         depth: usize,
         visited: &mut HashSet<(PathBuf, BytePos)>,
     ) {
+        let class = ctx.class.clone();
         for member in &class.body {
             match member {
                 // An overload signature carries no body and no implementation
                 // to anchor to; the implementation that follows it does.
                 ClassMember::Method(method)
-                    if method.function.body.is_some() && method.kind == MethodKind::Method =>
+                    if method.function.body.is_some()
+                        && method.kind == MethodKind::Method
+                        && is_public(method.accessibility) =>
                 {
                     let Some(name) = member_name(&method.key) else {
                         continue;
                     };
-                    self.emit(export, prefix, &name, file, method.span);
+                    let delegates =
+                        self.delegates_of(ctx, this_calls_of_function(&method.function));
+                    self.emit(export, prefix, &name, &ctx.file, method.span, delegates);
+                    let returned = self.returned_declaration(
+                        ctx,
+                        method.function.return_type.as_deref(),
+                        method
+                            .function
+                            .body
+                            .as_ref()
+                            .and_then(block_returned_expr)
+                            .cloned(),
+                    );
+                    self.hop(export, prefix, &name, returned, ctx, depth, visited);
                 }
-                ClassMember::ClassProp(property) => {
+                ClassMember::ClassProp(property) if is_public(property.accessibility) => {
                     let Some(name) = member_name(&property.key) else {
                         continue;
                     };
-                    // A field holding a function IS a callable member.
-                    if matches!(
-                        property.value.as_deref(),
-                        Some(Expr::Arrow(_) | Expr::Fn(_))
-                    ) {
-                        self.emit(export, prefix, &name, file, property.span);
+                    // A field holding a function IS a callable member — and, if
+                    // that function hands back a sub-resource, a hop as well.
+                    if let Some(function) = function_value(property.value.as_deref()) {
+                        let delegates = self.delegates_of(ctx, function.this_calls());
+                        self.emit(export, prefix, &name, &ctx.file, property.span, delegates);
+                        let returned = self.returned_declaration(
+                            ctx,
+                            function.return_type(),
+                            function.returned_expr(),
+                        );
+                        self.hop(export, prefix, &name, returned, ctx, depth, visited);
+                        continue;
+                    }
+                    // An inline object literal keeps this class's `this`: the
+                    // arrows inside it are declared in its body.
+                    if let Some(Expr::Object(object)) = property.value.as_deref() {
+                        let declared = Declared::Object(
+                            ctx.file.clone(),
+                            ctx.module.clone(),
+                            Rc::new(object.clone()),
+                        );
+                        self.walk_member(
+                            export,
+                            prefix,
+                            &name,
+                            declared,
+                            Some(ctx),
+                            depth,
+                            visited,
+                        );
                         continue;
                     }
                     // Otherwise the field is a sub-resource when its declared
@@ -497,40 +671,89 @@ impl SurfaceScanner {
                     // exists for declares the type and assigns the instance on
                     // one line, and the two always agree there.
                     let declared = annotation_path(property.type_ann.as_deref())
-                        .and_then(|path| self.resolve_type_path(file, module, &path))
+                        .and_then(|path| self.resolve_type_path(&ctx.file, &ctx.module, &path))
                         .or_else(|| {
-                            property
-                                .value
-                                .as_deref()
-                                .and_then(|value| self.value_declaration(file, module, value))
+                            property.value.as_deref().and_then(|value| {
+                                self.value_declaration(&ctx.file, &ctx.module, value)
+                            })
                         });
                     let Some(declared) = declared else {
                         continue;
                     };
-                    self.walk_member(export, prefix, &name, declared, depth, visited);
+                    self.walk_member(export, prefix, &name, declared, None, depth, visited);
+                }
+                // `constructor(public payments: Payments) {}` declares a field
+                // as surely as a `ClassProp` does.
+                ClassMember::Constructor(constructor) => {
+                    for parameter in constructor.params.clone() {
+                        let ParamOrTsParamProp::TsParamProp(property) = parameter else {
+                            continue;
+                        };
+                        if !is_public(property.accessibility) {
+                            continue;
+                        }
+                        let Some(ident) = param_prop_ident(&property.param) else {
+                            continue;
+                        };
+                        let name = ident.id.sym.to_string();
+                        let Some(declared) = annotation_path(ident.type_ann.as_deref())
+                            .and_then(|path| self.resolve_type_path(&ctx.file, &ctx.module, &path))
+                        else {
+                            continue;
+                        };
+                        self.walk_member(export, prefix, &name, declared, None, depth, visited);
+                    }
                 }
                 _ => {}
             }
         }
     }
 
+    /// Compose a returned sub-resource's members under `name`, so a consumer's
+    /// `client.transfers().send(...)` finds `transfers.send`. The
+    /// member itself was already emitted: this only walks what it hands back.
+    #[allow(clippy::too_many_arguments)]
+    fn hop(
+        &mut self,
+        export: &str,
+        prefix: &str,
+        name: &str,
+        returned: Option<Declared>,
+        ctx: &ClassCtx,
+        depth: usize,
+        visited: &mut HashSet<(PathBuf, BytePos)>,
+    ) {
+        let Some(declared) = returned else {
+            return;
+        };
+        // A returned function is not a resource to compose under: it is called
+        // by the member's own name.
+        if declared.function_span().is_some() {
+            return;
+        }
+        let nested = format!("{}{}.", prefix, name);
+        self.walk(export, &nested, declared, Some(ctx), depth + 1, visited);
+    }
+
     /// A resolved field or property: a function is the member itself, anything
     /// else is a sub-resource whose own members compose under this name.
+    #[allow(clippy::too_many_arguments)]
     fn walk_member(
         &mut self,
         export: &str,
         prefix: &str,
         name: &str,
         declared: Declared,
+        this_ctx: Option<&ClassCtx>,
         depth: usize,
         visited: &mut HashSet<(PathBuf, BytePos)>,
     ) {
         if let Some((file, span)) = declared.function_span() {
-            self.emit(export, prefix, name, &file, span);
+            self.emit(export, prefix, name, &file, span, Vec::new());
             return;
         }
         let nested = format!("{}{}.", prefix, name);
-        self.walk(export, &nested, declared, depth + 1, visited);
+        self.walk(export, &nested, declared, this_ctx, depth + 1, visited);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -541,6 +764,7 @@ impl SurfaceScanner {
         file: &Path,
         module: &Rc<Module>,
         object: &ObjectLit,
+        this_ctx: Option<&ClassCtx>,
         depth: usize,
         visited: &mut HashSet<(PathBuf, BytePos)>,
     ) {
@@ -553,20 +777,25 @@ impl SurfaceScanner {
                     let Some(name) = member_name(&method.key) else {
                         continue;
                     };
-                    self.emit(export, prefix, &name, file, method.function.span);
+                    let delegates = self.object_delegates(this_ctx, &method.function);
+                    self.emit(export, prefix, &name, file, method.function.span, delegates);
                 }
                 Prop::KeyValue(entry) => {
                     let Some(name) = member_name(&entry.key) else {
                         continue;
                     };
-                    if matches!(&*entry.value, Expr::Arrow(_) | Expr::Fn(_)) {
-                        self.emit(export, prefix, &name, file, entry.value.span());
+                    if let Some(function) = function_value(Some(&entry.value)) {
+                        let delegates = match this_ctx {
+                            Some(ctx) => self.delegates_of(ctx, function.this_calls()),
+                            None => Vec::new(),
+                        };
+                        self.emit(export, prefix, &name, file, entry.value.span(), delegates);
                         continue;
                     }
                     let Some(declared) = self.value_declaration(file, module, &entry.value) else {
                         continue;
                     };
-                    self.walk_member(export, prefix, &name, declared, depth, visited);
+                    self.walk_member(export, prefix, &name, declared, this_ctx, depth, visited);
                 }
                 // `{ payments }` is `{ payments: payments }`.
                 Prop::Shorthand(ident) => {
@@ -576,14 +805,33 @@ impl SurfaceScanner {
                     else {
                         continue;
                     };
-                    self.walk_member(export, prefix, &name, declared, depth, visited);
+                    self.walk_member(export, prefix, &name, declared, this_ctx, depth, visited);
                 }
                 _ => {}
             }
         }
     }
 
-    fn emit(&mut self, export: &str, prefix: &str, name: &str, file: &Path, span: Span) {
+    fn object_delegates(
+        &mut self,
+        this_ctx: Option<&ClassCtx>,
+        function: &Function,
+    ) -> Vec<SdkSpan> {
+        match this_ctx {
+            Some(ctx) => self.delegates_of(ctx, this_calls_of_function(function)),
+            None => Vec::new(),
+        }
+    }
+
+    fn emit(
+        &mut self,
+        export: &str,
+        prefix: &str,
+        name: &str,
+        file: &Path,
+        span: Span,
+        delegates: Vec<SdkSpan>,
+    ) {
         if self.members.len() >= MAX_MEMBERS {
             if !self.truncated {
                 warn!(
@@ -600,7 +848,143 @@ impl SurfaceScanner {
             file: self.repo_relative(file),
             line: self.line_of(span.lo),
             end_line: self.line_of(span.hi),
+            delegates,
         });
+    }
+
+    /// What a method or function-valued field hands back, when that is a
+    /// declaration this can reach.
+    ///
+    /// The declared return type is read first — same rule as a field's
+    /// annotation — and the returned expression is the fallback for the
+    /// commonest accessor of all, `transfers = () => this.transfersClient`, which
+    /// declares nothing. A `Promise<Payments>` return type names nothing here,
+    /// by the same no-generics rule fields follow.
+    fn returned_declaration(
+        &mut self,
+        ctx: &ClassCtx,
+        return_type: Option<&TsTypeAnn>,
+        returned: Option<Expr>,
+    ) -> Option<Declared> {
+        if let Some(path) = annotation_path(return_type)
+            && let Some(declared) = self.resolve_type_path(&ctx.file, &ctx.module, &path)
+        {
+            return Some(declared);
+        }
+        let expr = returned?;
+        if let Some(field) = this_field_name(&expr) {
+            return self.class_field(ctx, &field);
+        }
+        self.value_declaration(&ctx.file, &ctx.module, &expr)
+    }
+
+    /// The declaration a `this.<name>` receiver holds: a field, or a
+    /// constructor parameter property (`constructor(private api: Api) {}`),
+    /// which is the shape every layered client in the wild writes.
+    ///
+    /// Accessibility is deliberately not consulted. This resolves what the
+    /// SDK's own code reaches, not what it publishes: a public accessor
+    /// returning `this.transfersClient` has to find that private field.
+    fn class_field(&mut self, ctx: &ClassCtx, name: &str) -> Option<Declared> {
+        let class = ctx.class.clone();
+        for member in &class.body {
+            match member {
+                ClassMember::ClassProp(property)
+                    if member_name(&property.key).as_deref() == Some(name) =>
+                {
+                    return annotation_path(property.type_ann.as_deref())
+                        .and_then(|path| self.resolve_type_path(&ctx.file, &ctx.module, &path))
+                        .or_else(|| {
+                            property.value.as_deref().and_then(|value| {
+                                self.value_declaration(&ctx.file, &ctx.module, value)
+                            })
+                        });
+                }
+                ClassMember::Constructor(constructor) => {
+                    for parameter in &constructor.params {
+                        let ParamOrTsParamProp::TsParamProp(property) = parameter else {
+                            continue;
+                        };
+                        let Some(ident) = param_prop_ident(&property.param) else {
+                            continue;
+                        };
+                        if ident.id.sym.as_ref() != name {
+                            continue;
+                        }
+                        let path = annotation_path(ident.type_ann.as_deref())?;
+                        return self.resolve_type_path(&ctx.file, &ctx.module, &path);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    /// The spans of the same-repo methods a member's body calls, and what those
+    /// call in turn. See the module docs on delegates.
+    fn delegates_of(&mut self, ctx: &ClassCtx, calls: Vec<Vec<String>>) -> Vec<SdkSpan> {
+        let mut spans = Vec::new();
+        let mut seen = HashSet::new();
+        self.collect_delegates(ctx, calls, 0, &mut seen, &mut spans);
+        spans.sort();
+        spans.dedup();
+        spans
+    }
+
+    fn collect_delegates(
+        &mut self,
+        ctx: &ClassCtx,
+        calls: Vec<Vec<String>>,
+        depth: usize,
+        seen: &mut HashSet<(PathBuf, BytePos)>,
+        spans: &mut Vec<SdkSpan>,
+    ) {
+        if depth >= MAX_DELEGATE_DEPTH {
+            return;
+        }
+        for path in calls {
+            if spans.len() >= MAX_DELEGATES {
+                return;
+            }
+            let Some((target, span)) = self.resolve_this_call(ctx, &path) else {
+                continue;
+            };
+            if !seen.insert((target.file.clone(), span.lo)) {
+                continue;
+            }
+            spans.push(SdkSpan {
+                file: self.repo_relative(&target.file),
+                line: self.line_of(span.lo),
+                end_line: self.line_of(span.hi),
+            });
+            let Some(name) = path.last() else {
+                continue;
+            };
+            let nested = callable_this_calls(&target.class, name);
+            self.collect_delegates(&target, nested, depth + 1, seen, spans);
+        }
+    }
+
+    /// Follow a `this`-rooted call path — `["api", "send"]` — to
+    /// the class method it names, and to the context that method's own `this`
+    /// resolves against. Only class hops are followed: an intermediate field
+    /// holding an object literal names no declaration to look a method up in.
+    fn resolve_this_call(&mut self, ctx: &ClassCtx, path: &[String]) -> Option<(ClassCtx, Span)> {
+        let (name, fields) = path.split_last()?;
+        let mut current = ctx.clone();
+        for field in fields {
+            let Declared::Class(file, module, class) = self.class_field(&current, field)? else {
+                return None;
+            };
+            current = ClassCtx {
+                file,
+                module,
+                class,
+            };
+        }
+        let span = class_callable_span(&current.class, name)?;
+        Some((current, span))
     }
 
     fn line_of(&self, pos: BytePos) -> u32 {
@@ -656,6 +1040,131 @@ fn anonymous_default(file: &Path, module: &Rc<Module>) -> Option<Declared> {
         }
     }
     None
+}
+
+/// The span of the callable `name` a class declares: a method with a body, or
+/// a field holding a function.
+fn class_callable_span(class: &Class, name: &str) -> Option<Span> {
+    for member in &class.body {
+        match member {
+            ClassMember::Method(method)
+                if method.function.body.is_some()
+                    && member_name(&method.key).as_deref() == Some(name) =>
+            {
+                return Some(method.span);
+            }
+            ClassMember::ClassProp(property)
+                if member_name(&property.key).as_deref() == Some(name)
+                    && function_value(property.value.as_deref()).is_some() =>
+            {
+                return Some(property.span);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// The `this`-rooted calls in the body of the callable `name` a class declares.
+fn callable_this_calls(class: &Class, name: &str) -> Vec<Vec<String>> {
+    for member in &class.body {
+        match member {
+            ClassMember::Method(method)
+                if method.function.body.is_some()
+                    && member_name(&method.key).as_deref() == Some(name) =>
+            {
+                return this_calls_of_function(&method.function);
+            }
+            ClassMember::ClassProp(property)
+                if member_name(&property.key).as_deref() == Some(name) =>
+            {
+                if let Some(function) = function_value(property.value.as_deref()) {
+                    return function.this_calls();
+                }
+            }
+            _ => {}
+        }
+    }
+    Vec::new()
+}
+
+fn this_calls_of_function(function: &Function) -> Vec<Vec<String>> {
+    let mut collector = ThisCallCollector::default();
+    if let Some(body) = &function.body {
+        body.visit_with(&mut collector);
+    }
+    collector.paths
+}
+
+fn this_calls_of_arrow(arrow: &ArrowExpr) -> Vec<Vec<String>> {
+    let mut collector = ThisCallCollector::default();
+    arrow.body.visit_with(&mut collector);
+    collector.paths
+}
+
+/// Every call whose receiver chain starts at `this`, as the property names it
+/// walks: `this.api.send(...)` -> `["api", "send"]`.
+#[derive(Default)]
+struct ThisCallCollector {
+    paths: Vec<Vec<String>>,
+}
+
+impl Visit for ThisCallCollector {
+    fn visit_call_expr(&mut self, node: &CallExpr) {
+        if let Callee::Expr(callee) = &node.callee
+            && let Some(path) = this_rooted_path(callee)
+        {
+            self.paths.push(path);
+        }
+        node.visit_children_with(self);
+    }
+}
+
+fn this_rooted_path(expr: &Expr) -> Option<Vec<String>> {
+    match expr {
+        Expr::Member(member) => {
+            let name = member.prop.as_ident()?.sym.to_string();
+            match &*member.obj {
+                Expr::This(_) => Some(vec![name]),
+                other => {
+                    let mut path = this_rooted_path(other)?;
+                    path.push(name);
+                    Some(path)
+                }
+            }
+        }
+        Expr::Paren(inner) => this_rooted_path(&inner.expr),
+        _ => None,
+    }
+}
+
+/// The field name a `this.<field>` expression reads, and nothing else.
+fn this_field_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Member(member) if matches!(&*member.obj, Expr::This(_)) => {
+            Some(member.prop.as_ident()?.sym.to_string())
+        }
+        Expr::Paren(inner) => this_field_name(&inner.expr),
+        Expr::TsAs(cast) => this_field_name(&cast.expr),
+        Expr::TsNonNull(inner) => this_field_name(&inner.expr),
+        _ => None,
+    }
+}
+
+/// The expression an arrow hands back: its expression body, or the last
+/// top-level `return` in its block.
+fn arrow_returned_expr(arrow: &ArrowExpr) -> Option<&Expr> {
+    match &*arrow.body {
+        BlockStmtOrExpr::Expr(expr) => Some(expr),
+        BlockStmtOrExpr::BlockStmt(block) => block_returned_expr(block),
+    }
+}
+
+fn block_returned_expr(block: &BlockStmt) -> Option<&Expr> {
+    block.stmts.iter().rev().find_map(|stmt| match stmt {
+        Stmt::Return(statement) => statement.arg.as_deref(),
+        _ => None,
+    })
 }
 
 fn member_name(key: &PropName) -> Option<String> {
@@ -838,6 +1347,75 @@ mod tests {
 
         // And a function is never recursed into as if it were a resource.
         assert!(!members.iter().any(|m| m.chain.starts_with("chargeCard.")));
+    }
+
+    /// The shape a layered client publishes: `ledger.transfers().send(...)`.
+    /// The accessor is a callable member of its own AND a hop, so the resource
+    /// it hands back composes under its name — which is the chain the consumer
+    /// writes, with the call in the middle.
+    #[test]
+    fn a_member_that_hands_back_a_resource_composes_under_its_name() {
+        let root = fixture();
+        let members = scan(&root, &root);
+
+        // The arrow-valued field, resolved through the private field it reads.
+        let send = member(&members, "default", "transfers.send").expect("transfers.send");
+        assert_eq!(send.file, "src/resources/transfers.ts");
+        // And the accessor itself stays callable.
+        assert!(member(&members, "default", "transfers").is_some());
+
+        // The method form, resolved through its declared return type.
+        let issue = member(&members, "default", "refunds.issue").expect("refunds.issue");
+        assert_eq!(issue.file, "src/resources/refunds.ts");
+    }
+
+    /// A layered client writes its route one hop below the published method:
+    /// `Transfers.send` calls `this.api.send(...)`, and only THAT method holds
+    /// the URL. The member carries that span so the join can find the call.
+    #[test]
+    fn a_member_carries_the_spans_it_delegates_to() {
+        let root = fixture();
+        let members = scan(&root, &root);
+
+        let send = member(&members, "default", "transfers.send").expect("transfers.send");
+        let delegate = send
+            .delegates
+            .iter()
+            .find(|span| span.file == "src/api/transfers.ts")
+            .expect("the api wrapper's span");
+        assert!(delegate.line < delegate.end_line);
+
+        // A member that calls nothing of its own delegates to nothing.
+        let list = member(&members, "default", "payments.list").expect("payments.list");
+        assert!(list.delegates.is_empty());
+    }
+
+    /// TypeScript forbids a consumer writing a `private` member, so publishing
+    /// one names a chain nobody can call. It stays resolvable internally: the
+    /// public accessor above reaches its resource through exactly that field.
+    #[test]
+    fn private_members_are_not_surface() {
+        let root = fixture();
+        let members = scan(&root, &root);
+        assert!(
+            !members
+                .iter()
+                .any(|m| m.chain == "transfersClient" || m.chain.starts_with("transfersClient.")),
+            "{:?}",
+            members
+        );
+        assert!(member(&members, "default", "transfers.send").is_some());
+    }
+
+    /// `constructor(public receipts: Refunds)` declares a field as surely as a
+    /// `ClassProp` does, and a consumer writes it the same way.
+    #[test]
+    fn a_public_constructor_parameter_property_is_a_field() {
+        let root = fixture();
+        let members = scan(&root, &root);
+        assert!(member(&members, "default", "receipts.issue").is_some());
+        // The private parameter property beside it is not surface.
+        assert!(!members.iter().any(|m| m.chain.starts_with("baseUrl")));
     }
 
     /// A getter is not a call, a constructor is not a member, and neither is

--- a/tests/fixtures/sdk-surface/src/api/transfers.ts
+++ b/tests/fixtures/sdk-surface/src/api/transfers.ts
@@ -1,0 +1,8 @@
+export class TransfersApi {
+  send(body: { amount: number }): Promise<unknown> {
+    return fetch("/v1/transfers", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+}

--- a/tests/fixtures/sdk-surface/src/index.ts
+++ b/tests/fixtures/sdk-surface/src/index.ts
@@ -1,12 +1,27 @@
 import * as API from "./resources/index.js";
+import { TransfersApi } from "./api/transfers.js";
 import { auditLog } from "./util/audit.js";
 import { chargeCard } from "./util/direct.js";
 
 export default class Ledger {
   payments: API.Payments = new API.Payments(this);
   reports: API.Reports = new API.Reports(this);
+  private readonly transfersClient: API.Transfers = new API.Transfers(
+    new TransfersApi(),
+  );
 
-  constructor(private readonly baseUrl: string) {}
+  constructor(
+    private readonly baseUrl: string,
+    public receipts: API.Refunds = new API.Refunds(),
+  ) {}
+
+  // Handed back by an arrow-valued field: `ledger.transfers().send(...)`.
+  transfers = () => this.transfersClient;
+
+  // Handed back by a method, named by its declared return type.
+  refunds(): API.Refunds {
+    return new API.Refunds();
+  }
 
   async scrape(target: string): Promise<unknown> {
     auditLog("scrape", target);

--- a/tests/fixtures/sdk-surface/src/resources/index.ts
+++ b/tests/fixtures/sdk-surface/src/resources/index.ts
@@ -1,2 +1,4 @@
 export { Payments } from "./payments.js";
 export { Reports } from "./reports.js";
+export { Refunds } from "./refunds.js";
+export { Transfers } from "./transfers.js";

--- a/tests/fixtures/sdk-surface/src/resources/transfers.ts
+++ b/tests/fixtures/sdk-surface/src/resources/transfers.ts
@@ -1,0 +1,9 @@
+import { TransfersApi } from "../api/transfers.js";
+
+export class Transfers {
+  constructor(private readonly api: TransfersApi) {}
+
+  send(body: { amount: number }): Promise<unknown> {
+    return this.api.send(body);
+  }
+}


### PR DESCRIPTION
Fixes the SDK join for a published client whose root export hands back sub-resources, which is the shape the benchmark SDK mirror uses: construct the root class, then `client.transfers().send(...)`.

Package and symbol names below are neutralised.

## What was actually broken

The issue title blames scoped-package lookup, but the offline repro disproves that. Scanning the SDK mirror and then the consumer through `LocalDirStorage` (phase A per repo, phase B for the join) shows the peer blob carrying the scoped name in `packages.package_jsons[0].name`, and the lookup resolves it on the first try.

The `26 no_sdk_repo_in_project` in the issue is the signature of a run where the SDK blob was not among the downloaded peers at all. An isolated phase-A run of the consumer reproduces that count exactly, because isolation returns no peers. That points at a re-scan of the bench project rather than a code change.

With both blobs present, the 26 candidate rows fall into three classes, not 26 calls:

| Rows | Shape | Reason before | Reason after |
| ---: | :--- | :--- | :--- |
| 12 | `client.x().y`, the calls the consumer writes | `receiver_unresolved` | `no_matching_producer` |
| 12 | `client.x`, the accessor step the chain extractor records on its way to the row above | `no_matching_producer` | `no_matching_producer` |
| 2 | `records.records.map`, chained off the awaited result rather than the client | `member_not_found` | `member_not_found` |

Only the first class was blocked by this diff's bugs. The second already resolved to the accessor member, whose one-line body holds no route either way.

Underneath that, the surface published the resource's methods under the name of the `private` field holding it, which no consumer can write, and never under the public accessor's name.

## The fix

1. **The surface walker only recursed into class fields.** A method or arrow-valued field that returns a sub-resource contributed one callable and nothing under it. It now reads what a member hands back, declared return type first and then the returned expression (including `this.<field>`), and composes that resource's members under the member's name. Constructor parameter properties are fields like any other, which is how `constructor(private api: Api) {}` resolves. `private` and `protected` members are dropped from the surface, since TypeScript forbids a consumer writing them. They stay resolvable internally, which is how the public accessor reaches the private field it returns.

2. **The join rejected any callee chain containing a call.** An accessor call inside the chain names a member exactly as a field does. `client.transfers().send` now reduces to the member `transfers.send`, and whether that member exists is the surface's answer (`member_not_found`) rather than a claim the receiver was unresolvable.

3. **A layered client writes its route one hop below the published method.** The published `send` calls `this.api.send(...)`, and only that method holds the URL. Each member now carries the spans of the same-repo methods its body reaches through a `this.<field>` receiver, two hops deep and class hops only, and the join looks for the SDK's own outbound call in the member's span or any of those. `SdkMember.delegates` is `#[serde(default)]`, so a surface written before the field reads as an unlayered member.

## Verification

The offline run on the benchmark mirrors, with `CARRICK_MOCK_ALL=1` and `CARRICK_LOCAL_STORAGE_DIR`, gives these results:

- The SDK's published surface goes from 68 members to 32, and the set difference is 61 members leaving and 25 arriving. All 61 that left are rooted at a `private` field or are the one `private` method, so none of them was writable by a consumer. All 25 that arrived are public accessor chains, each carrying the api-wrapper span that holds the URL. One accessor whose body builds its resource from local consts still publishes the accessor itself and nothing under it, which is the documented object-literal limit rather than a regression.
- The 12 rows the consumer actually writes move from `receiver_unresolved` to `no_matching_producer`. Every one now resolves to a published member.
- They stop there in this harness because `CARRICK_MOCK_ALL` mocks the file-analyzer, so the SDK repo's `mount_graph.data_calls` comes back empty and there is no outbound call to find.

Step 3 therefore cannot be exercised end to end by the mocked run. Stubbing what the analyzer would have emitted (one `DataFetchingCall` in the api wrapper, one matching `calls` row, and a producer blob serving that route) forms the edge: the consumer call site named in #538 renders in the Consumers via SDK table, through the published member, to the producer endpoint, and the unresolved count drops to 23. Treat that as a harness demonstration that the three steps compose, not as a scan result. The consumer half is real; the producer and the SDK's own outbound call are hand-built.

Unit tests cover both halves without that stub: `an_accessor_call_in_the_chain_resolves_to_the_member_it_names` and `a_layered_call_outside_every_known_span_is_unresolved` in `sdk_edges`, plus four new `sdk_surface` tests over an extended fixture (accessor hop by return type and by returned expression, delegate spans, private exclusion, public parameter property).

## Test commands

```
cargo fmt && cargo clippy --all-targets && cargo test
```

All 22 test binaries pass. `llm_cassette_hard_gate_test` needs the sidecar built first (`cd src/sidecar && npm install && npm run build`); without it, it fails on a clean checkout too.

## Follow-ups filed, not fixed here

- #543: the SDK service reports 13 endpoints. All 13 come from one build-time script holding an array of `{ path, method }` records used to filter an OpenAPI spec. Endpoint extraction is eval-gated, so the tightening belongs in its own change.
- #544: two candidate rows inherit the package from the awaited result of an SDK call they are chained off, inflating the unresolved counts.

Closes #538.

