### PR TITLE
feat(scanner): stamp the scanner version on uploads and report an already-current index

### DIFF
--- a/src/cloud_storage/aws_storage.rs
+++ b/src/cloud_storage/aws_storage.rs
@@ -1,4 +1,4 @@
-use crate::cloud_storage::{CloudRepoData, CloudStorage, StorageError};
+use crate::cloud_storage::{CloudRepoData, CloudStorage, StorageError, UploadOutcome};
 use crate::oidc::OidcProvider;
 use async_trait::async_trait;
 use reqwest::Client;
@@ -195,12 +195,18 @@ struct PostPrResultRequest<'a> {
     payload: &'a crate::findings::PrResultPayload,
 }
 
-#[derive(Deserialize)]
-struct StoreMetadataResponse {
-    #[allow(dead_code)]
-    success: bool,
-    #[allow(dead_code)]
-    message: String,
+/// The 200 body of either write action (`store-metadata` / `complete-upload`).
+/// Both also return `success` / `message` (and complete-upload an `s3Url` +
+/// `metadata`), none of which the scanner reads — only whether the cloud
+/// short-circuited. Every field is defaulted so a body that omits any of them
+/// still parses.
+#[derive(Deserialize, Default)]
+struct WriteActionResponse {
+    /// True when the cloud found a stored row already carrying this commit
+    /// hash AND this scanner version, so it skipped re-indexing. Absent on
+    /// clouds deployed before the check existed, which reads as "it indexed".
+    #[serde(default)]
+    already_current: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -447,7 +453,7 @@ impl AwsStorage {
         data: &CloudRepoData,
         s3_url: &str,
         staged: Option<&StagedPayload>,
-    ) -> Result<(), StorageError> {
+    ) -> Result<UploadOutcome, StorageError> {
         let request = LambdaRequest {
             action: "store-metadata".to_string(),
             repo: data.repo_name.clone(),
@@ -462,10 +468,12 @@ impl AwsStorage {
             payload_size: staged.map(|s| s.size),
         };
 
-        let _response: StoreMetadataResponse = self.call_lambda(&request).await?;
+        let response: WriteActionResponse = self.call_lambda(&request).await?;
         debug!("Successfully stored metadata for {}", data.repo_name);
 
-        Ok(())
+        Ok(UploadOutcome {
+            already_current: response.already_current.unwrap_or(false),
+        })
     }
 
     /// Stage an oversized serialized CloudRepoData to the presigned URL from
@@ -500,7 +508,7 @@ impl AwsStorage {
 
 #[async_trait]
 impl CloudStorage for AwsStorage {
-    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<(), StorageError> {
+    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<UploadOutcome, StorageError> {
         let repo = &data.repo_name;
 
         // Payload staging decision (carrick#486): measure the serialized
@@ -563,24 +571,25 @@ impl CloudStorage for AwsStorage {
                     payload_size: staged.as_ref().map(|s| s.size),
                 };
 
-                let _complete_response: serde_json::Value =
+                let complete_response: WriteActionResponse =
                     self.call_lambda(&complete_request).await?;
                 debug!("Successfully completed upload and stored metadata");
+                Ok(UploadOutcome {
+                    already_current: complete_response.already_current.unwrap_or(false),
+                })
             } else {
                 debug!(
                     "No bundled types available for {}; storing metadata only",
                     repo
                 );
                 self.store_repo_metadata(data, &lambda_response.s3_url, staged.as_ref())
-                    .await?;
+                    .await
             }
         } else {
             debug!("Type file already exists, just updating metadata");
             self.store_repo_metadata(data, &lambda_response.s3_url, staged.as_ref())
-                .await?;
+                .await
         }
-
-        Ok(())
     }
 
     async fn upload_type_file(
@@ -667,6 +676,7 @@ impl CloudStorage for AwsStorage {
                     sdk_surface: None,
                     sdk_edges: None,
                     sdk_unresolved: None,
+                    scanner_version: None,
                 };
                 repo_s3_urls.insert(adjacent.repo.clone(), adjacent.s3_url);
                 all_repo_data.push(repo_data);
@@ -871,6 +881,41 @@ mod tests {
     /// the cloud reads, and are omitted on every request that does not stage —
     /// the inline body is itself the authenticated payload, so there is no
     /// second hop to verify.
+    /// Both write actions answer 200 either way, so `already_current` is the
+    /// only thing separating "the cloud re-indexed" from "the cloud skipped".
+    /// It is snake_case on the wire (matching `scanner_version` on the payload,
+    /// not the camelCase request fields), and its absence — an older cloud, or
+    /// a body that carries only `success`/`message` — must read as "indexed".
+    #[test]
+    fn write_action_response_reads_already_current_and_defaults_to_indexed() {
+        let skipped: WriteActionResponse = serde_json::from_str(
+            r#"{"success":true,"message":"Metadata stored successfully","already_current":true}"#,
+        )
+        .expect("a short-circuit body parses");
+        assert_eq!(skipped.already_current, Some(true));
+
+        let indexed: WriteActionResponse = serde_json::from_str(
+            r#"{"success":true,"message":"Metadata stored successfully","already_current":false}"#,
+        )
+        .expect("an explicit false parses");
+        assert_eq!(indexed.already_current, Some(false));
+
+        // Absent (older cloud, or the complete-upload body with its extra
+        // fields): parses, and `unwrap_or(false)` reads it as "indexed".
+        let legacy: WriteActionResponse = serde_json::from_str(
+            r#"{"success":true,"message":"done","s3Url":"s3://b/k","metadata":{"pk":"w","sk":"p"}}"#,
+        )
+        .expect("a body without the field still parses");
+        assert!(legacy.already_current.is_none());
+        assert!(!legacy.already_current.unwrap_or(false));
+
+        // And a body with neither field — the write actions have carried
+        // different shapes over time and none of them may be dropped.
+        let bare: WriteActionResponse =
+            serde_json::from_str("{}").expect("an empty body still parses");
+        assert!(bare.already_current.is_none());
+    }
+
     #[test]
     fn integrity_fields_serialize_by_name_and_omit_when_none() {
         let inline = LambdaRequest {

--- a/src/cloud_storage/local_dir_storage.rs
+++ b/src/cloud_storage/local_dir_storage.rs
@@ -16,7 +16,7 @@
 //! `CARRICK_LOCAL_STORAGE_DIR` env var (see `main.rs`). The engine never learns
 //! it is in eval mode — same contract as `MockStorage`.
 
-use crate::cloud_storage::{CloudRepoData, CloudStorage, StorageError};
+use crate::cloud_storage::{CloudRepoData, CloudStorage, StorageError, UploadOutcome};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -73,7 +73,7 @@ impl LocalDirStorage {
 
 #[async_trait]
 impl CloudStorage for LocalDirStorage {
-    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<(), StorageError> {
+    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<UploadOutcome, StorageError> {
         let path = self.cache_path(&data.repo_name, data.service_name.as_deref());
         debug!(
             "LOCAL: Uploading repo data for {} (service: {:?}) -> {}",
@@ -86,7 +86,11 @@ impl CloudStorage for LocalDirStorage {
         std::fs::write(&path, json).map_err(|e| {
             StorageError::ConnectionError(format!("Failed to write {}: {e}", path.display()))
         })?;
-        Ok(())
+        // The cache file is rewritten unconditionally — there is no freshness
+        // check to short-circuit on.
+        Ok(UploadOutcome {
+            already_current: false,
+        })
     }
 
     // Cache files are keyed by (repo, service), so each service of a

--- a/src/cloud_storage/mock_storage.rs
+++ b/src/cloud_storage/mock_storage.rs
@@ -1,4 +1,4 @@
-use crate::cloud_storage::{CloudRepoData, CloudStorage, StorageError};
+use crate::cloud_storage::{CloudRepoData, CloudStorage, StorageError, UploadOutcome};
 use crate::packages::{PackageJson, Packages};
 use async_trait::async_trait;
 use chrono::Utc;
@@ -29,13 +29,17 @@ impl MockStorage {
 
 #[async_trait]
 impl CloudStorage for MockStorage {
-    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<(), StorageError> {
+    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<UploadOutcome, StorageError> {
         debug!(
             "MOCK: Uploading repo data for repo: {} (service: {:?})",
             data.repo_name, data.service_name
         );
         self.data.lock().unwrap().push(data.clone());
-        Ok(())
+        // The mock always stores what it is given — it has no freshness check
+        // to short-circuit on.
+        Ok(UploadOutcome {
+            already_current: false,
+        })
     }
 
     // In-memory store keyed per uploaded entry — safe to hold many services
@@ -125,6 +129,7 @@ impl CloudStorage for MockStorage {
                     sdk_surface: None,
                     sdk_edges: None,
                     sdk_unresolved: None,
+                    scanner_version: None,
                 },
                 CloudRepoData {
                     repo_name: "repo-b".to_string(),
@@ -157,6 +162,7 @@ impl CloudStorage for MockStorage {
                     sdk_surface: None,
                     sdk_edges: None,
                     sdk_unresolved: None,
+                    scanner_version: None,
                 },
             ];
             result.extend(mock_repos);

--- a/src/cloud_storage/mod.rs
+++ b/src/cloud_storage/mod.rs
@@ -338,6 +338,21 @@ pub struct CloudRepoData {
     /// "no SDK calls".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sdk_unresolved: Option<Vec<SdkUnresolved>>,
+    /// The scanner release (`CARGO_PKG_VERSION`) that produced this upload.
+    /// The cloud treats a stored row as current only when the commit hash AND
+    /// the `scanner_version` match, so a scanner release re-indexes an
+    /// unchanged repo once instead of being short-circuited forever by the hash
+    /// alone. Without it, a release that fixes extraction could never refresh a
+    /// repo whose code had not moved: the run printed "Uploaded" and the index
+    /// kept the rows the previous scanner wrote.
+    ///
+    /// Additive and optional: blobs written before the field existed carry
+    /// `None`. Set on every production upload; test fixtures leave it `None`,
+    /// and it is deliberately absent from the placeholder blob the download
+    /// path builds for an adjacent repo with no metadata — that row is someone
+    /// else's scan, not this scanner's.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scanner_version: Option<String>,
 }
 
 /// Version of the v2 capture stub artifact schema. Bumped on incompatible
@@ -499,6 +514,10 @@ impl CloudRepoData {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            // Stamp the release that produced this blob so the cloud can tell
+            // "same commit, same scanner" (skip) from "same commit, newer
+            // scanner" (re-index).
+            scanner_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         }
     }
 }
@@ -580,9 +599,19 @@ impl std::fmt::Display for StorageError {
 
 impl Error for StorageError {}
 
+/// What the cloud did with one uploaded payload.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct UploadOutcome {
+    /// The cloud already held a row for this (repo, service) carrying both this
+    /// commit hash and this scanner version, so it skipped re-indexing and
+    /// nothing this run computed was stored. Only ever true for `AwsStorage`;
+    /// the mock and local-dir backends always write, so they report `false`.
+    pub already_current: bool,
+}
+
 #[async_trait]
 pub trait CloudStorage {
-    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<(), StorageError>;
+    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<UploadOutcome, StorageError>;
 
     /// Whether this backend can store more than one service per git repo
     /// without collision. The production index keys on
@@ -732,6 +761,69 @@ mod tests {
     use super::*;
     use crate::services::type_sidecar::InferKind;
 
+    /// The cloud compares the stored row's scanner version against this field,
+    /// so it has to survive the wire under exactly that name — and stay absent
+    /// (not `null`) when unset, so a blob written by an older scanner still
+    /// deserializes into `None` rather than failing the whole download.
+    #[test]
+    fn scanner_version_rides_the_wire_and_is_omitted_when_unset() {
+        let mut repo = empty_repo("orders-service", None);
+        repo.scanner_version = Some("1.2.3".to_string());
+
+        let json = serde_json::to_value(&repo).unwrap();
+        assert_eq!(json["scanner_version"], "1.2.3");
+
+        let back: CloudRepoData = serde_json::from_str(&serde_json::to_string(&repo).unwrap())
+            .expect("a stamped blob round-trips");
+        assert_eq!(back.scanner_version.as_deref(), Some("1.2.3"));
+
+        // Unset: the key is absent from the payload, which is exactly the
+        // shape of every blob the cloud stored before this field existed.
+        let unstamped = empty_repo("orders-service", None);
+        let json = serde_json::to_string(&unstamped).unwrap();
+        assert!(
+            !json.contains("scanner_version"),
+            "an unset scanner_version must be omitted, not serialized as null"
+        );
+        let back: CloudRepoData =
+            serde_json::from_str(&json).expect("old cloud data (no field) still deserializes");
+        assert!(back.scanner_version.is_none());
+    }
+
+    /// The full-analysis upload path stamps the running release. Without this
+    /// the cloud can never tell "same commit, newer scanner" from "same commit,
+    /// same scanner" and a release would never re-index an unchanged repo.
+    #[test]
+    fn from_multi_agent_results_stamps_the_running_scanner_version() {
+        let analysis_result = MultiAgentAnalysisResult {
+            framework_detection: DetectionResult {
+                frameworks: vec![],
+                data_fetchers: vec![],
+                messaging_clients: vec![],
+                notes: String::new(),
+            },
+            framework_guidance: ProtocolGuidance::new(),
+            mount_graph: MountGraph::new(),
+            file_results: HashMap::new(),
+            stats: Default::default(),
+        };
+
+        let data = CloudRepoData::from_multi_agent_results(
+            "orders-service".to_string(),
+            ".",
+            &analysis_result,
+            None,
+            None,
+            None,
+            HashMap::new(),
+        );
+
+        assert_eq!(
+            data.scanner_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+    }
+
     /// The flattened key is the wire contract with the manifest matcher:
     /// entries must serialize with flat `protocol`/`method`/`path` fields,
     /// and round-trip back into the tagged key.
@@ -836,6 +928,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         }
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4,7 +4,7 @@ use crate::agents::framework_guidance_agent::{FrameworkGuidanceAgent, ProtocolGu
 use crate::analyzer::{Analyzer, ApiEndpointDetails, builder::AnalyzerBuilder};
 use crate::cloud_storage::{
     CloudRepoData, CloudStorage, INLINE_PAYLOAD_LIMIT_BYTES, ManifestRole, ManifestTypeKind,
-    ManifestTypeState, TypeDegradation, TypeManifestEntry, get_current_commit_hash,
+    ManifestTypeState, TypeDegradation, TypeManifestEntry, UploadOutcome, get_current_commit_hash,
     mount_graph_to_api_details,
 };
 use crate::config::Config;
@@ -713,28 +713,47 @@ async fn upload_service_payloads<T: CloudStorage>(
     payloads: &[CloudRepoData],
 ) -> Result<(), Box<dyn std::error::Error>> {
     let sp = logging::spinner("Uploading results...");
+    let mut outcomes: Vec<UploadOutcome> = Vec::with_capacity(payloads.len());
     for (i, payload) in payloads.iter().enumerate() {
-        if let Err(e) = storage.upload_repo_data(payload).await {
-            let uploaded: Vec<&str> = payloads[..i]
-                .iter()
-                .map(|d| d.service_name.as_deref().unwrap_or(&d.repo_name))
-                .collect();
-            let not_uploaded: Vec<&str> = payloads[i..]
-                .iter()
-                .map(|d| d.service_name.as_deref().unwrap_or(&d.repo_name))
-                .collect();
-            return Err(format!(
-                "Failed to upload repo data: {}. Uploaded: [{}]; not uploaded: [{}]. \
-                 The index is mixed-generation for this repo until a successful re-run.",
-                e,
-                uploaded.join(", "),
-                not_uploaded.join(", ")
-            )
-            .into());
+        match storage.upload_repo_data(payload).await {
+            Ok(outcome) => outcomes.push(outcome),
+            Err(e) => {
+                let uploaded: Vec<&str> = payloads[..i]
+                    .iter()
+                    .map(|d| d.service_name.as_deref().unwrap_or(&d.repo_name))
+                    .collect();
+                let not_uploaded: Vec<&str> = payloads[i..]
+                    .iter()
+                    .map(|d| d.service_name.as_deref().unwrap_or(&d.repo_name))
+                    .collect();
+                return Err(format!(
+                    "Failed to upload repo data: {}. Uploaded: [{}]; not uploaded: [{}]. \
+                     The index is mixed-generation for this repo until a successful re-run.",
+                    e,
+                    uploaded.join(", "),
+                    not_uploaded.join(", ")
+                )
+                .into());
+            }
         }
     }
-    logging::finish_spinner(&sp, "Uploaded results to Carrick Cloud");
+    logging::finish_spinner(&sp, upload_finish_message(&outcomes));
     Ok(())
+}
+
+/// What the upload spinner says once every payload has landed.
+///
+/// "Uploaded" is a lie when the cloud short-circuited: it already held a row
+/// for this commit hash and this scanner version, so nothing this run computed
+/// was stored. Only claim that when EVERY service was skipped — a partial skip
+/// in a multi-service repo did re-index something, and an empty slice never
+/// uploaded anything to call current.
+fn upload_finish_message(outcomes: &[UploadOutcome]) -> &'static str {
+    if !outcomes.is_empty() && outcomes.iter().all(|o| o.already_current) {
+        "Index already current for this commit and scanner version; nothing re-indexed"
+    } else {
+        "Uploaded results to Carrick Cloud"
+    }
 }
 
 /// Remove AST nodes from CloudRepoData for serialization, then run the payload
@@ -2598,6 +2617,10 @@ fn build_cloud_data_from_mount_graph(
         sdk_surface: None,
         sdk_edges: None,
         sdk_unresolved: None,
+        // Stamp the release that produced this blob so the cloud can tell
+        // "same commit, same scanner" (skip) from "same commit, newer
+        // scanner" (re-index).
+        scanner_version: Some(env!("CARGO_PKG_VERSION").to_string()),
     }
 }
 
@@ -3838,6 +3861,58 @@ mod tests {
     use super::*;
     use crate::analyzer::ApiEndpointDetails;
 
+    /// The incremental upload path stamps the running release, same as the
+    /// full-analysis path. Miss it here and every incremental scan — the common
+    /// case — uploads an unattributed blob the cloud can never re-index.
+    #[test]
+    fn incremental_cloud_data_stamps_the_running_scanner_version() {
+        let data = build_cloud_data_from_mount_graph(
+            "orders-service",
+            ".",
+            &MountGraph::new(),
+            &Config::default(),
+            &crate::packages::Packages::default(),
+            HashMap::new(),
+        );
+
+        assert_eq!(
+            data.scanner_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+    }
+
+    /// "Uploaded" would be a lie when the cloud short-circuited every payload,
+    /// and "already current" would be a lie when it re-indexed any of them.
+    #[test]
+    fn upload_finish_message_only_claims_current_when_every_payload_was_skipped() {
+        let skipped = UploadOutcome {
+            already_current: true,
+        };
+        let indexed = UploadOutcome {
+            already_current: false,
+        };
+
+        assert_eq!(
+            upload_finish_message(&[skipped, skipped]),
+            "Index already current for this commit and scanner version; nothing re-indexed"
+        );
+        // A multi-service repo where one service did get re-indexed uploaded
+        // something, so it must not claim otherwise.
+        assert_eq!(
+            upload_finish_message(&[skipped, indexed]),
+            "Uploaded results to Carrick Cloud"
+        );
+        assert_eq!(
+            upload_finish_message(&[indexed]),
+            "Uploaded results to Carrick Cloud"
+        );
+        // Vacuously "all skipped" — but nothing was uploaded to call current.
+        assert_eq!(
+            upload_finish_message(&[]),
+            "Uploaded results to Carrick Cloud"
+        );
+    }
+
     /// A blank service payload, named, with nothing resolved.
     fn service_data(repo: &str, service: Option<&str>) -> CloudRepoData {
         CloudRepoData {
@@ -3871,6 +3946,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         }
     }
 
@@ -4201,6 +4277,7 @@ mod tests {
             }]),
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         };
 
         relativize_cloud_paths(&mut data, repo_path);
@@ -4332,6 +4409,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         };
 
         // Verify strip_ast_nodes removes AST nodes
@@ -4379,6 +4457,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         }];
 
         // Test Config merging
@@ -4463,6 +4542,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         }];
 
         // Test that cross-repo builder doesn't fail with SourceMap issues
@@ -5065,6 +5145,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         };
 
         // Staging unavailable: the request body has to carry the payload, so
@@ -5117,6 +5198,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         };
 
         let stripped = strip_ast_nodes(data, true);
@@ -5180,6 +5262,7 @@ mod tests {
                 sdk_surface: None,
                 sdk_edges: None,
                 sdk_unresolved: None,
+                scanner_version: None,
             }
         }
 
@@ -5254,6 +5337,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         };
 
         // Size the file_results filler so the payload lands just UNDER the 5MB
@@ -5470,6 +5554,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         };
 
         let json = serde_json::to_string(&data).expect("should serialize");
@@ -5541,6 +5626,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         };
 
         attach_external_call_candidates(&mut data, &fixture_str, &files, &service);
@@ -5639,6 +5725,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         };
 
         attach_external_call_candidates(&mut data, &fixture_str, &files, &service);
@@ -5745,6 +5832,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         };
 
         let json = serde_json::to_string(&data).expect("should serialize");
@@ -8112,6 +8200,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         }
     }
 }

