### PR TITLE
chore: re-enable the self-scan and onboard this repo onto Carrick

### DIFF
--- a/.claude/search-gate.sh
+++ b/.claude/search-gate.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Stops the FIRST repo-wide search of a session and nothing after it.
+# Fails OPEN on any internal error (no jq, malformed payload, unwritable
+# marker): a gate that cannot read its input must not become a block.
+payload=$(cat 2>/dev/null) || exit 0
+tool=$(printf %s "$payload" | jq -r '.tool_name // ""' 2>/dev/null) || exit 0
+case "$tool" in
+  Grep) ;;
+  Bash)
+    # A tool-level matcher is not enough on its own: an agent denied Grep
+    # reaches for grep through the shell. Matched on the command text so an
+    # ordinary non-search Bash call passes through and does not spend the nudge.
+    cmd=$(printf %s "$payload" | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
+    printf %s "$cmd" | grep -qE '(^|[^[:alnum:]_.-])(grep|egrep|fgrep|rg|ag|ack)([[:space:]]|$)' || exit 0
+    ;;
+  *) exit 0 ;;
+esac
+# Session-scoped marker, outside the repo, so the nudge happens once per
+# session and no marker file is ever committed.
+sid=$(printf %s "$payload" | jq -r '.session_id // ""' 2>/dev/null) || exit 0
+[ -n "$sid" ] || exit 0
+marker="${TMPDIR:-/tmp}/carrick-search-nudged-$sid"
+[ -e "$marker" ] && exit 0
+touch "$marker" 2>/dev/null || exit 0
+# Exit 2 blocks that one call and hands the message to the model.
+echo "Prior art first: run mcp__carrick__search_by_intent with a plain-English description of the behaviour you are looking for, then run this search if you still need it. This is the only time this will interrupt you." >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,34 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/turn-reminder.sh\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/search-gate.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/search-gate.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/turn-reminder.sh
+++ b/.claude/turn-reminder.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Prints one line of context at the top of the turn. No state, no branching:
+# the same bytes every time it runs, and nothing that can fail.
+printf %s 'Before writing a helper or searching for existing behaviour, call mcp__carrick__search_by_intent with project: "scanner-evals" first, and state "Carrick checked: <query> -> <result count>" before you write new code.'
+exit 0

--- a/.github/workflows/carrick.yml
+++ b/.github/workflows/carrick.yml
@@ -1,16 +1,21 @@
 name: Carrick
 
-# DISABLED 2026-06-26 (manual-only): the dogfooding self-scan runs the real
-# Carrick Action (Vertex/Gemini inference) on every push/PR. During heavy
-# iteration that's pure wasted inference cost, so it's reduced to on-demand.
-# Re-enable real dogfooding by restoring the triggers below:
-#   push: { branches: [main] }
-#   pull_request: { branches: [main] }
-#   repository_dispatch: { types: [carrick-sibling-updated] }
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Reserved for Carrick Cloud dispatches (currently dormant). Cross-repo
+  # results stay current without it: every scan reads the live index, and
+  # Carrick re-runs affected open PRs when a sibling repo changes.
+  repository_dispatch:
+    types: [carrick-sibling-updated]
+  # Kept so a backfill scan can be forced without pushing to main.
   workflow_dispatch:
 
 permissions:
+  # Mint a short-lived OIDC token Carrick exchanges for keyless upload auth
+  # (no upload secret to configure).
   id-token: write
   contents: read
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ examples/*/package-lock.json
 
 # Captured scanner output from example runs — never commit
 examples/*/output/
+
+# Local git worktrees created under .claude/ — never committed
+.claude/worktrees/
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,59 @@
 # Repository Guidelines
 
