### PR TITLE
fix(scanner): honour declared externalDomains for literal absolute URLs

### DIFF
--- a/src/agents/file_orchestrator.rs
+++ b/src/agents/file_orchestrator.rs
@@ -6444,6 +6444,58 @@ export * from "./aFetch.js";"#,
         );
     }
 
+    /// A call to a DECLARED external domain keeps its origin on
+    /// `canonical_path` — the key `mount_graph_to_api_details` uploads and the
+    /// matcher looks up. Stripping it there is what made a declared third-party
+    /// call arrive at matching as a bare `/user`, indistinguishable from an
+    /// internal call and reported as a missing endpoint.
+    #[test]
+    fn declared_external_absolute_url_keeps_its_host_on_the_match_key() {
+        let orchestrator = FileOrchestrator::new(AgentService::new());
+        let config = crate::config::Config {
+            external_domains: ["https://api.vendor.test".to_string()]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+
+        let mut file_results = HashMap::new();
+        file_results.insert(
+            "src/service.ts".to_string(),
+            FileAnalysisResult {
+                graphql_consumer_locates: vec![],
+                mounts: vec![],
+                endpoints: vec![],
+                data_calls: vec![
+                    call_with_span(12, "https://api.vendor.test/v1/charges", Some(200)),
+                    call_with_span(18, "https://orders.undeclared.test/orders", Some(210)),
+                ],
+                graphql_operations: vec![],
+                pubsub_operations: vec![],
+            },
+        );
+
+        let graph = orchestrator.build_mount_graph(
+            &file_results,
+            &UrlNormalizer::new(&config),
+            Path::new(""),
+            Path::new(""),
+        );
+
+        let mut keys: Vec<&str> = graph
+            .data_calls
+            .iter()
+            .map(|call| call.canonical_path.as_str())
+            .collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["/orders", "https://api.vendor.test/v1/charges"],
+            "a declared-external host survives on the key; an undeclared origin \
+             is still stripped so a self-call can match"
+        );
+    }
+
     /// A data call as the fifth pass sees it. `span` carries the
     /// `apply_candidate_map` stamp: `Some` when the model's `candidate_id`
     /// joined a real SWC HTTP candidate, `None` when the model reported an

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -3656,6 +3656,61 @@ mod tests {
         assert!(cross_repo_matches.is_empty());
     }
 