--- a/src/engine/type_compat_v2.rs
+++ b/src/engine/type_compat_v2.rs
@@ -1146,6 +1146,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         }
     }
 

--- a/src/mount_graph.rs
+++ b/src/mount_graph.rs
@@ -1048,6 +1048,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         }
     }
 

--- a/src/sdk_edges.rs
+++ b/src/sdk_edges.rs
@@ -611,6 +611,7 @@ mod tests {
             sdk_surface: None,
             sdk_edges: None,
             sdk_unresolved: None,
+            scanner_version: None,
         }
     }
 

--- a/tests/intent_incremental_test.rs
+++ b/tests/intent_incremental_test.rs
@@ -5,7 +5,9 @@
 //! `intent` absent.
 
 use async_trait::async_trait;
-use carrick::cloud_storage::{CloudRepoData, CloudStorage, MockStorage, StorageError};
+use carrick::cloud_storage::{
+    CloudRepoData, CloudStorage, MockStorage, StorageError, UploadOutcome,
+};
 use carrick::engine::run_analysis_engine_with_sidecar;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -17,7 +19,7 @@ struct SharedMock(Arc<MockStorage>);
 
 #[async_trait]
 impl CloudStorage for SharedMock {
-    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<(), StorageError> {
+    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<UploadOutcome, StorageError> {
         self.0.upload_repo_data(data).await
     }
     async fn download_all_repo_data(
@@ -57,9 +59,9 @@ struct StubStorage {
 
 #[async_trait]
 impl CloudStorage for StubStorage {
-    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<(), StorageError> {
+    async fn upload_repo_data(&self, data: &CloudRepoData) -> Result<UploadOutcome, StorageError> {
         self.repos.lock().unwrap().push(data.clone());
-        Ok(())
+        Ok(UploadOutcome::default())
     }
     async fn download_all_repo_data(
         &self,

--- a/tests/mock_storage_test.rs
+++ b/tests/mock_storage_test.rs
@@ -55,6 +55,7 @@ fn create_test_repo_data(repo_name: &str, commit_hash: &str) -> CloudRepoData {
         sdk_surface: None,
         sdk_edges: None,
         sdk_unresolved: None,
+        scanner_version: None,
     }
 }
 


### PR DESCRIPTION
## Why

The cloud's `store-metadata` short-circuits with 200 when the stored index row already carries the incoming commit hash (`isIndexCurrent`, `lambdas/check-or-upload/index_freshness.js`). It knows nothing about *which scanner* produced that row, so a scanner release can never refresh a repo whose code has not changed: a repo rescanned on 0.3.19 (which fixed declared `externalDomains`) printed `✓ Uploaded results to Carrick Cloud` and the index kept the 0.3.17 rows.

The cloud side is being changed in parallel to compare a `scanner_version` carried on the upload and to answer `already_current: true` when it skips. This is the scanner half, built against exactly the contract below.

## Wire contract

**Payload field — `scanner_version`**

- snake_case, no `#[serde(rename)]`, top-level on `CloudRepoData`, so it rides **inside `cloudRepoData`** on `store-metadata` / `complete-upload` (and through the staged-payload path, which serialises the same struct). It is deliberately **not** on the bare check-or-upload existence check, which carries no `cloudRepoData`.
- `Option<String>` with `#[serde(default, skip_serializing_if = "Option::is_none")]` — omitted, never `null`, when unset; a payload without the key still deserializes (old cloud data).
- Value is the scanner release `env!("CARGO_PKG_VERSION")`. The cloud should treat a stored row as current only when the commit hash **and** `scanner_version` match, so a release re-indexes unchanged repos once.

**Response field — `already_current`**

- snake_case, no `#[serde(rename)]`, **top-level** on the `store-metadata` / `complete-upload` 200 body, alongside the existing `success` / `message` (and complete-upload's `s3Url` / `metadata`).
- Optional on the scanner side: absent (older cloud, or any other body shape) reads as `false`, i.e. "the cloud indexed".

> Note for the cloud PR: both keys are **snake_case**, unlike the camelCase request/response keys next to them (`s3Url`, `payloadUploadUrl`, `hasCloudRepoData`, `lastUpdated`). Neither side's tests can catch a casing mismatch — both suites would stay green and the line would simply never print — so this is the one thing worth diffing against.

## What changed

- `CloudRepoData` gains `scanner_version`. Both **production** construction paths stamp it:
  - `CloudRepoData::from_multi_agent_results` (`src/cloud_storage/mod.rs`) — the full-analysis path.
  - `build_cloud_data_from_mount_graph` (`src/engine/mod.rs`) — the incremental path.

  Both are reached from the two `upload_payloads` assembly points in `run_analysis_engine`. Test fixtures leave it `None`, and so does the placeholder blob the download path builds for an adjacent repo with no metadata (`aws_storage.rs`) — that row is someone else's scan, not this scanner's.

- Response handling: the unused `StoreMetadataResponse` (both fields were already `#[allow(dead_code)]`; nothing read them) is replaced by a fully-defaulted `WriteActionResponse` carrying only `already_current`. It is now read on **both** write actions — `complete-upload`'s parse moves off `serde_json::Value` onto the same struct.

- `CloudStorage::upload_repo_data` returns `UploadOutcome { already_current: bool }` instead of `()`. `MockStorage` and `LocalDirStorage` always write, so they report `false`. `upload_service_payloads` collects the outcomes and the spinner's final line comes from a new `upload_finish_message` helper:
  - every payload skipped → `Index already current for this commit and scanner version; nothing re-indexed`
  - otherwise (including a partial skip in a multi-service repo, and an empty payload set) → `Uploaded results to Carrick Cloud`

  Exit status and everything else are unchanged.

## Tests

`cargo test --lib`: **939 passed; 0 failed; 0 ignored**. `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

Five new tests:

- `cloud_storage::tests::scanner_version_rides_the_wire_and_is_omitted_when_unset` — `Some("1.2.3")` serialises the key and round-trips; `None` omits it entirely, and that same payload deserializes back to `None` (the old-cloud-data shape).
- `cloud_storage::tests::from_multi_agent_results_stamps_the_running_scanner_version`
- `engine::tests::incremental_cloud_data_stamps_the_running_scanner_version`
- `cloud_storage::aws_storage::tests::write_action_response_reads_already_current_and_defaults_to_indexed` — `true` / `false` / absent-with-complete-upload's-extra-fields / `{}`.
- `engine::tests::upload_finish_message_only_claims_current_when_every_payload_was_skipped`

**Not covered end-to-end:** that the engine *prints* the already-current line. The message goes through `logging::finish_spinner`, whose output isn't capturable without refactoring `logging`, so the decision is tested as the pure `upload_finish_message` helper and the bool's path into it is covered by the response-parsing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)