+## Carrick
+
+**If the answer is defined by another service — its endpoints, its real
+request/response types, who consumes it, or any local type, constant, or
+SDK helper that mirrors it — ask Carrick before you rely on anything
+local.** Local copies of another service's contract drift and lie; the
+producing service defines the contract, and if two definitions disagree,
+the producer's definition wins. Load the Carrick tools now so they are ready at that
+moment.
+
+**Inside this repo, grep and read are faster — use them.** One exception:
+before writing any new helper, parser, validator, or domain function, run
+`search_by_intent` with a plain-English description of the behaviour.
+Grep can prove a name is absent; it can never prove the behaviour is.
+
+Then, before you write new code, state one line naming what you asked and
+what came back:
+
+`Carrick checked: <query> -> <result count>`
+
+The loop for cross-service work: `get_service_graph` (who calls whom) →
+`search_by_intent` (prior art) → `get_endpoint_types` (real contracts) →
+build → `check_compatibility` (each consumer, before changing a response
+shape, removing an endpoint, or renaming a path). Before adding or bumping
+an npm package, `get_service_dependencies` surfaces cross-service version
+conflicts at design time. For audit-shaped work, such as inventorying what
+a service calls outside itself, `list_external_calls` enumerates the
+recorded outbound-call candidates (SDK calls, external domains, env-var URL
+bases) with their file and line.
+
+Carrick indexes every service in the project **scanner-evals**
+(workspace **daveymoores**): every function with an intent
+description, its dependencies, and API endpoints with their real
+request/response types, on each repo's main branch, exported or not. Pass
+`project: "scanner-evals"` (or `repo: "<owner/repo>"` from the git
+remote) on every call. Carrick is read-only; data reflects the most recent
+scan of each repo. The index at main is what production integrates
+against, so build against a sibling's contract from the index and merge —
+your unmerged local state does not need to be visible to Carrick.
+
+Write correct, idiomatic, explicitly typed code; never contort code so the
+scanner can read it. If Carrick fails to extract something written
+normally, that is a Carrick bug to report, not a constraint to code
+around.
+
+### Connect the agent
+
+```
+claude mcp add --scope user --transport http carrick https://api.carrick.tools/mcp
+```
+
+One install serves every project in the workspace.
+
+
 ## Core Goals (Read First)
 - Build a live, type-aware, intent-aware index of TypeScript services across a GitHub org. The index is the product surface; AI coding agents query it over MCP.
 - The Rust scanner in this repo is the index-population component. Per scanned function it extracts structural facts, request/response types, and intent.
@@ -73,54 +127,3 @@ Install hooks once per clone: `./scripts/install-hooks.sh`.
 - `carrick.json` is resolved by `Config::load_services` into one `Config` per service. A flat config (or none) is a single service rooted at the repo root; a `services` array fans out per directory (`directory`, `include`, `tsconfig` + the call-classification fields). The engine runs the analysis pipeline, per-service type extraction, and upload once per service. Multi-service index upload is gated on `CloudStorage::supports_multi_service`, driven by the cloud's `multiService` capability flag. See the README "Monorepos" section for the user-facing shape.
 - Runtime env vars: `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` (auto-set by GitHub Actions when the job grants `id-token: write`; the scanner mints an OIDC token from these and sends it as the `X-Carrick-OIDC` header — the cloud derives repo identity from the signed claims, so no API key is needed), `CARRICK_MOCK_ALL` (test-only, returns canned responses without hitting the cloud), `CARRICK_API_ENDPOINT` (override the default `https://api.carrick.tools` endpoint at build time; optional).
 - Terraform, Lambdas, and dashboard code live in `carrick-cloud`. No infrastructure or server-side code belongs in this repo.
-
-## Carrick
-
-This repo is part of the **carrick-tools / carrick-ci** Carrick
-project. Carrick indexes every service in the project: functions with
-intent descriptions (exported or not), dependencies, and API endpoints
-with their real request/response types.
-
-### Connect the agent
-
-```
-claude mcp add --scope user --transport http carrick https://api.carrick.tools/mcp
-```
-
-One install serves every project in the workspace. On Carrick tool calls
-from this repo, pass `project: "carrick-ci"` (or `repo: "<owner/repo>"`
-from the git remote) so Carrick queries the right system.
-
-### The loop for cross-service work
-
-1. Topology: `get_service_graph` shows who calls whom across the project.
-2. Prior art: `search_by_intent` with a plain-English description of what
-   you are about to write. Do this before writing any helper, parser,
-   validator, or domain function, even when you are sure it is new.
-3. Contracts: `get_endpoint_types` for the real request/response types of
-   anything you will call; `get_api_endpoints` first only when you don't
-   yet know which operations exist.
-4. Build.
-5. Consumers: `check_compatibility` against each consumer before changing
-   a response shape, removing an endpoint, or renaming a path.
-
-Also call `get_service_dependencies` before adding or bumping an npm
-package.
-
-### Building against a sibling before merge
-
-Pull the producer's contract with `get_endpoint_types`, code to it, done.
-The index at main is what production integrates against; your unmerged
-local state does not need to be visible to Carrick. All matching runs the
-same shared carrick-match code in the scanner, the cloud, and the MCP
-server (responses carry its `matcher_version`), so what the tools report
-is what the scan will compute.
-
-### Division of labor
-
-Write correct, idiomatic, explicitly typed code, and never contort code so
-the scanner can read it. If Carrick fails to extract something written
-normally, that is a Carrick bug to report, not a constraint to code
-around.
-
-Carrick is read-only; data reflects the most recent scan of each repo.

--- a/carrick.json
+++ b/carrick.json
@@ -1,3 +1,9 @@
 {
-  "services": [{ "name": "type-sidecar", "directory": "src/sidecar" }]
+  "services": [
+    {
+      "name": "type-sidecar",
+      "directory": "src/sidecar",
+      "tsconfig": "tsconfig.json"
+    }
+  ]
 }


