### PR TITLE
fix(scanner): carry a wrapper's fixed method to the sites that delegate to it

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -48,6 +48,7 @@ use crate::{
     },
     url_normalizer::UrlNormalizer,
     visitor::{ImportSymbolExtractor, ImportedSymbol, SymbolKind, TypeSymbolExtractor},
+    wrapper_request_shape::{self, WrapperRequestShape},
 };
 use futures::stream::StreamExt;
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -115,8 +116,24 @@ pub struct ProcessingStats {
     /// a topic from a wrapper-function NAME (`publishStatusChanged` ->
     /// `status.changed`); the real op lives in the file that holds the literal.
     pub pubsub_phantom_topic_drops: usize,
+    /// Wrapper-resolved data calls whose HTTP method was corrected from what
+    /// extraction gave them to the method their wrapper module hardcodes
+    /// (carrick-cloud#386). A subset of `total_data_calls`.
+    pub wrapper_method_propagations: usize,
     pub total_data_calls: usize,
     pub errors: Vec<String>,
+}
+
+/// A same-repo module that itself performs HTTP and exports a binding — the
+/// shape of a request wrapper another file imports (#369/#370).
+struct WrapperModule {
+    /// The module's source, injected into the importing file's prompt so its
+    /// delegating call sites can be emitted with a resolved target.
+    snippet: String,
+    /// The method (and body presence) every request in the module agrees on,
+    /// read off the AST. `None` when the module parameterizes its method, its
+    /// requests disagree, or none is readable. See `crate::wrapper_request_shape`.
+    request_shape: Option<WrapperRequestShape>,
 }
 
 /// Owner assigned to endpoints declared by file location (file-based routing).
@@ -669,6 +686,14 @@ impl FileOrchestrator {
             /// user message so call sites of an imported wrapper can be emitted
             /// as resolved data calls. Empty for files with no such imports.
             wrapper_context: Vec<String>,
+            /// The request shape every wrapper module behind `wrapper_context`
+            /// agrees on (carrick-cloud#386): the literal HTTP method, and
+            /// whether the request carries a body. `None` — the common case —
+            /// whenever the wrappers parameterize the method, disagree, or this
+            /// file imports none. Propagated onto the resolved call sites after
+            /// the LLM pass, because the delegating site itself carries no
+            /// method and would otherwise default to GET.
+            wrapper_request_shape: Option<WrapperRequestShape>,
             /// Pub/sub operations asserted deterministically from the AST
             /// (carrick#387), merged in after the LLM pass so an extraction
             /// omission cannot lose them. Empty when Signal 7's gates are off.
@@ -955,6 +980,7 @@ impl FileOrchestrator {
                 graphql_producer_hints: graphql_producer_hints.lines.clone(),
                 graphql_consumer_hints: graphql_consumer_hints.lines.clone(),
                 wrapper_context: Vec::new(),
+                wrapper_request_shape: None,
                 pubsub_anchor_ops: scan_result.pubsub_anchor_ops,
             });
         }
@@ -966,7 +992,7 @@ impl FileOrchestrator {
         // (size-capped) file is the context snippet: wrappers are small client
         // modules, and slicing exact function spans buys little over the cap.
         const WRAPPER_SNIPPET_MAX: usize = 4_000;
-        let mut wrapper_map: HashMap<PathBuf, String> = HashMap::new();
+        let mut wrapper_map: HashMap<PathBuf, WrapperModule> = HashMap::new();
         for pf in &pending {
             // Rescued files (graphql/messaging fall-throughs) carry no HTTP
             // candidates and are not wrapper material.
@@ -995,7 +1021,21 @@ impl FileOrchestrator {
             } else {
                 snippet.push_str(&pf.content);
             }
-            wrapper_map.insert(canonical, snippet);
+            // The method the module's own request calls fix, read off the AST
+            // candidates the gatekeeper already raised for it
+            // (carrick-cloud#386). `None` whenever the module parameterizes its
+            // method or its requests disagree, in which case the delegating
+            // site keeps whatever extraction gave it.
+            let request_shape = wrapper_request_shape::fold_module(
+                pf.candidate_map.values().map(|c| &c.request_shape),
+            );
+            wrapper_map.insert(
+                canonical,
+                WrapperModule {
+                    snippet,
+                    request_shape,
+                },
+            );
         }
 
         // Attach wrapper context to files that import a wrapper module via a
@@ -1034,9 +1074,15 @@ impl FileOrchestrator {
                 // wrapper context.
                 matched.sort();
                 matched.dedup();
+                pf.wrapper_request_shape = wrapper_request_shape::fold_wrappers(
+                    matched
+                        .iter()
+                        .filter_map(|path| wrapper_map.get(path))
+                        .map(|module| module.request_shape.as_ref()),
+                );
                 pf.wrapper_context = matched
                     .iter()
-                    .filter_map(|path| wrapper_map.get(path).cloned())
+                    .filter_map(|path| wrapper_map.get(path).map(|m| m.snippet.clone()))
                     .collect();
             }
         }
@@ -1070,9 +1116,15 @@ impl FileOrchestrator {
                 matched.sort();
                 matched.dedup();
             }
+            let rescued_shape = wrapper_request_shape::fold_wrappers(
+                matched
+                    .iter()
+                    .filter_map(|path| wrapper_map.get(path))
+                    .map(|module| module.request_shape.as_ref()),
+            );
             let ctx: Vec<String> = matched
                 .iter()
