### PR TITLE
feat(scanner): keep the raw dependency spec alongside the cleaned version

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4113,6 +4113,7 @@ mod tests {
             PackageInfo {
                 name: "express".to_string(),
                 version: "4.18.0".to_string(),
+                spec: "^4.18.0".to_string(),
                 source_path: PathBuf::from(abs("package.json")),
             },
         );

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -40,7 +40,17 @@ pub struct PackageJson {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PackageInfo {
     pub name: String,
+    /// The cleaned version: range operators stripped and ranges collapsed to a
+    /// single version (see `clean_version_spec`). Lossy by design — `^3.0.0`
+    /// and a `3.0.0` pin both clean to `3.0.0`.
     pub version: String,
+    /// The dependency specifier exactly as written in package.json (`^3.0.0`,
+    /// `~1.2.3`, `>=2 <3`, `workspace:*`, a git URL). The cloud uses this raw
+    /// form for semver-range conflict analysis, which `version` cannot answer
+    /// because the operators are already gone by then. `default` for payloads
+    /// serialised before the field existed.
+    #[serde(default)]
+    pub spec: String,
     pub source_path: PathBuf,
 }
 
@@ -166,6 +176,7 @@ impl Packages {
                                     PackageInfo {
                                         name: name.clone(),
                                         version: clean_version,
+                                        spec: version_spec.clone(),
                                         source_path: source_path.clone(),
                                     },
                                 );
@@ -177,6 +188,7 @@ impl Packages {
                                 PackageInfo {
                                     name: name.clone(),
                                     version: clean_version,
+                                    spec: version_spec.clone(),
                                     source_path: source_path.clone(),
                                 },
                             );
@@ -288,6 +300,78 @@ mod tests {
             !names.contains("koa"),
             "node_modules packages are not internal"
         );
+    }
+
+    /// `version` is the lossy cleaned form; `spec` must carry the declaration
+    /// byte-for-byte so the cloud can tell a caret range from a pin. Expected
+    /// versions are hardcoded rather than re-derived from `clean_version_spec`,
+    /// so a regression in the cleaning is caught here too.
+    #[test]
+    fn resolve_dependencies_keeps_the_raw_spec_beside_the_cleaned_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("package.json");
+        std::fs::write(
+            &manifest,
+            r#"{
+                "name": "svc",
+                "dependencies": {
+                    "a": "^3.0.0",
+                    "b": "~1.2.3",
+                    "c": "1.0.0 - 2.0.0",
+                    "d": "workspace:*"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let packages = Packages::new(vec![manifest]).unwrap();
+        let expected = [
+            ("a", "3.0.0", "^3.0.0"),
+            ("b", "1.2.3", "~1.2.3"),
+            ("c", "2.0.0", "1.0.0 - 2.0.0"),
+            ("d", "workspace:*", "workspace:*"),
+        ];
+        for (name, version, spec) in expected {
+            let info = packages
+                .merged_dependencies
+                .get(name)
+                .unwrap_or_else(|| panic!("{name} missing from merged_dependencies"));
+            assert_eq!(info.version, version, "cleaned version for {name}");
+            assert_eq!(info.spec, spec, "raw spec for {name}");
+        }
+    }
+
+    /// When two manifests declare the same package the higher version wins —
+    /// and `spec` must follow the winner, in both file orders (the update
+    /// branch and the keep-existing branch).
+    #[test]
+    fn resolve_dependencies_keeps_the_winning_manifests_spec() {
+        let dir = tempfile::tempdir().unwrap();
+        let low = dir.path().join("low/package.json");
+        let high = dir.path().join("high/package.json");
+        std::fs::create_dir_all(low.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(high.parent().unwrap()).unwrap();
+        std::fs::write(
+            &low,
+            r#"{ "name": "low", "dependencies": { "lodash": "^4.17.20" } }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            &high,
+            r#"{ "name": "high", "dependencies": { "lodash": "~4.17.30" } }"#,
+        )
+        .unwrap();
+
+        for paths in [
+            vec![low.clone(), high.clone()],
+            vec![high.clone(), low.clone()],
+        ] {
+            let packages = Packages::new(paths.clone()).unwrap();
+            let info = packages.merged_dependencies.get("lodash").unwrap();
+            assert_eq!(info.version, "4.17.30", "order {paths:?}");
+            assert_eq!(info.spec, "~4.17.30", "order {paths:?}");
+            assert_eq!(info.source_path, high, "order {paths:?}");
+        }
     }
 
     /// Regression anchor on the real corpus-3 fixture: the workspace member


### PR DESCRIPTION
## What

`PackageInfo` now carries `spec` — the dependency specifier exactly as written
in package.json — alongside the existing cleaned `version`.

## Why

`clean_version_spec` strips range operators (`^`, `~`, `>=`, `…`) and collapses
ranges before upload, so `"^3.0.0"` and a `"3.0.0"` pin both arrive at the cloud
as `3.0.0`. That is lossy in exactly the dimension semver-range conflict
analysis needs: the cloud cannot tell a caret range (which two repos may well
resolve compatibly) from a hard pin (which they cannot). Keeping the raw
declaration beside the cleaned one restores that signal without touching any
existing behaviour.

## Wire contract

Each `merged_dependencies[<name>]` object gains a field named exactly `spec`, a
string:

```json
"merged_dependencies": {
  "express": {
    "name": "express",
    "version": "4.18.0",
    "spec": "^4.18.0",
    "source_path": "package.json"
  }
}
```

`PackageInfo` derives plain `Serialize`/`Deserialize` with no `rename_all`, so
the Rust field name is the wire name — no rename attribute needed. The field is
`#[serde(default)]`, so payloads serialised before it existed still deserialise
(with `spec: ""`).

`version` keeps its current meaning and value; neither the cleaning nor the
highest-version selection changed.

Note for consumers: already-indexed repos carry no `spec` until they are
re-scanned, so expect an absent key or `""` for anything whose last scan
predates this merge. Treat empty as "unknown range, fall back to `version`",
not as a parse failure.

## Populating it

`resolve_dependencies` stores the raw `version_spec` of whichever manifest entry
wins — the same entry whose cleaned version is stored — on both the insert path
and the "new version is higher" update path.

## Tests

Two new unit tests in `src/packages.rs`:

- `resolve_dependencies_keeps_the_raw_spec_beside_the_cleaned_version` — builds a
  `Packages` from a temp package.json declaring `"a": "^3.0.0"`,
  `"b": "~1.2.3"`, `"c": "1.0.0 - 2.0.0"`, `"d": "workspace:*"` and asserts each
  entry's `version` against a hardcoded expectation (`3.0.0`, `1.2.3`, `2.0.0`,
  `workspace:*` — what `clean_version_spec` produces today) and its `spec`
  against the raw string. Expectations are literals rather than re-derived from
  `clean_version_spec`, so a regression in the cleaning fails here too.
- `resolve_dependencies_keeps_the_winning_manifests_spec` — two manifests declare
  `lodash` as `^4.17.20` and `~4.17.30`; the stored `spec` must be `~4.17.30`
  (the winner's), asserted in both manifest orders so the update branch and the
  keep-existing branch are each exercised.

The one other construction site, the `relativize_cloud_paths_…` fixture in
`src/engine/mod.rs`, was updated with a matching raw spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