### PR DESCRIPTION
## Why

This repo is the one member of the `scanner-evals` project that no longer uploads. `list_services` returns 14 rows for `carrick-cloud` and `carrick-site` and zero for `carrick`, so the type sidecar's 340 functions are invisible to `search_by_intent` while every sibling repo's are indexed. We tell users to run the Action on push, and it was not running on this repo.

## What changed

**1. The self-scan runs again.** `.github/workflows/carrick.yml` was cut to `workflow_dispatch` only on 2026-06-26 to stop inference spend during heavy iteration. It now runs on push to `main` and on pull requests to `main`, with `repository_dispatch: [carrick-sibling-updated]` and `workflow_dispatch` both kept, so a backfill scan can still be forced by hand. It runs a single job with no matrix and `fetch-depth: 0`, so scans stay incremental against the last upload.

**2. `carrick.json` pins the sidecar's tsconfig.**

```diff
 {
   "services": [
-    { "name": "type-sidecar", "directory": "src/sidecar" }
+    {
+      "name": "type-sidecar",
+      "directory": "src/sidecar",
+      "tsconfig": "tsconfig.json"
+    }
   ]
 }
```

Eight of the eleven service entries in `carrick-cloud/carrick.json` carry `tsconfig`; this one did not, and relied on the sidecar's default discovery instead. A measured A/B on a local mock scan produced identical output with and without it (340 functions, 0 endpoints either way). It aligns this repo with the sibling convention and removes a discovery fallback, but it was not the reason the index is empty.

**3. The Claude Code hook pack is checked in**, exactly as `mcp__carrick__scaffold` returns it for `carrick-tools/carrick`: `.claude/turn-reminder.sh`, `.claude/search-gate.sh` (both `chmod +x`, both fail open), `.claude/settings.json`. No `.claude/settings.json` existed, so nothing was merged. `.gitignore` now excludes `.claude/worktrees/` and `.claude/settings.local.json` so local state stays out of the tracked directory. A smoke test confirmed that the gate blocks the first `Grep` of a session with exit 2, passes the second, and lets a non-search `Bash` call through untouched.

**4. The Carrick section moved to the top of `AGENTS.md`.** It sat at the bottom, below the estimation conventions, and named the project slug `carrick-ci`. The live slug is `scanner-evals`, so any agent that followed it passed a project that does not exist. The section now carries the current scaffold text.

## Why the index was empty

The Rust scanner and `crates/carrick-match` are out of scope by construction: Carrick indexes TypeScript, so a Rust crate produces no rows no matter how it is declared. The GitHub Action is a composite action, shell steps only, no TypeScript. `src/sidecar` is the whole TypeScript surface of this repo, and it was already declared correctly.

The configuration was therefore not the problem. `gh run list --workflow=carrick.yml` shows the last scan of `main` succeeded on 2026-06-26 at 09:47 UTC, minutes before the triggers were removed, and nothing has run since. Two months of index migrations have passed since then, so whatever those June runs wrote is gone. Whether those rows were pruned or re-keyed is not determinable from this repo, and the fix is the same either way: start scanning again.

## Local verification

Running `CARRICK_MOCK_ALL=1 cargo run -- .` against this worktree, with `CARRICK_LOCAL_STORAGE_DIR` set to inspect the upload payload, gave:

- 1 service resolved, `type-sidecar`
- **340 function definitions** across 23 files under `src/sidecar/src/`
- **0 endpoints, 0 cross-service calls**, which is correct because the sidecar is a stdio JSON process with no HTTP surface. It will land in the index as a function-and-intent service, which is what `search_by_intent` reads.
- 536 SDK call candidates recorded (`ts-morph`, `typescript`, `zod`), unresolved because those packages are not repos in this project

Pre-commit ran `cargo fmt`, `cargo clippy`, and the full Rust suite: 864 + 879 tests pass.

## Scan coverage

25 of 27 non-test TypeScript source files fall inside a declared service, 93%. The two left out are `examples/express-single` and `examples/express-multi`, the reference Express services CI uses as e2e fixtures. Declaring them would put fixture endpoints into the real index as if they were services we run.

## After merge

The new `pull_request` trigger already fired on this PR, and that run is the first non-mock evidence in two months. It minted an OIDC token, connected to the cloud, downloaded 14 sibling repos and analysed `carrick` as one service in 66 seconds. PR runs do not upload, so the index is still empty until the first push to `main` after merge. `list_services` for `scanner-evals` should then gain a `carrick / type-sidecar` row carrying roughly 340 functions.

That run carries one caveat: every intent request came back `llm_disabled`, because the installation's daily LLM budget was already spent. Function rows still land, but without intent text, and `search_by_intent` reads intents. If the first post-merge scan hits the same wall, re-run the workflow by hand after the budget resets at midnight UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