-                .filter_map(|path| wrapper_map.get(path).cloned())
+                .filter_map(|path| wrapper_map.get(path).map(|m| m.snippet.clone()))
                 .collect();
             if ctx.is_empty() {
                 debug!(
@@ -1115,6 +1167,7 @@ impl FileOrchestrator {
                 graphql_producer_hints: graphql_producer_hints.lines.clone(),
                 graphql_consumer_hints: graphql_consumer_hints.lines.clone(),
                 wrapper_context: ctx,
+                wrapper_request_shape: rescued_shape,
                 // Rescued zero-candidate files by definition raised no Signal 7
                 // candidate, so they can carry no anchor ops either.
                 pubsub_anchor_ops: Vec::new(),
@@ -1190,6 +1243,15 @@ impl FileOrchestrator {
 
                     let mut adjusted = result;
                     Self::apply_candidate_map(&mut adjusted, &pf.candidate_map, &pf.path_str);
+                    // Carry the wrapper's own request shape onto the sites that
+                    // delegate to it (carrick-cloud#386). Runs immediately after
+                    // `apply_candidate_map` because that is what stamps the span
+                    // this reads to tell a delegating site from a real client
+                    // call, and before every downstream method reader.
+                    stats.wrapper_method_propagations += Self::propagate_wrapper_request_shape(
+                        &mut adjusted,
+                        pf.wrapper_request_shape.as_ref(),
+                    );
                     // Collapse inline env-var fallbacks the model rendered
                     // verbatim (`${A ?? "http://localhost"}/p` -> `${A}/p`,
                     // carrick#399) BEFORE alias resolution: a local alias with
@@ -1287,6 +1349,10 @@ impl FileOrchestrator {
             stats.route_descriptor_endpoints
         );
         debug!("  - Total data calls: {}", stats.total_data_calls);
+        debug!(
+            "  - Wrapper method propagations: {}",
+            stats.wrapper_method_propagations
+        );
 
         // STEP 5: Build aggregated mount graph from all file results
         let mount_graph =
@@ -2598,7 +2664,7 @@ impl FileOrchestrator {
     fn wrapper_modules_behind(
         resolved: &Path,
         self_canon: Option<&PathBuf>,
-        wrapper_map: &HashMap<PathBuf, String>,
+        wrapper_map: &HashMap<PathBuf, WrapperModule>,
         reexport_cache: &mut HashMap<PathBuf, Vec<String>>,
         cm: &Lrc<SourceMap>,
         handler: &Handler,
@@ -3636,6 +3702,61 @@ impl FileOrchestrator {
                 data_call.target = normalized;
             }
         }
+    }
+
+    /// Carry an imported wrapper's fixed request shape onto the call sites that
+    /// delegate to it (carrick-cloud#386).
+    ///
+    /// Cross-file wrapper-site resolution (#369/#370) resolves the TARGET of a
+    /// delegating call because the wrapper's source is in the prompt. The METHOD
+    /// is not resolvable that way when the wrapper hardcodes it: the delegating
+    /// site's own arguments carry no method, so extraction emits none and
+    /// `normalize_consumer_method` falls back to `GET`. A POST-only client then
+    /// appears in the index as a set of GETs.
+    ///
+    /// A delegating site is identified exactly as the wrapper-echo suppression
+    /// in `build_mount_graph` identifies it: no `call_expression_span_start`,
+    /// i.e. the deterministic scanner raised no HTTP candidate there, because
+    /// `this.client.load()` is not a client call it recognizes. Using the same
+    /// discriminator is deliberate — a record this pass rewrites is exactly a
+    /// record that pass may collapse, so the two can never disagree about which
+    /// row is the wrapper's echo.
+    ///
+    /// A wrapper that sends no body at all takes the site's payload anchor with
+    /// it: a non-GET method turns on request-body inference downstream
+    /// (`should_infer_request_body`), and a request with no body must not
+    /// acquire a request type from whatever expression extraction pointed at.
+    /// Only a definite `Some(false)` does this; an unreadable argument list
+    /// leaves the anchor alone.
+    fn propagate_wrapper_request_shape(
+        result: &mut FileAnalysisResult,
+        shape: Option<&WrapperRequestShape>,
+    ) -> usize {
+        let Some(shape) = shape else {
+            return 0;
+        };
+        let mut propagated = 0;
+        for data_call in &mut result.data_calls {
+            // Extracted at its own client call site, not through the wrapper —
+            // its method is the one the scanner saw.
+            if data_call.call_expression_span_start.is_some() {
+                continue;
+            }
+            let existing = data_call
+                .method
+                .as_deref()
+                .map(normalize_manifest_method)
+                .unwrap_or_default();
+            if existing != shape.method {
+                data_call.method = Some(shape.method.clone());
+                propagated += 1;
+            }
+            if shape.has_body == Some(false) {
+                data_call.payload_expression_text = None;
+                data_call.payload_expression_line = None;
+            }
+        }
+        propagated
     }
 
     fn resolve_env_var_aliases(result: &mut FileAnalysisResult, env_alias_map: &EnvAliasMap) {
@@ -4889,13 +5010,16 @@ mod tests {
         (cm, handler)
     }
 
-    fn wrapper_map_of(wrappers: &[PathBuf]) -> HashMap<PathBuf, String> {
+    fn wrapper_map_of(wrappers: &[PathBuf]) -> HashMap<PathBuf, WrapperModule> {
         wrappers
             .iter()
             .map(|p| {
                 (
                     p.canonicalize().expect("wrapper must exist"),
-                    format!("--- wrapper module: {} ---\n", p.display()),
+                    WrapperModule {
+                        snippet: format!("--- wrapper module: {} ---\n", p.display()),
+                        request_shape: None,
+                    },
                 )
             })
             .collect()
@@ -6101,6 +6225,203 @@ export * from "./aFetch.js";"#,
             primary_type_symbol: None,
             type_import_source: None,
         }
+    }
+
+    /// A data call with no method at all — what extraction emits for a site
+    /// that only delegates (`this.client.load(id)`), because the site's own
+    /// arguments carry no method.
+    fn methodless_call(line: i32, target: &str, span: Option<u32>) -> DataCallResult {
+        DataCallResult {
+            method: None,
+            pattern_matched: "client.load(".to_string(),
+            ..call_with_span(line, target, span)
+        }
+    }
+
+    /// carrick-cloud#386: a wrapper that hardcodes `method: "POST"` inside its
+    /// own request tells the delegating site nothing, so the site's method is
+    /// empty and `normalize_consumer_method` turns it into a GET. The wrapper's
+    /// method is a structural fact, so it is carried to the site instead.
+    ///
+    /// The wrapper's OWN request call is untouched: it is candidate-backed, so
+    /// its method is the one the scanner saw at a real client call.
+    #[test]
+    fn a_wrapper_hardcoded_method_reaches_the_delegating_site() {
+        let mut result = result_with_data_calls(vec![
+            methodless_call(115, "${CATALOG_API_URL}/catalog/sync", Some(400)),
+            methodless_call(23, "/catalog/sync", None),
+        ]);
+        let shape = WrapperRequestShape {
+            method: "POST".to_string(),
+            has_body: Some(true),
+        };
+
+        let propagated =
+            FileOrchestrator::propagate_wrapper_request_shape(&mut result, Some(&shape));
+
+        assert_eq!(propagated, 1, "only the delegating site is rewritten");
+        assert_eq!(
+            result.data_calls[0].method, None,
+            "the wrapper's own candidate-backed request keeps what extraction gave it"
+        );
+        assert_eq!(result.data_calls[1].method.as_deref(), Some("POST"));
+    }
+
+    /// With no wrapper behind the file — or a wrapper that parameterizes its
+    /// method — nothing is rewritten. This is the majority of files, and the
+    /// case where the delegating site's own argument IS the method.
+    #[test]
+    fn an_unknown_wrapper_shape_rewrites_nothing() {
+        let mut result = result_with_data_calls(vec![methodless_call(23, "/catalog/sync", None)]);
+        assert_eq!(
+            FileOrchestrator::propagate_wrapper_request_shape(&mut result, None),
+            0
+        );
+        assert_eq!(result.data_calls[0].method, None);
+    }
+
+    /// The method flip turns on request-body inference downstream
+    /// (`should_infer_request_body`), so a wrapper that demonstrably sends no
+    /// body must take the site's payload anchor with it — otherwise the site
+    /// acquires a request type for a request that has no request body.
+    #[test]
+    fn a_bodyless_wrapper_clears_the_sites_payload_anchor() {
+        let mut call = methodless_call(23, "/catalog/things/42", None);
+        call.payload_expression_text = Some("{ id }".to_string());
+        call.payload_expression_line = Some(23);
+        let mut result = result_with_data_calls(vec![call]);
+
+        FileOrchestrator::propagate_wrapper_request_shape(
+            &mut result,
+            Some(&WrapperRequestShape {
+                method: "DELETE".to_string(),
+                has_body: Some(false),
+            }),
+        );
+
+        assert_eq!(result.data_calls[0].method.as_deref(), Some("DELETE"));
+        assert_eq!(result.data_calls[0].payload_expression_text, None);
+        assert_eq!(result.data_calls[0].payload_expression_line, None);
+    }
+
+    /// A wrapper whose body presence cannot be read leaves the anchor alone: a
+    /// positional payload the site itself passes is a real request body.
+    #[test]
+    fn an_unreadable_body_presence_leaves_the_payload_anchor_alone() {
+        let mut call = methodless_call(23, "/catalog/things", None);
+        call.payload_expression_text = Some("payload".to_string());
+        call.payload_expression_line = Some(23);
+        let mut result = result_with_data_calls(vec![call]);
+
+        FileOrchestrator::propagate_wrapper_request_shape(
+            &mut result,
+            Some(&WrapperRequestShape {
+                method: "POST".to_string(),
+                has_body: None,
+            }),
+        );
+
+        assert_eq!(
+            result.data_calls[0].payload_expression_text.as_deref(),
+            Some("payload")
+        );
+    }
+
+    /// carrick-cloud#386, second half: a wrapper-resolved site and the
+    /// wrapper's own templated request are ONE outbound operation, and must
+    /// key as one.
+    ///
+    /// They agree on the path already — the wrapper's `${CATALOG_API_URL}` base
+    /// is a declared-internal env var, so `consumer_call_path` strips it to the
+    /// bare route the resolved site reports. What kept them apart was the
+    /// method: the delegating site defaulted to GET against the wrapper's POST,
+    /// so the existing wrapper-echo suppression never saw one key. With the
+    /// method propagated they collapse, and the candidate-backed record — the
+    /// real client call, the only one with spans for the type sidecar — wins.
+    #[test]
+    fn a_resolved_wrapper_site_and_its_template_call_key_as_one_operation() {
+        let orchestrator = FileOrchestrator::new(AgentService::new());
+        let config = crate::config::Config {
+            internal_env_vars: ["CATALOG_API_URL".to_string()].into_iter().collect(),
+            ..Default::default()
+        };
+
+        let post = |line: i32, target: &str, span: Option<u32>| DataCallResult {
+            method: Some("POST".to_string()),
+            ..call_with_span(line, target, span)
+        };
+
+        let mut file_results = HashMap::new();
+        file_results.insert(
+            "src/catalog-client.ts".to_string(),
+            result_with_data_calls(vec![post(
+                115,
+                "${CATALOG_API_URL}/catalog/sync",
+                Some(400),
+            )]),
+        );
+        file_results.insert(
+            "src/tools/sync-catalog.ts".to_string(),
+            result_with_data_calls(vec![post(23, "/catalog/sync", None)]),
+        );
+
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::new(&config),
+            Path::new(""),
+            Path::new(""),
+        );
+
+        assert_eq!(
+            graph.data_calls.len(),
+            1,
+            "one physical request must key as one operation, got {:?}",
+            graph
+                .data_calls
+                .iter()
+                .map(|c| (&c.method, &c.canonical_path, &c.file_location))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(graph.data_calls[0].method, "POST");
+        assert_eq!(graph.data_calls[0].canonical_path, "/catalog/sync");
+        assert_eq!(
+            graph.data_calls[0].file_location, "src/catalog-client.ts:115",
+            "the candidate-backed client call is the record that survives"
+        );
+    }
+
+    /// The counterfactual for the test above: with the delegating site still
+    /// recorded as a GET, the two records carry different keys and both
+    /// survive. This is the state carrick-cloud#386 reported.
+    #[test]
+    fn a_delegating_site_left_as_get_does_not_collapse() {
+        let orchestrator = FileOrchestrator::new(AgentService::new());
+        let config = crate::config::Config {
+            internal_env_vars: ["CATALOG_API_URL".to_string()].into_iter().collect(),
+            ..Default::default()
+        };
+
+        let mut file_results = HashMap::new();
+        file_results.insert(
+            "src/catalog-client.ts".to_string(),
+            result_with_data_calls(vec![DataCallResult {
+                method: Some("POST".to_string()),
+                ..call_with_span(115, "${CATALOG_API_URL}/catalog/sync", Some(400))
+            }]),
+        );
+        file_results.insert(
+            "src/tools/sync-catalog.ts".to_string(),
+            result_with_data_calls(vec![call_with_span(23, "/catalog/sync", None)]),
+        );
+
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::new(&config),
+            Path::new(""),
+            Path::new(""),
+        );
+
+        assert_eq!(graph.data_calls.len(), 2);
     }
 
     /// Reproduction of the cross-service call double-count.
@@ -8412,6 +8733,7 @@ export { routes };
             path_snippet: snippet.map(|s| s.to_string()),
             code_snippet: "router.get(...)".to_string(),
             request_spec: None,
+            request_shape: crate::wrapper_request_shape::RequestShapeSignal::NotARequest,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,3 +36,4 @@ pub mod url_normalizer;
 pub mod utils;
 pub mod visitor;
 pub mod workspace_resolver;
+pub mod wrapper_request_shape;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ mod url_normalizer;
 mod utils;
 mod visitor;
 mod workspace_resolver;
+mod wrapper_request_shape;
 
 use crate::cloud_storage::{AwsStorage, LocalDirStorage, MockStorage};
 use crate::services::TypeSidecar;

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -27,6 +27,7 @@ use swc_ecma_visit::{Visit, VisitWith};
 
 use crate::operation::{Protocol, PubsubRole};
 use crate::parser::parse_file;
+use crate::wrapper_request_shape::{RequestShapeSignal, call_request_shape};
 
 /// A candidate API call site detected by the SWC scanner.
 /// This is passed as a "hint" to the LLM to ensure 100% recall.
@@ -67,6 +68,16 @@ pub struct CandidateTarget {
     /// facts are used to overrule the model's answer after it replies (#537).
     #[serde(skip)]
     pub request_spec: Option<RequestSpec>,
+    /// What this call site says about the request shape of the module it lives
+    /// in — the literal HTTP method and body presence, when they are readable
+    /// off the AST (carrick-cloud#386). Read only when this module is another
+    /// file's imported HTTP wrapper, to resolve the METHOD of the delegating
+    /// site the same way #369/#370 resolves its target. Where `request_spec`
+    /// reads a call that declares its whole request as data, this reads the
+    /// options bag of a call whose URL is an expression — the shape a request
+    /// wrapper is built out of. Not serialized, for the same reason.
+    #[serde(skip)]
+    pub request_shape: RequestShapeSignal,
 }
 
 /// The HTTP method and URL a call declares as data on one object-literal
@@ -1073,6 +1084,10 @@ impl CandidateVisitor {
             Some(spec) => Some(format!("'{}'", spec.url)),
             None => self.extract_first_arg_snippet(call),
         };
+        // What this site says about its own module's request shape, for when
+        // another file imports this module as its HTTP wrapper
+        // (carrick-cloud#386).
+        let request_shape = call_request_shape(call, callee_property.as_deref());
 
         self.candidates.push(CandidateTarget {
             protocol: Protocol::Http,
@@ -1086,6 +1101,7 @@ impl CandidateVisitor {
             path_snippet,
             code_snippet,
             request_spec,
+            request_shape,
         });
     }
 
@@ -1120,6 +1136,8 @@ impl CandidateVisitor {
             path_snippet,
             code_snippet,
             request_spec: None,
+            // Not a call expression, so there are no request arguments to read.
+            request_shape: RequestShapeSignal::NotARequest,
         });
     }
 
@@ -2882,6 +2900,7 @@ async function fetchUser(id: string) {
             path_snippet: Some("'/users'".to_string()),
             code_snippet: "app.get('/users', handler)".to_string(),
             request_spec: None,
+            request_shape: RequestShapeSignal::NotARequest,
         };
 
         let hint = candidate.format_hint();

--- a/src/wrapper_request_shape.rs
+++ b/src/wrapper_request_shape.rs
@@ -1,0 +1,503 @@
+//! The request shape a wrapper module fixes for every call site that delegates
+//! to it: the HTTP method, and whether the request carries a body.
+//!
+//! Cross-file wrapper-site resolution (#369/#370) resolves the TARGET of a call
+//! that delegates to a same-repo request wrapper, because the wrapper's source
+//! is injected into the analyzing prompt. The METHOD was never resolved the
+//! same way: a wrapper that hardcodes `method: "POST"` inside its own `fetch`
+//! tells the delegating site nothing, the model emits no method for the site,
+//! and `normalize_consumer_method` falls back to `GET`. Every resolved site of
+//! a POST-only client is then indexed as a GET (carrick-cloud#386).
+//!
+//! The method is a structural fact of the wrapper's own request call, so it is
+//! read off the AST rather than asked for. What is read is deliberately narrow:
+//!
+//! - A call counts as a REQUEST only on a structural signature — an HTTP-verb
+//!   callee property (`client.post(...)`), or an object-literal argument
+//!   carrying at least one of `method` / `headers` / `body` / `data`, which is
+//!   the shape of a request-options bag in any client library. Response
+//!   handling on the same module (`response.json()`, `response.text()`) raises
+//!   an HTTP candidate too, and must not be mistaken for a second request with
+//!   an unreadable method.
+//! - A request whose method is not a literal (`fetch(url, { method })` — the
+//!   wrapper parameterizes it, so the SITE's argument is the real method) makes
+//!   the whole module's shape unknown. The site keeps whatever extraction gave
+//!   it.
+//! - Requests that disagree on the method make the module's shape unknown: a
+//!   delegating site could be reaching either.
+//!
+//! No library, framework or package name appears anywhere in here — the rules
+//! are the shape of the syntax, not a list of clients.
+
+use swc_ecma_ast::*;
+
+use crate::type_manifest::{is_http_method, normalize_manifest_method};
+
+/// The request a wrapper module issues, as far as it can be read off the AST.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WrapperRequestShape {
+    /// Normalized (uppercase) HTTP method every request in the module uses.
+    pub method: String,
+    /// Whether the request carries a body: `Some(true)` / `Some(false)` when
+    /// the argument list settles it, `None` when it does not. Only a definite
+    /// `Some(false)` is acted on downstream, so an unreadable argument list
+    /// never deletes a real payload anchor.
+    pub has_body: Option<bool>,
+}
+
+/// What one candidate call site says about the module's request shape.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum RequestShapeSignal {
+    /// Not a request at all (no request-options bag, no HTTP-verb callee) —
+    /// contributes nothing. Response handling lands here.
+    #[default]
+    NotARequest,
+    /// A request whose method cannot be read as a literal. Poisons the module:
+    /// the wrapper parameterizes its method, so only the call site knows it.
+    Unreadable,
+    /// A request with a literal method.
+    Known(WrapperRequestShape),
+}
+
+/// The HTTP-verb callee properties a request may be spelled with
+/// (`client.post(url, body)`). `is_http_method` is the single definition of
+/// what an HTTP method is; `connect`/`trace` are excluded because a bare
+/// `.connect(...)` is overwhelmingly a transport/database call, not a request.
+fn verb_from_callee_property(prop: Option<&str>) -> Option<String> {
+    let prop = prop?;
+    let upper = prop.to_uppercase();
+    if matches!(
+        upper.as_str(),
+        "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS"
+    ) {
+        Some(upper)
+    } else {
+        None
+    }
+}
+
+/// The literal string an expression evaluates to, or `None` when it is not a
+/// literal (an identifier, a member expression, an interpolated template).
+fn literal_string(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Lit(Lit::Str(s)) => Some(s.value.to_string()),
+        Expr::Tpl(tpl) if tpl.exprs.is_empty() && tpl.quasis.len() == 1 => {
+            Some(tpl.quasis[0].raw.to_string())
+        }
+        Expr::Paren(paren) => literal_string(&paren.expr),
+        Expr::TsAs(as_expr) => literal_string(&as_expr.expr),
+        Expr::TsConstAssertion(assertion) => literal_string(&assertion.expr),
+        _ => None,
+    }
+}
+
+/// The property name of an object-literal member, when it is a plain key.
+fn prop_key_name(prop: &PropOrSpread) -> Option<String> {
+    let PropOrSpread::Prop(prop) = prop else {
+        return None;
+    };
+    let key = match &**prop {
+        Prop::KeyValue(kv) => &kv.key,
+        Prop::Shorthand(ident) => return Some(ident.sym.to_string()),
+        Prop::Method(method) => &method.key,
+        Prop::Getter(getter) => &getter.key,
+        Prop::Setter(setter) => &setter.key,
+        Prop::Assign(_) => return None,
+    };
+    match key {
+        PropName::Ident(ident) => Some(ident.sym.to_string()),
+        PropName::Str(s) => Some(s.value.to_string()),
+        _ => None,
+    }
+}
+
+/// The value expression of an object-literal member named `name`, or `None`
+/// when the member is absent or a shorthand (`{ method }` — present, but its
+/// value is a binding, not a literal).
+fn prop_value<'a>(obj: &'a ObjectLit, name: &str) -> Option<Option<&'a Expr>> {
+    for prop in &obj.props {
+        if prop_key_name(prop).as_deref() != Some(name) {
+            continue;
+        }
+        let PropOrSpread::Prop(prop) = prop else {
+            continue;
+        };
+        return Some(match &**prop {
+            Prop::KeyValue(kv) => Some(&*kv.value),
+            _ => None,
+        });
+    }
+    None
+}
+
+/// Whether an object literal looks like a request-options bag: it carries at
+/// least one of the four keys every HTTP client spells the same way.
+fn is_request_options(obj: &ObjectLit) -> bool {
+    obj.props.iter().any(|prop| {
+        matches!(
+            prop_key_name(prop).as_deref(),
+            Some("method") | Some("headers") | Some("body") | Some("data")
+        )
+    })
+}
+
+/// The object literal among a call's arguments, when exactly one argument is
+/// one. Two object-literal arguments (a payload plus an options bag) is not a
+/// shape this reads.
+fn sole_object_literal(call: &CallExpr) -> Option<(usize, &ObjectLit)> {
+    let mut found: Option<(usize, &ObjectLit)> = None;
+    for (index, arg) in call.args.iter().enumerate() {
+        if arg.spread.is_some() {
+            continue;
+        }
+        if let Expr::Object(obj) = &*arg.expr {
+            if found.is_some() {
+                return None;
+            }
+            found = Some((index, obj));
+        }
+    }
+    found
+}
+
+/// Read what one call site says about its module's request shape.
+///
+/// `callee_property` is the property the call was made through (`post` in
+/// `client.post(...)`), as the candidate scanner already recorded it.
+pub fn call_request_shape(call: &CallExpr, callee_property: Option<&str>) -> RequestShapeSignal {
+    let verb = verb_from_callee_property(callee_property);
+    let options = sole_object_literal(call).filter(|(_, obj)| is_request_options(obj));
+
+    // Not request-shaped: no verb, no options bag. Response handling
+    // (`response.json()`), config builders and everything else land here and
+    // contribute nothing.
+    if verb.is_none() && options.is_none() {
+        return RequestShapeSignal::NotARequest;
+    }
+
+    // The method: an explicit literal in the options bag wins over the verb the
+    // call was spelled with, because a client that accepts both is configured
+    // by the bag.
+    let method = match options {
+        Some((_, obj)) => match prop_value(obj, "method") {
+            // A `method` key whose value is not a string literal is the
+            // parameterized wrapper: only the delegating site knows the method.
+            Some(value) => match value.and_then(literal_string) {
+                Some(literal) => {
+                    let normalized = normalize_manifest_method(&literal);
+                    if !is_http_method(&normalized) {
+                        return RequestShapeSignal::Unreadable;
+                    }
+                    normalized
+                }
+                None => return RequestShapeSignal::Unreadable,
+            },
+            // No `method` key at all. The verb the call was spelled with is the
+            // method; without one the request's method is a library default
+            // this must not guess at.
+            None => match verb {
+                Some(verb) => verb,
+                None => return RequestShapeSignal::Unreadable,
+            },
+        },
+        None => match verb {
+            Some(verb) => verb,
+            None => return RequestShapeSignal::Unreadable,
+        },
+    };
+
+    RequestShapeSignal::Known(WrapperRequestShape {
+        method,
+        has_body: body_presence(call, options),
+    })
+}
+
+/// Whether the call carries a request body.
+///
+/// `Some(true)` when an options bag names one, or when a verb-spelled call
+/// passes a positional payload after the URL. `Some(false)` when the argument
+/// list is exhausted by the URL and an options bag that names no body.
+/// `None` when neither is settled.
+fn body_presence(call: &CallExpr, options: Option<(usize, &ObjectLit)>) -> Option<bool> {
+    let positional = call.args.len();
+    if let Some((index, obj)) = options {
+        if prop_value(obj, "body").is_some() || prop_value(obj, "data").is_some() {
+            return Some(true);
+        }
+        // A third argument beside the URL and the options bag is a payload this
+        // does not model; only the plain `(url, options)` shape settles it.
+        if positional <= index + 1 {
+            return Some(false);
+        }
+        return None;
+    }
+    // Verb-spelled with no options bag: `client.get(url)` sends no body,
+    // `client.post(url, payload)` does.
+    match positional {
+        0 | 1 => Some(false),
+        _ => Some(true),
+    }
+}
+
+/// The shape a whole module fixes, folded over its call sites.
+///
+/// `None` — no propagation — whenever the module issues no readable request,
+/// issues one whose method cannot be read, or issues requests that disagree.
+/// Body presence collapses to `None` on disagreement, which downstream reads as
+/// "do not touch the payload anchor".
+pub fn fold_module<'a>(
+    signals: impl IntoIterator<Item = &'a RequestShapeSignal>,
+) -> Option<WrapperRequestShape> {
+    let mut folded: Option<WrapperRequestShape> = None;
+    for signal in signals {
+        match signal {
+            RequestShapeSignal::NotARequest => continue,
+            RequestShapeSignal::Unreadable => return None,
+            RequestShapeSignal::Known(shape) => match &mut folded {
+                None => folded = Some(shape.clone()),
+                Some(acc) => {
+                    if acc.method != shape.method {
+                        return None;
+                    }
+                    if acc.has_body != shape.has_body {
+                        acc.has_body = None;
+                    }
+                }
+            },
+        }
+    }
+    folded
+}
+
+/// The shape one importing file may propagate, folded over every wrapper module
+/// its imports resolved to. An unknown shape on any of them makes the whole
+/// thing unknown: the file could be delegating to either.
+pub fn fold_wrappers<'a>(
+    shapes: impl IntoIterator<Item = Option<&'a WrapperRequestShape>>,
+) -> Option<WrapperRequestShape> {
+    let mut folded: Option<WrapperRequestShape> = None;
+    let mut any = false;
+    for shape in shapes {
+        any = true;
+        let shape = shape?;
+        match &mut folded {
+            None => folded = Some(shape.clone()),
+            Some(acc) => {
+                if acc.method != shape.method {
+                    return None;
+                }
+                if acc.has_body != shape.has_body {
+                    acc.has_body = None;
+                }
+            }
+        }
+    }
+    if any { folded } else { None }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::swc_scanner::SwcScanner;
+    use std::path::PathBuf;
+
+    /// Fold the request shape of a module the way the orchestrator does: over
+    /// the HTTP candidates the gatekeeper raised for it.
+    fn module_shape(content: &str) -> Option<WrapperRequestShape> {
+        let scanner = SwcScanner::new();
+        let result = scanner.scan_content(&PathBuf::from("client.ts"), content, &[], &[]);
+        assert!(!result.parse_failed, "fixture must parse");
+        fold_module(result.candidates.iter().map(|c| &c.request_shape))
+    }
+
+    #[test]
+    fn a_hardcoded_method_is_read_off_the_options_bag() {
+        // The carrick-cloud#386 shape: every request the wrapper issues is a
+        // POST, and no delegating site says so.
+        let shape = module_shape(
+            r#"
+export class Client {
+  async load(id: string) {
+    const response = await fetch(this.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    return response.json();
+  }
+}
+"#,
+        );
+        assert_eq!(
+            shape,
+            Some(WrapperRequestShape {
+                method: "POST".to_string(),
+                has_body: Some(true),
+            })
+        );
+    }
+
+    #[test]
+    fn response_handling_does_not_poison_the_module() {
+        // `response.json()` / `response.text()` raise HTTP candidates of their
+        // own. Reading them as requests with an unreadable method would make
+        // every real wrapper unknown — which is the whole population #386 is
+        // about.
+        let shape = module_shape(
+            r#"
+export async function load(id: string) {
+  const response = await fetch(`${BASE}/things/${id}`, { method: "DELETE" });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text);
+  }
+  return response.json();
+}
+"#,
+        );
+        assert_eq!(
+            shape,
+            Some(WrapperRequestShape {
+                method: "DELETE".to_string(),
+                has_body: Some(false),
+            })
+        );
+    }
+
+    #[test]
+    fn a_parameterized_method_leaves_the_module_unknown() {
+        // The wrapper takes the method from its caller, so only the delegating
+        // site knows it — exactly the case the resolution prompt already
+        // handles, and the one this must not overwrite.
+        assert_eq!(
+            module_shape(
+                r#"
+export async function request(method: string, path: string) {
+  return fetch(`${BASE}${path}`, { method, headers: {} });
+}
+"#,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn requests_that_disagree_leave_the_module_unknown() {
+        assert_eq!(
+            module_shape(
+                r#"
+export async function read(id: string) {
+  return fetch(`${BASE}/things/${id}`, { method: "GET" });
+}
+export async function write(body: unknown) {
+  return fetch(`${BASE}/things`, { method: "POST", body: JSON.stringify(body) });
+}
+"#,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn a_module_with_no_request_is_unknown() {
+        assert_eq!(
+            module_shape("export function label(v: string) { return v.trim(); }"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_lowercase_literal_method_is_normalized() {
+        let shape = module_shape(
+            r#"
+export async function send(payload: unknown) {
+  return client.request({ method: "put", url: `${BASE}/things`, data: payload });
+}
+"#,
+        );
+        assert_eq!(
+            shape,
+            Some(WrapperRequestShape {
+                method: "PUT".to_string(),
+                has_body: Some(true),
+            })
+        );
+    }
+
+    #[test]
+    fn a_verb_spelled_call_carries_its_method_and_payload() {
+        let shape = module_shape(
+            r#"
+export async function create(payload: unknown) {
+  return client.post(`${BASE}/things`, payload);
+}
+"#,
+        );
+        assert_eq!(
+            shape,
+            Some(WrapperRequestShape {
+                method: "POST".to_string(),
+                has_body: Some(true),
+            })
+        );
+    }
+
+    #[test]
+    fn a_verb_spelled_call_with_only_a_url_sends_no_body() {
+        let shape = module_shape(
+            r#"
+export async function list() {
+  return client.get(`${BASE}/things`);
+}
+"#,
+        );
+        assert_eq!(
+            shape,
+            Some(WrapperRequestShape {
+                method: "GET".to_string(),
+                has_body: Some(false),
+            })
+        );
+    }
+
+    #[test]
+    fn an_off_enum_literal_method_leaves_the_module_unknown() {
+        assert_eq!(
+            module_shape(
+                r#"export async function go() { return fetch(URL, { method: "SUBSCRIBE" }); }"#,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn one_unknown_wrapper_makes_the_importer_unknown() {
+        let known = WrapperRequestShape {
+            method: "POST".to_string(),
+            has_body: Some(true),
+        };
+        assert_eq!(fold_wrappers([Some(&known)]), Some(known.clone()));
+        assert_eq!(fold_wrappers([Some(&known), None]), None);
+        // No wrapper at all is not "agreed": there is nothing to propagate.
+        assert_eq!(fold_wrappers([]), None);
+    }
+
+    #[test]
+    fn wrappers_that_agree_on_the_method_but_not_the_body_keep_the_method() {
+        let with_body = WrapperRequestShape {
+            method: "POST".to_string(),
+            has_body: Some(true),
+        };
+        let without_body = WrapperRequestShape {
+            method: "POST".to_string(),
+            has_body: Some(false),
+        };
+        assert_eq!(
+            fold_wrappers([Some(&with_body), Some(&without_body)]),
+            Some(WrapperRequestShape {
+                method: "POST".to_string(),
+                has_body: None,
+            })
+        );
+    }
+}

--- a/tests/file_centric_analysis_test.rs
+++ b/tests/file_centric_analysis_test.rs
@@ -272,6 +272,7 @@ fn test_processing_stats_tracking() {
         files_skipped_no_candidates: 1,
         files_parse_failed: 1,
         files_skipped_unrouted_protocol: 0,
+        wrapper_method_propagations: 0,
         total_mounts: 3,
         total_endpoints: 10,
         file_based_endpoints: 2,


### PR DESCRIPTION
## What

Cross-file wrapper-site resolution (#369/#370) resolves the **target** of a call that delegates to a same-repo request wrapper, because the wrapper's source is injected into the analyzing prompt. The **method** was never resolved the same way. A wrapper that hardcodes `method: "POST"` inside its own `fetch` tells the delegating site nothing, so extraction emits no method for the site and `normalize_consumer_method` (`src/agents/file_orchestrator.rs`) falls back to `GET`. Every resolved site of a POST-only client is indexed as a GET.

A read-only reproduction on the mcp-server package shows it. The only three fetches in the package are POST, and five wrapper-resolved sites are recorded as `GET /types/check-or-upload`.

## The fix

New `src/wrapper_request_shape.rs` reads one candidate call site into a method plus body presence, off the AST. The guards are narrow and structural, and no client library is named anywhere:

- A call counts as a request only on an HTTP-verb callee property (`client.post(...)`) or an object-literal argument carrying one of `method` / `headers` / `body` / `data`. Response handling on the same module (`response.json()`) raises an HTTP candidate too and contributes nothing.
- A request whose method is not a literal (`fetch(url, { method })`) leaves the module's shape unknown. That wrapper parameterises its method, so the delegating site's own argument is the real one and it is kept.
- Requests that disagree leave the module's shape unknown.

The signal rides on `CandidateTarget` behind `#[serde(skip)]`, alongside `request_spec` from #541, so the candidate JSON the prompt receives is byte-identical and no cached prompt changes.

`FileOrchestrator` folds the shape per wrapper module and per importing file, on both wrapper-context paths (the pending loop and the zero-candidate rescue, which is the path the reported files take), and propagates it in phase 3 right after `apply_candidate_map`. A delegating site is identified by the absence of a `call_expression_span_start`, the same discriminator the wrapper-echo suppression already uses, so the two passes cannot disagree about which row is the echo.

A wrapper that demonstrably sends no body also clears the site's payload anchor. The corrected method turns on request-body inference downstream (`should_infer_request_body`), and a request with no body must not acquire a request type from whatever expression extraction pointed at. Only a definite "no body" does this; an unreadable argument list leaves the anchor alone.

## Deduplication

A resolved wrapper site and the wrapper's own templated request already agree on the canonical path when the wrapper's base is a declared-internal env var: `consumer_call_path` strips `${CATALOG_API_URL}` to the bare route the resolved site reports. The method was what kept them apart. With it propagated, the existing echo suppression collapses them to one operation key and the candidate-backed record wins, since it is the real client call and the only one with spans for the type sidecar.

## Tests

- 11 in `wrapper_request_shape`: hardcoded method, parameterised, disagreeing, verb-spelled with and without a payload, lowercase normalisation, off-enum method, response handling not poisoning the module, and the per-importer fold.
- 4 on `propagate_wrapper_request_shape`: the delegating site is rewritten and the candidate-backed one is not, an unknown shape rewrites nothing, a body-less wrapper clears the payload anchor, an unreadable one does not.
- 2 in `build_mount_graph`: the collapse to one operation key, and the GET counterfactual that still produces two rows.

`cargo test` green (910 lib tests plus every integration target, including the cassette hard gate). `cargo fmt` and `cargo clippy --all-targets` clean.

## Scope notes

- The method flip is a behaviour change for the type layer on calls that previously never received request-body inference. Cassettes cannot measure that, so it needs a live check on the next eval run.
- The mcp-server duplicate in #386 also needs its env alias to resolve. The wrapper's base is recorded as `${API_ENDPOINT}`, a local const aliased to `CARRICK_API_ENDPOINT`, and only the latter is declared internal in the cloud repo's `carrick.json`. This PR fixes the method on both halves; whether the two rows then collapse in production depends on that alias resolving.

Fixes carrick-tools/carrick-cloud#386

🤖 Generated with [Claude Code](https://claude.com/claude-code)