+    /// The `externalDomains` half of the same rule: a literal absolute URL to a
+    /// declared host reaches matching with its origin intact (see
+    /// `UrlNormalizer::consumer_call_path`) and is excluded — no missing
+    /// endpoint, no cross-repo edge. Had the origin been stripped to
+    /// `/v1/charges`, the declaration would be invisible here and the call
+    /// would report as a gap in the service graph.
+    #[test]
+    fn external_domain_calls_stay_excluded_and_silent() {
+        let config = Config {
+            external_domains: ["https://api.vendor.test".to_string()]
+                .into_iter()
+                .collect(),
+            ..Config::default()
+        };
+        let mut analyzer = Analyzer::new(config);
+        for route in [
+            "https://api.vendor.test/v1/charges",
+            "https://undeclared.test/v1/orders",
+        ] {
+            analyzer.calls.push(ApiEndpointDetails {
+                owner: None,
+                key: OperationKey::http("GET", route),
+                params: vec![],
+                request_body: None,
+                response_body: None,
+                handler_name: None,
+                request_type: None,
+                response_type: None,
+                file_path: PathBuf::from("src/client.ts"),
+                repo_name: None,
+                service_name: None,
+                provenance: Default::default(),
+            });
+        }
+
+        let (findings, verified, cross_repo_matches) =
+            analyzer.analyze_matches_with_mount_graph(&MountGraph::new());
+
+        let missing: Vec<&str> = findings
+            .iter()
+            .filter_map(|f| match f {
+                Finding::MissingEndpoint { path, .. } => Some(path.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            missing,
+            vec!["/v1/orders"],
+            "only the UNDECLARED host reports a gap: {:?}",
+            findings
+        );
+        assert!(verified.is_empty());
+        assert!(cross_repo_matches.is_empty());
+    }
+
     /// A consumer call whose path exists in the index under a different verb
     /// must surface exactly once, as a method-mismatch risk — not as a
     /// missing-endpoint + orphaned-endpoint pair.

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -544,6 +544,13 @@ impl UrlNormalizer {
     /// path and match its own endpoint (a literal origin that survived into the
     /// key could match nothing and evaded the self-call / decoy checks).
     ///
+    /// The one exception is a host DECLARED in `externalDomains`: it is kept
+    /// VERBATIM, like a declared-external env-var base. For a declared host the
+    /// origin is not incidental prefix, it is the classification — stripped, the
+    /// key is a bare path that reads exactly like an internal call, and the
+    /// declaration can no longer exclude it from matching. `internalDomains`
+    /// still wins for a host named in both.
+    ///
     /// An UNKNOWN/undeclared ENV-VAR base (`${SOME_URL}/charges`,
     /// `${process.env.STRIPE_URL}/charges` — not in `internalEnvVars`) is still
     /// returned VERBATIM: there is no concrete origin to strip, so keeping the
@@ -574,7 +581,23 @@ impl UrlNormalizer {
             || trimmed.starts_with("https://")
             || trimmed.starts_with("//");
         let normalized = self.normalize(url);
-        if normalized.is_internal || is_relative_path || is_absolute_url {
+        if normalized.is_internal {
+            return normalized.path;
+        }
+        // A host the service DECLARED in `externalDomains` keeps its origin,
+        // even though a literal absolute origin is otherwise a structural
+        // prefix to strip. The origin IS the classification here: stripped, the
+        // key is a bare `/user` that no longer carries the declaration, so
+        // every downstream consumer of the key (`find_matching_endpoints_with_
+        // normalizer`, the uploaded call in `mount_graph_to_api_details`) reads
+        // the call as internal and reports it as a missing endpoint. Trimmed,
+        // not raw: `canonical_path_has_literal_segment` and
+        // `is_valid_route_shape` gate on a bare `http(s)://` prefix, so a
+        // surviving source quote would drop the call as noise instead.
+        if normalized.is_external && is_absolute_url {
+            return trimmed.to_string();
+        }
+        if is_relative_path || is_absolute_url {
             return normalized.path;
         }
         // A base the user DECLARED external stays verbatim whatever its shape —
@@ -1094,6 +1117,92 @@ mod tests {
         assert!(
             !param.contains("process.env"),
             "internal base var must be stripped, got {param}"
+        );
+    }
+
+    /// A literal absolute URL whose host the service DECLARED in
+    /// `externalDomains` keeps its origin on the match key.
+    ///
+    /// The origin strip exists so a self-call over `http://localhost:PORT/...`
+    /// canonicalizes to a bare path; applying it to a declared-external host
+    /// destroys the only evidence downstream has that the call leaves the
+    /// system — the key becomes `/user`, indistinguishable from an internal
+    /// call to a producer nobody declares, and the call is reported missing.
+    #[test]
+    fn consumer_call_path_keeps_declared_external_absolute_url_verbatim() {
+        // Written as full URLs, exactly as carrick.json allows.
+        let config = Config {
+            external_domains: [
+                "https://api.github.com".to_string(),
+                "https://github.com".to_string(),
+                "https://api.resend.com".to_string(),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        };
+        let normalizer = UrlNormalizer::new(&config);
+
+        assert_eq!(
+            normalizer.consumer_call_path("https://api.github.com/user"),
+            "https://api.github.com/user"
+        );
+        assert_eq!(
+            normalizer.consumer_call_path("https://github.com/login/oauth/access_token"),
+            "https://github.com/login/oauth/access_token"
+        );
+        // A declared-external host with `${...}` PATH segments stays whole too.
+        assert_eq!(
+            normalizer.consumer_call_path(
+                "https://api.github.com/user/installations/${installationId}/repositories"
+            ),
+            "https://api.github.com/user/installations/${installationId}/repositories"
+        );
+
+        // A module-level const base (`const RESEND_ENDPOINT = "https://…"`)
+        // reaches here already resolved to its literal URL, so it is the same
+        // case — no separate const resolution runs in this crate.
+        assert_eq!(
+            normalizer.consumer_call_path("https://api.resend.com/emails"),
+            "https://api.resend.com/emails"
+        );
+
+        // Source quoting must not survive: `canonical_path_has_literal_segment`
+        // and `is_valid_route_shape` both gate on a bare `http(s)://` prefix, so
+        // a retained wrapper quote would silently drop the call as noise.
+        assert_eq!(
+            normalizer.consumer_call_path("\"https://api.github.com/user\""),
+            "https://api.github.com/user"
+        );
+        assert_eq!(
+            normalizer.consumer_call_path("`https://api.github.com/user`"),
+            "https://api.github.com/user"
+        );
+
+        // Unchanged: an UNDECLARED absolute origin is still a structural prefix
+        // and is still stripped, which is what lets a self-call match.
+        assert_eq!(
+            normalizer.consumer_call_path("http://localhost:4002/warehouses/${wid}"),
+            "/warehouses/:wid"
+        );
+        assert_eq!(
+            normalizer.consumer_call_path("https://orders.internal/api/orders"),
+            "/api/orders"
+        );
+    }
+
+    /// `internalDomains` still wins over `externalDomains` for a host named in
+    /// both, so the fix cannot silently reclassify an internal call.
+    #[test]
+    fn consumer_call_path_internal_declaration_wins_over_external() {
+        let config = Config {
+            internal_domains: ["api.company.com".to_string()].into_iter().collect(),
+            external_domains: ["api.company.com".to_string()].into_iter().collect(),
+            ..Default::default()
+        };
+        assert_eq!(
+            UrlNormalizer::new(&config).consumer_call_path("https://api.company.com/users"),
+            "/users"
         );
     }
 

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -577,9 +577,8 @@ impl UrlNormalizer {
     pub fn consumer_call_path(&self, url: &str) -> String {
         let trimmed = url.trim_matches(|c| c == '`' || c == '"' || c == '\'');
         let is_relative_path = trimmed.starts_with('/') && !trimmed.starts_with("//");
-        let is_absolute_url = trimmed.starts_with("http://")
-            || trimmed.starts_with("https://")
-            || trimmed.starts_with("//");
+        let has_scheme = trimmed.starts_with("http://") || trimmed.starts_with("https://");
+        let is_absolute_url = has_scheme || trimmed.starts_with("//");
         let normalized = self.normalize(url);
         if normalized.is_internal {
             return normalized.path;
@@ -594,7 +593,13 @@ impl UrlNormalizer {
         // not raw: `canonical_path_has_literal_segment` and
         // `is_valid_route_shape` gate on a bare `http(s)://` prefix, so a
         // surviving source quote would drop the call as noise instead.
-        if normalized.is_external && is_absolute_url {
+        //
+        // Scheme-prefixed only, not every `is_absolute_url` shape: a
+        // protocol-relative `//host/path` key would fail the same `http(s)://`
+        // prefix test that every reader of this key applies, so keeping it
+        // whole would produce a shape nothing downstream recognises as
+        // external. That shape keeps its existing strip.
+        if normalized.is_external && has_scheme {
             return trimmed.to_string();
         }
         if is_relative_path || is_absolute_url {
@@ -1177,6 +1182,24 @@ mod tests {
         assert_eq!(
             normalizer.consumer_call_path("`https://api.github.com/user`"),
             "https://api.github.com/user"
+        );
+
+        // A query string rides along on the key. Every reader tolerates it —
+        // `canonical_path_has_literal_segment` cuts at `?` before its prefix
+        // test, `is_valid_route_shape`'s cleanliness test permits it — and it
+        // is part of the verbatim target, so it is retained rather than
+        // trimmed to a bare path.
+        assert_eq!(
+            normalizer.consumer_call_path("https://api.github.com/user/emails?per_page=100"),
+            "https://api.github.com/user/emails?per_page=100"
+        );
+
+        // A protocol-relative origin is NOT kept whole even when declared: the
+        // key would fail the `http(s)://` test every reader applies, so it
+        // keeps its existing strip rather than gaining an unrecognised shape.
+        assert_eq!(
+            normalizer.consumer_call_path("//api.github.com/user"),
+            "/user"
         );
 
         // Unchanged: an UNDECLARED absolute origin is still a structural prefix


### PR DESCRIPTION
## The bug

A service that declares

```json
{ "name": "carrick-web", "directory": "app",
  "externalDomains": ["https://api.github.com", "https://github.com", "https://api.resend.com"] }
```

still had every one of its `fetch("https://api.github.com/user", …)` calls
reported as a **missing endpoint** by the scanner, and recorded in the cloud
index as an *internal* unmatched call with the host stripped
(`get_service_graph` reason `producer_routeless`, canonical `GET /user`).

## Root cause

`UrlNormalizer::consumer_call_path` (`src/url_normalizer.rs`) folded
`is_absolute_url` into the same branch as `is_internal`:

```rust
if normalized.is_internal || is_relative_path || is_absolute_url {
    return normalized.path;      // origin stripped — before the external check below
}
```

The declared-external check sat *after* it and was unreachable for any literal
`http(s)://` target. The stripped path is exactly the key
`mount_graph_to_api_details` uploads and `find_matching_endpoints_with_normalizer`
re-normalises, so the declaration was gone by the time anything could act on it:
`normalize("/user")` finds no host, classifies internal, and the call falls
through to the missing-endpoint report.

The `externalEnvVars` half of the same rule already returned its base verbatim.
Only the literal-URL half was lost.

## The fix

Order the branches internal → declared-external → structural strip. A
declared-external **scheme-prefixed** URL keeps its origin on the match key,
trimmed of any source quoting (`canonical_path_has_literal_segment` and
`is_valid_route_shape` both gate on a bare `http(s)://` prefix, so a surviving
quote would silently drop the call as noise instead). A query string rides along
on the retained key — it is part of the verbatim target, and every reader
tolerates it.

Unchanged:

- an **undeclared** absolute origin is still stripped, so a service's self-call
  over `http://localhost:PORT/...` still matches its own endpoint;
- a **protocol-relative** `//host/path` is still stripped even when declared: a
  `//api.github.com/user` key would fail the `http(s)://` prefix test every
  reader of the key applies, so keeping it whole would produce a shape nothing
  downstream recognises as external;
- `internalDomains` still wins for a host declared in both sets;
- nothing in the PR-comment formatter or in external-call reporting
  (`external_call_candidates.rs` reads `call.host`, which this does not touch).

A module-level const base (`const RESEND_ENDPOINT = "https://api.resend.com/emails";
fetch(RESEND_ENDPOINT)`) is resolved to its literal URL upstream of this crate —
the index recorded `POST /emails`, not `/RESEND_ENDPOINT` — so it is the same
case and needs no separate handling.

## Tests

Written failing first:

- `url_normalizer::consumer_call_path_keeps_declared_external_absolute_url_verbatim`
  — literal URLs (incl. `${…}` path segments, a resolved const base, quoted
  targets, a query string) stay whole; undeclared and protocol-relative origins
  still strip.
- `url_normalizer::consumer_call_path_internal_declaration_wins_over_external`
- `agents::file_orchestrator::declared_external_absolute_url_keeps_its_host_on_the_match_key`
  — the host survives onto `DataFetchingCall::canonical_path`, the uploaded key.
- `analyzer::external_domain_calls_stay_excluded_and_silent` — end-to-end: only
  the undeclared host produces a `MissingEndpoint` finding.

`cargo test --lib`: 931 passed, 0 failed. `cargo fmt --check` and
`cargo clippy --all-targets --all-features -- -D warnings` clean; the full
pre-commit suite passed.

No cloud-side change is needed: `lambdas/mcp-server/src/tools/get-graph.ts:195`
already classifies a scheme-prefixed canonical as `external_target`, so these
rows move to that reason on the next scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
