### PR TITLE
feat(config): declare classification once on a shared include root

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ When Carrick sees a call like `fetch(process.env.ORDER_SERVICE_URL + '/orders')`
 
 ```json
 {
+  "includes": {
+    "lambdas/_shared": {
+      "externalEnvVars": ["GITHUB_API_BASE"],
+      "externalDomains": ["https://api.github.com"]
+    }
+  },
   "services": [
     {
       "name": "check-or-upload",
@@ -149,7 +155,30 @@ When Carrick sees a call like `fetch(process.env.ORDER_SERVICE_URL + '/orders')`
 | `include` | Extra source roots to pull in for type/function resolution (e.g. shared libraries copied in at build time), relative to `carrick.json` |
 | `tsconfig` | Path to this service's `tsconfig.json`, relative to `directory`. Scopes type extraction to the service |
 
+Alongside `services`, the optional top-level `includes` map declares classification for a shared source root once. See [Declaring a shared root once](#declaring-a-shared-root-once).
+
 Each service also accepts the call-classification fields (`internalEnvVars`, `externalEnvVars`, `internalDomains`, `externalDomains`). When `services` is present, any sibling top-level flat fields are ignored. Cross-service drift, dependency conflicts, and duplicate intents are detected between the declared services just as they are across repositories.
+
+#### Declaring a shared root once
+
+When several services reach a third-party API through the same shared directory, the calls belong to that directory, not to each service that pulls it in. The optional top-level `includes` map declares classification per shared source root:
+
+```json
+{
+  "includes": {
+    "lambdas/_shared": {
+      "externalEnvVars": ["GITHUB_API_BASE"],
+      "externalDomains": ["https://api.github.com"]
+    }
+  }
+}
+```
+
+Each key is a source root spelled as a service names it in its `include` (a leading `./` and a trailing `/` are ignored when matching). Each value takes the same four classification fields a service takes.
+
+Every service whose `include` lists that root inherits those declarations, unioned with its own. A service keeps everything it declares itself, and a name declared in both places appears once. A service that does not include the root inherits nothing.
+
+A key that no service lists in its `include` fails the scan rather than doing nothing, so a mistyped root is reported instead of leaving the calls unclassified.
 
 ## How it works
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, io, path::PathBuf};
+use std::{
+    collections::{BTreeMap, HashSet},
+    io,
+    path::PathBuf,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -40,15 +44,54 @@ pub struct Config {
     pub external_domains: HashSet<String>,
 }
 
+/// Call-classification declarations attached to a shared source root.
+///
+/// The same four fields a service carries, minus everything that places a
+/// service in the tree: a shared root is not a service, it is a directory
+/// several services pull in.
+#[derive(Debug, Deserialize, Default, Clone)]
+struct IncludeDeclarations {
+    #[serde(default)]
+    #[serde(rename = "internalEnvVars")]
+    internal_env_vars: HashSet<String>,
+    #[serde(default)]
+    #[serde(rename = "internalDomains")]
+    internal_domains: HashSet<String>,
+    #[serde(default)]
+    #[serde(rename = "externalEnvVars")]
+    external_env_vars: HashSet<String>,
+    #[serde(default)]
+    #[serde(rename = "externalDomains")]
+    external_domains: HashSet<String>,
+}
+
 /// File-level shape of `carrick.json`: either a single flat service (the flat
 /// fields, captured via `flatten`) or an explicit `services` array for a
-/// monorepo. Resolved by [`Config::load_services`].
+/// monorepo, plus an optional `includes` map declaring classification for
+/// shared source roots. Resolved by [`Config::load_services`].
 #[derive(Debug, Deserialize)]
 struct RootConfig {
+    /// Shared source root (the same path a service names in its `include`) ->
+    /// declarations every service that includes it inherits. Lives on the file
+    /// rather than on `Config` deliberately: a shared root is declared once for
+    /// the repo, not once per service that reaches through it.
+    #[serde(default)]
+    includes: BTreeMap<String, IncludeDeclarations>,
     #[serde(default)]
     services: Vec<Config>,
     #[serde(flatten)]
     flat: Config,
+}
+
+/// Compare include paths by what they name, not by how they were typed:
+/// `lambdas/_shared`, `./lambdas/_shared`, and `lambdas/_shared/` are one root.
+/// Used only for matching an `includes` key against a service's `include`; the
+/// raw strings stay untouched for the engine's path-existence check.
+fn normalize_include_path(path: &str) -> String {
+    path.trim()
+        .trim_start_matches("./")
+        .trim_end_matches('/')
+        .to_string()
 }
 
 impl Config {
@@ -91,6 +134,13 @@ impl Config {
     /// is present, any sibling flat fields are ignored. Multiple input files
     /// are concatenated.
     ///
+    /// A top-level `includes` map declares call classification for a shared
+    /// source root once (`{"lambdas/_shared": {"externalEnvVars": [...]}}`);
+    /// every service whose `include` names that root inherits those
+    /// declarations, unioned with its own. Inheritance is resolved here, so
+    /// nothing downstream sees the map — a service config is complete on its
+    /// own. A key no service includes is an error, not a silent no-op.
+    ///
     /// This is distinct from [`Config::new`], which merges many repos'
     /// classifiers into one for cross-repo analysis.
     pub fn load_services(file_paths: Vec<PathBuf>) -> Result<Vec<Config>, std::io::Error> {
@@ -99,13 +149,67 @@ impl Config {
             let content = std::fs::read_to_string(path)?;
             let root: RootConfig = serde_json::from_str(&content)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-            if root.services.is_empty() {
-                services.push(root.flat);
+
+            let includes: BTreeMap<String, IncludeDeclarations> = root
+                .includes
+                .into_iter()
+                .map(|(key, decls)| (normalize_include_path(&key), decls))
+                .collect();
+
+            let mut file_services = if root.services.is_empty() {
+                vec![root.flat]
             } else {
-                services.extend(root.services);
+                root.services
+            };
+
+            let mut inherited: HashSet<String> = HashSet::new();
+            for service in file_services.iter_mut() {
+                for raw in service.include.clone() {
+                    let key = normalize_include_path(&raw);
+                    if let Some(decls) = includes.get(&key) {
+                        service.inherit(decls);
+                        inherited.insert(key);
+                    }
+                }
             }
+
+            // A key no service includes is dead config that reads as if it
+            // applies. Same reasoning as the engine's check on a directory that
+            // does not exist: silently doing nothing is the failure this
+            // feature exists to remove.
+            if let Some(unused) = includes.keys().find(|key| !inherited.contains(*key)) {
+                // `InvalidInput`, not `InvalidData`: the file parsed fine, its
+                // declarations just don't line up. The engine keys off the kind
+                // to report this as itself rather than as a parse failure.
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "{}: `includes` declares '{}', which no service lists in its \
+                         `include`. Add it to a service's `include`, or remove the entry.",
+                        path.display(),
+                        unused
+                    ),
+                ));
+            }
+
+            services.extend(file_services);
         }
         Ok(services)
+    }
+
+    /// Union a shared root's declarations into this service's own.
+    ///
+    /// Union, not override: a service that also declares a name keeps it, and
+    /// order of application never changes the result.
+    fn inherit(&mut self, decls: &IncludeDeclarations) {
+        self.internal_env_vars
+            .extend(decls.internal_env_vars.iter().cloned());
+        self.internal_domains
+            .extend(decls.internal_domains.iter().cloned());
+        self.external_env_vars
+            .extend(decls.external_env_vars.iter().cloned());
+        self.external_domains
+            .extend(decls.external_domains.iter().cloned());
     }
 
     pub fn is_internal_call(&self, route: &str) -> bool {
@@ -282,6 +386,175 @@ mod tests {
         assert_eq!(second.service_name, Some("dashboard".to_string()));
         assert_eq!(second.directory, Some("app".to_string()));
         assert_eq!(second.tsconfig, Some("tsconfig.json".to_string()));
+    }
+
+    #[test]
+    fn test_includes_declarations_are_inherited_by_including_services() {
+        // The carrick#387 shape: one shared root, declared once, inherited by
+        // every service that pulls it in — and by nothing else.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("carrick.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "includes": {
+                    "lambdas/_shared": {
+                        "externalEnvVars": ["GITHUB_API_BASE"],
+                        "externalDomains": ["https://api.github.com"],
+                        "internalEnvVars": ["CARRICK_API_ENDPOINT"],
+                        "internalDomains": ["https://api.carrick.tools"]
+                    }
+                },
+                "services": [
+                    {
+                        "name": "check-or-upload",
+                        "directory": "lambdas/check-or-upload",
+                        "include": ["lambdas/_shared"]
+                    },
+                    {
+                        "name": "mcp-server",
+                        "directory": "lambdas/mcp-server",
+                        "include": ["lambdas/_shared"]
+                    },
+                    {
+                        "name": "dashboard",
+                        "directory": "app"
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let services = Config::load_services(vec![path]).unwrap();
+        assert_eq!(services.len(), 3);
+
+        // Every service that includes the root inherits, not just the first.
+        for service in &services[..2] {
+            assert!(service.external_env_vars.contains("GITHUB_API_BASE"));
+            assert!(service.external_domains.contains("https://api.github.com"));
+            assert!(service.internal_env_vars.contains("CARRICK_API_ENDPOINT"));
+            assert!(
+                service
+                    .internal_domains
+                    .contains("https://api.carrick.tools")
+            );
+            assert!(service.is_external_call("ENV_VAR:GITHUB_API_BASE:/repos"));
+        }
+
+        // A service that does not include the root inherits nothing.
+        let dashboard = &services[2];
+        assert!(dashboard.external_env_vars.is_empty());
+        assert!(dashboard.external_domains.is_empty());
+        assert!(dashboard.internal_env_vars.is_empty());
+        assert!(dashboard.internal_domains.is_empty());
+        assert!(!dashboard.is_external_call("ENV_VAR:GITHUB_API_BASE:/repos"));
+    }
+
+    #[test]
+    fn test_includes_declarations_union_with_the_services_own() {
+        // Inherited declarations are added to the service's own, never replace
+        // them, and a name declared in both places is still just declared.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("carrick.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "includes": {
+                    "lambdas/_shared": {
+                        "externalEnvVars": ["GITHUB_API_BASE", "SHARED_AND_OWN"]
+                    }
+                },
+                "services": [
+                    {
+                        "name": "check-or-upload",
+                        "directory": "lambdas/check-or-upload",
+                        "include": ["lambdas/_shared"],
+                        "externalEnvVars": ["STRIPE_API", "SHARED_AND_OWN"],
+                        "internalEnvVars": ["CARRICK_API_ENDPOINT"]
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let services = Config::load_services(vec![path]).unwrap();
+        let service = &services[0];
+        assert!(service.external_env_vars.contains("GITHUB_API_BASE"));
+        assert!(service.external_env_vars.contains("STRIPE_API"));
+        assert!(service.external_env_vars.contains("SHARED_AND_OWN"));
+        assert_eq!(service.external_env_vars.len(), 3);
+        assert!(service.internal_env_vars.contains("CARRICK_API_ENDPOINT"));
+    }
+
+    #[test]
+    fn test_includes_key_matching_ignores_path_spelling() {
+        // `./lambdas/_shared/` and `lambdas/_shared` name one root.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("carrick.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "includes": {
+                    "./lambdas/_shared/": { "externalEnvVars": ["GITHUB_API_BASE"] }
+                },
+                "services": [
+                    { "name": "a", "directory": "lambdas/a", "include": ["lambdas/_shared"] }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let services = Config::load_services(vec![path]).unwrap();
+        assert!(services[0].external_env_vars.contains("GITHUB_API_BASE"));
+    }
+
+    #[test]
+    fn test_includes_apply_to_a_flat_single_service_config() {
+        // A flat config can carry `include` too, so it inherits the same way.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("carrick.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "serviceName": "single",
+                "include": ["packages/shared"],
+                "includes": {
+                    "packages/shared": { "externalDomains": ["https://api.github.com"] }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let services = Config::load_services(vec![path]).unwrap();
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].service_name, Some("single".to_string()));
+        assert!(services[0].is_external_call("https://api.github.com/repos"));
+    }
+
+    #[test]
+    fn test_includes_key_no_service_includes_is_an_error() {
+        // Dead config reads as if it applies; fail loudly instead.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("carrick.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "includes": {
+                    "lambdas/_shard": { "externalEnvVars": ["GITHUB_API_BASE"] }
+                },
+                "services": [
+                    { "name": "a", "directory": "lambdas/a", "include": ["lambdas/_shared"] }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let err = Config::load_services(vec![path]).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        let message = err.to_string();
+        assert!(message.contains("lambdas/_shard"), "{message}");
+        assert!(message.contains("include"), "{message}");
+        assert!(message.contains("carrick.json"), "{message}");
     }
 
     #[test]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2875,12 +2875,20 @@ fn resolve_services(repo_path: &str) -> Result<Vec<Config>, Box<dyn std::error::
     let services = if config_path.is_file() {
         debug!("Found carrick.json: {}", config_path.display());
         Config::load_services(vec![config_path.clone()]).map_err(|e| {
-            format!(
-                "Failed to parse {}: {}. Fix the config or delete it to scan \
-                 the repo as a single zero-config service.",
-                config_path.display(),
-                e
-            )
+            // A config that parsed but declares something inconsistent already
+            // names the file and the offending declaration; wrapping it in the
+            // parse-failure advice would tell the user to delete a file whose
+            // only problem is one line.
+            if e.kind() == std::io::ErrorKind::InvalidInput {
+                e.to_string()
+            } else {
+                format!(
+                    "Failed to parse {}: {}. Fix the config or delete it to scan \
+                     the repo as a single zero-config service.",
+                    config_path.display(),
+                    e
+                )
+            }
         })?
     } else {
         Vec::new()
@@ -5531,6 +5539,62 @@ mod tests {
             err.to_string().contains("Failed to parse"),
             "expected parse error, got: {err}"
         );
+    }
+
+    #[test]
+    fn resolve_services_rejects_unreferenced_includes_key() {
+        // Reported as itself, not wrapped in the parse-failure advice.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("lambdas/api")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("lambdas/_shared")).unwrap();
+        std::fs::write(
+            tmp.path().join("carrick.json"),
+            r#"{
+                "includes": { "lambdas/_shard": { "externalEnvVars": ["GITHUB_API_BASE"] } },
+                "services": [
+                    { "name": "api", "directory": "lambdas/api", "include": ["lambdas/_shared"] }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let err = resolve_services(tmp.path().to_str().unwrap()).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("lambdas/_shard"), "{message}");
+        assert!(
+            !message.contains("Failed to parse"),
+            "a semantic error should not be reported as a parse failure: {message}"
+        );
+    }
+
+    #[test]
+    fn resolve_services_inherits_include_root_declarations() {
+        // The whole engine path: parse, inherit, validate declared paths exist.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("lambdas/api")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("lambdas/worker")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("lambdas/_shared")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("app")).unwrap();
+        std::fs::write(
+            tmp.path().join("carrick.json"),
+            r#"{
+                "includes": {
+                    "lambdas/_shared": { "externalEnvVars": ["GITHUB_API_BASE"] }
+                },
+                "services": [
+                    { "name": "api", "directory": "lambdas/api", "include": ["lambdas/_shared"] },
+                    { "name": "worker", "directory": "lambdas/worker", "include": ["lambdas/_shared"] },
+                    { "name": "web", "directory": "app" }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let services = resolve_services(tmp.path().to_str().unwrap()).unwrap();
+        assert_eq!(services.len(), 3);
+        assert!(services[0].is_external_call("ENV_VAR:GITHUB_API_BASE:/repos"));
+        assert!(services[1].is_external_call("ENV_VAR:GITHUB_API_BASE:/repos"));
+        assert!(!services[2].is_external_call("ENV_VAR:GITHUB_API_BASE:/repos"));
     }
 
     #[test]


### PR DESCRIPTION
## What

`carrick.json` gains an optional top-level `includes` map, so a shared source root declares its outbound-call classification once instead of every service that pulls it in repeating it.

```json
{
  "includes": {
    "lambdas/_shared": {
      "externalEnvVars": ["GITHUB_API_BASE"],
      "externalDomains": ["https://api.github.com"]
    }
  },
  "services": [
    { "name": "check-or-upload", "directory": "lambdas/check-or-upload", "include": ["lambdas/_shared"] },
    { "name": "mcp-server", "directory": "lambdas/mcp-server", "include": ["lambdas/_shared"] }
  ]
}
```

Each key is a source root spelled as a service names it in its `include` (a leading `./` and a trailing `/` are ignored when matching). Each value takes the same four classification fields a service takes.

## Semantics

- Every service whose `include` lists the root inherits its declarations, unioned with the service's own. A service keeps everything it declares itself.
- A service that does not include the root inherits nothing.
- Inheritance is resolved in `Config::load_services`, so nothing downstream sees the map. A resolved service config is complete on its own, including the copy serialised into `config_json` and merged by `Config::new` for cross-repo analysis.
- Per-service declarations are unchanged, and the map is optional.
- A key that no service lists in its `include` fails the scan rather than doing nothing quietly, which is the failure mode this feature removes.
- Failing the scan matches how `resolve_services` already treats a `directory` or `include` path that does not exist.

`includes` lives on the file-level `RootConfig`, not on `Config`, so a `services` entry cannot declare its own map.

## Tests

`src/config.rs` gains five cases:

- two services including the same root both inherit, all four fields; a third service that does not include it inherits nothing
- inherited declarations union with the service's own, including a name declared in both places
- `./lambdas/_shared/` as a key matches `lambdas/_shared` in an `include`
- a flat single-service config with `include` inherits the same way
- a key no service includes returns an error naming the key and the file

The full `cargo test` suite is green: 22 test binaries, 0 failures. `cargo fmt --check` and `cargo clippy --all-targets` are clean.

## Docs

This PR updates the README "Monorepos" section in this repo, adding the example and a "Declaring a shared root once" subsection.

The same addition is needed in `carrick-cloud`, which is read-only from here:

- `docs-site/src/content/docs/carrick-json.md`, the published schema page at docs.carrick.tools/carrick-json
- `docs/carrick-json.md`, the repo copy, which differs from the docs-site one
- `lambdas/mcp-server/src/tools/scaffold.ts`, the generator for the `carrick.json` skeleton, which links the schema page

Fixes carrick-tools/carrick-cloud#387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
