### PR TITLE
fix(ci): run every integration test, build the sidecar in the hook, sort walks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,36 @@ jobs:
       - name: Run cross-repo scorer unit tests
         run: cargo test --test eval_xrepo --verbose
 
+      # Fixture- and mock-driven; no live LLM, no env beyond what they set
+      # themselves. route_request_anchor_test needs the sidecar built above.
+      - name: Run fixture-driven extraction tests
+        run: >-
+          cargo test --verbose
+          --test extraction_config_test
+          --test file_based_routing_test
+          --test framework_coverage_test
+          --test graphql_extraction_test
+          --test intent_incremental_test
+          --test llm_mock_pipeline_test
+          --test route_request_anchor_test
+          --test socket_extraction_test
+
+      # Every tests/*.rs must be run by a step above or be listed here with a
+      # reason. Nine of twenty were silently local-only before this step.
+      - name: Every integration test is wired into CI
+        run: |
+          excluded="eval_tier_a"  # eval harness; needs CARRICK_API_ENDPOINT, skips without it
+          missing=0
+          for f in tests/*.rs; do
+            n=$(basename "$f" .rs)
+            case " $excluded " in *" $n "*) continue;; esac
+            if ! grep -q -- "--test $n" .github/workflows/ci.yml; then
+              echo "::error::tests/$n.rs is not run by any CI step (add it or list it in 'excluded' with a reason)"
+              missing=1
+            fi
+          done
+          exit $missing
+
       - name: Run sidecar unit tests
         run: cd src/sidecar && npm test
 

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -95,6 +95,20 @@ fi
 rm -f /tmp/carrick-clippy-output.txt
 echo "✅ Clippy checks passed!"
 
+# Build the type sidecar first: several integration tests spawn
+# src/sidecar/dist and either fail against a stale build or skip silently
+# when there is none, so a green run on an old dist proves nothing.
+if [ -f src/sidecar/package.json ]; then
+    echo ""
+    echo "Building type sidecar..."
+    if ! (cd src/sidecar && npm run build --silent); then
+        echo ""
+        echo "❌ Sidecar build failed. Run: cd src/sidecar && npm ci && npm run build"
+        exit 1
+    fi
+    echo "✅ Sidecar built"
+fi
+
 # Run Rust tests
 echo ""
 echo "Running Rust test suite..."

--- a/src/file_finder.rs
+++ b/src/file_finder.rs
@@ -155,7 +155,11 @@ pub fn find_files(dir: &str, ignore_patterns: &[&str]) -> (Vec<PathBuf>, Option<
     let mut config_file = None;
     let root_path = Path::new(dir);
 
+    // Sorted so the walk is the same on every host: readdir order differs
+    // between APFS and ext4, and any "first/last one wins" over an unsorted
+    // walk is a host-dependent result (#569 found one).
     for entry in WalkDir::new(dir)
+        .sort_by_file_name()
         .follow_links(true)
         .into_iter()
         .filter_map(|e| e.ok())

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -291,6 +291,7 @@ pub fn scan_repo(scan_roots: &[PathBuf], service_files: &[PathBuf]) -> GraphqlEx
     let mut seen_sdl: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
     for root in scan_roots {
         for entry in WalkDir::new(root)
+            .sort_by_file_name()
             .into_iter()
             .filter_entry(|e| {
                 !e.file_name()

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,6 +311,7 @@ fn is_deno_native_project(repo_root: &Path) -> bool {
     // depth() == 0 keeps the scan root traversable even when its own basename
     // matches a skip dir (a service directory named `build` is still a repo).
     let walker = walkdir::WalkDir::new(repo_root)
+        .sort_by_file_name()
         .into_iter()
         .filter_entry(|e| {
             e.depth() == 0

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -84,6 +84,7 @@ pub fn collect_internal_package_names(
 ) -> std::collections::HashSet<String> {
     let mut names = std::collections::HashSet::new();
     let walker = walkdir::WalkDir::new(repo_root)
+        .sort_by_file_name()
         .into_iter()
         .filter_entry(|e| {
             e.depth() == 0

--- a/src/workspace_resolver.rs
+++ b/src/workspace_resolver.rs
@@ -256,6 +256,7 @@ impl WorkspaceIndex {
 /// hands back.
 fn manifest_paths(repo_root: &Path) -> Vec<PathBuf> {
     let walker = walkdir::WalkDir::new(repo_root)
+        .sort_by_file_name()
         .follow_links(true)
         .into_iter()
         .filter_entry(|e| {

--- a/tests/intent_incremental_test.rs
+++ b/tests/intent_incremental_test.rs
@@ -122,6 +122,12 @@ async fn incremental_path_populates_intent() {
     // depends on these vars.
     unsafe {
         std::env::set_var("CARRICK_MOCK_ALL", "1");
+        // The engine refuses to upload from a pull_request run or a
+        // non-main ref (anti-pollution guard). This scan targets a temp repo
+        // and a mock store, so the runner's GitHub context must not apply —
+        // in CI on a PR it made scan #1 upload nothing.
+        std::env::remove_var("GITHUB_EVENT_NAME");
+        std::env::remove_var("GITHUB_REF");
     }
 
     let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/koa-api");
@@ -211,6 +217,12 @@ async fn incremental_path_populates_intent() {
 async fn incremental_path_reuses_intents_from_previous_scan() {
     unsafe {
         std::env::set_var("CARRICK_MOCK_ALL", "1");
+        // The engine refuses to upload from a pull_request run or a
+        // non-main ref (anti-pollution guard). This scan targets a temp repo
+        // and a mock store, so the runner's GitHub context must not apply —
+        // in CI on a PR it made scan #1 upload nothing.
+        std::env::remove_var("GITHUB_EVENT_NAME");
+        std::env::remove_var("GITHUB_REF");
     }
 
     let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/koa-api");


### PR DESCRIPTION
## What

Three structural guards from the retro on #569.

1. **CI runs every integration test.** `ci.yml` ran an allowlist of 11 `--test` targets; 9 of the 20 files under `tests/` ran only in the local pre-commit hook — including `route_request_anchor_test`, the test for #542. The eight deterministic ones (fixture/mock driven, no live LLM) now run in one step. A new step fails the build if any `tests/*.rs` is neither run by a step nor listed in `excluded` with a reason. `eval_tier_a` is excluded: it is the env-gated eval harness and skips without `CARRICK_API_ENDPOINT`.
2. **Pre-commit hook builds the sidecar first.** `src/sidecar/dist` is gitignored. Tests that spawn it fail against a stale build (this session: a `dist` from 2026-08-08 failed tests for a 2026-08-23 change) and return early — pass — when there is no build at all (fresh clone or worktree). The hook now runs `npm run build` before `cargo test` and fails loudly if that fails.
3. **Every `WalkDir` is `sort_by_file_name()`.** #569's bug was a last-one-wins over an unsorted walk, so the winner depended on the host's readdir order (APFS vs ext4: the same commit indexed different dependency sets on macOS and ubuntu-latest). Sorting the five walks (`file_finder`, `packages`, `graphql`, `main`, `workspace_resolver`) removes the class.

## Verification

- clippy clean; the eight newly wired tests pass locally against a fresh sidecar build
- The orphan check passes against this `ci.yml`
- This commit went through the updated hook (sidecar build → full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)