### PR TITLE
fix: extract outbound calls written as verb-named object requests

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -41,7 +41,9 @@ use crate::{
         ExtractionConfig, InferKind, InferRequestItem, SymbolRequest, TypeResolutionResult,
         TypeSidecar,
     },
-    swc_scanner::{CandidateTarget, PubsubAnchorOp, RouteDescriptorEndpoint, SwcScanner},
+    swc_scanner::{
+        CandidateTarget, PubsubAnchorOp, RouteDescriptorEndpoint, SwcScanner, normalize_path_params,
+    },
     type_manifest::{
         build_call_site_id, build_manifest_type_alias, build_manifest_type_alias_with_call_id,
         is_http_method, normalize_manifest_method, parse_file_location,
@@ -116,6 +118,11 @@ pub struct ProcessingStats {
     /// a topic from a wrapper-function NAME (`publishStatusChanged` ->
     /// `status.changed`); the real op lives in the file that holds the literal.
     pub pubsub_phantom_topic_drops: usize,
+    /// Outbound calls asserted deterministically from a verb-named request
+    /// spec (`client.post({ url: "/v1/things" })`) and merged in because the
+    /// file-analyzer's extraction omitted them (#529). A subset of
+    /// `total_data_calls`.
+    pub request_spec_call_backfills: usize,
     /// Wrapper-resolved data calls whose HTTP method was corrected from what
     /// extraction gave them to the method their wrapper module hardcodes
     /// (carrick-cloud#386). A subset of `total_data_calls`.
@@ -1310,6 +1317,14 @@ impl FileOrchestrator {
                     stats.pubsub_anchor_backfills +=
                         Self::merge_pubsub_anchor_ops(&mut adjusted, pf.pubsub_anchor_ops);
 
+                    // Merge the outbound calls a verb-named request spec states
+                    // outright (`client.post({ url: "/v1/things" })`) and the
+                    // extraction did not report (#529). Runs after
+                    // `apply_candidate_map` so the coverage check reads the
+                    // model's calls already re-anchored to their spec.
+                    stats.request_spec_call_backfills +=
+                        Self::merge_request_spec_calls(&mut adjusted, &pf.candidate_map);
+
                     stats.total_mounts += adjusted.mounts.len();
                     stats.total_endpoints += adjusted.endpoints.len();
                     stats.total_data_calls += adjusted.data_calls.len();
@@ -1349,6 +1364,10 @@ impl FileOrchestrator {
             stats.route_descriptor_endpoints
         );
         debug!("  - Total data calls: {}", stats.total_data_calls);
+        debug!(
+            "  - Request-spec call backfills: {}",
+            stats.request_spec_call_backfills
+        );
         debug!(
             "  - Wrapper method propagations: {}",
             stats.wrapper_method_propagations
@@ -3592,14 +3611,14 @@ impl FileOrchestrator {
             data_call.method = Some(spec.method.clone());
         }
 
-        let target = data_call.target.trim();
-        let carries_spec_url = match target.strip_suffix(spec.url.as_str()) {
-            // The whole target IS the literal, or the literal is the tail of a
-            // longer target that ends at a segment boundary.
-            Some(prefix) => prefix.is_empty() || !prefix.ends_with('/'),
-            None => false,
-        };
-        if carries_spec_url {
+        // Both sides in the router spelling before they are compared: the spec
+        // url already is, and a model that copied an OpenAPI-style `{param}`
+        // out of the source is stating the same path (#529).
+        let target = normalize_path_params(data_call.target.trim());
+        if Self::target_carries_url(&target, &spec.url) {
+            if target != data_call.target {
+                data_call.target = target;
+            }
             return;
         }
 
@@ -3608,6 +3627,111 @@ impl FileOrchestrator {
             data_call.target, spec.url, file_path, candidate.line_number
         );
         data_call.target = spec.url.clone();
+    }
+
+    /// Does `target` already state `url` — either as the whole target, or as
+    /// its tail behind a base (`${API_URL}/v1/things`)? The tail must start at
+    /// a segment boundary, so `/things` does not "carry" `/other-things`.
+    /// Both arguments are expected in the router param spelling.
+    fn target_carries_url(target: &str, url: &str) -> bool {
+        match target.trim().strip_suffix(url) {
+            Some(prefix) => prefix.is_empty() || !prefix.ends_with('/'),
+            None => false,
+        }
+    }
+
+    /// Emit the outbound calls a verb-named request spec states outright, for
+    /// the call sites the file analyzer returned nothing for (#529).
+    ///
+    /// `client.post({ url: "/v1/sessions/{sessionId}/release" })` is how a
+    /// generated OpenAPI client issues an operation, and the method and path
+    /// are both AST facts there — the same standing as a route descriptor's
+    /// `{ method, path }`, which is merged deterministically by #234. When
+    /// extraction misses such a file (a generated client is hundreds of
+    /// near-identical wrappers, and the analyzer routinely returns none of
+    /// them), the consumer side of every one of those operations is lost and
+    /// the producer's endpoints are reported orphaned — the index asserting no
+    /// consumer where one exists.
+    ///
+    /// Only `method_from_callee` specs qualify; see [`RequestSpec`] for why
+    /// the `{ method, url }` object form stays the analyzer's to classify.
+    /// A spec whose site the analyzer DID answer is left alone, and so is one
+    /// whose (method, url) another call in the file already carries — a target
+    /// behind a base URL included, since the base is the one thing the
+    /// analyzer knows and this backfill does not.
+    fn merge_request_spec_calls(
+        result: &mut FileAnalysisResult,
+        candidate_map: &HashMap<String, CandidateTarget>,
+    ) -> usize {
+        let mut specs: Vec<&CandidateTarget> = candidate_map
+            .values()
+            .filter(|candidate| {
+                candidate
+                    .request_spec
+                    .as_ref()
+                    .is_some_and(|spec| spec.method_from_callee)
+            })
+            .collect();
+        // The map iterates in hash order; emit in source order so a scan of the
+        // same file always produces the same rows.
+        specs.sort_by_key(|candidate| candidate.span_start);
+
+        let mut added = 0;
+        for candidate in specs {
+            let Some(spec) = candidate.request_spec.as_ref() else {
+                continue;
+            };
+            let covered = result.data_calls.iter().any(|data_call| {
+                data_call.candidate_id == candidate.candidate_id
+                    || (data_call
+                        .method
+                        .as_deref()
+                        .map(|method| method.trim().to_uppercase())
+                        .as_deref()
+                        == Some(spec.method.as_str())
+                        && Self::target_carries_url(
+                            &normalize_path_params(&data_call.target),
+                            &spec.url,
+                        ))
+            });
+            if covered {
+                continue;
+            }
+            debug!(
+                "Backfilling outbound call the extraction missed: {} {} at line {}",
+                spec.method, spec.url, candidate.line_number
+            );
+            result.data_calls.push(DataCallResult {
+                candidate_id: candidate.candidate_id.clone(),
+                line_number: i32::try_from(candidate.line_number).unwrap_or(i32::MAX),
+                target: spec.url.clone(),
+                method: Some(spec.method.clone()),
+                // Classification is judgment, not an AST fact: the URL is a
+                // bare path with no host to classify from.
+                call_kind: None,
+                pattern_matched: if candidate.callee_object.starts_with('<') {
+                    // The receiver is an expression, not a name (the
+                    // `(options?.client ?? client)` shape).
+                    "http-client".to_string()
+                } else {
+                    candidate.callee_object.clone()
+                },
+                // The span is what the type sidecar anchors on, and it is also
+                // what marks this call candidate-backed downstream.
+                call_expression_span_start: Some(candidate.span_start),
+                call_expression_span_end: Some(candidate.span_end),
+                call_expression_text: None,
+                call_expression_line: Some(
+                    i32::try_from(candidate.line_number).unwrap_or(i32::MAX),
+                ),
+                payload_expression_text: None,
+                payload_expression_line: None,
+                primary_type_symbol: None,
+                type_import_source: None,
+            });
+            added += 1;
+        }
+        added
     }
 
     /// Extract the route path from a candidate's first-arg source snippet when
@@ -9145,7 +9269,20 @@ export { routes };
         candidate.request_spec = Some(crate::swc_scanner::RequestSpec {
             method: method.to_string(),
             url: url.to_string(),
+            method_from_callee: false,
         });
+        candidate
+    }
+
+    /// The #529 form: the verb is the member being invoked, so the spec is one
+    /// the backfill may emit on its own.
+    fn verb_call_candidate(id: &str, method: &str, url: &str) -> CandidateTarget {
+        let mut candidate = request_spec_candidate(id, method, url);
+        candidate.callee_object = "client".to_string();
+        candidate.callee_property = Some(method.to_ascii_lowercase());
+        if let Some(spec) = candidate.request_spec.as_mut() {
+            spec.method_from_callee = true;
+        }
         candidate
     }
 
@@ -9247,6 +9384,128 @@ export { routes };
 
         assert_eq!(result.data_calls[0].target, "${API_URL}/things");
         assert_eq!(result.data_calls[0].method.as_deref(), Some("GET"));
+    }
+
+    /// #529: a generated OpenAPI client is hundreds of near-identical
+    /// wrappers, and extraction routinely returns none of them. The method and
+    /// the path are AST facts at every one of those sites, so the operations
+    /// are emitted deterministically rather than lost — otherwise the producer
+    /// reports its endpoints orphaned while a consumer in the index calls them.
+    #[test]
+    fn merge_request_spec_calls_backfills_operations_extraction_missed() {
+        let mut result = FileAnalysisResult::default();
+        let mut candidate_map = HashMap::new();
+        let mut release = verb_call_candidate("c1", "POST", "/v1/sessions/:sessionId/release");
+        release.span_start = 400;
+        let mut list = verb_call_candidate("c2", "GET", "/v1/sessions");
+        list.span_start = 100;
+        candidate_map.insert("c1".to_string(), release);
+        candidate_map.insert("c2".to_string(), list);
+
+        let added = FileOrchestrator::merge_request_spec_calls(&mut result, &candidate_map);
+
+        assert_eq!(added, 2);
+        // Source order, not hash order: the same file must produce the same
+        // rows on every scan.
+        let emitted: Vec<(&str, Option<&str>)> = result
+            .data_calls
+            .iter()
+            .map(|call| (call.target.as_str(), call.method.as_deref()))
+            .collect();
+        assert_eq!(
+            emitted,
+            vec![
+                ("/v1/sessions", Some("GET")),
+                ("/v1/sessions/:sessionId/release", Some("POST")),
+            ]
+        );
+        // The span makes the backfilled call candidate-backed downstream and is
+        // what the type sidecar anchors on.
+        assert_eq!(result.data_calls[0].call_expression_span_start, Some(100));
+        assert_eq!(result.data_calls[0].call_expression_span_end, Some(140));
+        assert_eq!(result.data_calls[0].line_number, 12);
+    }
+
+    /// The backfill never duplicates an operation the analyzer did report —
+    /// neither at the same site, nor as the same (method, path) behind the base
+    /// URL the analyzer resolved and this pass cannot see.
+    #[test]
+    fn merge_request_spec_calls_skips_operations_already_extracted() {
+        let mut result = FileAnalysisResult {
+            data_calls: vec![
+                data_call_with("c1", "/v1/sessions/:sessionId/release", Some("POST")),
+                data_call_with("other", "${API_URL}/v1/sessions", Some("GET")),
+            ],
+            ..Default::default()
+        };
+        let mut candidate_map = HashMap::new();
+        candidate_map.insert(
+            "c1".to_string(),
+            verb_call_candidate("c1", "POST", "/v1/sessions/:sessionId/release"),
+        );
+        // Same operation, reported against another candidate id with the base
+        // in front of it.
+        candidate_map.insert(
+            "c2".to_string(),
+            verb_call_candidate("c2", "GET", "/v1/sessions"),
+        );
+        // A different operation on the same path prefix must still be emitted.
+        candidate_map.insert(
+            "c3".to_string(),
+            verb_call_candidate("c3", "DELETE", "/v1/sessions"),
+        );
+
+        let added = FileOrchestrator::merge_request_spec_calls(&mut result, &candidate_map);
+
+        assert_eq!(added, 1);
+        assert_eq!(result.data_calls.len(), 3);
+        assert_eq!(result.data_calls[2].target, "/v1/sessions");
+        assert_eq!(result.data_calls[2].method.as_deref(), Some("DELETE"));
+    }
+
+    /// A `{ method, url }` object states a request and a route registration
+    /// identically, so only the verb-named form — where the verb is the
+    /// operation being performed — is emitted without the analyzer. The config
+    /// form keeps its #537 anchoring role and nothing more.
+    #[test]
+    fn merge_request_spec_calls_ignores_config_object_specs() {
+        let mut result = FileAnalysisResult::default();
+        let mut candidate_map = HashMap::new();
+        candidate_map.insert(
+            "c1".to_string(),
+            request_spec_candidate("c1", "GET", "/v1/health"),
+        );
+
+        let added = FileOrchestrator::merge_request_spec_calls(&mut result, &candidate_map);
+
+        assert_eq!(added, 0);
+        assert!(result.data_calls.is_empty());
+    }
+
+    /// An OpenAPI-style path the model copied verbatim states the same route as
+    /// the spec, so it is normalized in place rather than stripped of the base.
+    #[test]
+    fn request_spec_normalizes_a_target_written_with_openapi_params() {
+        let mut result = FileAnalysisResult {
+            data_calls: vec![data_call_with(
+                "c1",
+                "${API_URL}/v1/sessions/{sessionId}/release",
+                Some("POST"),
+            )],
+            ..Default::default()
+        };
+        let mut candidate_map = HashMap::new();
+        candidate_map.insert(
+            "c1".to_string(),
+            verb_call_candidate("c1", "POST", "/v1/sessions/:sessionId/release"),
+        );
+
+        FileOrchestrator::apply_candidate_map(&mut result, &candidate_map, "src/client.ts");
+
+        assert_eq!(
+            result.data_calls[0].target,
+            "${API_URL}/v1/sessions/:sessionId/release"
+        );
     }
 
     /// `collect_pubsub_type_requests` walks a `HashMap<String, _>`, whose

--- a/src/swc_scanner.rs
+++ b/src/swc_scanner.rs
@@ -86,10 +86,53 @@ pub struct CandidateTarget {
 /// named anywhere.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RequestSpec {
-    /// The `method` literal, upper-cased and known to be an HTTP verb.
+    /// The HTTP verb, upper-cased. Read from the object's `method` literal, or
+    /// from the invoked member name when the object carries only a `url` (see
+    /// `method_from_callee`).
     pub method: String,
-    /// The `url` (or `path`) literal, verbatim.
+    /// The `url` (or `path`) literal, with OpenAPI-style `{param}` segments
+    /// rewritten to the router spelling `:param` (see
+    /// [`normalize_path_params`]).
     pub url: String,
+    /// True when the verb came from the invoked member name
+    /// (`client.post({ url: "/v1/things" })`) rather than a `method` property.
+    ///
+    /// That form is unambiguously a REQUEST: the verb is the operation being
+    /// performed, and `url` is the request-side spelling of the target (a
+    /// declarative route registration spells it `path` and carries a handler).
+    /// The consumer backfill emits only this form deterministically; a
+    /// `{ method, url }` object alone can equally be a producer's route
+    /// descriptor, so it stays an anchor for the analyzer's answer.
+    pub method_from_callee: bool,
+}
+
+/// Rewrite OpenAPI-style path parameters (`/v1/sessions/{sessionId}/release`)
+/// to the router spelling the rest of Carrick keys on (`/v1/sessions/:sessionId/release`),
+/// so a call written in the OpenAPI spelling joins the producer route that
+/// declares the same path.
+///
+/// Whole segments only: `${BASE}` and `foo{bar}baz` are left alone, so a
+/// target that interpolates an env-var base survives untouched.
+pub fn normalize_path_params(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for (i, segment) in path.split('/').enumerate() {
+        if i > 0 {
+            out.push('/');
+        }
+        let inner = segment
+            .strip_prefix('{')
+            .and_then(|s| s.strip_suffix('}'))
+            .map(str::trim)
+            .filter(|inner| !inner.is_empty() && !inner.contains(['{', '}']));
+        match inner {
+            Some(inner) => {
+                out.push(':');
+                out.push_str(inner);
+            }
+            None => out.push_str(segment),
+        }
+    }
+    out
 }
 
 impl CandidateTarget {
@@ -1182,8 +1225,10 @@ impl CandidateVisitor {
 
     /// The request spec of a call that declares its method and URL as data on
     /// its first argument (`client({ method: "post", url: "/api/v1/login" })`,
-    /// `axios({ ... })`, `client.request({ ... })`). `None` for every other
-    /// call shape.
+    /// `axios({ ... })`, `client.request({ ... })`), or that names its method
+    /// as the member it invokes and carries the URL on that object
+    /// (`client.post({ url: "/v1/things" })`, see
+    /// [`Self::verb_call_request_spec`]). `None` for every other call shape.
     ///
     /// This is the config-object form of an outbound HTTP call, and nothing in
     /// the candidate layer could see it before (#537): no argument is a
@@ -1206,7 +1251,83 @@ impl CandidateVisitor {
         let Expr::Object(obj) = &*arg.expr else {
             return None;
         };
-        Self::request_spec(obj)
+        if let Some(spec) = Self::request_spec(obj) {
+            return Some(spec);
+        }
+        // The verb-named form: the method is the member being invoked and the
+        // object carries only the URL (#529).
+        let Callee::Expr(callee) = &call.callee else {
+            return None;
+        };
+        let verb = Self::callee_member_prop(callee)?;
+        Self::verb_call_request_spec(&verb, obj)
+    }
+
+    /// The request spec of `client.post({ url: "/v1/things" })` — a verb-named
+    /// method on a receiver, handed one object literal that carries the URL.
+    /// This is how generated OpenAPI clients issue every operation, and until
+    /// #529 nothing saw them: the object is the only argument, so no string
+    /// argument exists for the URL-scheme or stringish signals to read, and
+    /// the receiver is routinely an expression (`(options?.client ?? client)`)
+    /// rather than a name the receiver heuristics recognise.
+    ///
+    /// Three structural guards keep this off producer-side route
+    /// registrations, which are the one other thing that puts a route literal
+    /// on an object argument of a verb-named method:
+    ///
+    /// - the URL key must be `url`, the request-side spelling — a declarative
+    ///   route spells it `path` (and #241 pins that a `{ method, path }`
+    ///   object is never a deterministic route by itself);
+    /// - the object may carry no `handler` property and no function value —
+    ///   both are the registration side declaring what answers the route,
+    ///   which a request has no use for;
+    /// - the URL must be route-shaped, so an options bag whose `url` holds a
+    ///   bare token is not a request.
+    ///
+    /// Structural throughout: the shape is the whole signal and no client
+    /// library, generator, or framework is named.
+    fn verb_call_request_spec(verb: &str, obj: &ObjectLit) -> Option<RequestSpec> {
+        if !crate::type_manifest::is_http_method(verb) {
+            return None;
+        }
+
+        let mut url = None;
+        for prop in &obj.props {
+            // A spread (`{ ...options, url: "/x" }`) carries no key to read and
+            // no handler to fear; the generated clients all pass one.
+            let PropOrSpread::Prop(prop) = prop else {
+                continue;
+            };
+            let Prop::KeyValue(kv) = &**prop else {
+                continue;
+            };
+            if matches!(&*kv.value, Expr::Arrow(_) | Expr::Fn(_)) {
+                return None;
+            }
+            let key = match &kv.key {
+                PropName::Ident(id) => id.sym.to_string(),
+                PropName::Str(s) => s.value.to_string(),
+                _ => continue,
+            };
+            if key == "handler" {
+                return None;
+            }
+            if key == "url"
+                && let Expr::Lit(Lit::Str(value)) = &*kv.value
+            {
+                url = Some(value.value.to_string());
+            }
+        }
+
+        let url = url?;
+        if !RouteDescriptorVisitor::is_route_shaped_path(&url) {
+            return None;
+        }
+        Some(RequestSpec {
+            method: verb.trim().to_uppercase(),
+            url: normalize_path_params(&url),
+            method_from_callee: true,
+        })
     }
 
     /// The `{ method, url }` pair of an object literal, when both are string
@@ -1257,7 +1378,8 @@ impl CandidateVisitor {
         }
         Some(RequestSpec {
             method: method.trim().to_uppercase(),
-            url,
+            url: normalize_path_params(&url),
+            method_from_callee: false,
         })
     }
 
@@ -2744,6 +2866,126 @@ export function register(server) {
         let spec = candidate.request_spec.as_ref().expect("checked above");
         assert_eq!((spec.method.as_str(), spec.url.as_str()), ("GET", "/*"));
         assert_eq!(candidate.path_snippet.as_deref(), Some("'/*'"));
+    }
+
+    /// #529: a generated OpenAPI client issues every operation as a verb-named
+    /// method handed one object that carries the URL, on a receiver that is an
+    /// expression rather than a name. No argument is a string and the callee
+    /// heuristics have nothing to read, so before this the call raised no
+    /// candidate carrying its path and the operation never reached the index.
+    #[test]
+    fn verb_named_object_call_yields_a_candidate_carrying_method_and_url() {
+        let content = r#"
+export const releaseSession = <ThrowOnError extends boolean = false>(options?: Options) => {
+  return (options?.client ?? client).post<ReleaseResponse, ReleaseError, ThrowOnError>({
+    ...options,
+    url: "/v1/sessions/{sessionId}/release",
+  });
+};
+"#;
+        let result = scan_test_content(content);
+        let candidate = result
+            .candidates
+            .iter()
+            .find(|c| c.request_spec.is_some())
+            .unwrap_or_else(|| {
+                panic!(
+                    "verb-named object call must raise a candidate: {:#?}",
+                    result.candidates
+                )
+            });
+
+        let spec = candidate.request_spec.as_ref().expect("checked above");
+        assert_eq!(spec.method, "POST");
+        // OpenAPI `{param}` placeholders arrive in the router spelling so the
+        // call joins the route the producer declares.
+        assert_eq!(spec.url, "/v1/sessions/:sessionId/release");
+        assert!(spec.method_from_callee);
+        // The hint must show the URL, not the object's opening brace.
+        assert_eq!(
+            candidate.path_snippet.as_deref(),
+            Some("'/v1/sessions/:sessionId/release'")
+        );
+    }
+
+    /// The same shape on a plainly named receiver, with and without the
+    /// leading spread. Structural, so the callee spelling is irrelevant.
+    #[test]
+    fn verb_named_object_call_is_recognised_whatever_the_callee_is() {
+        let content = r#"
+export async function run() {
+  await client.get({ ...options, url: "/v1/sessions" });
+  await sdk.http.delete({ url: "/v1/sessions/{sessionId}" });
+}
+"#;
+        let result = scan_test_content(content);
+        let mut seen: Vec<(String, String)> = result
+            .candidates
+            .iter()
+            .filter_map(|c| {
+                c.request_spec
+                    .as_ref()
+                    .map(|s| (s.method.clone(), s.url.clone()))
+            })
+            .collect();
+        seen.sort();
+        assert_eq!(
+            seen,
+            vec![
+                ("DELETE".to_string(), "/v1/sessions/:sessionId".to_string()),
+                ("GET".to_string(), "/v1/sessions".to_string()),
+            ]
+        );
+    }
+
+    /// The guards that keep the verb-named form off route registrations and
+    /// ordinary options bags.
+    #[test]
+    fn non_request_verb_named_object_calls_carry_no_spec() {
+        let cases = [
+            // `path`, not `url`: the declarative route-registration spelling.
+            r#"await router.get({ path: "/v1/things", handler: onThings });"#,
+            // Carries a handler, so it registers a route rather than issuing one.
+            r#"await api.get({ url: "/v1/things", handler: onThings });"#,
+            r#"await api.get({ url: "/v1/things", onError: (e) => log(e) });"#,
+            // The member is not an HTTP verb.
+            r#"await queue.send({ url: "/v1/things" });"#,
+            // `url` is a bare token, not a route.
+            r#"await client.post({ url: "queue-name" });"#,
+            // Shorthand property: no literal to read.
+            r#"await client.post({ url });"#,
+            // Template literal, so no unambiguous literal to anchor.
+            r#"await client.post({ url: `${base}/things` });"#,
+        ];
+        for case in cases {
+            let content = format!("export async function run() {{ {case} }}");
+            let result = scan_test_content(&content);
+            assert!(
+                result.candidates.iter().all(|c| c.request_spec.is_none()),
+                "must carry no request spec: {case}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_path_params_rewrites_whole_segments_only() {
+        assert_eq!(
+            normalize_path_params("/v1/sessions/{sessionId}/release"),
+            "/v1/sessions/:sessionId/release"
+        );
+        // Already in the router spelling, and idempotent.
+        assert_eq!(
+            normalize_path_params("/v1/sessions/:id"),
+            "/v1/sessions/:id"
+        );
+        // An interpolated base is not a path param.
+        assert_eq!(
+            normalize_path_params("${API_URL}/v1/sessions/{id}"),
+            "${API_URL}/v1/sessions/:id"
+        );
+        // Partial-segment braces are left alone.
+        assert_eq!(normalize_path_params("/v1/a{b}c"), "/v1/a{b}c");
+        assert_eq!(normalize_path_params("/v1/{}"), "/v1/{}");
     }
 
     #[test]

--- a/tests/file_centric_analysis_test.rs
+++ b/tests/file_centric_analysis_test.rs
@@ -279,6 +279,7 @@ fn test_processing_stats_tracking() {
         route_descriptor_endpoints: 1,
         pubsub_anchor_backfills: 0,
         pubsub_phantom_topic_drops: 0,
+        request_spec_call_backfills: 0,
         total_data_calls: 4,
         errors: vec!["Test error".to_string()],
     };


### PR DESCRIPTION
Carrick checked: "extract outbound HTTP call from method call expression" (project scanner-evals) -> 10 rows returned, 6 above threshold. The nearest prior art was the sidecar's call-expression locators and the cloud's external-call collector, none of them the candidate layer, so this builds on the existing request-spec reader in `swc_scanner.rs` rather than adding a second one.

## What was broken

Generated OpenAPI clients issue every operation as a verb-named method handed a single object that carries the URL, on a receiver that is an expression rather than a name:

```ts
return (options?.client ?? client).post<Res, Err, ThrowOnError>({
  ...options,
  url: "/v1/sessions/{sessionId}/release",
});
```

Nothing in the candidate layer could see that shape. No argument is a string, so the URL-scheme and stringish-argument signals never fire; the receiver is an expression, so the receiver heuristics have no name to read; and the object's first-line snippet is `{`, so even the candidates that did fire anchored nothing. The operations never reached the index, which means the index recorded no consumer for endpoints that have one, and reported those endpoints orphaned.

## The fix

`swc_scanner::CandidateVisitor::verb_call_request_spec` reads a request spec off that shape, taking the verb from the invoked member and the URL from the object literal, and `normalize_path_params` rewrites OpenAPI `{param}` segments to the router spelling `:param` so the call joins the route the producer declares. Whole segments only, so an interpolated `${BASE}` survives untouched. Both spellings now flow through `RequestSpec.url`, and `reanchor_data_call` normalizes the model's target the same way before comparing, so a target the model copied in the OpenAPI spelling keeps its base URL instead of being stripped back to the bare path.

Three structural guards keep this off declarative route registrations, which are the other thing that puts a route literal on an object argument of a verb-named method: the URL key must be `url` rather than the registration-side `path`; the object may carry no `handler` property and no function value; and the URL must be route-shaped. No library, generator, or framework is named anywhere in the matching logic.

A generated client is hundreds of near-identical wrappers, and extraction routinely returns none of them, so `merge_request_spec_calls` also emits these calls deterministically for the sites the analyzer answered nothing for. That is the same standing route descriptors have had since #234, and only the verb-named form qualifies: a bare `{ method, url }` object states a request and a route registration identically, so it keeps its #537 anchoring role and nothing more. A site the analyzer did answer keeps its answer, base URL included, and a duplicate is skipped whether it comes back under the same candidate id or as the same (method, path) behind a resolved base. Emission is sorted by span so the same file produces the same rows on every scan.

## Verification

Offline reproduction, model returning nothing (`CARRICK_MOCK_ALL=1 cargo run -- <fixture>`) on a fixture holding two operations in the shape above:

- before: `Indexed 0 endpoints and 0 cross-service calls`
- after: `Indexed 0 endpoints and 2 cross-service calls`

`cargo test`: 1974 passed, 0 failed, 3 ignored across all 23 binaries, including the cassette hard gate, which did not drift. `cargo fmt --check` and `cargo clippy --all-targets` clean. New tests cover the `{param}` mapping, the `{ ...options, url }` spread, both receiver spellings, the guards (`path` key, handler, non-verb member, bare token, shorthand, template literal), the backfill and its two duplicate cases, config-form specs staying out of the backfill, and target normalization.

## Left out

- **Generic type arguments.** `client.post<Res, Err, ThrowOnError>({ … })` carries the request and response types, and `CandidateTarget` has no field for them, so capturing them is not in this PR. The backfilled calls do stamp the SWC span, which is what the type sidecar anchors on, so the response type may resolve through the existing path; that is untested here and not claimed. Worth its own ticket alongside the sidecar's type work.
- **Same-service calls.** The existing self-call pass suppresses a data call matching one of the same service's own resolved endpoints. A repo whose client and API are separate services in `carrick.json` builds a graph per service and is unaffected; one scanned as a single flat service still suppresses, which is the standing behaviour for every call shape and not changed here.
- **The client label.** A backfilled call whose receiver is an expression records `http-client` as its client name, since there is no identifier to read. Framework-neutral and honest about what the AST shows.

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)
